### PR TITLE
Uncapped full-screen frame rate by bypassing DWM

### DIFF
--- a/Samples/D3D12Fullscreen/src/D3D12Fullscreen.h
+++ b/Samples/D3D12Fullscreen/src/D3D12Fullscreen.h
@@ -33,6 +33,7 @@ protected:
 private:
 	static const UINT FrameCount = 2;
 	static const UINT TriangleWidth = 500;
+	static const DXGI_FORMAT BufferFormat = DXGI_FORMAT_R8G8B8A8_UNORM;
 
 	struct Vertex
 	{
@@ -69,6 +70,9 @@ private:
 	// If it's minimized the app may decide not to render frames.
 	bool m_windowVisible;
 	bool m_resizeResources;
+	bool m_fullscreenState;
+	UINT m_windowWidth;
+	UINT m_windowHeight;
 
 	void LoadPipeline();
 	void LoadAssets();
@@ -76,4 +80,8 @@ private:
 	void PopulateCommandList();
 	void WaitForGpu();
 	void MoveToNextFrame();
+	void CheckFullscreenStateChanged();
+	void ChooseDisplayMode(bool fullscreenState);
+	void ResizeBuffers();
+
 };


### PR DESCRIPTION
Disabling vsync in DX12 is non-trivial, but possible. The D3D12Fullscreen sample doesn't allow uncapped frame rates because even the full-screen uses DWM. Fullscreen mode is basically just a maximized window without border.

To enable full-screen mode without DWM, I added DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH. This requires the swapchain buffers need to be resized after toggling between windowed and full-screen mode. I moved this functionality from OnSizeChanged() to a separate ResizeBuffers() function. This allows uncapped frame rates in full-screen on the primary monitor.
To avoid unnecessary flicker when switching to full-screen manually ('space' instead of alt-enter), the window is resized to the target resolution before the mode switch. The target resolution is currently the maximum output resolution (I couldn't find any method to get physical resolution on high-DPI screen).
