### PR TITLE
Close the event in D3D12Multithreading::OnUpdate

### DIFF
--- a/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.cpp
+++ b/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.cpp
@@ -667,6 +667,7 @@ void D3D12Multithreading::OnUpdate()
 		}
 		ThrowIfFailed(m_fence->SetEventOnCompletion(m_pCurrentFrameResource->m_fenceValue, eventHandle));
 		WaitForSingleObject(eventHandle, INFINITE);
+		CloseHandle(eventHandle);
 	}
 
 	m_cpuTimer.Tick(NULL);


### PR DESCRIPTION
There appears to be a leak in D3D12Multithreading. An event is created and stored in a local variable, but never closed.