### PR TITLE
Format string fix.

### DIFF
--- a/MiniEngine/Core/Utility.h
+++ b/MiniEngine/Core/Utility.h
@@ -17,8 +17,8 @@
 
 namespace Utility
 {
-	inline void Print( const char* msg ) { printf(msg); }
-	inline void Print( const wchar_t* msg ) { wprintf(msg); }
+	inline void Print( const char* msg ) { printf("%s", msg); }
+	inline void Print( const wchar_t* msg ) { wprintf(L"%ls", msg); }
 
 	inline void Printf( const char* format, ... )
 	{


### PR DESCRIPTION
String is output without format parameter. It's dangerous, because it will cause a program failure (format string exploit occurs).