### PR TITLE
fix crash on shutdown where the engine attempted to use debugInterfac…

### DIFF
--- a/MiniEngine/Core/GraphicsCore.cpp
+++ b/MiniEngine/Core/GraphicsCore.cpp
@@ -455,10 +455,9 @@ void Graphics::Shutdown(void)
 
 #ifdef _DEBUG
 	ID3D12DebugDevice* debugInterface;
-	g_Device->QueryInterface(&debugInterface);
-	assert(debugInterface != nullptr);
-	if (debugInterface != nullptr)
+	if (SUCCEEDED(g_Device->QueryInterface(&debugInterface)))
 	{
+		assert(debugInterface != nullptr);
 		debugInterface->ReportLiveDeviceObjects(D3D12_RLDO_DETAIL | D3D12_RLDO_IGNORE_INTERNAL);
 		debugInterface->Release();
 	}

--- a/MiniEngine/Core/GraphicsCore.cpp
+++ b/MiniEngine/Core/GraphicsCore.cpp
@@ -457,7 +457,6 @@ void Graphics::Shutdown(void)
 	ID3D12DebugDevice* debugInterface;
 	if (SUCCEEDED(g_Device->QueryInterface(&debugInterface)))
 	{
-		assert(debugInterface != nullptr);
 		debugInterface->ReportLiveDeviceObjects(D3D12_RLDO_DETAIL | D3D12_RLDO_IGNORE_INTERNAL);
 		debugInterface->Release();
 	}

--- a/MiniEngine/Core/GraphicsCore.cpp
+++ b/MiniEngine/Core/GraphicsCore.cpp
@@ -456,8 +456,12 @@ void Graphics::Shutdown(void)
 #ifdef _DEBUG
 	ID3D12DebugDevice* debugInterface;
 	g_Device->QueryInterface(&debugInterface);
-	debugInterface->ReportLiveDeviceObjects(D3D12_RLDO_DETAIL | D3D12_RLDO_IGNORE_INTERNAL);
-	debugInterface->Release();
+	assert(debugInterface != nullptr);
+	if (debugInterface != nullptr)
+	{
+		debugInterface->ReportLiveDeviceObjects(D3D12_RLDO_DETAIL | D3D12_RLDO_IGNORE_INTERNAL);
+		debugInterface->Release();
+	}
 #endif
 
 	SAFE_RELEASE(g_Device);


### PR DESCRIPTION
…e even if it was null. Added an assert for now - but should likely change this to spawn a message to the user if we care (or, just skip the debug checks silently, if we don't)...