### PR TITLE
Factoring out Win32-specific code from DXSample

### DIFF
--- a/Samples/D3D1211On12/src/D3D1211On12.cpp
+++ b/Samples/D3D1211On12/src/D3D1211On12.cpp
@@ -40,7 +40,7 @@ void D3D1211on12::LoadPipeline()
 {
 	UINT d3d11DeviceFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
 	D2D1_FACTORY_OPTIONS d2dFactoryOptions = {};
-#ifdef _DEBUG
+#if defined(_DEBUG)
 	// Enable the D2D debug layer.
 	d2dFactoryOptions.debugLevel = D2D1_DEBUG_LEVEL_INFORMATION;
 
@@ -98,7 +98,7 @@ void D3D1211on12::LoadPipeline()
 	swapChainDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
 	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
 	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-	swapChainDesc.OutputWindow = m_hwnd;
+	swapChainDesc.OutputWindow = Win32Application::GetHwnd();
 	swapChainDesc.SampleDesc.Count = 1;
 	swapChainDesc.Windowed = TRUE;
 
@@ -112,7 +112,7 @@ void D3D1211on12::LoadPipeline()
 	ThrowIfFailed(swapChain.As(&m_swapChain));
 
 	// This sample does not support fullscreen transitions.
-	ThrowIfFailed(factory->MakeWindowAssociation(m_hwnd, DXGI_MWA_NO_ALT_ENTER));
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
 	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
@@ -230,7 +230,7 @@ void D3D1211on12::LoadAssets()
 		ComPtr<ID3DBlob> vertexShader;
 		ComPtr<ID3DBlob> pixelShader;
 
-#ifdef _DEBUG
+#if defined(_DEBUG)
 		// Enable better shader debugging with the graphics debugging tools.
 		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
@@ -374,7 +374,7 @@ void D3D1211on12::OnRender()
 	RenderUI();
 
 	// Present the frame.
-	ThrowIfFailed(m_swapChain->Present(0, 0));
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 
 	MoveToNextFrame();
 }
@@ -417,11 +417,6 @@ void D3D1211on12::OnDestroy()
 	WaitForGpu();
 
 	CloseHandle(m_fenceEvent);
-}
-
-bool D3D1211on12::OnEvent(MSG)
-{
-	return false;
 }
 
 void D3D1211on12::PopulateCommandList()

--- a/Samples/D3D1211On12/src/D3D1211On12.h
+++ b/Samples/D3D1211On12/src/D3D1211On12.h
@@ -21,12 +21,10 @@ class D3D1211on12 : public DXSample
 public:
 	D3D1211on12(UINT width, UINT height, std::wstring name);
 
-protected:
 	virtual void OnInit();
 	virtual void OnUpdate();
 	virtual void OnRender();
 	virtual void OnDestroy();
-	virtual bool OnEvent(MSG msg);
 
 private:
 	static const UINT FrameCount = 3;

--- a/Samples/D3D1211On12/src/D3D1211On12.vcxproj
+++ b/Samples/D3D1211On12/src/D3D1211On12.vcxproj
@@ -96,6 +96,7 @@
     </CustomBuild>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Win32Application.h" />
     <ClInclude Include="D3D1211On12.h" />
     <ClInclude Include="d3dx12.h" />
     <ClInclude Include="DXSample.h" />
@@ -103,6 +104,7 @@
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Win32Application.cpp" />
     <ClCompile Include="D3D1211On12.cpp" />
     <ClCompile Include="DXSample.cpp" />
     <ClCompile Include="Main.cpp" />

--- a/Samples/D3D1211On12/src/D3D1211On12.vcxproj.filters
+++ b/Samples/D3D1211On12/src/D3D1211On12.vcxproj.filters
@@ -44,6 +44,9 @@
     <ClInclude Include="stdafx.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Win32Application.h">
+      <Filter>Header Files\Util</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="D3D1211On12.cpp">
@@ -57,6 +60,9 @@
     </ClCompile>
     <ClCompile Include="stdafx.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Win32Application.cpp">
+      <Filter>Source Files\Util</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/Samples/D3D1211On12/src/DXSample.cpp
+++ b/Samples/D3D1211On12/src/DXSample.cpp
@@ -11,17 +11,13 @@
 
 #include "stdafx.h"
 #include "DXSample.h"
-#include <shellapi.h>
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_title(name),
 	m_useWarpDevice(false)
 {
-	ParseCommandLineArgs();
-
-	m_title = name + (m_useWarpDevice ? L" (WARP)" : L"");
-
 	WCHAR assetsPath[512];
 	GetAssetsPath(assetsPath, _countof(assetsPath));
 	m_assetsPath = assetsPath;
@@ -33,67 +29,6 @@ DXSample::~DXSample()
 {
 }
 
-int DXSample::Run(HINSTANCE hInstance, int nCmdShow)
-{
-	// Initialize the window class.
-	WNDCLASSEX windowClass = { 0 };
-	windowClass.cbSize = sizeof(WNDCLASSEX);
-	windowClass.style = CS_HREDRAW | CS_VREDRAW;
-	windowClass.lpfnWndProc = WindowProc;
-	windowClass.hInstance = hInstance;
-	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-	windowClass.lpszClassName = L"WindowClass1";
-	RegisterClassEx(&windowClass);
-
-	RECT windowRect = { 0, 0, static_cast<LONG>(m_width), static_cast<LONG>(m_height) };
-	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
-
-	// Create the window and store a handle to it.
-	m_hwnd = CreateWindowEx(NULL,
-		L"WindowClass1",
-		m_title.c_str(),
-		WS_OVERLAPPEDWINDOW,
-		300,
-		300,
-		windowRect.right - windowRect.left,
-		windowRect.bottom - windowRect.top,
-		NULL,		// We have no parent window, NULL.
-		NULL,		// We aren't using menus, NULL.
-		hInstance,
-		NULL);		// We aren't using multiple windows, NULL.
-
-	ShowWindow(m_hwnd, nCmdShow);
-
-	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-	OnInit();
-
-	// Main sample loop.
-	MSG msg = { 0 };
-	while (true)
-	{
-		// Process any messages in the queue.
-		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-		{
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-
-			if (msg.message == WM_QUIT)
-				break;
-
-			// Pass events into our sample.
-			OnEvent(msg);
-		}
-
-		OnUpdate();
-		OnRender();
-	}
-
-	OnDestroy();
-
-	// Return this part of the WM_QUIT message to Windows.
-	return static_cast<char>(msg.wParam);
-}
-
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
@@ -102,7 +37,8 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
-void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter)
+_Use_decl_annotations_
+void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
 {
 	IDXGIAdapter1* pAdapter = nullptr;
 	*ppAdapter = nullptr;
@@ -134,36 +70,20 @@ void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_m
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
 	std::wstring windowText = m_title + L": " + text;
-	SetWindowText(m_hwnd, windowText.c_str());
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
-void DXSample::ParseCommandLineArgs()
+_Use_decl_annotations_
+void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-	int argc;
-	LPWSTR *argv = CommandLineToArgvW(GetCommandLineW(), &argc);
 	for (int i = 1; i < argc; ++i)
 	{
 		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
 			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
 		{
 			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
 		}
 	}
-	LocalFree(argv);
-}
-
-// Main message handler for the sample.
-LRESULT CALLBACK DXSample::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
-{
-	// Handle destroy/shutdown messages.
-	switch (message)
-	{
-	case WM_DESTROY:
-		PostQuitMessage(0);
-		return 0;
-	}
-
-	// Handle any messages the switch statement didn't.
-	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/D3D1211On12/src/DXSample.h
+++ b/Samples/D3D1211On12/src/DXSample.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "DXSampleHelper.h"
+#include "Win32Application.h"
 
 class DXSample
 {
@@ -19,35 +20,36 @@ public:
 	DXSample(UINT width, UINT height, std::wstring name);
 	virtual ~DXSample();
 
-	int Run(HINSTANCE hInstance, int nCmdShow);
-	void SetCustomWindowText(LPCWSTR text);
-
-protected:
 	virtual void OnInit() = 0;
 	virtual void OnUpdate() = 0;
 	virtual void OnRender() = 0;
 	virtual void OnDestroy() = 0;
-	virtual bool OnEvent(MSG msg) = 0;
 
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
+
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
+
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+
+protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
-	void GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-
-	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+	void SetCustomWindowText(LPCWSTR text);
 
 	// Viewport dimensions.
 	UINT m_width;
 	UINT m_height;
 	float m_aspectRatio;
 
-	// Window handle.
-	HWND m_hwnd;
-
 	// Adapter info.
 	bool m_useWarpDevice;
 
 private:
-	void ParseCommandLineArgs();
-
 	// Root assets path.
 	std::wstring m_assetsPath;
 

--- a/Samples/D3D1211On12/src/Main.cpp
+++ b/Samples/D3D1211On12/src/Main.cpp
@@ -16,5 +16,5 @@ _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
 	D3D1211on12 sample(1280, 720, L"D3D12 11 on 12 Sample");
-	return sample.Run(hInstance, nCmdShow);
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/D3D1211On12/src/Win32Application.cpp
+++ b/Samples/D3D1211On12/src/Win32Application.cpp
@@ -1,0 +1,119 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#include "stdafx.h"
+#include "Win32Application.h"
+
+HWND Win32Application::m_hwnd = nullptr;
+
+int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
+{
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
+
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
+
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
+
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
+
+	ShowWindow(m_hwnd, nCmdShow);
+
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
+
+	pSample->OnDestroy();
+
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
+}
+
+// Main message handler for the sample.
+LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
+
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
+
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
+
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
+}

--- a/Samples/D3D1211On12/src/Win32Application.h
+++ b/Samples/D3D1211On12/src/Win32Application.h
@@ -1,0 +1,29 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#pragma once
+
+#include "DXSample.h"
+
+class DXSample;
+
+class Win32Application
+{
+public:
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
+
+protected:
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+
+private:
+	static HWND m_hwnd;
+};

--- a/Samples/D3D1211On12/src/stdafx.h
+++ b/Samples/D3D1211On12/src/stdafx.h
@@ -32,3 +32,4 @@
 
 #include <string>
 #include <wrl.h>
+#include <shellapi.h>

--- a/Samples/D3D12Bundles/src/D3D12Bundles.cpp
+++ b/Samples/D3D12Bundles/src/D3D12Bundles.cpp
@@ -43,7 +43,7 @@ void D3D12Bundles::OnInit()
 // Load the rendering pipeline dependencies.
 void D3D12Bundles::LoadPipeline()
 {
-#ifdef _DEBUG
+#if defined(_DEBUG)
 	// Enable the D3D12 debug layer.
 	{
 		ComPtr<ID3D12Debug> debugController;
@@ -95,7 +95,7 @@ void D3D12Bundles::LoadPipeline()
 	swapChainDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
 	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
 	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-	swapChainDesc.OutputWindow = m_hwnd;
+	swapChainDesc.OutputWindow = Win32Application::GetHwnd();
 	swapChainDesc.SampleDesc.Count = 1;
 	swapChainDesc.Windowed = TRUE;
 
@@ -109,7 +109,7 @@ void D3D12Bundles::LoadPipeline()
 	ThrowIfFailed(swapChain.As(&m_swapChain));
 
 	// This sample does not support fullscreen transitions.
-	ThrowIfFailed(factory->MakeWindowAssociation(m_hwnd, DXGI_MWA_NO_ALT_ENTER));
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
 	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
@@ -485,7 +485,7 @@ void D3D12Bundles::OnRender()
 	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
 	// Present and update the frame index for the next frame.
-	ThrowIfFailed(m_swapChain->Present(0, 0));
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
 	// Signal and increment the fence value.
@@ -519,20 +519,14 @@ void D3D12Bundles::OnDestroy()
 	}
 }
 
-bool D3D12Bundles::OnEvent(MSG msg)
+void D3D12Bundles::OnKeyDown(UINT8 key)
 {
-	switch (msg.message)
-	{
-	case WM_KEYDOWN:
-		m_camera.OnKeyDown(msg.wParam);
-		break;
+	m_camera.OnKeyDown(key);
+}
 
-	case WM_KEYUP:
-		m_camera.OnKeyUp(msg.wParam);
-		break;
-	}
-
-	return false;
+void D3D12Bundles::OnKeyUp(UINT8 key)
+{
+	m_camera.OnKeyUp(key);
 }
 
 // Create the resources that will be used every frame.

--- a/Samples/D3D12Bundles/src/D3D12Bundles.h
+++ b/Samples/D3D12Bundles/src/D3D12Bundles.h
@@ -25,12 +25,12 @@ class D3D12Bundles : public DXSample
 public:
 	D3D12Bundles(UINT width, UINT height, std::wstring name);
 
-protected:
 	virtual void OnInit();
 	virtual void OnUpdate();
 	virtual void OnRender();
 	virtual void OnDestroy();
-	virtual bool OnEvent(MSG msg);
+	virtual void OnKeyDown(UINT8 key);
+	virtual void OnKeyUp(UINT8 key);
 
 private:
 	static const UINT FrameCount = 3;

--- a/Samples/D3D12Bundles/src/D3D12Bundles.vcxproj
+++ b/Samples/D3D12Bundles/src/D3D12Bundles.vcxproj
@@ -103,6 +103,7 @@
     </CustomBuild>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="Win32Application.h" />
     <ClInclude Include="D3D12Bundles.h" />
     <ClInclude Include="d3dx12.h" />
     <ClInclude Include="DXSample.h" />
@@ -114,6 +115,7 @@
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Win32Application.cpp" />
     <ClCompile Include="D3D12Bundles.cpp" />
     <ClCompile Include="DXSample.cpp" />
     <ClCompile Include="FrameResource.cpp" />

--- a/Samples/D3D12Bundles/src/D3D12Bundles.vcxproj.filters
+++ b/Samples/D3D12Bundles/src/D3D12Bundles.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClInclude Include="stdafx.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Win32Application.h">
+      <Filter>Header Files\Util</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -69,6 +72,9 @@
       <Filter>Source Files\Util</Filter>
     </ClCompile>
     <ClCompile Include="DXSample.cpp">
+      <Filter>Source Files\Util</Filter>
+    </ClCompile>
+    <ClCompile Include="Win32Application.cpp">
       <Filter>Source Files\Util</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Samples/D3D12Bundles/src/DXSample.cpp
+++ b/Samples/D3D12Bundles/src/DXSample.cpp
@@ -11,17 +11,13 @@
 
 #include "stdafx.h"
 #include "DXSample.h"
-#include <shellapi.h>
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_title(name),
 	m_useWarpDevice(false)
 {
-	ParseCommandLineArgs();
-
-	m_title = name + (m_useWarpDevice ? L" (WARP)" : L"");
-
 	WCHAR assetsPath[512];
 	GetAssetsPath(assetsPath, _countof(assetsPath));
 	m_assetsPath = assetsPath;
@@ -33,67 +29,6 @@ DXSample::~DXSample()
 {
 }
 
-int DXSample::Run(HINSTANCE hInstance, int nCmdShow)
-{
-	// Initialize the window class.
-	WNDCLASSEX windowClass = { 0 };
-	windowClass.cbSize = sizeof(WNDCLASSEX);
-	windowClass.style = CS_HREDRAW | CS_VREDRAW;
-	windowClass.lpfnWndProc = WindowProc;
-	windowClass.hInstance = hInstance;
-	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-	windowClass.lpszClassName = L"WindowClass1";
-	RegisterClassEx(&windowClass);
-
-	RECT windowRect = { 0, 0, static_cast<LONG>(m_width), static_cast<LONG>(m_height) };
-	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
-
-	// Create the window and store a handle to it.
-	m_hwnd = CreateWindowEx(NULL,
-		L"WindowClass1",
-		m_title.c_str(),
-		WS_OVERLAPPEDWINDOW,
-		300,
-		300,
-		windowRect.right - windowRect.left,
-		windowRect.bottom - windowRect.top,
-		NULL,		// We have no parent window, NULL.
-		NULL,		// We aren't using menus, NULL.
-		hInstance,
-		NULL);		// We aren't using multiple windows, NULL.
-
-	ShowWindow(m_hwnd, nCmdShow);
-
-	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-	OnInit();
-
-	// Main sample loop.
-	MSG msg = { 0 };
-	while (true)
-	{
-		// Process any messages in the queue.
-		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-		{
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-
-			if (msg.message == WM_QUIT)
-				break;
-
-			// Pass events into our sample.
-			OnEvent(msg);
-		}
-
-		OnUpdate();
-		OnRender();
-	}
-
-	OnDestroy();
-
-	// Return this part of the WM_QUIT message to Windows.
-	return static_cast<char>(msg.wParam);
-}
-
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
@@ -102,7 +37,8 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
-void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter)
+_Use_decl_annotations_
+void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
 {
 	IDXGIAdapter1* pAdapter = nullptr;
 	*ppAdapter = nullptr;
@@ -134,36 +70,20 @@ void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_m
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
 	std::wstring windowText = m_title + L": " + text;
-	SetWindowText(m_hwnd, windowText.c_str());
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
-void DXSample::ParseCommandLineArgs()
+_Use_decl_annotations_
+void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-	int argc;
-	LPWSTR *argv = CommandLineToArgvW(GetCommandLineW(), &argc);
 	for (int i = 1; i < argc; ++i)
 	{
 		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
 			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
 		{
 			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
 		}
 	}
-	LocalFree(argv);
-}
-
-// Main message handler for the sample.
-LRESULT CALLBACK DXSample::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
-{
-	// Handle destroy/shutdown messages.
-	switch (message)
-	{
-	case WM_DESTROY:
-		PostQuitMessage(0);
-		return 0;
-	}
-
-	// Handle any messages the switch statement didn't.
-	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/D3D12Bundles/src/DXSample.h
+++ b/Samples/D3D12Bundles/src/DXSample.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "DXSampleHelper.h"
+#include "Win32Application.h"
 
 class DXSample
 {
@@ -19,35 +20,36 @@ public:
 	DXSample(UINT width, UINT height, std::wstring name);
 	virtual ~DXSample();
 
-	int Run(HINSTANCE hInstance, int nCmdShow);
-	void SetCustomWindowText(LPCWSTR text);
-
-protected:
 	virtual void OnInit() = 0;
 	virtual void OnUpdate() = 0;
 	virtual void OnRender() = 0;
 	virtual void OnDestroy() = 0;
-	virtual bool OnEvent(MSG msg) = 0;
 
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
+
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
+
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+
+protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
-	void GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-
-	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+	void SetCustomWindowText(LPCWSTR text);
 
 	// Viewport dimensions.
 	UINT m_width;
 	UINT m_height;
 	float m_aspectRatio;
 
-	// Window handle.
-	HWND m_hwnd;
-
 	// Adapter info.
 	bool m_useWarpDevice;
 
 private:
-	void ParseCommandLineArgs();
-
 	// Root assets path.
 	std::wstring m_assetsPath;
 

--- a/Samples/D3D12Bundles/src/Main.cpp
+++ b/Samples/D3D12Bundles/src/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-	D3D12Bundles sample(1280, 720, L"D3D12 Bundles");
-	return sample.Run(hInstance, nCmdShow);
+	D3D12Bundles sample(1280, 720, L"D3D12 Bundles Sample");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/D3D12Bundles/src/Win32Application.cpp
+++ b/Samples/D3D12Bundles/src/Win32Application.cpp
@@ -1,0 +1,119 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#include "stdafx.h"
+#include "Win32Application.h"
+
+HWND Win32Application::m_hwnd = nullptr;
+
+int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
+{
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
+
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
+
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
+
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
+
+	ShowWindow(m_hwnd, nCmdShow);
+
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
+
+	pSample->OnDestroy();
+
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
+}
+
+// Main message handler for the sample.
+LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
+
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
+
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
+
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
+}

--- a/Samples/D3D12Bundles/src/Win32Application.h
+++ b/Samples/D3D12Bundles/src/Win32Application.h
@@ -1,0 +1,29 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#pragma once
+
+#include "DXSample.h"
+
+class DXSample;
+
+class Win32Application
+{
+public:
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
+
+protected:
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+
+private:
+	static HWND m_hwnd;
+};

--- a/Samples/D3D12Bundles/src/stdafx.h
+++ b/Samples/D3D12Bundles/src/stdafx.h
@@ -31,3 +31,4 @@
 #include <vector>
 #include <fstream>
 #include <wrl.h>
+#include <shellapi.h>

--- a/Samples/D3D12DynamicIndexing/src/D3D12DynamicIndexing.cpp
+++ b/Samples/D3D12DynamicIndexing/src/D3D12DynamicIndexing.cpp
@@ -47,7 +47,7 @@ void D3D12DynamicIndexing::OnInit()
 // Load the rendering pipeline dependencies.
 void D3D12DynamicIndexing::LoadPipeline()
 {
-#ifdef _DEBUG
+#if defined(_DEBUG)
 	// Enable the D3D12 debug layer.
 	{
 		ComPtr<ID3D12Debug> debugController;
@@ -99,7 +99,7 @@ void D3D12DynamicIndexing::LoadPipeline()
 	swapChainDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
 	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
 	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-	swapChainDesc.OutputWindow = m_hwnd;
+	swapChainDesc.OutputWindow = Win32Application::GetHwnd();
 	swapChainDesc.SampleDesc.Count = 1;
 	swapChainDesc.Windowed = TRUE;
 
@@ -113,7 +113,7 @@ void D3D12DynamicIndexing::LoadPipeline()
 	ThrowIfFailed(swapChain.As(&m_swapChain));
 
 	// This sample does not support fullscreen transitions.
-	ThrowIfFailed(factory->MakeWindowAssociation(m_hwnd, DXGI_MWA_NO_ALT_ENTER));
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
 	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
@@ -583,7 +583,7 @@ void D3D12DynamicIndexing::OnRender()
 	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
 	// Present and update the frame index for the next frame.
-	ThrowIfFailed(m_swapChain->Present(0, 0));
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
 	// Signal and increment the fence value.
@@ -617,20 +617,14 @@ void D3D12DynamicIndexing::OnDestroy()
 	}
 }
 
-bool D3D12DynamicIndexing::OnEvent(MSG msg)
+void D3D12DynamicIndexing::OnKeyDown(UINT8 key)
 {
-	switch (msg.message)
-	{
-	case WM_KEYDOWN:
-		m_camera.OnKeyDown(msg.wParam);
-		break;
+	m_camera.OnKeyDown(key);
+}
 
-	case WM_KEYUP:
-		m_camera.OnKeyUp(msg.wParam);
-		break;
-	}
-
-	return false;
+void D3D12DynamicIndexing::OnKeyUp(UINT8 key)
+{
+	m_camera.OnKeyUp(key);
 }
 
 // Create the resources that will be used every frame.

--- a/Samples/D3D12DynamicIndexing/src/D3D12DynamicIndexing.h
+++ b/Samples/D3D12DynamicIndexing/src/D3D12DynamicIndexing.h
@@ -25,12 +25,12 @@ class D3D12DynamicIndexing : public DXSample
 public:
 	D3D12DynamicIndexing(UINT width, UINT height, std::wstring name);
 
-protected:
 	virtual void OnInit();
 	virtual void OnUpdate();
 	virtual void OnRender();
 	virtual void OnDestroy();
-	virtual bool OnEvent(MSG msg);
+	virtual void OnKeyDown(UINT8 key);
+	virtual void OnKeyUp(UINT8 key);
 
 private:
 	static const UINT FrameCount = 3;

--- a/Samples/D3D12DynamicIndexing/src/D3D12DynamicIndexing.vcxproj
+++ b/Samples/D3D12DynamicIndexing/src/D3D12DynamicIndexing.vcxproj
@@ -103,6 +103,7 @@
     </CustomBuild>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="Win32Application.h" />
     <ClInclude Include="D3D12DynamicIndexing.h" />
     <ClInclude Include="d3dx12.h" />
     <ClInclude Include="DXSample.h" />
@@ -114,6 +115,7 @@
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Win32Application.cpp" />
     <ClCompile Include="D3D12DynamicIndexing.cpp" />
     <ClCompile Include="DXSample.cpp" />
     <ClCompile Include="FrameResource.cpp" />

--- a/Samples/D3D12DynamicIndexing/src/D3D12DynamicIndexing.vcxproj.filters
+++ b/Samples/D3D12DynamicIndexing/src/D3D12DynamicIndexing.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClInclude Include="stdafx.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Win32Application.h">
+      <Filter>Header Files\Util</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -69,6 +72,9 @@
       <Filter>Source Files\Util</Filter>
     </ClCompile>
     <ClCompile Include="DXSample.cpp">
+      <Filter>Source Files\Util</Filter>
+    </ClCompile>
+    <ClCompile Include="Win32Application.cpp">
       <Filter>Source Files\Util</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Samples/D3D12DynamicIndexing/src/DXSample.cpp
+++ b/Samples/D3D12DynamicIndexing/src/DXSample.cpp
@@ -11,17 +11,13 @@
 
 #include "stdafx.h"
 #include "DXSample.h"
-#include <shellapi.h>
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_title(name),
 	m_useWarpDevice(false)
 {
-	ParseCommandLineArgs();
-
-	m_title = name + (m_useWarpDevice ? L" (WARP)" : L"");
-
 	WCHAR assetsPath[512];
 	GetAssetsPath(assetsPath, _countof(assetsPath));
 	m_assetsPath = assetsPath;
@@ -33,67 +29,6 @@ DXSample::~DXSample()
 {
 }
 
-int DXSample::Run(HINSTANCE hInstance, int nCmdShow)
-{
-	// Initialize the window class.
-	WNDCLASSEX windowClass = { 0 };
-	windowClass.cbSize = sizeof(WNDCLASSEX);
-	windowClass.style = CS_HREDRAW | CS_VREDRAW;
-	windowClass.lpfnWndProc = WindowProc;
-	windowClass.hInstance = hInstance;
-	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-	windowClass.lpszClassName = L"WindowClass1";
-	RegisterClassEx(&windowClass);
-
-	RECT windowRect = { 0, 0, static_cast<LONG>(m_width), static_cast<LONG>(m_height) };
-	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
-
-	// Create the window and store a handle to it.
-	m_hwnd = CreateWindowEx(NULL,
-		L"WindowClass1",
-		m_title.c_str(),
-		WS_OVERLAPPEDWINDOW,
-		300,
-		300,
-		windowRect.right - windowRect.left,
-		windowRect.bottom - windowRect.top,
-		NULL,		// We have no parent window, NULL.
-		NULL,		// We aren't using menus, NULL.
-		hInstance,
-		NULL);		// We aren't using multiple windows, NULL.
-
-	ShowWindow(m_hwnd, nCmdShow);
-
-	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-	OnInit();
-
-	// Main sample loop.
-	MSG msg = { 0 };
-	while (true)
-	{
-		// Process any messages in the queue.
-		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-		{
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-
-			if (msg.message == WM_QUIT)
-				break;
-
-			// Pass events into our sample.
-			OnEvent(msg);
-		}
-
-		OnUpdate();
-		OnRender();
-	}
-
-	OnDestroy();
-
-	// Return this part of the WM_QUIT message to Windows.
-	return static_cast<char>(msg.wParam);
-}
-
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
@@ -102,7 +37,8 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
-void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter)
+_Use_decl_annotations_
+void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
 {
 	IDXGIAdapter1* pAdapter = nullptr;
 	*ppAdapter = nullptr;
@@ -134,36 +70,20 @@ void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_m
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
 	std::wstring windowText = m_title + L": " + text;
-	SetWindowText(m_hwnd, windowText.c_str());
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
-void DXSample::ParseCommandLineArgs()
+_Use_decl_annotations_
+void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-	int argc;
-	LPWSTR *argv = CommandLineToArgvW(GetCommandLineW(), &argc);
 	for (int i = 1; i < argc; ++i)
 	{
 		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
 			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
 		{
 			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
 		}
 	}
-	LocalFree(argv);
-}
-
-// Main message handler for the sample.
-LRESULT CALLBACK DXSample::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
-{
-	// Handle destroy/shutdown messages.
-	switch (message)
-	{
-	case WM_DESTROY:
-		PostQuitMessage(0);
-		return 0;
-	}
-
-	// Handle any messages the switch statement didn't.
-	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/D3D12DynamicIndexing/src/DXSample.h
+++ b/Samples/D3D12DynamicIndexing/src/DXSample.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "DXSampleHelper.h"
+#include "Win32Application.h"
 
 class DXSample
 {
@@ -19,35 +20,36 @@ public:
 	DXSample(UINT width, UINT height, std::wstring name);
 	virtual ~DXSample();
 
-	int Run(HINSTANCE hInstance, int nCmdShow);
-	void SetCustomWindowText(LPCWSTR text);
-
-protected:
 	virtual void OnInit() = 0;
 	virtual void OnUpdate() = 0;
 	virtual void OnRender() = 0;
 	virtual void OnDestroy() = 0;
-	virtual bool OnEvent(MSG msg) = 0;
 
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
+
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
+
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+
+protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
-	void GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-
-	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+	void SetCustomWindowText(LPCWSTR text);
 
 	// Viewport dimensions.
 	UINT m_width;
 	UINT m_height;
 	float m_aspectRatio;
 
-	// Window handle.
-	HWND m_hwnd;
-
 	// Adapter info.
 	bool m_useWarpDevice;
 
 private:
-	void ParseCommandLineArgs();
-
 	// Root assets path.
 	std::wstring m_assetsPath;
 

--- a/Samples/D3D12DynamicIndexing/src/Main.cpp
+++ b/Samples/D3D12DynamicIndexing/src/Main.cpp
@@ -16,5 +16,5 @@ _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
 	D3D12DynamicIndexing sample(1280, 720, L"D3D12 Dynamic Indexing Sample");
-	return sample.Run(hInstance, nCmdShow);
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/D3D12DynamicIndexing/src/Win32Application.cpp
+++ b/Samples/D3D12DynamicIndexing/src/Win32Application.cpp
@@ -1,0 +1,119 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#include "stdafx.h"
+#include "Win32Application.h"
+
+HWND Win32Application::m_hwnd = nullptr;
+
+int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
+{
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
+
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
+
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
+
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
+
+	ShowWindow(m_hwnd, nCmdShow);
+
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
+
+	pSample->OnDestroy();
+
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
+}
+
+// Main message handler for the sample.
+LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
+
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
+
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
+
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
+}

--- a/Samples/D3D12DynamicIndexing/src/Win32Application.h
+++ b/Samples/D3D12DynamicIndexing/src/Win32Application.h
@@ -1,0 +1,29 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#pragma once
+
+#include "DXSample.h"
+
+class DXSample;
+
+class Win32Application
+{
+public:
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
+
+protected:
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+
+private:
+	static HWND m_hwnd;
+};

--- a/Samples/D3D12DynamicIndexing/src/stdafx.h
+++ b/Samples/D3D12DynamicIndexing/src/stdafx.h
@@ -30,3 +30,4 @@
 #include <string>
 #include <vector>
 #include <wrl.h>
+#include <shellapi.h>

--- a/Samples/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.h
+++ b/Samples/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.h
@@ -21,12 +21,11 @@ class D3D12ExecuteIndirect : public DXSample
 public:
 	D3D12ExecuteIndirect(UINT width, UINT height, std::wstring name);
 
-protected:
 	virtual void OnInit();
 	virtual void OnUpdate();
 	virtual void OnRender();
 	virtual void OnDestroy();
-	virtual bool OnEvent(MSG msg);
+	virtual void OnKeyDown(UINT8 key);
 
 private:
 	static const UINT FrameCount = 3;

--- a/Samples/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.vcxproj
+++ b/Samples/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.vcxproj
@@ -98,6 +98,7 @@
     </CustomBuild>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="Win32Application.h" />
     <ClInclude Include="D3D12ExecuteIndirect.h" />
     <ClInclude Include="d3dx12.h" />
     <ClInclude Include="DXSampleHelper.h" />
@@ -105,6 +106,7 @@
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Win32Application.cpp" />
     <ClCompile Include="D3D12ExecuteIndirect.cpp" />
     <ClCompile Include="DXSample.cpp" />
     <ClCompile Include="Main.cpp" />

--- a/Samples/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.vcxproj.filters
+++ b/Samples/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClInclude Include="D3D12ExecuteIndirect.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Win32Application.h">
+      <Filter>Header Files\Util</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -52,6 +55,9 @@
     </ClCompile>
     <ClCompile Include="D3D12ExecuteIndirect.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Win32Application.cpp">
+      <Filter>Source Files\Util</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Samples/D3D12ExecuteIndirect/src/DXSample.cpp
+++ b/Samples/D3D12ExecuteIndirect/src/DXSample.cpp
@@ -11,17 +11,13 @@
 
 #include "stdafx.h"
 #include "DXSample.h"
-#include <shellapi.h>
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_title(name),
 	m_useWarpDevice(false)
 {
-	ParseCommandLineArgs();
-
-	m_title = name + (m_useWarpDevice ? L" (WARP)" : L"");
-
 	WCHAR assetsPath[512];
 	GetAssetsPath(assetsPath, _countof(assetsPath));
 	m_assetsPath = assetsPath;
@@ -33,67 +29,6 @@ DXSample::~DXSample()
 {
 }
 
-int DXSample::Run(HINSTANCE hInstance, int nCmdShow)
-{
-	// Initialize the window class.
-	WNDCLASSEX windowClass = { 0 };
-	windowClass.cbSize = sizeof(WNDCLASSEX);
-	windowClass.style = CS_HREDRAW | CS_VREDRAW;
-	windowClass.lpfnWndProc = WindowProc;
-	windowClass.hInstance = hInstance;
-	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-	windowClass.lpszClassName = L"WindowClass1";
-	RegisterClassEx(&windowClass);
-
-	RECT windowRect = { 0, 0, static_cast<LONG>(m_width), static_cast<LONG>(m_height) };
-	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
-
-	// Create the window and store a handle to it.
-	m_hwnd = CreateWindowEx(NULL,
-		L"WindowClass1",
-		m_title.c_str(),
-		WS_OVERLAPPEDWINDOW,
-		300,
-		300,
-		windowRect.right - windowRect.left,
-		windowRect.bottom - windowRect.top,
-		NULL,		// We have no parent window, NULL.
-		NULL,		// We aren't using menus, NULL.
-		hInstance,
-		NULL);		// We aren't using multiple windows, NULL.
-
-	ShowWindow(m_hwnd, nCmdShow);
-
-	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-	OnInit();
-
-	// Main sample loop.
-	MSG msg = { 0 };
-	while (true)
-	{
-		// Process any messages in the queue.
-		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-		{
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-
-			if (msg.message == WM_QUIT)
-				break;
-
-			// Pass events into our sample.
-			OnEvent(msg);
-		}
-
-		OnUpdate();
-		OnRender();
-	}
-
-	OnDestroy();
-
-	// Return this part of the WM_QUIT message to Windows.
-	return static_cast<char>(msg.wParam);
-}
-
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
@@ -102,7 +37,8 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
-void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter)
+_Use_decl_annotations_
+void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
 {
 	IDXGIAdapter1* pAdapter = nullptr;
 	*ppAdapter = nullptr;
@@ -134,36 +70,20 @@ void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_m
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
 	std::wstring windowText = m_title + L": " + text;
-	SetWindowText(m_hwnd, windowText.c_str());
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
-void DXSample::ParseCommandLineArgs()
+_Use_decl_annotations_
+void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-	int argc;
-	LPWSTR *argv = CommandLineToArgvW(GetCommandLineW(), &argc);
 	for (int i = 1; i < argc; ++i)
 	{
 		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
 			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
 		{
 			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
 		}
 	}
-	LocalFree(argv);
-}
-
-// Main message handler for the sample.
-LRESULT CALLBACK DXSample::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
-{
-	// Handle destroy/shutdown messages.
-	switch (message)
-	{
-	case WM_DESTROY:
-		PostQuitMessage(0);
-		return 0;
-	}
-
-	// Handle any messages the switch statement didn't.
-	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/D3D12ExecuteIndirect/src/DXSample.h
+++ b/Samples/D3D12ExecuteIndirect/src/DXSample.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "DXSampleHelper.h"
+#include "Win32Application.h"
 
 class DXSample
 {
@@ -19,35 +20,36 @@ public:
 	DXSample(UINT width, UINT height, std::wstring name);
 	virtual ~DXSample();
 
-	int Run(HINSTANCE hInstance, int nCmdShow);
-	void SetCustomWindowText(LPCWSTR text);
-
-protected:
 	virtual void OnInit() = 0;
 	virtual void OnUpdate() = 0;
 	virtual void OnRender() = 0;
 	virtual void OnDestroy() = 0;
-	virtual bool OnEvent(MSG msg) = 0;
 
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
+
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
+
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+
+protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
-	void GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-
-	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+	void SetCustomWindowText(LPCWSTR text);
 
 	// Viewport dimensions.
 	UINT m_width;
 	UINT m_height;
 	float m_aspectRatio;
 
-	// Window handle.
-	HWND m_hwnd;
-
 	// Adapter info.
 	bool m_useWarpDevice;
 
 private:
-	void ParseCommandLineArgs();
-
 	// Root assets path.
 	std::wstring m_assetsPath;
 

--- a/Samples/D3D12ExecuteIndirect/src/Main.cpp
+++ b/Samples/D3D12ExecuteIndirect/src/Main.cpp
@@ -16,5 +16,5 @@ _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
 	D3D12ExecuteIndirect sample(1280, 720, L"D3D12 Execute Indirect sample - Press the SPACE bar to toggle GPU primitive culling");
-	return sample.Run(hInstance, nCmdShow);
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/D3D12ExecuteIndirect/src/Win32Application.cpp
+++ b/Samples/D3D12ExecuteIndirect/src/Win32Application.cpp
@@ -1,0 +1,119 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#include "stdafx.h"
+#include "Win32Application.h"
+
+HWND Win32Application::m_hwnd = nullptr;
+
+int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
+{
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
+
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
+
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
+
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
+
+	ShowWindow(m_hwnd, nCmdShow);
+
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
+
+	pSample->OnDestroy();
+
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
+}
+
+// Main message handler for the sample.
+LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
+
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
+
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
+
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
+}

--- a/Samples/D3D12ExecuteIndirect/src/Win32Application.h
+++ b/Samples/D3D12ExecuteIndirect/src/Win32Application.h
@@ -1,0 +1,29 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#pragma once
+
+#include "DXSample.h"
+
+class DXSample;
+
+class Win32Application
+{
+public:
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
+
+protected:
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+
+private:
+	static HWND m_hwnd;
+};

--- a/Samples/D3D12ExecuteIndirect/src/stdafx.h
+++ b/Samples/D3D12ExecuteIndirect/src/stdafx.h
@@ -29,3 +29,4 @@
 
 #include <wrl.h>
 #include <vector>
+#include <shellapi.h>

--- a/Samples/D3D12Fullscreen/src/D3D12Fullscreen.cpp
+++ b/Samples/D3D12Fullscreen/src/D3D12Fullscreen.cpp
@@ -33,7 +33,7 @@ void D3D12Fullscreen::OnInit()
 // Load the rendering pipeline dependencies.
 void D3D12Fullscreen::LoadPipeline()
 {
-#ifdef _DEBUG
+#if defined(_DEBUG)
 	// Enable the D3D12 debug layer.
 	{
 		ComPtr<ID3D12Debug> debugController;
@@ -85,7 +85,7 @@ void D3D12Fullscreen::LoadPipeline()
 	swapChainDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
 	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
 	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-	swapChainDesc.OutputWindow = m_hwnd;
+	swapChainDesc.OutputWindow = Win32Application::GetHwnd();
 	swapChainDesc.SampleDesc.Count = 1;
 	swapChainDesc.Windowed = TRUE;
 
@@ -137,16 +137,17 @@ void D3D12Fullscreen::LoadAssets()
 	{
 		ComPtr<ID3DBlob> vertexShader;
 		ComPtr<ID3DBlob> pixelShader;
+		ComPtr<ID3DBlob> error;
 
-#ifdef _DEBUG
+#if defined(_DEBUG)
 		// Enable better shader debugging with the graphics debugging tools.
 		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
 		UINT compileFlags = 0;
 #endif
 
-		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, &error));
 
 		// Define the vertex input layout.
 		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
@@ -354,11 +355,11 @@ void D3D12Fullscreen::OnDestroy()
 	CloseHandle(m_fenceEvent);
 }
 
-bool D3D12Fullscreen::OnEvent(MSG msg)
+void D3D12Fullscreen::OnKeyDown(UINT8 key)
 {
-	switch (msg.message)
+	switch (key)
 	{
-	case WM_KEYDOWN:
+	case VK_SPACE:
 		// Instrument the Space Bar to toggle between fullscreen states.
 		// The window message loop callback will receive a WM_SIZE message once the
 		// window is in the fullscreen state. At that point, the IDXGISwapChain should
@@ -366,7 +367,6 @@ bool D3D12Fullscreen::OnEvent(MSG msg)
 		//
 		// NOTE: ALT+Enter will perform a similar operation; the code below is not
 		// required to enable that key combination.
-		if (msg.wParam == VK_SPACE)
 		{
 			BOOL fullscreenState;
 			ThrowIfFailed(m_swapChain->GetFullscreenState(&fullscreenState, nullptr));
@@ -381,7 +381,6 @@ bool D3D12Fullscreen::OnEvent(MSG msg)
 		}
 		break;
 	}
-	return false;
 }
 
 // Fill the command list with all the render commands and dependent state.

--- a/Samples/D3D12Fullscreen/src/D3D12Fullscreen.h
+++ b/Samples/D3D12Fullscreen/src/D3D12Fullscreen.h
@@ -28,7 +28,7 @@ protected:
 	virtual void OnRender();
 	virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
 	virtual void OnDestroy();
-	virtual bool OnEvent(MSG msg);
+	virtual void OnKeyDown(UINT8 key);
 
 private:
 	static const UINT FrameCount = 2;

--- a/Samples/D3D12Fullscreen/src/D3D12Fullscreen.vcxproj
+++ b/Samples/D3D12Fullscreen/src/D3D12Fullscreen.vcxproj
@@ -103,6 +103,7 @@
     <ClInclude Include="DXSampleHelper.h" />
     <ClInclude Include="DXSample.h" />
     <ClInclude Include="stdafx.h" />
+    <ClInclude Include="Win32Application.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="D3D12Fullscreen.cpp" />
@@ -112,11 +113,13 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="Win32Application.cpp" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="shaders.hlsl">
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
       <FileType>Document</FileType>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </CustomBuild>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Samples/D3D12Fullscreen/src/D3D12Fullscreen.vcxproj.filters
+++ b/Samples/D3D12Fullscreen/src/D3D12Fullscreen.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClInclude Include="DXSample.h">
       <Filter>Header Files\Util</Filter>
     </ClInclude>
+    <ClInclude Include="Win32Application.h">
+      <Filter>Header Files\Util</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -51,6 +54,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="DXSample.cpp">
+      <Filter>Source Files\Util</Filter>
+    </ClCompile>
+    <ClCompile Include="Win32Application.cpp">
       <Filter>Source Files\Util</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Samples/D3D12Fullscreen/src/DXSample.cpp
+++ b/Samples/D3D12Fullscreen/src/DXSample.cpp
@@ -11,18 +11,14 @@
 
 #include "stdafx.h"
 #include "DXSample.h"
-#include <shellapi.h>
-
-using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
+	m_width(width),
+	m_height(height),
+	m_title(name),
 	m_aspectRatio(0.0f),
 	m_useWarpDevice(false)
 {
-	ParseCommandLineArgs();
-
-	m_title = name + (m_useWarpDevice ? L" (WARP)" : L"");
-
 	WCHAR assetsPath[512];
 	GetAssetsPath(assetsPath, _countof(assetsPath));
 	m_assetsPath = assetsPath;
@@ -32,61 +28,6 @@ DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 
 DXSample::~DXSample()
 {
-}
-
-int DXSample::Run(HINSTANCE hInstance, int nCmdShow)
-{
-	// Initialize the window class.
-	WNDCLASSEX windowClass = { 0 };
-	windowClass.cbSize = sizeof(WNDCLASSEX);
-	windowClass.style = CS_HREDRAW | CS_VREDRAW;
-	windowClass.lpfnWndProc = WindowProc;
-	windowClass.hInstance = hInstance;
-	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-	windowClass.lpszClassName = L"WindowClass1";
-	RegisterClassEx(&windowClass);
-
-	RECT windowRect = { 0, 0, static_cast<LONG>(m_width), static_cast<LONG>(m_height) };
-	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
-
-	// Create the window and store a handle to it.
-	m_hwnd = CreateWindow(
-		L"WindowClass1",
-		m_title.c_str(),
-		WS_OVERLAPPEDWINDOW,
-		300,
-		300,
-		windowRect.right - windowRect.left,
-		windowRect.bottom - windowRect.top,
-		NULL,		// We have no parent window, NULL.
-		NULL,		// We aren't using menus, NULL.
-		hInstance,
-		this);
-
-	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-	OnInit();
-
-	ShowWindow(m_hwnd, nCmdShow);
-
-	// Main sample loop.
-	MSG msg = {};
-	while (msg.message != WM_QUIT)
-	{
-		// Process any messages in the queue.
-		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-		{
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-
-			// Pass events into our sample.
-			OnEvent(msg);
-		}
-	}
-
-	OnDestroy();
-
-	// Return this part of the WM_QUIT message to Windows.
-	return static_cast<char>(msg.wParam);
 }
 
 void DXSample::UpdateForSizeChange(UINT clientWidth, UINT clientHeight)
@@ -105,7 +46,7 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory4* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
 {
 	IDXGIAdapter1* pAdapter = nullptr;
 	*ppAdapter = nullptr;
@@ -137,62 +78,20 @@ void DXSample::GetHardwareAdapter(IDXGIFactory4* pFactory, IDXGIAdapter1** ppAda
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
 	std::wstring windowText = m_title + L": " + text;
-	SetWindowText(m_hwnd, windowText.c_str());
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
-void DXSample::ParseCommandLineArgs()
+_Use_decl_annotations_
+void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-	int argc;
-	LPWSTR *argv = CommandLineToArgvW(GetCommandLineW(), &argc);
 	for (int i = 1; i < argc; ++i)
 	{
 		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 ||
 			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
 		{
 			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
 		}
 	}
-	LocalFree(argv);
-}
-
-// Main message handler for the sample.
-LRESULT CALLBACK DXSample::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
-{
-	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
-
-	switch (message)
-	{
-	case WM_CREATE:
-		{
-			// Save a pointer to the DXSample passed in to CreateWindow.
-			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
-			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
-		}
-		return 0;
-
-	case WM_PAINT:
-		if (pSample)
-		{
-			pSample->OnUpdate();
-			pSample->OnRender();
-		}
-		return 0;
-
-	case WM_SIZE:
-		if (pSample)
-		{
-			RECT clientRect = {};
-			GetClientRect(hWnd, &clientRect);
-			pSample->OnSizeChanged(clientRect.right - clientRect.left, clientRect.bottom - clientRect.top, wParam == SIZE_MINIMIZED);
-		}
-		return 0;
-
-	case WM_DESTROY:
-		PostQuitMessage(0);
-		return 0;
-	}
-
-	// Handle any messages the switch statement didn't.
-	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/D3D12Fullscreen/src/DXSample.h
+++ b/Samples/D3D12Fullscreen/src/DXSample.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "DXSampleHelper.h"
+#include "Win32Application.h"
 
 class DXSample
 {
@@ -19,38 +20,38 @@ public:
 	DXSample(UINT width, UINT height, std::wstring name);
 	virtual ~DXSample();
 
-	int Run(HINSTANCE hInstance, int nCmdShow);
-	void SetCustomWindowText(LPCWSTR text);
-
-protected:
 	virtual void OnInit() = 0;
 	virtual void OnUpdate() = 0;
 	virtual void OnRender() = 0;
 	virtual void OnSizeChanged(UINT width, UINT height, bool minimized) = 0;
 	virtual void OnDestroy() = 0;
-	virtual bool OnEvent(MSG msg) = 0;
 
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
+
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
+
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 	void UpdateForSizeChange(UINT clientWidth, UINT clientHeight);
 
+protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
-	void GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-
-	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+	void SetCustomWindowText(LPCWSTR text);
 
 	// Viewport dimensions.
 	UINT m_width;
 	UINT m_height;
 	float m_aspectRatio;
 
-	// Window handle.
-	HWND m_hwnd;
-
 	// Adapter info.
 	bool m_useWarpDevice;
 
 private:
-	void ParseCommandLineArgs();
-
 	// Root assets path.
 	std::wstring m_assetsPath;
 

--- a/Samples/D3D12Fullscreen/src/Main.cpp
+++ b/Samples/D3D12Fullscreen/src/Main.cpp
@@ -16,5 +16,5 @@ _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
 	D3D12Fullscreen sample(1280, 720, L"D3D12 Fullscreen sample - Press the SPACE bar or ALT+Enter to toggle fullscreen mode");
-	return sample.Run(hInstance, nCmdShow);
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/D3D12Fullscreen/src/Win32Application.cpp
+++ b/Samples/D3D12Fullscreen/src/Win32Application.cpp
@@ -1,0 +1,128 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#include "stdafx.h"
+#include "Win32Application.h"
+
+HWND Win32Application::m_hwnd = nullptr;
+
+int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
+{
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
+
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
+
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
+
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
+
+	ShowWindow(m_hwnd, nCmdShow);
+
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
+
+	pSample->OnDestroy();
+
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
+}
+
+// Main message handler for the sample.
+LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
+
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
+
+	case WM_SIZE:
+		if (pSample)
+		{
+			RECT clientRect = {};
+			GetClientRect(hWnd, &clientRect);
+			pSample->OnSizeChanged(clientRect.right - clientRect.left, clientRect.bottom - clientRect.top, wParam == SIZE_MINIMIZED);
+		}
+		return 0;
+
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
+
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
+}

--- a/Samples/D3D12Fullscreen/src/Win32Application.h
+++ b/Samples/D3D12Fullscreen/src/Win32Application.h
@@ -1,0 +1,29 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#pragma once
+
+#include "DXSample.h"
+
+class DXSample;
+
+class Win32Application
+{
+public:
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
+
+protected:
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+
+private:
+	static HWND m_hwnd;
+};

--- a/Samples/D3D12Fullscreen/src/stdafx.h
+++ b/Samples/D3D12Fullscreen/src/stdafx.h
@@ -29,3 +29,4 @@
 
 #include <wrl.h>
 #include <string>
+#include <shellapi.h>

--- a/Samples/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.cpp
+++ b/Samples/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.cpp
@@ -36,7 +36,7 @@ void D3D12HelloBundles::OnInit()
 // Load the rendering pipeline dependencies.
 void D3D12HelloBundles::LoadPipeline()
 {
-#ifdef _DEBUG
+#if defined(_DEBUG)
 	// Enable the D3D12 debug layer.
 	{
 		ComPtr<ID3D12Debug> debugController;
@@ -88,7 +88,7 @@ void D3D12HelloBundles::LoadPipeline()
 	swapChainDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
 	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
 	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-	swapChainDesc.OutputWindow = m_hwnd;
+	swapChainDesc.OutputWindow = Win32Application::GetHwnd();
 	swapChainDesc.SampleDesc.Count = 1;
 	swapChainDesc.Windowed = TRUE;
 
@@ -102,7 +102,7 @@ void D3D12HelloBundles::LoadPipeline()
 	ThrowIfFailed(swapChain.As(&m_swapChain));
 
 	// This sample does not support fullscreen transitions.
-	ThrowIfFailed(factory->MakeWindowAssociation(m_hwnd, DXGI_MWA_NO_ALT_ENTER));
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
 	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
@@ -154,7 +154,7 @@ void D3D12HelloBundles::LoadAssets()
 		ComPtr<ID3DBlob> vertexShader;
 		ComPtr<ID3DBlob> pixelShader;
 
-#ifdef _DEBUG
+#if defined(_DEBUG)
 		// Enable better shader debugging with the graphics debugging tools.
 		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
@@ -288,11 +288,6 @@ void D3D12HelloBundles::OnDestroy()
 	WaitForPreviousFrame();
 
 	CloseHandle(m_fenceEvent);
-}
-
-bool D3D12HelloBundles::OnEvent(MSG)
-{
-	return false;
 }
 
 void D3D12HelloBundles::PopulateCommandList()

--- a/Samples/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.h
+++ b/Samples/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.h
@@ -21,12 +21,10 @@ class D3D12HelloBundles : public DXSample
 public:
 	D3D12HelloBundles(UINT width, UINT height, std::wstring name);
 
-protected:
 	virtual void OnInit();
 	virtual void OnUpdate();
 	virtual void OnRender();
 	virtual void OnDestroy();
-	virtual bool OnEvent(MSG msg);
 
 private:
 	static const UINT FrameCount = 2;

--- a/Samples/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.vcxproj
+++ b/Samples/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.vcxproj
@@ -109,6 +109,7 @@
     </FxCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="Win32Application.h" />
     <ClInclude Include="D3D12HelloBundles.h" />
     <ClInclude Include="d3dx12.h" />
     <ClInclude Include="DXSample.h" />
@@ -116,6 +117,7 @@
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Win32Application.cpp" />
     <ClCompile Include="D3D12HelloBundles.cpp" />
     <ClCompile Include="DXSample.cpp" />
     <ClCompile Include="Main.cpp" />

--- a/Samples/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.vcxproj.filters
+++ b/Samples/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClInclude Include="D3D12HelloBundles.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Win32Application.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -42,6 +45,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="D3D12HelloBundles.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Win32Application.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Samples/D3D12HelloWorld/src/HelloBundles/DXSample.cpp
+++ b/Samples/D3D12HelloWorld/src/HelloBundles/DXSample.cpp
@@ -11,17 +11,13 @@
 
 #include "stdafx.h"
 #include "DXSample.h"
-#include <shellapi.h>
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_title(name),
 	m_useWarpDevice(false)
 {
-	ParseCommandLineArgs();
-
-	m_title = name + (m_useWarpDevice ? L" (WARP)" : L"");
-
 	WCHAR assetsPath[512];
 	GetAssetsPath(assetsPath, _countof(assetsPath));
 	m_assetsPath = assetsPath;
@@ -33,67 +29,6 @@ DXSample::~DXSample()
 {
 }
 
-int DXSample::Run(HINSTANCE hInstance, int nCmdShow)
-{
-	// Initialize the window class.
-	WNDCLASSEX windowClass = { 0 };
-	windowClass.cbSize = sizeof(WNDCLASSEX);
-	windowClass.style = CS_HREDRAW | CS_VREDRAW;
-	windowClass.lpfnWndProc = WindowProc;
-	windowClass.hInstance = hInstance;
-	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-	windowClass.lpszClassName = L"WindowClass1";
-	RegisterClassEx(&windowClass);
-
-	RECT windowRect = { 0, 0, static_cast<LONG>(m_width), static_cast<LONG>(m_height) };
-	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
-
-	// Create the window and store a handle to it.
-	m_hwnd = CreateWindowEx(NULL,
-		L"WindowClass1",
-		m_title.c_str(),
-		WS_OVERLAPPEDWINDOW,
-		300,
-		300,
-		windowRect.right - windowRect.left,
-		windowRect.bottom - windowRect.top,
-		NULL,		// We have no parent window, NULL.
-		NULL,		// We aren't using menus, NULL.
-		hInstance,
-		NULL);		// We aren't using multiple windows, NULL.
-
-	ShowWindow(m_hwnd, nCmdShow);
-
-	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-	OnInit();
-
-	// Main sample loop.
-	MSG msg = { 0 };
-	while (true)
-	{
-		// Process any messages in the queue.
-		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-		{
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-
-			if (msg.message == WM_QUIT)
-				break;
-
-			// Pass events into our sample.
-			OnEvent(msg);
-		}
-
-		OnUpdate();
-		OnRender();
-	}
-
-	OnDestroy();
-
-	// Return this part of the WM_QUIT message to Windows.
-	return static_cast<char>(msg.wParam);
-}
-
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
@@ -102,7 +37,8 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
-void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter)
+_Use_decl_annotations_
+void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
 {
 	IDXGIAdapter1* pAdapter = nullptr;
 	*ppAdapter = nullptr;
@@ -134,36 +70,20 @@ void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_m
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
 	std::wstring windowText = m_title + L": " + text;
-	SetWindowText(m_hwnd, windowText.c_str());
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
-void DXSample::ParseCommandLineArgs()
+_Use_decl_annotations_
+void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-	int argc;
-	LPWSTR *argv = CommandLineToArgvW(GetCommandLineW(), &argc);
 	for (int i = 1; i < argc; ++i)
 	{
 		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
 			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
 		{
 			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
 		}
 	}
-	LocalFree(argv);
-}
-
-// Main message handler for the sample.
-LRESULT CALLBACK DXSample::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
-{
-	// Handle destroy/shutdown messages.
-	switch (message)
-	{
-	case WM_DESTROY:
-		PostQuitMessage(0);
-		return 0;
-	}
-
-	// Handle any messages the switch statement didn't.
-	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/D3D12HelloWorld/src/HelloBundles/DXSample.h
+++ b/Samples/D3D12HelloWorld/src/HelloBundles/DXSample.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "DXSampleHelper.h"
+#include "Win32Application.h"
 
 class DXSample
 {
@@ -19,35 +20,36 @@ public:
 	DXSample(UINT width, UINT height, std::wstring name);
 	virtual ~DXSample();
 
-	int Run(HINSTANCE hInstance, int nCmdShow);
-	void SetCustomWindowText(LPCWSTR text);
-
-protected:
 	virtual void OnInit() = 0;
 	virtual void OnUpdate() = 0;
 	virtual void OnRender() = 0;
 	virtual void OnDestroy() = 0;
-	virtual bool OnEvent(MSG msg) = 0;
 
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
+
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
+
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+
+protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
-	void GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-
-	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+	void SetCustomWindowText(LPCWSTR text);
 
 	// Viewport dimensions.
 	UINT m_width;
 	UINT m_height;
 	float m_aspectRatio;
 
-	// Window handle.
-	HWND m_hwnd;
-
 	// Adapter info.
 	bool m_useWarpDevice;
 
 private:
-	void ParseCommandLineArgs();
-
 	// Root assets path.
 	std::wstring m_assetsPath;
 

--- a/Samples/D3D12HelloWorld/src/HelloBundles/Main.cpp
+++ b/Samples/D3D12HelloWorld/src/HelloBundles/Main.cpp
@@ -16,5 +16,5 @@ _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
 	D3D12HelloBundles sample(1280, 720, L"D3D12 Hello Bundles");
-	return sample.Run(hInstance, nCmdShow);
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/D3D12HelloWorld/src/HelloBundles/Win32Application.cpp
+++ b/Samples/D3D12HelloWorld/src/HelloBundles/Win32Application.cpp
@@ -1,0 +1,119 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#include "stdafx.h"
+#include "Win32Application.h"
+
+HWND Win32Application::m_hwnd = nullptr;
+
+int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
+{
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
+
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
+
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
+
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
+
+	ShowWindow(m_hwnd, nCmdShow);
+
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
+
+	pSample->OnDestroy();
+
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
+}
+
+// Main message handler for the sample.
+LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
+
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
+
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
+
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
+}

--- a/Samples/D3D12HelloWorld/src/HelloBundles/Win32Application.h
+++ b/Samples/D3D12HelloWorld/src/HelloBundles/Win32Application.h
@@ -1,0 +1,29 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#pragma once
+
+#include "DXSample.h"
+
+class DXSample;
+
+class Win32Application
+{
+public:
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
+
+protected:
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+
+private:
+	static HWND m_hwnd;
+};

--- a/Samples/D3D12HelloWorld/src/HelloBundles/stdafx.h
+++ b/Samples/D3D12HelloWorld/src/HelloBundles/stdafx.h
@@ -29,3 +29,4 @@
 
 #include <string>
 #include <wrl.h>
+#include <shellapi.h>

--- a/Samples/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.cpp
+++ b/Samples/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.cpp
@@ -37,7 +37,7 @@ void D3D12HelloConstBuffers::OnInit()
 // Load the rendering pipeline dependencies.
 void D3D12HelloConstBuffers::LoadPipeline()
 {
-#ifdef _DEBUG
+#if defined(_DEBUG)
 	// Enable the D3D12 debug layer.
 	{
 		ComPtr<ID3D12Debug> debugController;
@@ -89,7 +89,7 @@ void D3D12HelloConstBuffers::LoadPipeline()
 	swapChainDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
 	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
 	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-	swapChainDesc.OutputWindow = m_hwnd;
+	swapChainDesc.OutputWindow = Win32Application::GetHwnd();
 	swapChainDesc.SampleDesc.Count = 1;
 	swapChainDesc.Windowed = TRUE;
 
@@ -103,7 +103,7 @@ void D3D12HelloConstBuffers::LoadPipeline()
 	ThrowIfFailed(swapChain.As(&m_swapChain));
 
 	// This sample does not support fullscreen transitions.
-	ThrowIfFailed(factory->MakeWindowAssociation(m_hwnd, DXGI_MWA_NO_ALT_ENTER));
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
 	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
@@ -177,7 +177,7 @@ void D3D12HelloConstBuffers::LoadAssets()
 		ComPtr<ID3DBlob> vertexShader;
 		ComPtr<ID3DBlob> pixelShader;
 
-#ifdef _DEBUG
+#if defined(_DEBUG)
 		// Enable better shader debugging with the graphics debugging tools.
 		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
@@ -334,11 +334,6 @@ void D3D12HelloConstBuffers::OnDestroy()
 	WaitForPreviousFrame();
 
 	CloseHandle(m_fenceEvent);
-}
-
-bool D3D12HelloConstBuffers::OnEvent(MSG)
-{
-	return false;
 }
 
 // Fill the command list with all the render commands and dependent state.

--- a/Samples/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.h
+++ b/Samples/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.h
@@ -21,12 +21,10 @@ class D3D12HelloConstBuffers : public DXSample
 public:
 	D3D12HelloConstBuffers(UINT width, UINT height, std::wstring name);
 
-protected:
 	virtual void OnInit();
 	virtual void OnUpdate();
 	virtual void OnRender();
 	virtual void OnDestroy();
-	virtual bool OnEvent(MSG msg);
 
 private:
 	static const UINT FrameCount = 2;

--- a/Samples/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.vcxproj
+++ b/Samples/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.vcxproj
@@ -109,6 +109,7 @@
     </FxCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="Win32Application.h" />
     <ClInclude Include="D3D12HelloConstBuffers.h" />
     <ClInclude Include="d3dx12.h" />
     <ClInclude Include="DXSample.h" />
@@ -116,6 +117,7 @@
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Win32Application.cpp" />
     <ClCompile Include="D3D12HelloConstBuffers.cpp" />
     <ClCompile Include="DXSample.cpp" />
     <ClCompile Include="Main.cpp" />

--- a/Samples/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.vcxproj.filters
+++ b/Samples/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClInclude Include="D3D12HelloConstBuffers.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Win32Application.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -42,6 +45,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="D3D12HelloConstBuffers.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Win32Application.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Samples/D3D12HelloWorld/src/HelloConstBuffers/DXSample.cpp
+++ b/Samples/D3D12HelloWorld/src/HelloConstBuffers/DXSample.cpp
@@ -11,17 +11,13 @@
 
 #include "stdafx.h"
 #include "DXSample.h"
-#include <shellapi.h>
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_title(name),
 	m_useWarpDevice(false)
 {
-	ParseCommandLineArgs();
-
-	m_title = name + (m_useWarpDevice ? L" (WARP)" : L"");
-
 	WCHAR assetsPath[512];
 	GetAssetsPath(assetsPath, _countof(assetsPath));
 	m_assetsPath = assetsPath;
@@ -33,67 +29,6 @@ DXSample::~DXSample()
 {
 }
 
-int DXSample::Run(HINSTANCE hInstance, int nCmdShow)
-{
-	// Initialize the window class.
-	WNDCLASSEX windowClass = { 0 };
-	windowClass.cbSize = sizeof(WNDCLASSEX);
-	windowClass.style = CS_HREDRAW | CS_VREDRAW;
-	windowClass.lpfnWndProc = WindowProc;
-	windowClass.hInstance = hInstance;
-	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-	windowClass.lpszClassName = L"WindowClass1";
-	RegisterClassEx(&windowClass);
-
-	RECT windowRect = { 0, 0, static_cast<LONG>(m_width), static_cast<LONG>(m_height) };
-	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
-
-	// Create the window and store a handle to it.
-	m_hwnd = CreateWindowEx(NULL,
-		L"WindowClass1",
-		m_title.c_str(),
-		WS_OVERLAPPEDWINDOW,
-		300,
-		300,
-		windowRect.right - windowRect.left,
-		windowRect.bottom - windowRect.top,
-		NULL,		// We have no parent window, NULL.
-		NULL,		// We aren't using menus, NULL.
-		hInstance,
-		NULL);		// We aren't using multiple windows, NULL.
-
-	ShowWindow(m_hwnd, nCmdShow);
-
-	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-	OnInit();
-
-	// Main sample loop.
-	MSG msg = { 0 };
-	while (true)
-	{
-		// Process any messages in the queue.
-		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-		{
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-
-			if (msg.message == WM_QUIT)
-				break;
-
-			// Pass events into our sample.
-			OnEvent(msg);
-		}
-
-		OnUpdate();
-		OnRender();
-	}
-
-	OnDestroy();
-
-	// Return this part of the WM_QUIT message to Windows.
-	return static_cast<char>(msg.wParam);
-}
-
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
@@ -102,7 +37,8 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
-void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter)
+_Use_decl_annotations_
+void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
 {
 	IDXGIAdapter1* pAdapter = nullptr;
 	*ppAdapter = nullptr;
@@ -134,36 +70,20 @@ void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_m
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
 	std::wstring windowText = m_title + L": " + text;
-	SetWindowText(m_hwnd, windowText.c_str());
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
-void DXSample::ParseCommandLineArgs()
+_Use_decl_annotations_
+void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-	int argc;
-	LPWSTR *argv = CommandLineToArgvW(GetCommandLineW(), &argc);
 	for (int i = 1; i < argc; ++i)
 	{
 		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
 			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
 		{
 			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
 		}
 	}
-	LocalFree(argv);
-}
-
-// Main message handler for the sample.
-LRESULT CALLBACK DXSample::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
-{
-	// Handle destroy/shutdown messages.
-	switch (message)
-	{
-	case WM_DESTROY:
-		PostQuitMessage(0);
-		return 0;
-	}
-
-	// Handle any messages the switch statement didn't.
-	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/D3D12HelloWorld/src/HelloConstBuffers/DXSample.h
+++ b/Samples/D3D12HelloWorld/src/HelloConstBuffers/DXSample.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "DXSampleHelper.h"
+#include "Win32Application.h"
 
 class DXSample
 {
@@ -19,35 +20,36 @@ public:
 	DXSample(UINT width, UINT height, std::wstring name);
 	virtual ~DXSample();
 
-	int Run(HINSTANCE hInstance, int nCmdShow);
-	void SetCustomWindowText(LPCWSTR text);
-
-protected:
 	virtual void OnInit() = 0;
 	virtual void OnUpdate() = 0;
 	virtual void OnRender() = 0;
 	virtual void OnDestroy() = 0;
-	virtual bool OnEvent(MSG msg) = 0;
 
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
+
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
+
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+
+protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
-	void GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-
-	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+	void SetCustomWindowText(LPCWSTR text);
 
 	// Viewport dimensions.
 	UINT m_width;
 	UINT m_height;
 	float m_aspectRatio;
 
-	// Window handle.
-	HWND m_hwnd;
-
 	// Adapter info.
 	bool m_useWarpDevice;
 
 private:
-	void ParseCommandLineArgs();
-
 	// Root assets path.
 	std::wstring m_assetsPath;
 

--- a/Samples/D3D12HelloWorld/src/HelloConstBuffers/Main.cpp
+++ b/Samples/D3D12HelloWorld/src/HelloConstBuffers/Main.cpp
@@ -16,5 +16,5 @@ _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
 	D3D12HelloConstBuffers sample(1280, 720, L"D3D12 Hello Constant Buffers");
-	return sample.Run(hInstance, nCmdShow);
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/D3D12HelloWorld/src/HelloConstBuffers/Win32Application.cpp
+++ b/Samples/D3D12HelloWorld/src/HelloConstBuffers/Win32Application.cpp
@@ -1,0 +1,119 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#include "stdafx.h"
+#include "Win32Application.h"
+
+HWND Win32Application::m_hwnd = nullptr;
+
+int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
+{
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
+
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
+
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
+
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
+
+	ShowWindow(m_hwnd, nCmdShow);
+
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
+
+	pSample->OnDestroy();
+
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
+}
+
+// Main message handler for the sample.
+LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
+
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
+
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
+
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
+}

--- a/Samples/D3D12HelloWorld/src/HelloConstBuffers/Win32Application.h
+++ b/Samples/D3D12HelloWorld/src/HelloConstBuffers/Win32Application.h
@@ -1,0 +1,29 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#pragma once
+
+#include "DXSample.h"
+
+class DXSample;
+
+class Win32Application
+{
+public:
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
+
+protected:
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+
+private:
+	static HWND m_hwnd;
+};

--- a/Samples/D3D12HelloWorld/src/HelloConstBuffers/stdafx.h
+++ b/Samples/D3D12HelloWorld/src/HelloConstBuffers/stdafx.h
@@ -29,3 +29,4 @@
 
 #include <string>
 #include <wrl.h>
+#include <shellapi.h>

--- a/Samples/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.cpp
+++ b/Samples/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.cpp
@@ -36,7 +36,7 @@ void D3D12HelloTexture::OnInit()
 // Load the rendering pipeline dependencies.
 void D3D12HelloTexture::LoadPipeline()
 {
-#ifdef _DEBUG
+#if defined(_DEBUG)
 	// Enable the D3D12 debug layer.
 	{
 		ComPtr<ID3D12Debug> debugController;
@@ -88,7 +88,7 @@ void D3D12HelloTexture::LoadPipeline()
 	swapChainDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
 	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
 	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-	swapChainDesc.OutputWindow = m_hwnd;
+	swapChainDesc.OutputWindow = Win32Application::GetHwnd();
 	swapChainDesc.SampleDesc.Count = 1;
 	swapChainDesc.Windowed = TRUE;
 
@@ -102,7 +102,7 @@ void D3D12HelloTexture::LoadPipeline()
 	ThrowIfFailed(swapChain.As(&m_swapChain));
 
 	// This sample does not support fullscreen transitions.
-	ThrowIfFailed(factory->MakeWindowAssociation(m_hwnd, DXGI_MWA_NO_ALT_ENTER));
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
 	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
@@ -181,7 +181,7 @@ void D3D12HelloTexture::LoadAssets()
 		ComPtr<ID3DBlob> vertexShader;
 		ComPtr<ID3DBlob> pixelShader;
 
-#ifdef _DEBUG
+#if defined(_DEBUG)
 		// Enable better shader debugging with the graphics debugging tools.
 		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
@@ -400,11 +400,6 @@ void D3D12HelloTexture::OnDestroy()
 	WaitForPreviousFrame();
 
 	CloseHandle(m_fenceEvent);
-}
-
-bool D3D12HelloTexture::OnEvent(MSG)
-{
-	return false;
 }
 
 void D3D12HelloTexture::PopulateCommandList()

--- a/Samples/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.h
+++ b/Samples/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.h
@@ -21,12 +21,10 @@ class D3D12HelloTexture : public DXSample
 public:
 	D3D12HelloTexture(UINT width, UINT height, std::wstring name);
 
-protected:
 	virtual void OnInit();
 	virtual void OnUpdate();
 	virtual void OnRender();
 	virtual void OnDestroy();
-	virtual bool OnEvent(MSG msg);
 
 private:
 	static const UINT FrameCount = 2;

--- a/Samples/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.vcxproj
+++ b/Samples/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.vcxproj
@@ -109,6 +109,7 @@
     </FxCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="Win32Application.h" />
     <ClInclude Include="D3D12HelloTexture.h" />
     <ClInclude Include="d3dx12.h" />
     <ClInclude Include="DXSample.h" />
@@ -116,6 +117,7 @@
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Win32Application.cpp" />
     <ClCompile Include="D3D12HelloTexture.cpp" />
     <ClCompile Include="DXSample.cpp" />
     <ClCompile Include="Main.cpp" />

--- a/Samples/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.vcxproj.filters
+++ b/Samples/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClInclude Include="D3D12HelloTexture.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Win32Application.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -42,6 +45,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="D3D12HelloTexture.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Win32Application.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Samples/D3D12HelloWorld/src/HelloTexture/DXSample.cpp
+++ b/Samples/D3D12HelloWorld/src/HelloTexture/DXSample.cpp
@@ -11,17 +11,13 @@
 
 #include "stdafx.h"
 #include "DXSample.h"
-#include <shellapi.h>
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_title(name),
 	m_useWarpDevice(false)
 {
-	ParseCommandLineArgs();
-
-	m_title = name + (m_useWarpDevice ? L" (WARP)" : L"");
-
 	WCHAR assetsPath[512];
 	GetAssetsPath(assetsPath, _countof(assetsPath));
 	m_assetsPath = assetsPath;
@@ -33,67 +29,6 @@ DXSample::~DXSample()
 {
 }
 
-int DXSample::Run(HINSTANCE hInstance, int nCmdShow)
-{
-	// Initialize the window class.
-	WNDCLASSEX windowClass = { 0 };
-	windowClass.cbSize = sizeof(WNDCLASSEX);
-	windowClass.style = CS_HREDRAW | CS_VREDRAW;
-	windowClass.lpfnWndProc = WindowProc;
-	windowClass.hInstance = hInstance;
-	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-	windowClass.lpszClassName = L"WindowClass1";
-	RegisterClassEx(&windowClass);
-
-	RECT windowRect = { 0, 0, static_cast<LONG>(m_width), static_cast<LONG>(m_height) };
-	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
-
-	// Create the window and store a handle to it.
-	m_hwnd = CreateWindowEx(NULL,
-		L"WindowClass1",
-		m_title.c_str(),
-		WS_OVERLAPPEDWINDOW,
-		300,
-		300,
-		windowRect.right - windowRect.left,
-		windowRect.bottom - windowRect.top,
-		NULL,		// We have no parent window, NULL.
-		NULL,		// We aren't using menus, NULL.
-		hInstance,
-		NULL);		// We aren't using multiple windows, NULL.
-
-	ShowWindow(m_hwnd, nCmdShow);
-
-	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-	OnInit();
-
-	// Main sample loop.
-	MSG msg = { 0 };
-	while (true)
-	{
-		// Process any messages in the queue.
-		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-		{
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-
-			if (msg.message == WM_QUIT)
-				break;
-
-			// Pass events into our sample.
-			OnEvent(msg);
-		}
-
-		OnUpdate();
-		OnRender();
-	}
-
-	OnDestroy();
-
-	// Return this part of the WM_QUIT message to Windows.
-	return static_cast<char>(msg.wParam);
-}
-
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
@@ -102,7 +37,8 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
-void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter)
+_Use_decl_annotations_
+void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
 {
 	IDXGIAdapter1* pAdapter = nullptr;
 	*ppAdapter = nullptr;
@@ -134,36 +70,20 @@ void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_m
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
 	std::wstring windowText = m_title + L": " + text;
-	SetWindowText(m_hwnd, windowText.c_str());
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
-void DXSample::ParseCommandLineArgs()
+_Use_decl_annotations_
+void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-	int argc;
-	LPWSTR *argv = CommandLineToArgvW(GetCommandLineW(), &argc);
 	for (int i = 1; i < argc; ++i)
 	{
 		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
 			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
 		{
 			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
 		}
 	}
-	LocalFree(argv);
-}
-
-// Main message handler for the sample.
-LRESULT CALLBACK DXSample::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
-{
-	// Handle destroy/shutdown messages.
-	switch (message)
-	{
-	case WM_DESTROY:
-		PostQuitMessage(0);
-		return 0;
-	}
-
-	// Handle any messages the switch statement didn't.
-	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/D3D12HelloWorld/src/HelloTexture/DXSample.h
+++ b/Samples/D3D12HelloWorld/src/HelloTexture/DXSample.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "DXSampleHelper.h"
+#include "Win32Application.h"
 
 class DXSample
 {
@@ -19,35 +20,36 @@ public:
 	DXSample(UINT width, UINT height, std::wstring name);
 	virtual ~DXSample();
 
-	int Run(HINSTANCE hInstance, int nCmdShow);
-	void SetCustomWindowText(LPCWSTR text);
-
-protected:
 	virtual void OnInit() = 0;
 	virtual void OnUpdate() = 0;
 	virtual void OnRender() = 0;
 	virtual void OnDestroy() = 0;
-	virtual bool OnEvent(MSG msg) = 0;
 
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
+
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
+
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+
+protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
-	void GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-
-	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+	void SetCustomWindowText(LPCWSTR text);
 
 	// Viewport dimensions.
 	UINT m_width;
 	UINT m_height;
 	float m_aspectRatio;
 
-	// Window handle.
-	HWND m_hwnd;
-
 	// Adapter info.
 	bool m_useWarpDevice;
 
 private:
-	void ParseCommandLineArgs();
-
 	// Root assets path.
 	std::wstring m_assetsPath;
 

--- a/Samples/D3D12HelloWorld/src/HelloTexture/Main.cpp
+++ b/Samples/D3D12HelloWorld/src/HelloTexture/Main.cpp
@@ -16,5 +16,5 @@ _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
 	D3D12HelloTexture sample(1280, 720, L"D3D12 Hello Texture");
-	return sample.Run(hInstance, nCmdShow);
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/D3D12HelloWorld/src/HelloTexture/Win32Application.cpp
+++ b/Samples/D3D12HelloWorld/src/HelloTexture/Win32Application.cpp
@@ -1,0 +1,119 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#include "stdafx.h"
+#include "Win32Application.h"
+
+HWND Win32Application::m_hwnd = nullptr;
+
+int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
+{
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
+
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
+
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
+
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
+
+	ShowWindow(m_hwnd, nCmdShow);
+
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
+
+	pSample->OnDestroy();
+
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
+}
+
+// Main message handler for the sample.
+LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
+
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
+
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
+
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
+}

--- a/Samples/D3D12HelloWorld/src/HelloTexture/Win32Application.h
+++ b/Samples/D3D12HelloWorld/src/HelloTexture/Win32Application.h
@@ -1,0 +1,29 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#pragma once
+
+#include "DXSample.h"
+
+class DXSample;
+
+class Win32Application
+{
+public:
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
+
+protected:
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+
+private:
+	static HWND m_hwnd;
+};

--- a/Samples/D3D12HelloWorld/src/HelloTexture/stdafx.h
+++ b/Samples/D3D12HelloWorld/src/HelloTexture/stdafx.h
@@ -30,3 +30,4 @@
 #include <string>
 #include <vector>
 #include <wrl.h>
+#include <shellapi.h>

--- a/Samples/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.cpp
+++ b/Samples/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.cpp
@@ -36,7 +36,7 @@ void D3D12HelloTriangle::OnInit()
 // Load the rendering pipeline dependencies.
 void D3D12HelloTriangle::LoadPipeline()
 {
-#ifdef _DEBUG
+#if defined(_DEBUG)
 	// Enable the D3D12 debug layer.
 	{
 		ComPtr<ID3D12Debug> debugController;
@@ -88,7 +88,7 @@ void D3D12HelloTriangle::LoadPipeline()
 	swapChainDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
 	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
 	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-	swapChainDesc.OutputWindow = m_hwnd;
+	swapChainDesc.OutputWindow = Win32Application::GetHwnd();
 	swapChainDesc.SampleDesc.Count = 1;
 	swapChainDesc.Windowed = TRUE;
 
@@ -102,7 +102,7 @@ void D3D12HelloTriangle::LoadPipeline()
 	ThrowIfFailed(swapChain.As(&m_swapChain));
 
 	// This sample does not support fullscreen transitions.
-	ThrowIfFailed(factory->MakeWindowAssociation(m_hwnd, DXGI_MWA_NO_ALT_ENTER));
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
 	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
@@ -153,7 +153,7 @@ void D3D12HelloTriangle::LoadAssets()
 		ComPtr<ID3DBlob> vertexShader;
 		ComPtr<ID3DBlob> pixelShader;
 
-#ifdef _DEBUG
+#if defined(_DEBUG)
 		// Enable better shader debugging with the graphics debugging tools.
 		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
@@ -277,11 +277,6 @@ void D3D12HelloTriangle::OnDestroy()
 	WaitForPreviousFrame();
 
 	CloseHandle(m_fenceEvent);
-}
-
-bool D3D12HelloTriangle::OnEvent(MSG)
-{
-	return false;
 }
 
 void D3D12HelloTriangle::PopulateCommandList()

--- a/Samples/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.h
+++ b/Samples/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.h
@@ -21,12 +21,10 @@ class D3D12HelloTriangle : public DXSample
 public:
 	D3D12HelloTriangle(UINT width, UINT height, std::wstring name);
 
-protected:
 	virtual void OnInit();
 	virtual void OnUpdate();
 	virtual void OnRender();
 	virtual void OnDestroy();
-	virtual bool OnEvent(MSG msg);
 
 private:
 	static const UINT FrameCount = 2;

--- a/Samples/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.vcxproj
+++ b/Samples/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.vcxproj
@@ -109,6 +109,7 @@
     </FxCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="Win32Application.h" />
     <ClInclude Include="D3D12HelloTriangle.h" />
     <ClInclude Include="d3dx12.h" />
     <ClInclude Include="DXSample.h" />
@@ -116,6 +117,7 @@
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Win32Application.cpp" />
     <ClCompile Include="D3D12HelloTriangle.cpp" />
     <ClCompile Include="DXSample.cpp" />
     <ClCompile Include="Main.cpp" />

--- a/Samples/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.vcxproj.filters
+++ b/Samples/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClInclude Include="D3D12HelloTriangle.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Win32Application.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -42,6 +45,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="D3D12HelloTriangle.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Win32Application.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Samples/D3D12HelloWorld/src/HelloTriangle/DXSample.cpp
+++ b/Samples/D3D12HelloWorld/src/HelloTriangle/DXSample.cpp
@@ -11,17 +11,13 @@
 
 #include "stdafx.h"
 #include "DXSample.h"
-#include <shellapi.h>
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_title(name),
 	m_useWarpDevice(false)
 {
-	ParseCommandLineArgs();
-
-	m_title = name + (m_useWarpDevice ? L" (WARP)" : L"");
-
 	WCHAR assetsPath[512];
 	GetAssetsPath(assetsPath, _countof(assetsPath));
 	m_assetsPath = assetsPath;
@@ -33,67 +29,6 @@ DXSample::~DXSample()
 {
 }
 
-int DXSample::Run(HINSTANCE hInstance, int nCmdShow)
-{
-	// Initialize the window class.
-	WNDCLASSEX windowClass = { 0 };
-	windowClass.cbSize = sizeof(WNDCLASSEX);
-	windowClass.style = CS_HREDRAW | CS_VREDRAW;
-	windowClass.lpfnWndProc = WindowProc;
-	windowClass.hInstance = hInstance;
-	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-	windowClass.lpszClassName = L"WindowClass1";
-	RegisterClassEx(&windowClass);
-
-	RECT windowRect = { 0, 0, static_cast<LONG>(m_width), static_cast<LONG>(m_height) };
-	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
-
-	// Create the window and store a handle to it.
-	m_hwnd = CreateWindowEx(NULL,
-		L"WindowClass1",
-		m_title.c_str(),
-		WS_OVERLAPPEDWINDOW,
-		300,
-		300,
-		windowRect.right - windowRect.left,
-		windowRect.bottom - windowRect.top,
-		NULL,		// We have no parent window, NULL.
-		NULL,		// We aren't using menus, NULL.
-		hInstance,
-		NULL);		// We aren't using multiple windows, NULL.
-
-	ShowWindow(m_hwnd, nCmdShow);
-
-	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-	OnInit();
-
-	// Main sample loop.
-	MSG msg = { 0 };
-	while (true)
-	{
-		// Process any messages in the queue.
-		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-		{
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-
-			if (msg.message == WM_QUIT)
-				break;
-
-			// Pass events into our sample.
-			OnEvent(msg);
-		}
-
-		OnUpdate();
-		OnRender();
-	}
-
-	OnDestroy();
-
-	// Return this part of the WM_QUIT message to Windows.
-	return static_cast<char>(msg.wParam);
-}
-
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
@@ -102,7 +37,8 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
-void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter)
+_Use_decl_annotations_
+void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
 {
 	IDXGIAdapter1* pAdapter = nullptr;
 	*ppAdapter = nullptr;
@@ -134,36 +70,20 @@ void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_m
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
 	std::wstring windowText = m_title + L": " + text;
-	SetWindowText(m_hwnd, windowText.c_str());
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
-void DXSample::ParseCommandLineArgs()
+_Use_decl_annotations_
+void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-	int argc;
-	LPWSTR *argv = CommandLineToArgvW(GetCommandLineW(), &argc);
 	for (int i = 1; i < argc; ++i)
 	{
 		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
 			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
 		{
 			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
 		}
 	}
-	LocalFree(argv);
-}
-
-// Main message handler for the sample.
-LRESULT CALLBACK DXSample::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
-{
-	// Handle destroy/shutdown messages.
-	switch (message)
-	{
-	case WM_DESTROY:
-		PostQuitMessage(0);
-		return 0;
-	}
-
-	// Handle any messages the switch statement didn't.
-	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/D3D12HelloWorld/src/HelloTriangle/DXSample.h
+++ b/Samples/D3D12HelloWorld/src/HelloTriangle/DXSample.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "DXSampleHelper.h"
+#include "Win32Application.h"
 
 class DXSample
 {
@@ -19,35 +20,36 @@ public:
 	DXSample(UINT width, UINT height, std::wstring name);
 	virtual ~DXSample();
 
-	int Run(HINSTANCE hInstance, int nCmdShow);
-	void SetCustomWindowText(LPCWSTR text);
-
-protected:
 	virtual void OnInit() = 0;
 	virtual void OnUpdate() = 0;
 	virtual void OnRender() = 0;
 	virtual void OnDestroy() = 0;
-	virtual bool OnEvent(MSG msg) = 0;
 
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
+
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
+
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+
+protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
-	void GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-
-	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+	void SetCustomWindowText(LPCWSTR text);
 
 	// Viewport dimensions.
 	UINT m_width;
 	UINT m_height;
 	float m_aspectRatio;
 
-	// Window handle.
-	HWND m_hwnd;
-
 	// Adapter info.
 	bool m_useWarpDevice;
 
 private:
-	void ParseCommandLineArgs();
-
 	// Root assets path.
 	std::wstring m_assetsPath;
 

--- a/Samples/D3D12HelloWorld/src/HelloTriangle/Main.cpp
+++ b/Samples/D3D12HelloWorld/src/HelloTriangle/Main.cpp
@@ -16,5 +16,5 @@ _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
 	D3D12HelloTriangle sample(1280, 720, L"D3D12 Hello Triangle");
-	return sample.Run(hInstance, nCmdShow);
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/D3D12HelloWorld/src/HelloTriangle/Win32Application.cpp
+++ b/Samples/D3D12HelloWorld/src/HelloTriangle/Win32Application.cpp
@@ -1,0 +1,119 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#include "stdafx.h"
+#include "Win32Application.h"
+
+HWND Win32Application::m_hwnd = nullptr;
+
+int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
+{
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
+
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
+
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
+
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
+
+	ShowWindow(m_hwnd, nCmdShow);
+
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
+
+	pSample->OnDestroy();
+
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
+}
+
+// Main message handler for the sample.
+LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
+
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
+
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
+
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
+}

--- a/Samples/D3D12HelloWorld/src/HelloTriangle/Win32Application.h
+++ b/Samples/D3D12HelloWorld/src/HelloTriangle/Win32Application.h
@@ -1,0 +1,29 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#pragma once
+
+#include "DXSample.h"
+
+class DXSample;
+
+class Win32Application
+{
+public:
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
+
+protected:
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+
+private:
+	static HWND m_hwnd;
+};

--- a/Samples/D3D12HelloWorld/src/HelloTriangle/stdafx.h
+++ b/Samples/D3D12HelloWorld/src/HelloTriangle/stdafx.h
@@ -29,3 +29,4 @@
 
 #include <string>
 #include <wrl.h>
+#include <shellapi.h>

--- a/Samples/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.cpp
+++ b/Samples/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.cpp
@@ -28,7 +28,7 @@ void D3D12HelloWindow::OnInit()
 // Load the rendering pipeline dependencies.
 void D3D12HelloWindow::LoadPipeline()
 {
-#ifdef _DEBUG
+#if defined(_DEBUG)
 	// Enable the D3D12 debug layer.
 	{
 		ComPtr<ID3D12Debug> debugController;
@@ -80,7 +80,7 @@ void D3D12HelloWindow::LoadPipeline()
 	swapChainDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
 	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
 	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-	swapChainDesc.OutputWindow = m_hwnd;
+	swapChainDesc.OutputWindow = Win32Application::GetHwnd();
 	swapChainDesc.SampleDesc.Count = 1;
 	swapChainDesc.Windowed = TRUE;
 
@@ -94,7 +94,7 @@ void D3D12HelloWindow::LoadPipeline()
 	ThrowIfFailed(swapChain.As(&m_swapChain));
 
 	// This sample does not support fullscreen transitions.
-	ThrowIfFailed(factory->MakeWindowAssociation(m_hwnd, DXGI_MWA_NO_ALT_ENTER));
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
 	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
@@ -177,11 +177,6 @@ void D3D12HelloWindow::OnDestroy()
 	WaitForPreviousFrame();
 
 	CloseHandle(m_fenceEvent);
-}
-
-bool D3D12HelloWindow::OnEvent(MSG)
-{
-	return false;
 }
 
 void D3D12HelloWindow::PopulateCommandList()

--- a/Samples/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.h
+++ b/Samples/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.h
@@ -20,12 +20,10 @@ class D3D12HelloWindow : public DXSample
 public:
 	D3D12HelloWindow(UINT width, UINT height, std::wstring name);
 
-protected:
 	virtual void OnInit();
 	virtual void OnUpdate();
 	virtual void OnRender();
 	virtual void OnDestroy();
-	virtual bool OnEvent(MSG msg);
 
 private:
 	static const UINT FrameCount = 2;

--- a/Samples/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.vcxproj
+++ b/Samples/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.vcxproj
@@ -109,6 +109,7 @@
     </FxCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="Win32Application.h" />
     <ClInclude Include="D3D12HelloWindow.h" />
     <ClInclude Include="d3dx12.h" />
     <ClInclude Include="DXSample.h" />
@@ -116,6 +117,7 @@
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Win32Application.cpp" />
     <ClCompile Include="D3D12HelloWindow.cpp" />
     <ClCompile Include="DXSample.cpp" />
     <ClCompile Include="Main.cpp" />

--- a/Samples/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.vcxproj.filters
+++ b/Samples/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.vcxproj.filters
@@ -24,18 +24,24 @@
     <ClInclude Include="DXSampleHelper.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Win32Application.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="D3D12HelloWindow.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="Main.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="D3D12HelloWindow.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="DXSample.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Win32Application.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Samples/D3D12HelloWorld/src/HelloWindow/DXSample.cpp
+++ b/Samples/D3D12HelloWorld/src/HelloWindow/DXSample.cpp
@@ -11,17 +11,13 @@
 
 #include "stdafx.h"
 #include "DXSample.h"
-#include <shellapi.h>
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_title(name),
 	m_useWarpDevice(false)
 {
-	ParseCommandLineArgs();
-
-	m_title = name + (m_useWarpDevice ? L" (WARP)" : L"");
-
 	WCHAR assetsPath[512];
 	GetAssetsPath(assetsPath, _countof(assetsPath));
 	m_assetsPath = assetsPath;
@@ -33,67 +29,6 @@ DXSample::~DXSample()
 {
 }
 
-int DXSample::Run(HINSTANCE hInstance, int nCmdShow)
-{
-	// Initialize the window class.
-	WNDCLASSEX windowClass = { 0 };
-	windowClass.cbSize = sizeof(WNDCLASSEX);
-	windowClass.style = CS_HREDRAW | CS_VREDRAW;
-	windowClass.lpfnWndProc = WindowProc;
-	windowClass.hInstance = hInstance;
-	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-	windowClass.lpszClassName = L"WindowClass1";
-	RegisterClassEx(&windowClass);
-
-	RECT windowRect = { 0, 0, static_cast<LONG>(m_width), static_cast<LONG>(m_height) };
-	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
-
-	// Create the window and store a handle to it.
-	m_hwnd = CreateWindowEx(NULL,
-		L"WindowClass1",
-		m_title.c_str(),
-		WS_OVERLAPPEDWINDOW,
-		300,
-		300,
-		windowRect.right - windowRect.left,
-		windowRect.bottom - windowRect.top,
-		NULL,		// We have no parent window, NULL.
-		NULL,		// We aren't using menus, NULL.
-		hInstance,
-		NULL);		// We aren't using multiple windows, NULL.
-
-	ShowWindow(m_hwnd, nCmdShow);
-
-	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-	OnInit();
-
-	// Main sample loop.
-	MSG msg = { 0 };
-	while (true)
-	{
-		// Process any messages in the queue.
-		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-		{
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-
-			if (msg.message == WM_QUIT)
-				break;
-
-			// Pass events into our sample.
-			OnEvent(msg);
-		}
-
-		OnUpdate();
-		OnRender();
-	}
-
-	OnDestroy();
-
-	// Return this part of the WM_QUIT message to Windows.
-	return static_cast<char>(msg.wParam);
-}
-
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
@@ -102,7 +37,8 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
-void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter)
+_Use_decl_annotations_
+void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
 {
 	IDXGIAdapter1* pAdapter = nullptr;
 	*ppAdapter = nullptr;
@@ -134,36 +70,20 @@ void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_m
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
 	std::wstring windowText = m_title + L": " + text;
-	SetWindowText(m_hwnd, windowText.c_str());
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
-void DXSample::ParseCommandLineArgs()
+_Use_decl_annotations_
+void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-	int argc;
-	LPWSTR *argv = CommandLineToArgvW(GetCommandLineW(), &argc);
 	for (int i = 1; i < argc; ++i)
 	{
 		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
 			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
 		{
 			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
 		}
 	}
-	LocalFree(argv);
-}
-
-// Main message handler for the sample.
-LRESULT CALLBACK DXSample::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
-{
-	// Handle destroy/shutdown messages.
-	switch (message)
-	{
-	case WM_DESTROY:
-		PostQuitMessage(0);
-		return 0;
-	}
-
-	// Handle any messages the switch statement didn't.
-	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/D3D12HelloWorld/src/HelloWindow/DXSample.h
+++ b/Samples/D3D12HelloWorld/src/HelloWindow/DXSample.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "DXSampleHelper.h"
+#include "Win32Application.h"
 
 class DXSample
 {
@@ -19,35 +20,36 @@ public:
 	DXSample(UINT width, UINT height, std::wstring name);
 	virtual ~DXSample();
 
-	int Run(HINSTANCE hInstance, int nCmdShow);
-	void SetCustomWindowText(LPCWSTR text);
-
-protected:
 	virtual void OnInit() = 0;
 	virtual void OnUpdate() = 0;
 	virtual void OnRender() = 0;
 	virtual void OnDestroy() = 0;
-	virtual bool OnEvent(MSG msg) = 0;
 
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
+
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
+
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+
+protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
-	void GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-
-	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+	void SetCustomWindowText(LPCWSTR text);
 
 	// Viewport dimensions.
 	UINT m_width;
 	UINT m_height;
 	float m_aspectRatio;
 
-	// Window handle.
-	HWND m_hwnd;
-
 	// Adapter info.
 	bool m_useWarpDevice;
 
 private:
-	void ParseCommandLineArgs();
-
 	// Root assets path.
 	std::wstring m_assetsPath;
 

--- a/Samples/D3D12HelloWorld/src/HelloWindow/Main.cpp
+++ b/Samples/D3D12HelloWorld/src/HelloWindow/Main.cpp
@@ -16,5 +16,5 @@ _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
 	D3D12HelloWindow sample(1280, 720, L"D3D12 Hello Window");
-	return sample.Run(hInstance, nCmdShow);
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/D3D12HelloWorld/src/HelloWindow/Win32Application.cpp
+++ b/Samples/D3D12HelloWorld/src/HelloWindow/Win32Application.cpp
@@ -1,0 +1,119 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#include "stdafx.h"
+#include "Win32Application.h"
+
+HWND Win32Application::m_hwnd = nullptr;
+
+int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
+{
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
+
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
+
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
+
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
+
+	ShowWindow(m_hwnd, nCmdShow);
+
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
+
+	pSample->OnDestroy();
+
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
+}
+
+// Main message handler for the sample.
+LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
+
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
+
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
+
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
+}

--- a/Samples/D3D12HelloWorld/src/HelloWindow/Win32Application.h
+++ b/Samples/D3D12HelloWorld/src/HelloWindow/Win32Application.h
@@ -1,0 +1,29 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#pragma once
+
+#include "DXSample.h"
+
+class DXSample;
+
+class Win32Application
+{
+public:
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
+
+protected:
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+
+private:
+	static HWND m_hwnd;
+};

--- a/Samples/D3D12HelloWorld/src/HelloWindow/stdafx.h
+++ b/Samples/D3D12HelloWorld/src/HelloWindow/stdafx.h
@@ -29,3 +29,4 @@
 
 #include <string>
 #include <wrl.h>
+#include <shellapi.h>

--- a/Samples/D3D12Multithreading/src/D3D12Multithreading.cpp
+++ b/Samples/D3D12Multithreading/src/D3D12Multithreading.cpp
@@ -55,7 +55,7 @@ void D3D12Multithreading::OnInit()
 // Load the rendering pipeline dependencies.
 void D3D12Multithreading::LoadPipeline()
 {
-#ifdef _DEBUG
+#if defined(_DEBUG)
 	// Enable the D3D12 debug layer.
 	{
 		ComPtr<ID3D12Debug> debugController;
@@ -107,7 +107,7 @@ void D3D12Multithreading::LoadPipeline()
 	swapChainDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
 	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
 	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-	swapChainDesc.OutputWindow = m_hwnd;
+	swapChainDesc.OutputWindow = Win32Application::GetHwnd();
 	swapChainDesc.SampleDesc.Count = 1;
 	swapChainDesc.Windowed = TRUE;
 
@@ -121,7 +121,7 @@ void D3D12Multithreading::LoadPipeline()
 	ThrowIfFailed(swapChain.As(&m_swapChain));
 
 	// This sample does not support fullscreen transitions.
-	ThrowIfFailed(factory->MakeWindowAssociation(m_hwnd, DXGI_MWA_NO_ALT_ENTER));
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
 	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
@@ -201,7 +201,7 @@ void D3D12Multithreading::LoadAssets()
 		ComPtr<ID3DBlob> vertexShader;
 		ComPtr<ID3DBlob> pixelShader;
 
-#ifdef _DEBUG
+#if defined(_DEBUG)
 		// Enable better shader debugging with the graphics debugging tools.
 		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
@@ -741,7 +741,7 @@ void D3D12Multithreading::OnRender()
 
 	// Present and update the frame index for the next frame.
 	PIXBeginEvent(m_commandQueue.Get(), 0, L"Presenting to screen");
-	ThrowIfFailed(m_swapChain->Present(0, 0));
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 	PIXEndEvent(m_commandQueue.Get());
 	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
@@ -786,24 +786,9 @@ void D3D12Multithreading::OnDestroy()
 	}
 }
 
-bool D3D12Multithreading::OnEvent(MSG msg)
+void D3D12Multithreading::OnKeyDown(UINT8 key)
 {
-	switch (msg.message)
-	{
-	case WM_KEYDOWN:
-		OnKeyDown(msg.wParam);
-		break;
-	case WM_KEYUP:
-		OnKeyUp(msg.wParam);
-		break;
-	}
-
-	return false;
-}
-
-void D3D12Multithreading::OnKeyDown(WPARAM wParam)
-{
-	switch (wParam)
+	switch (key)
 	{
 	case VK_LEFT:
 		m_keyboardInput.leftArrowPressed = true;
@@ -823,9 +808,9 @@ void D3D12Multithreading::OnKeyDown(WPARAM wParam)
 	}
 }
 
-void D3D12Multithreading::OnKeyUp(WPARAM wParam)
+void D3D12Multithreading::OnKeyUp(UINT8 key)
 {
-	switch (wParam)
+	switch (key)
 	{
 	case VK_LEFT:
 		m_keyboardInput.leftArrowPressed = false;
@@ -839,7 +824,6 @@ void D3D12Multithreading::OnKeyUp(WPARAM wParam)
 	case VK_DOWN:
 		m_keyboardInput.downArrowPressed = false;
 		break;
-
 	}
 }
 

--- a/Samples/D3D12Multithreading/src/D3D12Multithreading.h
+++ b/Samples/D3D12Multithreading/src/D3D12Multithreading.h
@@ -51,12 +51,12 @@ public:
 
 	static D3D12Multithreading* Get() { return s_app; }
 
-protected:
 	virtual void OnInit();
 	virtual void OnUpdate();
 	virtual void OnRender();
 	virtual void OnDestroy();
-	virtual bool OnEvent(MSG msg);
+	virtual void OnKeyDown(UINT8 key);
+	virtual void OnKeyUp(UINT8 key);
 
 private:
 	struct InputState
@@ -134,8 +134,6 @@ private:
 	void LoadPipeline();
 	void LoadAssets();
 	void LoadContexts();
-	void OnKeyUp(WPARAM wParam);
-	void OnKeyDown(WPARAM wParam);
 	void BeginFrame();
 	void MidFrame();
 	void EndFrame();

--- a/Samples/D3D12Multithreading/src/D3D12Multithreading.vcxproj
+++ b/Samples/D3D12Multithreading/src/D3D12Multithreading.vcxproj
@@ -102,6 +102,7 @@
     </CustomBuild>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="Win32Application.h" />
     <ClInclude Include="Camera.h" />
     <ClInclude Include="D3D12Multithreading.h" />
     <ClInclude Include="d3dx12.h" />
@@ -113,6 +114,7 @@
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Win32Application.cpp" />
     <ClCompile Include="Camera.cpp" />
     <ClCompile Include="D3D12Multithreading.cpp" />
     <ClCompile Include="DXSample.cpp" />

--- a/Samples/D3D12Multithreading/src/D3D12Multithreading.vcxproj.filters
+++ b/Samples/D3D12Multithreading/src/D3D12Multithreading.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClInclude Include="Camera.h">
       <Filter>Header Files\Util</Filter>
     </ClInclude>
+    <ClInclude Include="Win32Application.h">
+      <Filter>Header Files\Util</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -69,6 +72,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Camera.cpp">
+      <Filter>Source Files\Util</Filter>
+    </ClCompile>
+    <ClCompile Include="Win32Application.cpp">
       <Filter>Source Files\Util</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Samples/D3D12Multithreading/src/DXSample.cpp
+++ b/Samples/D3D12Multithreading/src/DXSample.cpp
@@ -11,17 +11,13 @@
 
 #include "stdafx.h"
 #include "DXSample.h"
-#include <shellapi.h>
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_title(name),
 	m_useWarpDevice(false)
 {
-	ParseCommandLineArgs();
-
-	m_title = name + (m_useWarpDevice ? L" (WARP)" : L"");
-
 	WCHAR assetsPath[512];
 	GetAssetsPath(assetsPath, _countof(assetsPath));
 	m_assetsPath = assetsPath;
@@ -33,67 +29,6 @@ DXSample::~DXSample()
 {
 }
 
-int DXSample::Run(HINSTANCE hInstance, int nCmdShow)
-{
-	// Initialize the window class.
-	WNDCLASSEX windowClass = { 0 };
-	windowClass.cbSize = sizeof(WNDCLASSEX);
-	windowClass.style = CS_HREDRAW | CS_VREDRAW;
-	windowClass.lpfnWndProc = WindowProc;
-	windowClass.hInstance = hInstance;
-	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-	windowClass.lpszClassName = L"WindowClass1";
-	RegisterClassEx(&windowClass);
-
-	RECT windowRect = { 0, 0, static_cast<LONG>(m_width), static_cast<LONG>(m_height) };
-	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
-
-	// Create the window and store a handle to it.
-	m_hwnd = CreateWindowEx(NULL,
-		L"WindowClass1",
-		m_title.c_str(),
-		WS_OVERLAPPEDWINDOW,
-		300,
-		300,
-		windowRect.right - windowRect.left,
-		windowRect.bottom - windowRect.top,
-		NULL,		// We have no parent window, NULL.
-		NULL,		// We aren't using menus, NULL.
-		hInstance,
-		NULL);		// We aren't using multiple windows, NULL.
-
-	ShowWindow(m_hwnd, nCmdShow);
-
-	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-	OnInit();
-
-	// Main sample loop.
-	MSG msg = { 0 };
-	while (true)
-	{
-		// Process any messages in the queue.
-		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-		{
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-
-			if (msg.message == WM_QUIT)
-				break;
-
-			// Pass events into our sample.
-			OnEvent(msg);
-		}
-
-		OnUpdate();
-		OnRender();
-	}
-
-	OnDestroy();
-
-	// Return this part of the WM_QUIT message to Windows.
-	return static_cast<char>(msg.wParam);
-}
-
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
@@ -102,7 +37,8 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
-void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter)
+_Use_decl_annotations_
+void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
 {
 	IDXGIAdapter1* pAdapter = nullptr;
 	*ppAdapter = nullptr;
@@ -134,36 +70,20 @@ void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_m
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
 	std::wstring windowText = m_title + L": " + text;
-	SetWindowText(m_hwnd, windowText.c_str());
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
-void DXSample::ParseCommandLineArgs()
+_Use_decl_annotations_
+void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-	int argc;
-	LPWSTR *argv = CommandLineToArgvW(GetCommandLineW(), &argc);
 	for (int i = 1; i < argc; ++i)
 	{
 		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
 			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
 		{
 			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
 		}
 	}
-	LocalFree(argv);
-}
-
-// Main message handler for the sample.
-LRESULT CALLBACK DXSample::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
-{
-	// Handle destroy/shutdown messages.
-	switch (message)
-	{
-	case WM_DESTROY:
-		PostQuitMessage(0);
-		return 0;
-	}
-
-	// Handle any messages the switch statement didn't.
-	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/D3D12Multithreading/src/DXSample.h
+++ b/Samples/D3D12Multithreading/src/DXSample.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "DXSampleHelper.h"
+#include "Win32Application.h"
 
 class DXSample
 {
@@ -19,35 +20,36 @@ public:
 	DXSample(UINT width, UINT height, std::wstring name);
 	virtual ~DXSample();
 
-	int Run(HINSTANCE hInstance, int nCmdShow);
-	void SetCustomWindowText(LPCWSTR text);
-
-protected:
 	virtual void OnInit() = 0;
 	virtual void OnUpdate() = 0;
 	virtual void OnRender() = 0;
 	virtual void OnDestroy() = 0;
-	virtual bool OnEvent(MSG msg) = 0;
 
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
+
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
+
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+
+protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
-	void GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-
-	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+	void SetCustomWindowText(LPCWSTR text);
 
 	// Viewport dimensions.
 	UINT m_width;
 	UINT m_height;
 	float m_aspectRatio;
 
-	// Window handle.
-	HWND m_hwnd;
-
 	// Adapter info.
 	bool m_useWarpDevice;
 
 private:
-	void ParseCommandLineArgs();
-
 	// Root assets path.
 	std::wstring m_assetsPath;
 

--- a/Samples/D3D12Multithreading/src/Main.cpp
+++ b/Samples/D3D12Multithreading/src/Main.cpp
@@ -16,5 +16,5 @@ _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
 	D3D12Multithreading sample(1280, 720, L"D3D12 Multithreading Sample");
-	return sample.Run(hInstance, nCmdShow);
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/D3D12Multithreading/src/Win32Application.cpp
+++ b/Samples/D3D12Multithreading/src/Win32Application.cpp
@@ -1,0 +1,119 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#include "stdafx.h"
+#include "Win32Application.h"
+
+HWND Win32Application::m_hwnd = nullptr;
+
+int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
+{
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
+
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
+
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
+
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
+
+	ShowWindow(m_hwnd, nCmdShow);
+
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
+
+	pSample->OnDestroy();
+
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
+}
+
+// Main message handler for the sample.
+LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
+
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
+
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
+
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
+}

--- a/Samples/D3D12Multithreading/src/Win32Application.h
+++ b/Samples/D3D12Multithreading/src/Win32Application.h
@@ -1,0 +1,29 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#pragma once
+
+#include "DXSample.h"
+
+class DXSample;
+
+class Win32Application
+{
+public:
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
+
+protected:
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+
+private:
+	static HWND m_hwnd;
+};

--- a/Samples/D3D12Multithreading/src/stdafx.h
+++ b/Samples/D3D12Multithreading/src/stdafx.h
@@ -33,6 +33,7 @@
 #include <string>
 #include <wrl.h>
 #include <process.h>
+#include <shellapi.h>
 
 #define SINGLETHREADED FALSE
 

--- a/Samples/D3D12PipelineStateCache/src/D3D12PipelineStateCache.h
+++ b/Samples/D3D12PipelineStateCache/src/D3D12PipelineStateCache.h
@@ -24,12 +24,12 @@ class D3D12PipelineStateCache : public DXSample
 public:
 	D3D12PipelineStateCache(UINT width, UINT height, std::wstring name);
 
-protected:
 	virtual void OnInit();
 	virtual void OnUpdate();
 	virtual void OnRender();
 	virtual void OnDestroy();
-	virtual bool OnEvent(MSG msg);
+	virtual void OnKeyDown(UINT8 key);
+	virtual void OnKeyUp(UINT8 key);
 
 private:
 	static const UINT FrameCount = 2;
@@ -106,7 +106,6 @@ private:
 	void LoadAssets();
 	void PopulateCommandList();
 	void ToggleEffect(EffectPipelineType type);
-	void OnKeyUp(WPARAM key);
 	void UpdateWindowTextPso();
 	void WaitForGpu();
 	void MoveToNextFrame();

--- a/Samples/D3D12PipelineStateCache/src/D3D12PipelineStateCache.vcxproj
+++ b/Samples/D3D12PipelineStateCache/src/D3D12PipelineStateCache.vcxproj
@@ -101,6 +101,7 @@
     <ClInclude Include="BlitPixelShader.hlsl.h" />
     <ClInclude Include="BlurPixelShader.hlsl.h" />
     <ClInclude Include="D3D12PipelineStateCache.h" />
+    <ClInclude Include="Win32Application.h" />
     <ClInclude Include="d3dx12.h" />
     <ClInclude Include="DXSampleHelper.h" />
     <ClInclude Include="DXSample.h" />
@@ -123,6 +124,7 @@
     <ClInclude Include="WavePixelShader.hlsl.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Win32Application.cpp" />
     <ClCompile Include="D3D12PipelineStateCache.cpp" />
     <ClCompile Include="DXSample.cpp" />
     <ClCompile Include="DynamicConstantBuffer.cpp" />

--- a/Samples/D3D12PipelineStateCache/src/D3D12PipelineStateCache.vcxproj.filters
+++ b/Samples/D3D12PipelineStateCache/src/D3D12PipelineStateCache.vcxproj.filters
@@ -96,6 +96,9 @@
     <ClInclude Include="WarpPixelShader.hlsl.h">
       <Filter>Assets\PrecompiledShaders</Filter>
     </ClInclude>
+    <ClInclude Include="Win32Application.h">
+      <Filter>Header Files\Util</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -120,6 +123,9 @@
       <Filter>Source Files\Util</Filter>
     </ClCompile>
     <ClCompile Include="SimpleCamera.cpp">
+      <Filter>Source Files\Util</Filter>
+    </ClCompile>
+    <ClCompile Include="Win32Application.cpp">
       <Filter>Source Files\Util</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Samples/D3D12PipelineStateCache/src/DXSample.cpp
+++ b/Samples/D3D12PipelineStateCache/src/DXSample.cpp
@@ -11,17 +11,13 @@
 
 #include "stdafx.h"
 #include "DXSample.h"
-#include <shellapi.h>
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_title(name),
 	m_useWarpDevice(false)
 {
-	ParseCommandLineArgs();
-
-	m_title = name + (m_useWarpDevice ? L" (WARP)" : L"");
-
 	WCHAR assetsPath[512];
 	GetAssetsPath(assetsPath, _countof(assetsPath));
 	m_assetsPath = assetsPath;
@@ -33,67 +29,6 @@ DXSample::~DXSample()
 {
 }
 
-int DXSample::Run(HINSTANCE hInstance, int nCmdShow)
-{
-	// Initialize the window class.
-	WNDCLASSEX windowClass = { 0 };
-	windowClass.cbSize = sizeof(WNDCLASSEX);
-	windowClass.style = CS_HREDRAW | CS_VREDRAW;
-	windowClass.lpfnWndProc = WindowProc;
-	windowClass.hInstance = hInstance;
-	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-	windowClass.lpszClassName = L"WindowClass1";
-	RegisterClassEx(&windowClass);
-
-	RECT windowRect = { 0, 0, static_cast<LONG>(m_width), static_cast<LONG>(m_height) };
-	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
-
-	// Create the window and store a handle to it.
-	m_hwnd = CreateWindowEx(NULL,
-		L"WindowClass1",
-		m_title.c_str(),
-		WS_OVERLAPPEDWINDOW,
-		300,
-		300,
-		windowRect.right - windowRect.left,
-		windowRect.bottom - windowRect.top,
-		NULL,		// We have no parent window, NULL.
-		NULL,		// We aren't using menus, NULL.
-		hInstance,
-		NULL);		// We aren't using multiple windows, NULL.
-
-	ShowWindow(m_hwnd, nCmdShow);
-
-	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-	OnInit();
-
-	// Main sample loop.
-	MSG msg = { 0 };
-	while (true)
-	{
-		// Process any messages in the queue.
-		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-		{
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-
-			if (msg.message == WM_QUIT)
-				break;
-
-			// Pass events into our sample.
-			OnEvent(msg);
-		}
-
-		OnUpdate();
-		OnRender();
-	}
-
-	OnDestroy();
-
-	// Return this part of the WM_QUIT message to Windows.
-	return static_cast<char>(msg.wParam);
-}
-
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
@@ -102,7 +37,8 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
-void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter)
+_Use_decl_annotations_
+void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
 {
 	IDXGIAdapter1* pAdapter = nullptr;
 	*ppAdapter = nullptr;
@@ -134,36 +70,20 @@ void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_m
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
 	std::wstring windowText = m_title + L": " + text;
-	SetWindowText(m_hwnd, windowText.c_str());
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
-void DXSample::ParseCommandLineArgs()
+_Use_decl_annotations_
+void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-	int argc;
-	LPWSTR *argv = CommandLineToArgvW(GetCommandLineW(), &argc);
 	for (int i = 1; i < argc; ++i)
 	{
 		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
 			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
 		{
 			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
 		}
 	}
-	LocalFree(argv);
-}
-
-// Main message handler for the sample.
-LRESULT CALLBACK DXSample::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
-{
-	// Handle destroy/shutdown messages.
-	switch (message)
-	{
-	case WM_DESTROY:
-		PostQuitMessage(0);
-		return 0;
-	}
-
-	// Handle any messages the switch statement didn't.
-	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/D3D12PipelineStateCache/src/DXSample.h
+++ b/Samples/D3D12PipelineStateCache/src/DXSample.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "DXSampleHelper.h"
+#include "Win32Application.h"
 
 class DXSample
 {
@@ -19,35 +20,36 @@ public:
 	DXSample(UINT width, UINT height, std::wstring name);
 	virtual ~DXSample();
 
-	int Run(HINSTANCE hInstance, int nCmdShow);
-	void SetCustomWindowText(LPCWSTR text);
-
-protected:
 	virtual void OnInit() = 0;
 	virtual void OnUpdate() = 0;
 	virtual void OnRender() = 0;
 	virtual void OnDestroy() = 0;
-	virtual bool OnEvent(MSG msg) = 0;
 
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
+
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
+
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+
+protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
-	void GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-
-	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+	void SetCustomWindowText(LPCWSTR text);
 
 	// Viewport dimensions.
 	UINT m_width;
 	UINT m_height;
 	float m_aspectRatio;
 
-	// Window handle.
-	HWND m_hwnd;
-
 	// Adapter info.
 	bool m_useWarpDevice;
 
 private:
-	void ParseCommandLineArgs();
-
 	// Root assets path.
 	std::wstring m_assetsPath;
 

--- a/Samples/D3D12PipelineStateCache/src/Main.cpp
+++ b/Samples/D3D12PipelineStateCache/src/Main.cpp
@@ -48,7 +48,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 	D3D12PipelineStateCache sample(1280, 720, L"D3D12 Pipeline State Object Cache Sample");
 
 	FILE* pStreamOut = CreateConsoleAndPrintDemoInformation();
-	int result = sample.Run(hInstance, nCmdShow);
+	int result = Win32Application::Run(&sample, hInstance, nCmdShow);
 	DestroyConsole(pStreamOut);
 
 	return result;

--- a/Samples/D3D12PipelineStateCache/src/Win32Application.cpp
+++ b/Samples/D3D12PipelineStateCache/src/Win32Application.cpp
@@ -1,0 +1,119 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#include "stdafx.h"
+#include "Win32Application.h"
+
+HWND Win32Application::m_hwnd = nullptr;
+
+int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
+{
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
+
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
+
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
+
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
+
+	ShowWindow(m_hwnd, nCmdShow);
+
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
+
+	pSample->OnDestroy();
+
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
+}
+
+// Main message handler for the sample.
+LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
+
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
+
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
+
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
+}

--- a/Samples/D3D12PipelineStateCache/src/Win32Application.h
+++ b/Samples/D3D12PipelineStateCache/src/Win32Application.h
@@ -1,0 +1,29 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#pragma once
+
+#include "DXSample.h"
+
+class DXSample;
+
+class Win32Application
+{
+public:
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
+
+protected:
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+
+private:
+	static HWND m_hwnd;
+};

--- a/Samples/D3D12PipelineStateCache/src/stdafx.h
+++ b/Samples/D3D12PipelineStateCache/src/stdafx.h
@@ -34,3 +34,4 @@
 #include <sstream>
 #include <io.h>
 #include <fcntl.h>
+#include <shellapi.h>

--- a/Samples/D3D12PredicationQueries/src/D3D12PredicationQueries.cpp
+++ b/Samples/D3D12PredicationQueries/src/D3D12PredicationQueries.cpp
@@ -39,7 +39,7 @@ void D3D12PredicationQueries::OnInit()
 // Load the rendering pipeline dependencies.
 void D3D12PredicationQueries::LoadPipeline()
 {
-#ifdef _DEBUG
+#if defined(_DEBUG)
 	// Enable the D3D12 debug layer.
 	{
 		ComPtr<ID3D12Debug> debugController;
@@ -91,7 +91,7 @@ void D3D12PredicationQueries::LoadPipeline()
 	swapChainDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
 	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
 	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-	swapChainDesc.OutputWindow = m_hwnd;
+	swapChainDesc.OutputWindow = Win32Application::GetHwnd();
 	swapChainDesc.SampleDesc.Count = 1;
 	swapChainDesc.Windowed = TRUE;
 
@@ -105,7 +105,7 @@ void D3D12PredicationQueries::LoadPipeline()
 	ThrowIfFailed(swapChain.As(&m_swapChain));
 
 	// This sample does not support fullscreen transitions.
-	ThrowIfFailed(factory->MakeWindowAssociation(m_hwnd, DXGI_MWA_NO_ALT_ENTER));
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
 	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
@@ -191,7 +191,7 @@ void D3D12PredicationQueries::LoadAssets()
 		ComPtr<ID3DBlob> vertexShader;
 		ComPtr<ID3DBlob> pixelShader;
 
-#ifdef _DEBUG
+#if defined(_DEBUG)
 		// Enable better shader debugging with the graphics debugging tools.
 		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
@@ -374,10 +374,11 @@ void D3D12PredicationQueries::LoadAssets()
 
 	// Create the query result buffer.
 	{
+		D3D12_RESOURCE_DESC queryResultDesc = CD3DX12_RESOURCE_DESC::Buffer(8);
 		ThrowIfFailed(m_device->CreateCommittedResource(
 			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
 			D3D12_HEAP_FLAG_NONE,
-			&CD3DX12_RESOURCE_DESC::Buffer(8),
+			&queryResultDesc,
 			D3D12_RESOURCE_STATE_PREDICATION,
 			nullptr,
 			IID_PPV_ARGS(&m_queryResult)
@@ -438,7 +439,7 @@ void D3D12PredicationQueries::OnRender()
 	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
 	// Present the frame.
-	ThrowIfFailed(m_swapChain->Present(0, 0));
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 
 	MoveToNextFrame();
 }
@@ -449,11 +450,6 @@ void D3D12PredicationQueries::OnDestroy()
 	WaitForGpu();
 
 	CloseHandle(m_fenceEvent);
-}
-
-bool D3D12PredicationQueries::OnEvent(MSG)
-{
-	return false;
 }
 
 // Fill the command list with all the render commands and dependent state.

--- a/Samples/D3D12PredicationQueries/src/D3D12PredicationQueries.h
+++ b/Samples/D3D12PredicationQueries/src/D3D12PredicationQueries.h
@@ -22,12 +22,10 @@ class D3D12PredicationQueries : public DXSample
 public:
 	D3D12PredicationQueries(UINT width, UINT height, std::wstring name);
 
-protected:
 	virtual void OnInit();
 	virtual void OnUpdate();
 	virtual void OnRender();
 	virtual void OnDestroy();
-	virtual bool OnEvent(MSG msg);
 
 private:
 	static const UINT FrameCount = 2;

--- a/Samples/D3D12PredicationQueries/src/D3D12PredicationQueries.vcxproj
+++ b/Samples/D3D12PredicationQueries/src/D3D12PredicationQueries.vcxproj
@@ -98,6 +98,7 @@
     </CustomBuild>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="Win32Application.h" />
     <ClInclude Include="D3D12PredicationQueries.h" />
     <ClInclude Include="d3dx12.h" />
     <ClInclude Include="DXSampleHelper.h" />
@@ -105,6 +106,7 @@
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Win32Application.cpp" />
     <ClCompile Include="D3D12PredicationQueries.cpp" />
     <ClCompile Include="DXSample.cpp" />
     <ClCompile Include="Main.cpp" />

--- a/Samples/D3D12PredicationQueries/src/D3D12PredicationQueries.vcxproj.filters
+++ b/Samples/D3D12PredicationQueries/src/D3D12PredicationQueries.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClInclude Include="D3D12PredicationQueries.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Win32Application.h">
+      <Filter>Header Files\Util</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -52,6 +55,9 @@
     </ClCompile>
     <ClCompile Include="D3D12PredicationQueries.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Win32Application.cpp">
+      <Filter>Source Files\Util</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Samples/D3D12PredicationQueries/src/DXSample.cpp
+++ b/Samples/D3D12PredicationQueries/src/DXSample.cpp
@@ -11,17 +11,13 @@
 
 #include "stdafx.h"
 #include "DXSample.h"
-#include <shellapi.h>
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_title(name),
 	m_useWarpDevice(false)
 {
-	ParseCommandLineArgs();
-
-	m_title = name + (m_useWarpDevice ? L" (WARP)" : L"");
-
 	WCHAR assetsPath[512];
 	GetAssetsPath(assetsPath, _countof(assetsPath));
 	m_assetsPath = assetsPath;
@@ -33,67 +29,6 @@ DXSample::~DXSample()
 {
 }
 
-int DXSample::Run(HINSTANCE hInstance, int nCmdShow)
-{
-	// Initialize the window class.
-	WNDCLASSEX windowClass = { 0 };
-	windowClass.cbSize = sizeof(WNDCLASSEX);
-	windowClass.style = CS_HREDRAW | CS_VREDRAW;
-	windowClass.lpfnWndProc = WindowProc;
-	windowClass.hInstance = hInstance;
-	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-	windowClass.lpszClassName = L"WindowClass1";
-	RegisterClassEx(&windowClass);
-
-	RECT windowRect = { 0, 0, static_cast<LONG>(m_width), static_cast<LONG>(m_height) };
-	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
-
-	// Create the window and store a handle to it.
-	m_hwnd = CreateWindowEx(NULL,
-		L"WindowClass1",
-		m_title.c_str(),
-		WS_OVERLAPPEDWINDOW,
-		300,
-		300,
-		windowRect.right - windowRect.left,
-		windowRect.bottom - windowRect.top,
-		NULL,		// We have no parent window, NULL.
-		NULL,		// We aren't using menus, NULL.
-		hInstance,
-		NULL);		// We aren't using multiple windows, NULL.
-
-	ShowWindow(m_hwnd, nCmdShow);
-
-	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-	OnInit();
-
-	// Main sample loop.
-	MSG msg = { 0 };
-	while (true)
-	{
-		// Process any messages in the queue.
-		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-		{
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-
-			if (msg.message == WM_QUIT)
-				break;
-
-			// Pass events into our sample.
-			OnEvent(msg);
-		}
-
-		OnUpdate();
-		OnRender();
-	}
-
-	OnDestroy();
-
-	// Return this part of the WM_QUIT message to Windows.
-	return static_cast<char>(msg.wParam);
-}
-
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
@@ -102,7 +37,8 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
-void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter)
+_Use_decl_annotations_
+void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
 {
 	IDXGIAdapter1* pAdapter = nullptr;
 	*ppAdapter = nullptr;
@@ -134,36 +70,20 @@ void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_m
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
 	std::wstring windowText = m_title + L": " + text;
-	SetWindowText(m_hwnd, windowText.c_str());
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
-void DXSample::ParseCommandLineArgs()
+_Use_decl_annotations_
+void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-	int argc;
-	LPWSTR *argv = CommandLineToArgvW(GetCommandLineW(), &argc);
 	for (int i = 1; i < argc; ++i)
 	{
 		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
 			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
 		{
 			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
 		}
 	}
-	LocalFree(argv);
-}
-
-// Main message handler for the sample.
-LRESULT CALLBACK DXSample::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
-{
-	// Handle destroy/shutdown messages.
-	switch (message)
-	{
-	case WM_DESTROY:
-		PostQuitMessage(0);
-		return 0;
-	}
-
-	// Handle any messages the switch statement didn't.
-	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/D3D12PredicationQueries/src/DXSample.h
+++ b/Samples/D3D12PredicationQueries/src/DXSample.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "DXSampleHelper.h"
+#include "Win32Application.h"
 
 class DXSample
 {
@@ -19,35 +20,36 @@ public:
 	DXSample(UINT width, UINT height, std::wstring name);
 	virtual ~DXSample();
 
-	int Run(HINSTANCE hInstance, int nCmdShow);
-	void SetCustomWindowText(LPCWSTR text);
-
-protected:
 	virtual void OnInit() = 0;
 	virtual void OnUpdate() = 0;
 	virtual void OnRender() = 0;
 	virtual void OnDestroy() = 0;
-	virtual bool OnEvent(MSG msg) = 0;
 
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
+
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
+
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+
+protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
-	void GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-
-	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+	void SetCustomWindowText(LPCWSTR text);
 
 	// Viewport dimensions.
 	UINT m_width;
 	UINT m_height;
 	float m_aspectRatio;
 
-	// Window handle.
-	HWND m_hwnd;
-
 	// Adapter info.
 	bool m_useWarpDevice;
 
 private:
-	void ParseCommandLineArgs();
-
 	// Root assets path.
 	std::wstring m_assetsPath;
 

--- a/Samples/D3D12PredicationQueries/src/Main.cpp
+++ b/Samples/D3D12PredicationQueries/src/Main.cpp
@@ -16,5 +16,5 @@ _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
 	D3D12PredicationQueries sample(1280, 720, L"D3D12 Predication and Queries sample");
-	return sample.Run(hInstance, nCmdShow);
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/D3D12PredicationQueries/src/Win32Application.cpp
+++ b/Samples/D3D12PredicationQueries/src/Win32Application.cpp
@@ -1,0 +1,119 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#include "stdafx.h"
+#include "Win32Application.h"
+
+HWND Win32Application::m_hwnd = nullptr;
+
+int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
+{
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
+
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
+
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
+
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
+
+	ShowWindow(m_hwnd, nCmdShow);
+
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
+
+	pSample->OnDestroy();
+
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
+}
+
+// Main message handler for the sample.
+LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
+
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
+
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
+
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
+}

--- a/Samples/D3D12PredicationQueries/src/Win32Application.h
+++ b/Samples/D3D12PredicationQueries/src/Win32Application.h
@@ -1,0 +1,29 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#pragma once
+
+#include "DXSample.h"
+
+class DXSample;
+
+class Win32Application
+{
+public:
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
+
+protected:
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+
+private:
+	static HWND m_hwnd;
+};

--- a/Samples/D3D12PredicationQueries/src/stdafx.h
+++ b/Samples/D3D12PredicationQueries/src/stdafx.h
@@ -29,3 +29,4 @@
 
 #include <wrl.h>
 #include <vector>
+#include <shellapi.h>

--- a/Samples/D3D12nBodyGravity/src/D3D12nBodyGravity.cpp
+++ b/Samples/D3D12nBodyGravity/src/D3D12nBodyGravity.cpp
@@ -69,7 +69,7 @@ void D3D12nBodyGravity::OnInit()
 // Load the rendering pipeline dependencies.
 void D3D12nBodyGravity::LoadPipeline()
 {
-#ifdef _DEBUG
+#if defined(_DEBUG)
 	// Enable the D3D12 debug layer.
 	{
 		ComPtr<ID3D12Debug> debugController;
@@ -121,7 +121,7 @@ void D3D12nBodyGravity::LoadPipeline()
 	swapChainDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
 	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
 	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-	swapChainDesc.OutputWindow = m_hwnd;
+	swapChainDesc.OutputWindow = Win32Application::GetHwnd();
 	swapChainDesc.SampleDesc.Count = 1;
 	swapChainDesc.Windowed = TRUE;
 	swapChainDesc.Flags = DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
@@ -136,7 +136,7 @@ void D3D12nBodyGravity::LoadPipeline()
 	ThrowIfFailed(swapChain.As(&m_swapChain));
 
 	// This sample does not support fullscreen transitions.
-	ThrowIfFailed(factory->MakeWindowAssociation(m_hwnd, DXGI_MWA_NO_ALT_ENTER));
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
 	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
@@ -218,7 +218,7 @@ void D3D12nBodyGravity::LoadAssets()
 		ComPtr<ID3DBlob> pixelShader;
 		ComPtr<ID3DBlob> computeShader;
 
-#ifdef _DEBUG
+#if defined(_DEBUG)
 		// Enable better shader debugging with the graphics debugging tools.
 		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
@@ -441,6 +441,7 @@ void D3D12nBodyGravity::CreateParticleBuffers()
 	D3D12_HEAP_PROPERTIES defaultHeapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
 	D3D12_HEAP_PROPERTIES uploadHeapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
 	D3D12_RESOURCE_DESC bufferDesc = CD3DX12_RESOURCE_DESC::Buffer(dataSize, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+	D3D12_RESOURCE_DESC uploadBufferDesc = CD3DX12_RESOURCE_DESC::Buffer(dataSize);
 
 	for (UINT index = 0; index < ThreadCount; index++)
 	{
@@ -468,7 +469,7 @@ void D3D12nBodyGravity::CreateParticleBuffers()
 		ThrowIfFailed(m_device->CreateCommittedResource(
 			&uploadHeapProperties,
 			D3D12_HEAP_FLAG_NONE,
-			&bufferDesc,
+			&uploadBufferDesc,
 			D3D12_RESOURCE_STATE_GENERIC_READ,
 			nullptr,
 			IID_PPV_ARGS(&m_particleBuffer0Upload[index])));
@@ -476,7 +477,7 @@ void D3D12nBodyGravity::CreateParticleBuffers()
 		ThrowIfFailed(m_device->CreateCommittedResource(
 			&uploadHeapProperties,
 			D3D12_HEAP_FLAG_NONE,
-			&bufferDesc,
+			&uploadBufferDesc,
 			D3D12_RESOURCE_STATE_GENERIC_READ,
 			nullptr,
 			IID_PPV_ARGS(&m_particleBuffer1Upload[index])));
@@ -600,7 +601,7 @@ void D3D12nBodyGravity::OnRender()
 	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
 	// Present the frame.
-	ThrowIfFailed(m_swapChain->Present(0, 0));
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 
 	MoveToNextFrame();
 }
@@ -774,20 +775,14 @@ void D3D12nBodyGravity::OnDestroy()
 	}
 }
 
-bool D3D12nBodyGravity::OnEvent(MSG msg)
+void D3D12nBodyGravity::OnKeyDown(UINT8 key)
 {
-	switch (msg.message)
-	{
-	case WM_KEYDOWN:
-		m_camera.OnKeyDown(msg.wParam);
-		break;
+	m_camera.OnKeyDown(key);
+}
 
-	case WM_KEYUP:
-		m_camera.OnKeyUp(msg.wParam);
-		break;
-	}
-
-	return false;
+void D3D12nBodyGravity::OnKeyUp(UINT8 key)
+{
+	m_camera.OnKeyUp(key);
 }
 
 void D3D12nBodyGravity::WaitForRenderContext()

--- a/Samples/D3D12nBodyGravity/src/D3D12nBodyGravity.h
+++ b/Samples/D3D12nBodyGravity/src/D3D12nBodyGravity.h
@@ -23,12 +23,12 @@ class D3D12nBodyGravity : public DXSample
 public:
 	D3D12nBodyGravity(UINT width, UINT height, std::wstring name);
 
-protected:
 	virtual void OnInit();
 	virtual void OnUpdate();
 	virtual void OnRender();
 	virtual void OnDestroy();
-	virtual bool OnEvent(MSG msg);
+	virtual void OnKeyDown(UINT8 key);
+	virtual void OnKeyUp(UINT8 key);
 
 private:
 	static const UINT FrameCount = 2;

--- a/Samples/D3D12nBodyGravity/src/D3D12nBodyGravity.vcxproj
+++ b/Samples/D3D12nBodyGravity/src/D3D12nBodyGravity.vcxproj
@@ -98,6 +98,7 @@
     </CustomBuild>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="Win32Application.h" />
     <ClInclude Include="D3D12nBodyGravity.h" />
     <ClInclude Include="d3dx12.h" />
     <ClInclude Include="DXSampleHelper.h" />
@@ -107,6 +108,7 @@
     <ClInclude Include="StepTimer.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Win32Application.cpp" />
     <ClCompile Include="D3D12nBodyGravity.cpp" />
     <ClCompile Include="DXSample.cpp" />
     <ClCompile Include="Main.cpp" />

--- a/Samples/D3D12nBodyGravity/src/D3D12nBodyGravity.vcxproj.filters
+++ b/Samples/D3D12nBodyGravity/src/D3D12nBodyGravity.vcxproj.filters
@@ -45,6 +45,9 @@
     <ClInclude Include="StepTimer.h">
       <Filter>Header Files\Util</Filter>
     </ClInclude>
+    <ClInclude Include="Win32Application.h">
+      <Filter>Header Files\Util</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -60,6 +63,9 @@
       <Filter>Source Files\Util</Filter>
     </ClCompile>
     <ClCompile Include="SimpleCamera.cpp">
+      <Filter>Source Files\Util</Filter>
+    </ClCompile>
+    <ClCompile Include="Win32Application.cpp">
       <Filter>Source Files\Util</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Samples/D3D12nBodyGravity/src/DXSample.cpp
+++ b/Samples/D3D12nBodyGravity/src/DXSample.cpp
@@ -11,17 +11,13 @@
 
 #include "stdafx.h"
 #include "DXSample.h"
-#include <shellapi.h>
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_title(name),
 	m_useWarpDevice(false)
 {
-	ParseCommandLineArgs();
-
-	m_title = name + (m_useWarpDevice ? L" (WARP)" : L"");
-
 	WCHAR assetsPath[512];
 	GetAssetsPath(assetsPath, _countof(assetsPath));
 	m_assetsPath = assetsPath;
@@ -33,67 +29,6 @@ DXSample::~DXSample()
 {
 }
 
-int DXSample::Run(HINSTANCE hInstance, int nCmdShow)
-{
-	// Initialize the window class.
-	WNDCLASSEX windowClass = { 0 };
-	windowClass.cbSize = sizeof(WNDCLASSEX);
-	windowClass.style = CS_HREDRAW | CS_VREDRAW;
-	windowClass.lpfnWndProc = WindowProc;
-	windowClass.hInstance = hInstance;
-	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-	windowClass.lpszClassName = L"WindowClass1";
-	RegisterClassEx(&windowClass);
-
-	RECT windowRect = { 0, 0, static_cast<LONG>(m_width), static_cast<LONG>(m_height) };
-	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
-
-	// Create the window and store a handle to it.
-	m_hwnd = CreateWindowEx(NULL,
-		L"WindowClass1",
-		m_title.c_str(),
-		WS_OVERLAPPEDWINDOW,
-		300,
-		300,
-		windowRect.right - windowRect.left,
-		windowRect.bottom - windowRect.top,
-		NULL,		// We have no parent window, NULL.
-		NULL,		// We aren't using menus, NULL.
-		hInstance,
-		NULL);		// We aren't using multiple windows, NULL.
-
-	ShowWindow(m_hwnd, nCmdShow);
-
-	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-	OnInit();
-
-	// Main sample loop.
-	MSG msg = { 0 };
-	while (true)
-	{
-		// Process any messages in the queue.
-		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-		{
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-
-			if (msg.message == WM_QUIT)
-				break;
-
-			// Pass events into our sample.
-			OnEvent(msg);
-		}
-
-		OnUpdate();
-		OnRender();
-	}
-
-	OnDestroy();
-
-	// Return this part of the WM_QUIT message to Windows.
-	return static_cast<char>(msg.wParam);
-}
-
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
@@ -102,7 +37,8 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
-void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter)
+_Use_decl_annotations_
+void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
 {
 	IDXGIAdapter1* pAdapter = nullptr;
 	*ppAdapter = nullptr;
@@ -134,36 +70,20 @@ void DXSample::GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_m
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
 	std::wstring windowText = m_title + L": " + text;
-	SetWindowText(m_hwnd, windowText.c_str());
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
-void DXSample::ParseCommandLineArgs()
+_Use_decl_annotations_
+void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-	int argc;
-	LPWSTR *argv = CommandLineToArgvW(GetCommandLineW(), &argc);
 	for (int i = 1; i < argc; ++i)
 	{
 		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
 			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
 		{
 			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
 		}
 	}
-	LocalFree(argv);
-}
-
-// Main message handler for the sample.
-LRESULT CALLBACK DXSample::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
-{
-	// Handle destroy/shutdown messages.
-	switch (message)
-	{
-	case WM_DESTROY:
-		PostQuitMessage(0);
-		return 0;
-	}
-
-	// Handle any messages the switch statement didn't.
-	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/D3D12nBodyGravity/src/DXSample.h
+++ b/Samples/D3D12nBodyGravity/src/DXSample.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "DXSampleHelper.h"
+#include "Win32Application.h"
 
 class DXSample
 {
@@ -19,35 +20,36 @@ public:
 	DXSample(UINT width, UINT height, std::wstring name);
 	virtual ~DXSample();
 
-	int Run(HINSTANCE hInstance, int nCmdShow);
-	void SetCustomWindowText(LPCWSTR text);
-
-protected:
 	virtual void OnInit() = 0;
 	virtual void OnUpdate() = 0;
 	virtual void OnRender() = 0;
 	virtual void OnDestroy() = 0;
-	virtual bool OnEvent(MSG msg) = 0;
 
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
+
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
+
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+
+protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
-	void GetHardwareAdapter(_In_ IDXGIFactory4* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-
-	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+	void SetCustomWindowText(LPCWSTR text);
 
 	// Viewport dimensions.
 	UINT m_width;
 	UINT m_height;
 	float m_aspectRatio;
 
-	// Window handle.
-	HWND m_hwnd;
-
 	// Adapter info.
 	bool m_useWarpDevice;
 
 private:
-	void ParseCommandLineArgs();
-
 	// Root assets path.
 	std::wstring m_assetsPath;
 

--- a/Samples/D3D12nBodyGravity/src/Main.cpp
+++ b/Samples/D3D12nBodyGravity/src/Main.cpp
@@ -16,5 +16,5 @@ _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
 	D3D12nBodyGravity sample(1280, 720, L"D3D12 n-Body Gravity Simulation");
-	return sample.Run(hInstance, nCmdShow);
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/D3D12nBodyGravity/src/Win32Application.cpp
+++ b/Samples/D3D12nBodyGravity/src/Win32Application.cpp
@@ -1,0 +1,119 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#include "stdafx.h"
+#include "Win32Application.h"
+
+HWND Win32Application::m_hwnd = nullptr;
+
+int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
+{
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
+
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
+
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
+
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
+
+	ShowWindow(m_hwnd, nCmdShow);
+
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
+
+	pSample->OnDestroy();
+
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
+}
+
+// Main message handler for the sample.
+LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
+
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
+
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
+
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
+
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
+}

--- a/Samples/D3D12nBodyGravity/src/Win32Application.h
+++ b/Samples/D3D12nBodyGravity/src/Win32Application.h
@@ -1,0 +1,29 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#pragma once
+
+#include "DXSample.h"
+
+class DXSample;
+
+class Win32Application
+{
+public:
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
+
+protected:
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+
+private:
+	static HWND m_hwnd;
+};

--- a/Samples/D3D12nBodyGravity/src/stdafx.h
+++ b/Samples/D3D12nBodyGravity/src/stdafx.h
@@ -29,3 +29,4 @@
 
 #include <wrl.h>
 #include <vector>
+#include <shellapi.h>


### PR DESCRIPTION
In order to run the same code on multiple platforms (e.g. UWP, Xbox),
Win32-specific code needs to be decoupled from the DXSample base class.
This change is the first step in that direction.

+Win32Application class to encapsulate Win32-specific functionality.
*Generic Win32 OnEvent is replaced with specific handlers for messages
the samples currently handle.