### PR TITLE
Fix the black screen when g_bEnableHDROutput = true

### DIFF
--- a/MiniEngine/Core/GraphicsCore.cpp
+++ b/MiniEngine/Core/GraphicsCore.cpp
@@ -621,6 +621,7 @@ void Graphics::Initialize(void)
 	ObjName.Finalize();
 
 	CreatePSO(ConvertLDRToDisplayPS, g_pConvertLDRToDisplayPS);
+	CreatePSO(ConvertHDRToDisplayPS, g_pConvertHDRToDisplayPS);
 	CreatePSO(MagnifyPixelsPS, g_pMagnifyPixelsPS);
 	CreatePSO(BilinearUpsamplePS, g_pBilinearUpsamplePS);
 	CreatePSO(BicubicHorizontalUpsamplePS, g_pBicubicHorizontalUpsamplePS);


### PR DESCRIPTION
Creats a PSO for ConvertHDRToDisplayPS to fix the black screen. (#245)