### PR TITLE
Fix MiniEngine shaders for DXIL compat.

### DIFF
--- a/MiniEngine/Core/Shaders/AoBlurAndUpsampleCS.hlsli
+++ b/MiniEngine/Core/Shaders/AoBlurAndUpsampleCS.hlsli
@@ -27,7 +27,7 @@ RWTexture2D<float> AoResult : register(u0);
 
 SamplerState LinearSampler : register(s0);
 
-cbuffer ConstantBuffer : register(b1)
+cbuffer MainConstantBuffer : register(b1)
 {
 	float2 InvLowResolution;
 	float2 InvHighResolution;

--- a/MiniEngine/Core/Shaders/AoPrepareDepthBuffers1CS.hlsl
+++ b/MiniEngine/Core/Shaders/AoPrepareDepthBuffers1CS.hlsl
@@ -18,7 +18,7 @@ RWTexture2D<float2> DS2x : register(u1);
 RWTexture2DArray<float> DS2xAtlas : register(u2);
 RWTexture2D<float2> DS4x : register(u3);
 RWTexture2DArray<float> DS4xAtlas : register(u4);
-cbuffer ConstantBuffer : register(b0)
+cbuffer MainConstantBuffer : register(b0)
 {
 	float ZMagic;
 }

--- a/MiniEngine/Core/Shaders/AoPrepareDepthBuffers2CS.hlsl
+++ b/MiniEngine/Core/Shaders/AoPrepareDepthBuffers2CS.hlsl
@@ -19,7 +19,7 @@ RWTexture2DArray<float> DS8xAtlas : register(u1);
 RWTexture2D<float> DS16x : register(u2);
 RWTexture2DArray<float> DS16xAtlas : register(u3);
 
-cbuffer ConstantBuffer : register(b0)
+cbuffer MainConstantBuffer : register(b0)
 {
 	float2 InvSourceDimension;
 }

--- a/MiniEngine/Core/Shaders/AoRenderCS.hlsli
+++ b/MiniEngine/Core/Shaders/AoRenderCS.hlsli
@@ -24,7 +24,7 @@ Texture2D<float> DepthTex : register(t0);
 #endif
 RWTexture2D<float> Occlusion : register(u0);
 SamplerState LinearBorderSampler : register(s1);
-cbuffer ConstantBuffer : register(b1)
+cbuffer MainConstantBuffer : register(b1)
 {
 	float4 gInvThicknessTable[3];
 	float4 gSampleWeightTable[3];

--- a/MiniEngine/Core/Shaders/ApplyBloomCS.hlsl
+++ b/MiniEngine/Core/Shaders/ApplyBloomCS.hlsl
@@ -25,7 +25,7 @@ Texture2D<float3> SrcColor : register(t2);
 RWTexture2D<float> OutLuma : register( u1 );
 SamplerState LinearSampler : register( s0 );
 
-cbuffer ConstantBuffer : register( b0 )
+cbuffer MainConstantBuffer : register( b0 )
 {
 	float2 g_RcpBufferDim;
 	float g_BloomStrength;

--- a/MiniEngine/Core/Shaders/CameraMotionBlurPrePassCS.hlsl
+++ b/MiniEngine/Core/Shaders/CameraMotionBlurPrePassCS.hlsl
@@ -25,7 +25,7 @@ Texture2D<float> DepthBuffer : register(t1);
 RWTexture2D<float4> PrepBuffer : register(u0);
 RWTexture2D<float2> ReprojBuffer : register(u1);
 
-cbuffer ConstantBuffer : register(b1)
+cbuffer MainConstantBuffer : register(b1)
 {
 	matrix CurToPrevXForm;
 }

--- a/MiniEngine/Core/Shaders/CameraVelocityCS.hlsl
+++ b/MiniEngine/Core/Shaders/CameraVelocityCS.hlsl
@@ -22,7 +22,7 @@
 Texture2D<float> DepthBuffer : register(t0);
 RWTexture2D<float2> ReprojectionBuffer : register(u0);
 
-cbuffer ConstantBuffer : register(b1)
+cbuffer MainConstantBuffer : register(b1)
 {
 	matrix CurToPrevXForm;
 }

--- a/MiniEngine/Core/Shaders/DebugLuminanceHdrCS.hlsl
+++ b/MiniEngine/Core/Shaders/DebugLuminanceHdrCS.hlsl
@@ -26,7 +26,7 @@ Texture2D<float3> SrcColor : register(t2);
 RWTexture2D<float> OutLuma : register(u1);
 SamplerState LinearSampler : register( s0 );
 
-cbuffer ConstantBuffer : register( b0 )
+cbuffer MainConstantBuffer : register( b0 )
 {
 	float2 g_RcpBufferDim;
 	float g_BloomStrength;

--- a/MiniEngine/Core/Shaders/DebugLuminanceLdrCS.hlsl
+++ b/MiniEngine/Core/Shaders/DebugLuminanceLdrCS.hlsl
@@ -25,7 +25,7 @@ Texture2D<float3> SrcColor : register(t2);
 RWTexture2D<float> OutLuma : register(u1);
 SamplerState LinearSampler : register( s0 );
 
-cbuffer ConstantBuffer : register( b0 )
+cbuffer MainConstantBuffer : register( b0 )
 {
 	float2 g_RcpBufferDim;
 	float g_BloomStrength;

--- a/MiniEngine/Core/Shaders/DoFCommon.hlsli
+++ b/MiniEngine/Core/Shaders/DoFCommon.hlsli
@@ -19,7 +19,7 @@ SamplerState PointSampler : register(s0);
 SamplerState ClampSampler : register(s1);
 SamplerState BilinearSampler: register(s2);
 
-cbuffer ConstantBuffer : register(b0)
+cbuffer MainConstantBuffer : register(b0)
 {
 	float FocusCenter;
 	float FocalSpread;

--- a/MiniEngine/Core/Shaders/FXAAPass1CS.hlsli
+++ b/MiniEngine/Core/Shaders/FXAAPass1CS.hlsli
@@ -60,7 +60,7 @@ DAMAGES.
 #include "FXAARootSignature.hlsli"
 #include "PixelPacking.hlsli"
 
-cbuffer ConstantBuffer : register( b0 )
+cbuffer MainConstantBuffer : register( b0 )
 {
 	float2 RcpTextureSize;
 	float ContrastThreshold;	// default = 0.2, lower is more expensive

--- a/MiniEngine/Core/Shaders/LinearizeDepthCS.hlsl
+++ b/MiniEngine/Core/Shaders/LinearizeDepthCS.hlsl
@@ -16,7 +16,7 @@
 RWTexture2D<float> LinearZ : register(u0);
 Texture2D<float> Depth : register(t0);
 
-cbuffer ConstantBuffer : register(b0)
+cbuffer MainConstantBuffer : register(b0)
 {
 	float ZMagic;				// (zFar - zNear) / zNear
 }

--- a/MiniEngine/Core/Shaders/PixelPacking_R11G11B10.hlsli
+++ b/MiniEngine/Core/Shaders/PixelPacking_R11G11B10.hlsli
@@ -38,9 +38,9 @@ float3 Unpack_R11G11B10_FLOAT( uint rgb )
 // time the exponent increases by whole amounts.
 uint Pack_R11G11B10_FLOAT_LOG( float3 rgb )
 {
-	float3 flat_mantissa = asfloat(asuint(rgb) & 0x7FFFFF | 0x3F800000);
+	float3 flat_mantissa = asfloat((asuint(rgb) & 0x7FFFFF) | 0x3F800000);
 	float3 curved_mantissa = min(log2(flat_mantissa) + 1.0, asfloat(0x3FFFFFFF));
-	rgb = asfloat(asuint(rgb) & 0xFF800000 | asuint(curved_mantissa) & 0x7FFFFF);
+	rgb = asfloat((asuint(rgb) & 0xFF800000) | (asuint(curved_mantissa) & 0x7FFFFF));
 
 	uint r = ((f32tof16(rgb.x) + 8) >>  4) & 0x000007FF;
 	uint g = ((f32tof16(rgb.y) + 8) <<  7) & 0x003FF800;
@@ -51,9 +51,9 @@ uint Pack_R11G11B10_FLOAT_LOG( float3 rgb )
 float3 Unpack_R11G11B10_FLOAT_LOG( uint p )
 {
 	float3 rgb = f16tof32(uint3(p << 4, p >> 7, p >> 17) & uint3(0x7FF0, 0x7FF0, 0x7FE0));
-	float3 curved_mantissa = asfloat(asuint(rgb) & 0x7FFFFF | 0x3F800000);
+	float3 curved_mantissa = asfloat((asuint(rgb) & 0x7FFFFF) | 0x3F800000);
 	float3 flat_mantissa = exp2(curved_mantissa - 1.0);
-	return asfloat(asuint(rgb) & 0xFF800000 | asuint(flat_mantissa) & 0x7FFFFF);
+	return asfloat((asuint(rgb) & 0xFF800000) | (asuint(flat_mantissa) & 0x7FFFFF));
 }
 
 // As an alternative to floating point, we can store the log2 of a value in fixed point notation.

--- a/MiniEngine/Core/Shaders/ToneMapCS.hlsl
+++ b/MiniEngine/Core/Shaders/ToneMapCS.hlsl
@@ -26,7 +26,7 @@ Texture2D<float3> SrcColor : register( t2 );
 RWTexture2D<float> OutLuma : register( u1 );
 SamplerState LinearSampler : register( s0 );
 
-cbuffer ConstantBuffer : register( b0 )
+cbuffer MainConstantBuffer : register( b0 )
 {
 	float2 g_RcpBufferDim;
 	float g_BloomStrength;

--- a/MiniEngine/ModelViewer/Shaders/FillLightGridCS.hlsli
+++ b/MiniEngine/ModelViewer/Shaders/FillLightGridCS.hlsli
@@ -214,17 +214,18 @@ void main(
 		lightGrid.Store(tileOffset + 0, lightCount);
 
 		uint storeOffset = tileOffset + 4;
-		for (uint n = 0; n < tileLightCountSphere; n++)
+		uint n = 0;
+		for (n = 0; n < tileLightCountSphere; n++)
 		{
 			lightGrid.Store(storeOffset, tileLightIndicesSphere[n]);
 			storeOffset += 4;
 		}
-		for (uint n = 0; n < tileLightCountCone; n++)
+		for (n = 0; n < tileLightCountCone; n++)
 		{
 			lightGrid.Store(storeOffset, tileLightIndicesCone[n]);
 			storeOffset += 4;
 		}
-		for (uint n = 0; n < tileLightCountConeShadowed; n++)
+		for (n = 0; n < tileLightCountConeShadowed; n++)
 		{
 			lightGrid.Store(storeOffset, tileLightIndicesConeShadowed[n]);
 			storeOffset += 4;

--- a/MiniEngine/ModelViewer/Shaders/ModelViewerPS.hlsl
+++ b/MiniEngine/ModelViewer/Shaders/ModelViewerPS.hlsl
@@ -433,7 +433,8 @@ float3 main(VSOutput vsOutput) : SV_Target0
 		groupBitsMasks[i] = WaveActiveBitOr(GetGroupBits(i, tileIndex, lightBitMaskGroups));
     }
 
-	for (uint groupIndex = 0; groupIndex < pointLightGroupTail; groupIndex++)
+	uint groupIndex = 0;
+	for (groupIndex = 0; groupIndex < pointLightGroupTail; groupIndex++)
 	{
 		uint groupBits = groupBitsMasks[groupIndex];
 
@@ -448,7 +449,7 @@ float3 main(VSOutput vsOutput) : SV_Target0
 		}
 	}
 
-	for (uint groupIndex = pointLightGroupTail; groupIndex < spotLightGroupTail; groupIndex++)
+	for (groupIndex = pointLightGroupTail; groupIndex < spotLightGroupTail; groupIndex++)
 	{
 		uint groupBits = groupBitsMasks[groupIndex];
 
@@ -463,7 +464,7 @@ float3 main(VSOutput vsOutput) : SV_Target0
 		}
 	}
 
-	for (uint groupIndex = spotLightGroupTail; groupIndex < spotShadowLightGroupTail; groupIndex++)
+	for (groupIndex = spotLightGroupTail; groupIndex < spotShadowLightGroupTail; groupIndex++)
 	{
 		uint groupBits = groupBitsMasks[groupIndex];
 
@@ -499,7 +500,8 @@ float3 main(VSOutput vsOutput) : SV_Target0
 			uint tileLightLoadOffset = uniformTileOffset + 4;
 
 			// sphere
-			for (uint n = 0; n < tileLightCountSphere; n++, tileLightLoadOffset += 4)
+			uint n = 0;
+			for (n = 0; n < tileLightCountSphere; n++, tileLightLoadOffset += 4)
 			{
 				uint lightIndex = lightGrid.Load(tileLightLoadOffset);
 				LightData lightData = lightBuffer[lightIndex];
@@ -507,7 +509,7 @@ float3 main(VSOutput vsOutput) : SV_Target0
 			}
 
 			// cone
-			for (uint n = 0; n < tileLightCountCone; n++, tileLightLoadOffset += 4)
+			for (n = 0; n < tileLightCountCone; n++, tileLightLoadOffset += 4)
 			{
 				uint lightIndex = lightGrid.Load(tileLightLoadOffset);
 				LightData lightData = lightBuffer[lightIndex];
@@ -515,7 +517,7 @@ float3 main(VSOutput vsOutput) : SV_Target0
 			}
 
 			// cone w/ shadow map
-			for (uint n = 0; n < tileLightCountConeShadowed; n++, tileLightLoadOffset += 4)
+			for (n = 0; n < tileLightCountConeShadowed; n++, tileLightLoadOffset += 4)
 			{
 				uint lightIndex = lightGrid.Load(tileLightLoadOffset);
 				LightData lightData = lightBuffer[lightIndex];
@@ -542,7 +544,8 @@ float3 main(VSOutput vsOutput) : SV_Target0
 		uint tileLightLoadOffset = tileOffset + 4;
 
 		// sphere
-		for (uint n = 0; n < tileLightCountSphere; n++, tileLightLoadOffset += 4)
+		uint n = 0;
+		for (n = 0; n < tileLightCountSphere; n++, tileLightLoadOffset += 4)
 		{
 			uint lightIndex = lightGrid.Load(tileLightLoadOffset);
 			LightData lightData = lightBuffer[lightIndex];
@@ -550,7 +553,7 @@ float3 main(VSOutput vsOutput) : SV_Target0
 		}
 
 		// cone
-		for (uint n = 0; n < tileLightCountCone; n++, tileLightLoadOffset += 4)
+		for (n = 0; n < tileLightCountCone; n++, tileLightLoadOffset += 4)
 		{
 			uint lightIndex = lightGrid.Load(tileLightLoadOffset);
 			LightData lightData = lightBuffer[lightIndex];
@@ -558,7 +561,7 @@ float3 main(VSOutput vsOutput) : SV_Target0
 		}
 
 		// cone w/ shadow map
-		for (uint n = 0; n < tileLightCountConeShadowed; n++, tileLightLoadOffset += 4)
+		for (n = 0; n < tileLightCountConeShadowed; n++, tileLightLoadOffset += 4)
 		{
 			uint lightIndex = lightGrid.Load(tileLightLoadOffset);
 			LightData lightData = lightBuffer[lightIndex];
@@ -576,7 +579,8 @@ float3 main(VSOutput vsOutput) : SV_Target0
 		uint tileLightLoadOffset = tileOffset + 4;
 
 		// sphere
-		for (uint n = 0; n < tileLightCountSphere; n++, tileLightLoadOffset += 4)
+		uint n = 0;
+		for (n = 0; n < tileLightCountSphere; n++, tileLightLoadOffset += 4)
 		{
 			uint lightIndex = lightGrid.Load(tileLightLoadOffset);
 			LightData lightData = lightBuffer[lightIndex];
@@ -584,7 +588,7 @@ float3 main(VSOutput vsOutput) : SV_Target0
 		}
 
 		// cone
-		for (uint n = 0; n < tileLightCountCone; n++, tileLightLoadOffset += 4)
+		for (n = 0; n < tileLightCountCone; n++, tileLightLoadOffset += 4)
 		{
 			uint lightIndex = lightGrid.Load(tileLightLoadOffset);
 			LightData lightData = lightBuffer[lightIndex];
@@ -592,7 +596,7 @@ float3 main(VSOutput vsOutput) : SV_Target0
 		}
 
 		// cone w/ shadow map
-		for (uint n = 0; n < tileLightCountConeShadowed; n++, tileLightLoadOffset += 4)
+		for (n = 0; n < tileLightCountConeShadowed; n++, tileLightLoadOffset += 4)
 		{
 			uint lightIndex = lightGrid.Load(tileLightLoadOffset);
 			LightData lightData = lightBuffer[lightIndex];
@@ -610,7 +614,8 @@ float3 main(VSOutput vsOutput) : SV_Target0
 	uint tileLightLoadOffset = tileOffset + 4;
 
 	// sphere
-	for (uint n = 0; n < tileLightCountSphere; n++, tileLightLoadOffset += 4)
+	uint n = 0;
+	for (n = 0; n < tileLightCountSphere; n++, tileLightLoadOffset += 4)
 	{
 		uint lightIndex = lightGrid.Load(tileLightLoadOffset);
 		LightData lightData = lightBuffer[lightIndex];
@@ -618,7 +623,7 @@ float3 main(VSOutput vsOutput) : SV_Target0
 	}
 
 	// cone
-	for (uint n = 0; n < tileLightCountCone; n++, tileLightLoadOffset += 4)
+	for (n = 0; n < tileLightCountCone; n++, tileLightLoadOffset += 4)
 	{
 		uint lightIndex = lightGrid.Load(tileLightLoadOffset);
 		LightData lightData = lightBuffer[lightIndex];
@@ -626,7 +631,7 @@ float3 main(VSOutput vsOutput) : SV_Target0
 	}
 
 	// cone w/ shadow map
-	for (uint n = 0; n < tileLightCountConeShadowed; n++, tileLightLoadOffset += 4)
+	for (n = 0; n < tileLightCountConeShadowed; n++, tileLightLoadOffset += 4)
 	{
 		uint lightIndex = lightGrid.Load(tileLightLoadOffset);
 		LightData lightData = lightBuffer[lightIndex];


### PR DESCRIPTION
- Rename 'ConstantBuffer' to 'MainConstantBuffer'
- Fix variable-hiding warnings
- Fix bitwise operator precedence warnings
- Guard against negative operand to pow() with saturate()

The last point was committed separately by @stanard, but was in my change before rebasing, which is why it's still in the change description.