### PR TITLE
Updating samples to use the new PIX markers

### DIFF
--- a/Samples/.gitignore
+++ b/Samples/.gitignore
@@ -3,6 +3,7 @@
 x64/
 bin/
 obj/
+packages/
 *.ipch
 *.sdf
 *.opensdf

--- a/Samples/Desktop/D3D12Bundles/src/D3D12Bundles.vcxproj
+++ b/Samples/Desktop/D3D12Bundles/src/D3D12Bundles.vcxproj
@@ -167,7 +167,17 @@
       <DeploymentContent>true</DeploymentContent>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets" Condition="Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets'))" />
+  </Target>
 </Project>

--- a/Samples/Desktop/D3D12Bundles/src/D3D12Bundles.vcxproj.filters
+++ b/Samples/Desktop/D3D12Bundles/src/D3D12Bundles.vcxproj.filters
@@ -94,4 +94,7 @@
       <Filter>Assets</Filter>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Samples/Desktop/D3D12Bundles/src/packages.config
+++ b/Samples/Desktop/D3D12Bundles/src/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="WinPixEventRuntime" version="1.0.161208001" targetFramework="native" />
+</packages>

--- a/Samples/Desktop/D3D12Bundles/src/stdafx.h
+++ b/Samples/Desktop/D3D12Bundles/src/stdafx.h
@@ -26,7 +26,7 @@
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"
-#include <pix.h>
+#include <pix3.h>
 
 #include <string>
 #include <vector>

--- a/Samples/Desktop/D3D12DynamicIndexing/src/D3D12DynamicIndexing.vcxproj
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/D3D12DynamicIndexing.vcxproj
@@ -162,7 +162,17 @@
       <DeploymentContent>true</DeploymentContent>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets" Condition="Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets'))" />
+  </Target>
 </Project>

--- a/Samples/Desktop/D3D12DynamicIndexing/src/D3D12DynamicIndexing.vcxproj.filters
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/D3D12DynamicIndexing.vcxproj.filters
@@ -91,4 +91,7 @@
       <Filter>Assets</Filter>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Samples/Desktop/D3D12DynamicIndexing/src/packages.config
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="WinPixEventRuntime" version="1.0.161208001" targetFramework="native" />
+</packages>

--- a/Samples/Desktop/D3D12DynamicIndexing/src/stdafx.h
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/stdafx.h
@@ -26,7 +26,7 @@
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"
-#include <pix.h>
+#include <pix3.h>
 
 #include <string>
 #include <vector>

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.vcxproj
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.vcxproj
@@ -143,7 +143,17 @@
       <EnableDebuggingInformation Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</EnableDebuggingInformation>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets" Condition="Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets'))" />
+  </Target>
 </Project>

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.vcxproj.filters
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.vcxproj.filters
@@ -68,4 +68,7 @@
       <Filter>Assets\Shaders</Filter>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/packages.config
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="WinPixEventRuntime" version="1.0.161208001" targetFramework="native" />
+</packages>

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/stdafx.h
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/stdafx.h
@@ -26,7 +26,7 @@
 #include <D3Dcompiler.h>
 #include "d3dx12.h"
 #include <DirectXMath.h>
-#include <pix.h>
+#include <pix3.h>
 
 #include <wrl.h>
 #include <vector>

--- a/Samples/Desktop/D3D12Fullscreen/src/D3D12Fullscreen.vcxproj
+++ b/Samples/Desktop/D3D12Fullscreen/src/D3D12Fullscreen.vcxproj
@@ -139,7 +139,17 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets" Condition="Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets'))" />
+  </Target>
 </Project>

--- a/Samples/Desktop/D3D12Fullscreen/src/D3D12Fullscreen.vcxproj.filters
+++ b/Samples/Desktop/D3D12Fullscreen/src/D3D12Fullscreen.vcxproj.filters
@@ -68,4 +68,7 @@
       <Filter>Assets\Shaders</Filter>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Samples/Desktop/D3D12Fullscreen/src/packages.config
+++ b/Samples/Desktop/D3D12Fullscreen/src/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="WinPixEventRuntime" version="1.0.161208001" targetFramework="native" />
+</packages>

--- a/Samples/Desktop/D3D12Fullscreen/src/stdafx.h
+++ b/Samples/Desktop/D3D12Fullscreen/src/stdafx.h
@@ -26,7 +26,7 @@
 #include <D3Dcompiler.h>
 #include "d3dx12.h"
 #include <DirectXMath.h>
-#include <pix.h>
+#include <pix3.h>
 
 #include <wrl.h>
 #include <string>

--- a/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.vcxproj
+++ b/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.vcxproj
@@ -143,7 +143,17 @@
       <FileType>Document</FileType>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets" Condition="Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets'))" />
+  </Target>
 </Project>

--- a/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.vcxproj.filters
+++ b/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.vcxproj.filters
@@ -86,4 +86,7 @@
       <Filter>Assets\Shaders</Filter>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Samples/Desktop/D3D12Multithreading/src/packages.config
+++ b/Samples/Desktop/D3D12Multithreading/src/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="WinPixEventRuntime" version="1.0.161208001" targetFramework="native" />
+</packages>

--- a/Samples/Desktop/D3D12Multithreading/src/stdafx.h
+++ b/Samples/Desktop/D3D12Multithreading/src/stdafx.h
@@ -26,7 +26,7 @@
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"
-#include <pix.h>
+#include <pix3.h>
 
 #include <string>
 #include <wrl.h>

--- a/Samples/Desktop/D3D12PipelineStateCache/src/D3D12PipelineStateCache.vcxproj
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/D3D12PipelineStateCache.vcxproj
@@ -340,7 +340,17 @@
       <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">mainWave</EntryPointName>
     </FxCompile>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets" Condition="Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets'))" />
+  </Target>
 </Project>

--- a/Samples/Desktop/D3D12PipelineStateCache/src/D3D12PipelineStateCache.vcxproj.filters
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/D3D12PipelineStateCache.vcxproj.filters
@@ -140,4 +140,7 @@
       <Filter>Assets\Shaders</Filter>
     </FxCompile>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Samples/Desktop/D3D12PipelineStateCache/src/packages.config
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="WinPixEventRuntime" version="1.0.161208001" targetFramework="native" />
+</packages>

--- a/Samples/Desktop/D3D12PipelineStateCache/src/stdafx.h
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/stdafx.h
@@ -26,7 +26,7 @@
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"
-#include <pix.h>
+#include <pix3.h>
 
 #include <wrl.h>
 #include <list>

--- a/Samples/Desktop/D3D12PredicationQueries/src/D3D12PredicationQueries.vcxproj
+++ b/Samples/Desktop/D3D12PredicationQueries/src/D3D12PredicationQueries.vcxproj
@@ -128,7 +128,17 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets" Condition="Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets'))" />
+  </Target>
 </Project>

--- a/Samples/Desktop/D3D12PredicationQueries/src/D3D12PredicationQueries.vcxproj.filters
+++ b/Samples/Desktop/D3D12PredicationQueries/src/D3D12PredicationQueries.vcxproj.filters
@@ -65,4 +65,7 @@
       <Filter>Assets\Shaders</Filter>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Samples/Desktop/D3D12PredicationQueries/src/packages.config
+++ b/Samples/Desktop/D3D12PredicationQueries/src/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="WinPixEventRuntime" version="1.0.161208001" targetFramework="native" />
+</packages>

--- a/Samples/Desktop/D3D12PredicationQueries/src/stdafx.h
+++ b/Samples/Desktop/D3D12PredicationQueries/src/stdafx.h
@@ -26,7 +26,7 @@
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"
-#include <pix.h>
+#include <pix3.h>
 
 #include <wrl.h>
 #include <vector>

--- a/Samples/Desktop/D3D12Residency/src/D3D12Residency.vcxproj
+++ b/Samples/Desktop/D3D12Residency/src/D3D12Residency.vcxproj
@@ -120,7 +120,17 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets" Condition="Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets'))" />
+  </Target>
 </Project>

--- a/Samples/Desktop/D3D12Residency/src/D3D12Residency.vcxproj.filters
+++ b/Samples/Desktop/D3D12Residency/src/D3D12Residency.vcxproj.filters
@@ -68,4 +68,7 @@
       <Filter>Source Files\Util</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Samples/Desktop/D3D12Residency/src/packages.config
+++ b/Samples/Desktop/D3D12Residency/src/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="WinPixEventRuntime" version="1.0.161208001" targetFramework="native" />
+</packages>

--- a/Samples/Desktop/D3D12Residency/src/stdafx.h
+++ b/Samples/Desktop/D3D12Residency/src/stdafx.h
@@ -26,7 +26,7 @@
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"
-#include <pix.h>
+#include <pix3.h>
 
 #include <string>
 #include <mutex>

--- a/Samples/Desktop/D3D12SmallResources/src/D3D12SmallResources.vcxproj
+++ b/Samples/Desktop/D3D12SmallResources/src/D3D12SmallResources.vcxproj
@@ -128,7 +128,17 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets" Condition="Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets'))" />
+  </Target>
 </Project>

--- a/Samples/Desktop/D3D12SmallResources/src/D3D12SmallResources.vcxproj.filters
+++ b/Samples/Desktop/D3D12SmallResources/src/D3D12SmallResources.vcxproj.filters
@@ -65,4 +65,7 @@
       <Filter>Assets\Shaders</Filter>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Samples/Desktop/D3D12SmallResources/src/packages.config
+++ b/Samples/Desktop/D3D12SmallResources/src/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="WinPixEventRuntime" version="1.0.161208001" targetFramework="native" />
+</packages>

--- a/Samples/Desktop/D3D12SmallResources/src/stdafx.h
+++ b/Samples/Desktop/D3D12SmallResources/src/stdafx.h
@@ -26,7 +26,7 @@
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"
-#include <pix.h>
+#include <pix3.h>
 
 #include <wrl.h>
 #include <vector>

--- a/Samples/Desktop/D3D12nBodyGravity/src/D3D12nBodyGravity.vcxproj
+++ b/Samples/Desktop/D3D12nBodyGravity/src/D3D12nBodyGravity.vcxproj
@@ -136,7 +136,17 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets" Condition="Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets'))" />
+  </Target>
 </Project>

--- a/Samples/Desktop/D3D12nBodyGravity/src/D3D12nBodyGravity.vcxproj.filters
+++ b/Samples/Desktop/D3D12nBodyGravity/src/D3D12nBodyGravity.vcxproj.filters
@@ -77,4 +77,7 @@
       <Filter>Assets\Shaders</Filter>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Samples/Desktop/D3D12nBodyGravity/src/packages.config
+++ b/Samples/Desktop/D3D12nBodyGravity/src/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="WinPixEventRuntime" version="1.0.161208001" targetFramework="native" />
+</packages>

--- a/Samples/Desktop/D3D12nBodyGravity/src/stdafx.h
+++ b/Samples/Desktop/D3D12nBodyGravity/src/stdafx.h
@@ -26,7 +26,7 @@
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"
-#include <pix.h>
+#include <pix3.h>
 
 #include <wrl.h>
 #include <vector>

--- a/Samples/UWP/D3D12Bundles/src/D3D12Bundles.vcxproj
+++ b/Samples/UWP/D3D12Bundles/src/D3D12Bundles.vcxproj
@@ -371,10 +371,20 @@
       <DeploymentContent>true</DeploymentContent>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ImageContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\MeshContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ShaderGraphContentTask.targets" />
+    <Import Project="$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets" Condition="Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets'))" />
+  </Target>
 </Project>

--- a/Samples/UWP/D3D12Bundles/src/D3D12Bundles.vcxproj.filters
+++ b/Samples/UWP/D3D12Bundles/src/D3D12Bundles.vcxproj.filters
@@ -123,4 +123,7 @@
       <Filter>Assets</Filter>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Samples/UWP/D3D12Bundles/src/packages.config
+++ b/Samples/UWP/D3D12Bundles/src/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="WinPixEventRuntime" version="1.0.161208001" targetFramework="native" />
+</packages>

--- a/Samples/UWP/D3D12Bundles/src/stdafx.h
+++ b/Samples/UWP/D3D12Bundles/src/stdafx.h
@@ -26,7 +26,7 @@
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"
-#include <pix.h>
+#include <pix3.h>
 
 #include <string>
 #include <vector>

--- a/Samples/UWP/D3D12DynamicIndexing/src/D3D12DynamicIndexing.vcxproj
+++ b/Samples/UWP/D3D12DynamicIndexing/src/D3D12DynamicIndexing.vcxproj
@@ -356,10 +356,20 @@
       <DeploymentContent>true</DeploymentContent>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ImageContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\MeshContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ShaderGraphContentTask.targets" />
+    <Import Project="$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets" Condition="Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets'))" />
+  </Target>
 </Project>

--- a/Samples/UWP/D3D12DynamicIndexing/src/D3D12DynamicIndexing.vcxproj.filters
+++ b/Samples/UWP/D3D12DynamicIndexing/src/D3D12DynamicIndexing.vcxproj.filters
@@ -120,4 +120,7 @@
       <Filter>Assets</Filter>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Samples/UWP/D3D12DynamicIndexing/src/packages.config
+++ b/Samples/UWP/D3D12DynamicIndexing/src/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="WinPixEventRuntime" version="1.0.161208001" targetFramework="native" />
+</packages>

--- a/Samples/UWP/D3D12DynamicIndexing/src/stdafx.h
+++ b/Samples/UWP/D3D12DynamicIndexing/src/stdafx.h
@@ -26,7 +26,7 @@
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"
-#include <pix.h>
+#include <pix3.h>
 
 #include <string>
 #include <vector>

--- a/Samples/UWP/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.vcxproj
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.vcxproj
@@ -304,10 +304,20 @@
       <DeploymentContent>true</DeploymentContent>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ImageContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\MeshContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ShaderGraphContentTask.targets" />
+    <Import Project="$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets" Condition="Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets'))" />
+  </Target>
 </Project>

--- a/Samples/UWP/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.vcxproj.filters
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.vcxproj.filters
@@ -97,4 +97,7 @@
       <Filter>Assets\Shaders</Filter>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Samples/UWP/D3D12ExecuteIndirect/src/packages.config
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="WinPixEventRuntime" version="1.0.161208001" targetFramework="native" />
+</packages>

--- a/Samples/UWP/D3D12ExecuteIndirect/src/stdafx.h
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/stdafx.h
@@ -26,7 +26,7 @@
 #include <D3Dcompiler.h>
 #include "d3dx12.h"
 #include <DirectXMath.h>
-#include <pix.h>
+#include <pix3.h>
 
 #include <wrl.h>
 #include <vector>

--- a/Samples/UWP/D3D12Fullscreen/src/D3D12Fullscreen.vcxproj
+++ b/Samples/UWP/D3D12Fullscreen/src/D3D12Fullscreen.vcxproj
@@ -306,10 +306,20 @@
       <DeploymentContent>true</DeploymentContent>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ImageContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\MeshContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ShaderGraphContentTask.targets" />
+    <Import Project="$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets" Condition="Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets'))" />
+  </Target>
 </Project>

--- a/Samples/UWP/D3D12Fullscreen/src/D3D12Fullscreen.vcxproj.filters
+++ b/Samples/UWP/D3D12Fullscreen/src/D3D12Fullscreen.vcxproj.filters
@@ -97,4 +97,7 @@
       <Filter>Assets\Shaders</Filter>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Samples/UWP/D3D12Fullscreen/src/packages.config
+++ b/Samples/UWP/D3D12Fullscreen/src/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="WinPixEventRuntime" version="1.0.161208001" targetFramework="native" />
+</packages>

--- a/Samples/UWP/D3D12Fullscreen/src/stdafx.h
+++ b/Samples/UWP/D3D12Fullscreen/src/stdafx.h
@@ -26,7 +26,7 @@
 #include <D3Dcompiler.h>
 #include "d3dx12.h"
 #include <DirectXMath.h>
-#include <pix.h>
+#include <pix3.h>
 
 #include <wrl.h>
 #include <string>

--- a/Samples/UWP/D3D12PipelineStateCache/src/D3D12PipelineStateCache.vcxproj
+++ b/Samples/UWP/D3D12PipelineStateCache/src/D3D12PipelineStateCache.vcxproj
@@ -344,10 +344,20 @@
       <EntryPointName>mainWave</EntryPointName>
     </FxCompile>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ImageContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\MeshContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ShaderGraphContentTask.targets" />
+    <Import Project="$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets" Condition="Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets'))" />
+  </Target>
 </Project>

--- a/Samples/UWP/D3D12PipelineStateCache/src/D3D12PipelineStateCache.vcxproj.filters
+++ b/Samples/UWP/D3D12PipelineStateCache/src/D3D12PipelineStateCache.vcxproj.filters
@@ -169,4 +169,7 @@
       <Filter>Assets\Shaders</Filter>
     </FxCompile>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Samples/UWP/D3D12PipelineStateCache/src/packages.config
+++ b/Samples/UWP/D3D12PipelineStateCache/src/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="WinPixEventRuntime" version="1.0.161208001" targetFramework="native" />
+</packages>

--- a/Samples/UWP/D3D12PipelineStateCache/src/stdafx.h
+++ b/Samples/UWP/D3D12PipelineStateCache/src/stdafx.h
@@ -26,7 +26,7 @@
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"
-#include <pix.h>
+#include <pix3.h>
 
 #include <wrl.h>
 #include <list>

--- a/Samples/UWP/D3D12PredicationQueries/src/D3D12PredicationQueries.vcxproj
+++ b/Samples/UWP/D3D12PredicationQueries/src/D3D12PredicationQueries.vcxproj
@@ -300,10 +300,20 @@
       <DeploymentContent>true</DeploymentContent>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ImageContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\MeshContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ShaderGraphContentTask.targets" />
+    <Import Project="$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets" Condition="Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets'))" />
+  </Target>
 </Project>

--- a/Samples/UWP/D3D12PredicationQueries/src/D3D12PredicationQueries.vcxproj.filters
+++ b/Samples/UWP/D3D12PredicationQueries/src/D3D12PredicationQueries.vcxproj.filters
@@ -94,4 +94,7 @@
       <Filter>Assets\Shaders</Filter>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Samples/UWP/D3D12PredicationQueries/src/packages.config
+++ b/Samples/UWP/D3D12PredicationQueries/src/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="WinPixEventRuntime" version="1.0.161208001" targetFramework="native" />
+</packages>

--- a/Samples/UWP/D3D12PredicationQueries/src/stdafx.h
+++ b/Samples/UWP/D3D12PredicationQueries/src/stdafx.h
@@ -26,7 +26,7 @@
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"
-#include <pix.h>
+#include <pix3.h>
 
 #include <wrl.h>
 #include <vector>

--- a/Samples/UWP/D3D12Residency/src/D3D12Residency.vcxproj
+++ b/Samples/UWP/D3D12Residency/src/D3D12Residency.vcxproj
@@ -301,10 +301,20 @@
       <DeploymentContent>true</DeploymentContent>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ImageContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\MeshContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ShaderGraphContentTask.targets" />
+    <Import Project="$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets" Condition="Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets'))" />
+  </Target>
 </Project>

--- a/Samples/UWP/D3D12Residency/src/D3D12Residency.vcxproj.filters
+++ b/Samples/UWP/D3D12Residency/src/D3D12Residency.vcxproj.filters
@@ -97,4 +97,7 @@
       <Filter>Assets\Shaders</Filter>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Samples/UWP/D3D12Residency/src/packages.config
+++ b/Samples/UWP/D3D12Residency/src/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="WinPixEventRuntime" version="1.0.161208001" targetFramework="native" />
+</packages>

--- a/Samples/UWP/D3D12Residency/src/stdafx.h
+++ b/Samples/UWP/D3D12Residency/src/stdafx.h
@@ -26,7 +26,7 @@
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"
-#include <pix.h>
+#include <pix3.h>
 
 #include <string>
 #include <mutex>

--- a/Samples/UWP/D3D12SmallResources/src/D3D12SmallResources.vcxproj
+++ b/Samples/UWP/D3D12SmallResources/src/D3D12SmallResources.vcxproj
@@ -300,10 +300,20 @@
       <DeploymentContent>true</DeploymentContent>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ImageContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\MeshContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ShaderGraphContentTask.targets" />
+    <Import Project="$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets" Condition="Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets'))" />
+  </Target>
 </Project>

--- a/Samples/UWP/D3D12SmallResources/src/D3D12SmallResources.vcxproj.filters
+++ b/Samples/UWP/D3D12SmallResources/src/D3D12SmallResources.vcxproj.filters
@@ -94,4 +94,7 @@
       <Filter>Assets\Shaders</Filter>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Samples/UWP/D3D12SmallResources/src/packages.config
+++ b/Samples/UWP/D3D12SmallResources/src/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="WinPixEventRuntime" version="1.0.161208001" targetFramework="native" />
+</packages>

--- a/Samples/UWP/D3D12SmallResources/src/stdafx.h
+++ b/Samples/UWP/D3D12SmallResources/src/stdafx.h
@@ -26,7 +26,7 @@
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"
-#include <pix.h>
+#include <pix3.h>
 
 #include <wrl.h>
 #include <vector>

--- a/Samples/UWP/D3D12nBodyGravity/src/D3D12nBodyGravity.vcxproj
+++ b/Samples/UWP/D3D12nBodyGravity/src/D3D12nBodyGravity.vcxproj
@@ -306,10 +306,20 @@
       <DeploymentContent>true</DeploymentContent>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ImageContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\MeshContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ShaderGraphContentTask.targets" />
+    <Import Project="$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets" Condition="Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\WinPixEventRuntime.1.0.161208001\build\WinPixEventRuntime.targets'))" />
+  </Target>
 </Project>

--- a/Samples/UWP/D3D12nBodyGravity/src/D3D12nBodyGravity.vcxproj.filters
+++ b/Samples/UWP/D3D12nBodyGravity/src/D3D12nBodyGravity.vcxproj.filters
@@ -103,4 +103,7 @@
       <Filter>Assets\Shaders</Filter>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Samples/UWP/D3D12nBodyGravity/src/packages.config
+++ b/Samples/UWP/D3D12nBodyGravity/src/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="WinPixEventRuntime" version="1.0.161208001" targetFramework="native" />
+</packages>

--- a/Samples/UWP/D3D12nBodyGravity/src/stdafx.h
+++ b/Samples/UWP/D3D12nBodyGravity/src/stdafx.h
@@ -26,7 +26,7 @@
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"
-#include <pix.h>
+#include <pix3.h>
 
 #include <wrl.h>
 #include <vector>


### PR DESCRIPTION
PIX for Windows (beta) was released today:
https://blogs.msdn.microsoft.com/pix/2017/01/17/introducing-pix-on-windows-beta/

Update the samples to use the new PIX markers.