### PR TITLE
Changed DDSTextureLoader to initialize texture with correct subresource count using arraySize.

### DIFF
--- a/MiniEngine/Core/DDSTextureLoader.cpp
+++ b/MiniEngine/Core/DDSTextureLoader.cpp
@@ -1146,7 +1146,7 @@ static HRESULT CreateTextureFromDDS( _In_ ID3D12Device* d3dDevice,
     }
 
     {
-		auto subResourceCount = static_cast<UINT>(mipCount) * arraySize;
+        auto subResourceCount = static_cast<UINT>(mipCount) * arraySize;
 
         // Create the texture
         std::unique_ptr<D3D12_SUBRESOURCE_DATA[]> initData( new (std::nothrow) D3D12_SUBRESOURCE_DATA[ subResourceCount ] );

--- a/MiniEngine/Core/DDSTextureLoader.cpp
+++ b/MiniEngine/Core/DDSTextureLoader.cpp
@@ -1146,10 +1146,10 @@ static HRESULT CreateTextureFromDDS( _In_ ID3D12Device* d3dDevice,
     }
 
     {
-        auto subResourceCount = static_cast<UINT>(mipCount) * arraySize;
+        auto subresourceCount = static_cast<UINT>(mipCount) * arraySize;
 
         // Create the texture
-        std::unique_ptr<D3D12_SUBRESOURCE_DATA[]> initData( new (std::nothrow) D3D12_SUBRESOURCE_DATA[ subResourceCount ] );
+        std::unique_ptr<D3D12_SUBRESOURCE_DATA[]> initData( new (std::nothrow) D3D12_SUBRESOURCE_DATA[ subresourceCount ] );
         if ( !initData )
         {
             return E_OUTOFMEMORY;
@@ -1189,7 +1189,7 @@ static HRESULT CreateTextureFromDDS( _In_ ID3D12Device* d3dDevice,
 		if (SUCCEEDED(hr))
 		{
 			GpuResource DestTexture(*texture, D3D12_RESOURCE_STATE_COMMON);
-			CommandContext::InitializeTexture(DestTexture, subResourceCount, initData.get());
+			CommandContext::InitializeTexture(DestTexture, subresourceCount, initData.get());
 		}
 	}
 

--- a/MiniEngine/Core/DDSTextureLoader.cpp
+++ b/MiniEngine/Core/DDSTextureLoader.cpp
@@ -1146,8 +1146,10 @@ static HRESULT CreateTextureFromDDS( _In_ ID3D12Device* d3dDevice,
     }
 
     {
+		auto subResourceCount = static_cast<UINT>(mipCount) * arraySize;
+
         // Create the texture
-        std::unique_ptr<D3D12_SUBRESOURCE_DATA[]> initData( new (std::nothrow) D3D12_SUBRESOURCE_DATA[ mipCount * arraySize ] );
+        std::unique_ptr<D3D12_SUBRESOURCE_DATA[]> initData( new (std::nothrow) D3D12_SUBRESOURCE_DATA[ subResourceCount ] );
         if ( !initData )
         {
             return E_OUTOFMEMORY;
@@ -1187,7 +1189,7 @@ static HRESULT CreateTextureFromDDS( _In_ ID3D12Device* d3dDevice,
 		if (SUCCEEDED(hr))
 		{
 			GpuResource DestTexture(*texture, D3D12_RESOURCE_STATE_COMMON);
-			CommandContext::InitializeTexture(DestTexture, (UINT)mipCount, initData.get());
+			CommandContext::InitializeTexture(DestTexture, subResourceCount, initData.get());
 		}
 	}
 


### PR DESCRIPTION
CommandContext::InitializeTexture was only being given mip count which resulted in only the first texture in a texture array / cubemap to be uploaded.