### PR TITLE
Update samples projects to Win10 SDK 16299 and latest d3dx12.h. Updat…

### DIFF
--- a/Samples/Desktop/D3D1211On12/src/D3D1211On12.vcxproj
+++ b/Samples/Desktop/D3D1211On12/src/D3D1211On12.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D1211On12</RootNamespace>
     <ProjectName>D3D1211On12</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12Bundles/src/D3D12Bundles.vcxproj
+++ b/Samples/Desktop/D3D12Bundles/src/D3D12Bundles.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12Bundles</RootNamespace>
     <ProjectName>D3D12Bundles</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12DepthBoundsTest/src/D3D12DepthBoundsTest.vcxproj
+++ b/Samples/Desktop/D3D12DepthBoundsTest/src/D3D12DepthBoundsTest.vcxproj
@@ -11,11 +11,11 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{A6DB1D1C-E2EE-462D-AC61-0E3100C010DF}</ProjectGuid>
+    <ProjectGuid>{EDC25A65-E2D7-427E-8FEA-DB448AFD71AD}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12DepthBoundsTest</RootNamespace>
     <ProjectName>D3D12DepthBoundsTest</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12DynamicIndexing/src/D3D12DynamicIndexing.vcxproj
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/D3D12DynamicIndexing.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12DynamicIndexing</RootNamespace>
     <ProjectName>D3D12DynamicIndexing</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.vcxproj
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12ExecuteIndirect</RootNamespace>
     <ProjectName>D3D12ExecuteIndirect</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12Fullscreen/src/D3D12Fullscreen.cpp
+++ b/Samples/Desktop/D3D12Fullscreen/src/D3D12Fullscreen.cpp
@@ -911,3 +911,7 @@ void D3D12Fullscreen::UpdateTitle()
 	swprintf_s(updatedTitle, L"( %u x %u ) scaled to ( %u x %u )", m_resolutionOptions[m_resolutionIndex].Width, m_resolutionOptions[m_resolutionIndex].Height, m_width, m_height);
 	SetCustomWindowText(updatedTitle);
 }
+
+void D3D12Fullscreen::OnWindowMoved(int, int)
+{
+}

--- a/Samples/Desktop/D3D12Fullscreen/src/D3D12Fullscreen.h
+++ b/Samples/Desktop/D3D12Fullscreen/src/D3D12Fullscreen.h
@@ -33,6 +33,7 @@ protected:
 	virtual void OnUpdate();
 	virtual void OnRender();
 	virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
+    virtual void OnWindowMoved(int, int);
 	virtual void OnDestroy();
 	virtual void OnKeyDown(UINT8 key);
 

--- a/Samples/Desktop/D3D12Fullscreen/src/D3D12Fullscreen.vcxproj
+++ b/Samples/Desktop/D3D12Fullscreen/src/D3D12Fullscreen.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12Fullscreen</RootNamespace>
     <ProjectName>D3D12Fullscreen</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12Fullscreen/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12Fullscreen/src/DXSample.cpp
@@ -17,6 +17,7 @@ using namespace Microsoft::WRL;
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_windowBounds{0,0,0,0},
 	m_title(name),
 	m_aspectRatio(0.0f),
 	m_useWarpDevice(false)
@@ -120,4 +121,12 @@ void DXSample::CheckTearingSupport()
 	}
 
 	m_tearingSupport = SUCCEEDED(hr) && allowTearing;
+}
+
+void DXSample::SetWindowBounds(int left, int top, int right, int bottom)
+{
+    m_windowBounds.left = static_cast<LONG>(left);
+    m_windowBounds.top = static_cast<LONG>(top);
+    m_windowBounds.right = static_cast<LONG>(right);
+    m_windowBounds.bottom = static_cast<LONG>(bottom);
 }

--- a/Samples/Desktop/D3D12Fullscreen/src/DXSample.h
+++ b/Samples/Desktop/D3D12Fullscreen/src/DXSample.h
@@ -27,17 +27,24 @@ public:
 	virtual void OnDestroy() = 0;
 
 	// Samples override the event handlers to handle specific messages.
-	virtual void OnKeyDown(UINT8 /*key*/)   {}
-	virtual void OnKeyUp(UINT8 /*key*/)     {}
-
+	virtual void OnKeyDown(UINT8 /*key*/) {}
+	virtual void OnKeyUp(UINT8 /*key*/) {}
+	virtual void OnWindowMoved(int /*x*/, int /*y*/) {}
+	virtual void OnMouseMove(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnLeftButtonDown(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnLeftButtonUp(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnDisplayChanged() {}
+	
 	// Accessors.
 	UINT GetWidth() const           { return m_width; }
 	UINT GetHeight() const          { return m_height; }
 	const WCHAR* GetTitle() const   { return m_title.c_str(); }
-	bool GetTearingSupport()        { return m_tearingSupport; }
+	bool GetTearingSupport() const  { return m_tearingSupport; }
+	RECT GetWindowsBounds() const   { return m_windowBounds; }
 
 	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 	void UpdateForSizeChange(UINT clientWidth, UINT clientHeight);
+	void SetWindowBounds(int left, int top, int right, int bottom);
 
 protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
@@ -50,6 +57,9 @@ protected:
 	UINT m_height;
 	float m_aspectRatio;
 
+	// Window Bounds
+	RECT m_windowBounds;
+	
 	// Whether or not tearing is available for fullscreen borderless windowed mode.
 	bool m_tearingSupport;
 

--- a/Samples/Desktop/D3D12Fullscreen/src/Win32Application.cpp
+++ b/Samples/Desktop/D3D12Fullscreen/src/Win32Application.cpp
@@ -175,12 +175,61 @@ LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wP
 	case WM_SIZE:
 		if (pSample)
 		{
+			RECT windowRect = {};
+			GetWindowRect(hWnd, &windowRect);
+			pSample->SetWindowBounds(windowRect.left, windowRect.top, windowRect.right, windowRect.bottom);			
+			
 			RECT clientRect = {};
 			GetClientRect(hWnd, &clientRect);
 			pSample->OnSizeChanged(clientRect.right - clientRect.left, clientRect.bottom - clientRect.top, wParam == SIZE_MINIMIZED);
 		}
 		return 0;
 
+	case WM_MOVE:
+		if (pSample)
+		{
+			RECT windowRect = {};
+			GetWindowRect(hWnd, &windowRect);
+			pSample->SetWindowBounds(windowRect.left, windowRect.top, windowRect.right, windowRect.bottom);
+			
+			int xPos = (int)(short) LOWORD(lParam);
+			int yPos = (int)(short) HIWORD(lParam);
+			pSample->OnWindowMoved(xPos, yPos);
+		}
+		return 0;
+		
+    case WM_DISPLAYCHANGE:
+        if (pSample)
+        {
+            pSample->OnDisplayChanged();
+        }
+        return 0;		
+		
+    case WM_MOUSEMOVE:
+        if (pSample && static_cast<UINT8>(wParam)== MK_LBUTTON)
+        {
+            UINT x = LOWORD(lParam);
+            UINT y = HIWORD(lParam);
+            pSample->OnMouseMove(x, y);
+        }
+		return 0;
+		
+	case WM_LBUTTONDOWN:
+		{
+			UINT x = LOWORD(lParam);
+			UINT y = HIWORD(lParam);
+			pSample->OnLeftButtonDown(x, y);
+		}
+		return 0;
+	
+	case WM_LBUTTONUP:
+		{
+			UINT x = LOWORD(lParam);
+			UINT y = HIWORD(lParam);
+			pSample->OnLeftButtonUp(x, y);
+		}
+		return 0;
+		
 	case WM_DESTROY:
 		PostQuitMessage(0);
 		return 0;

--- a/Samples/Desktop/D3D12HDR/src/D3D12HDR.sln
+++ b/Samples/Desktop/D3D12HDR/src/D3D12HDR.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "D3D12HDR", "D3D12HDR.vcxproj", "{010274FF-11D2-4FBC-88E4-0B6DC174507F}"
 EndProject

--- a/Samples/Desktop/D3D12HDR/src/D3D12HDR.vcxproj
+++ b/Samples/Desktop/D3D12HDR/src/D3D12HDR.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12HDR</RootNamespace>
     <ProjectName>D3D12HDR</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12HDR/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12HDR/src/DXSample.cpp
@@ -17,6 +17,7 @@ using namespace Microsoft::WRL;
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_windowBounds{0,0,0,0},
 	m_title(name),
 	m_aspectRatio(0.0f),
 	m_useWarpDevice(false)
@@ -120,4 +121,12 @@ void DXSample::CheckTearingSupport()
 	}
 
 	m_tearingSupport = SUCCEEDED(hr) && allowTearing;
+}
+
+void DXSample::SetWindowBounds(int left, int top, int right, int bottom)
+{
+    m_windowBounds.left = static_cast<LONG>(left);
+    m_windowBounds.top = static_cast<LONG>(top);
+    m_windowBounds.right = static_cast<LONG>(right);
+    m_windowBounds.bottom = static_cast<LONG>(bottom);
 }

--- a/Samples/Desktop/D3D12HDR/src/DXSample.h
+++ b/Samples/Desktop/D3D12HDR/src/DXSample.h
@@ -27,17 +27,24 @@ public:
 	virtual void OnDestroy() = 0;
 
 	// Samples override the event handlers to handle specific messages.
-	virtual void OnKeyDown(UINT8 /*key*/)   {}
-	virtual void OnKeyUp(UINT8 /*key*/)     {}
-
+	virtual void OnKeyDown(UINT8 /*key*/) {}
+	virtual void OnKeyUp(UINT8 /*key*/) {}
+	virtual void OnWindowMoved(int /*x*/, int /*y*/) {}
+	virtual void OnMouseMove(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnLeftButtonDown(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnLeftButtonUp(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnDisplayChanged() {}
+	
 	// Accessors.
 	UINT GetWidth() const           { return m_width; }
 	UINT GetHeight() const          { return m_height; }
 	const WCHAR* GetTitle() const   { return m_title.c_str(); }
-	bool GetTearingSupport()        { return m_tearingSupport; }
+	bool GetTearingSupport() const  { return m_tearingSupport; }
+	RECT GetWindowsBounds() const   { return m_windowBounds; }
 
 	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 	void UpdateForSizeChange(UINT clientWidth, UINT clientHeight);
+	void SetWindowBounds(int left, int top, int right, int bottom);
 
 protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
@@ -50,6 +57,9 @@ protected:
 	UINT m_height;
 	float m_aspectRatio;
 
+	// Window Bounds
+	RECT m_windowBounds;
+	
 	// Whether or not tearing is available for fullscreen borderless windowed mode.
 	bool m_tearingSupport;
 

--- a/Samples/Desktop/D3D12HDR/src/UILayer.cpp
+++ b/Samples/Desktop/D3D12HDR/src/UILayer.cpp
@@ -20,7 +20,7 @@ UILayer::UILayer(D3D12HDR* pSample) :
 
 	m_labels[Format] = L"Back Buffer Format";
 	m_labels[Signal] = L"Output Signal";
-	m_labels[HDRSupport] = L"HDR Support";
+	m_labels[HDRSupport] = L"Current Output HDR Support";
 	m_labels[StandardGradient] = L"SDR Gradient [0,1]";
 	m_labels[BrightGradient] = L"HDR Gradient [0,9]";
 	m_labels[Rec709] = L"Rec 709";
@@ -28,6 +28,7 @@ UILayer::UILayer(D3D12HDR* pSample) :
 	m_labels[ChangeFormat] = L"PgUp/PgDn\tChange back buffer format";
 	m_labels[ChangeCurve] = L"H\tToggle between sRGB and ST.2084 (10-bit swap chain only)";
 	m_labels[HideUI] = L"U\tToggle UI Visibility";
+    m_labels[MetaData] = L"M\tToggle HDR Meta Data";
 
 	Initialize();
 }
@@ -135,12 +136,22 @@ void UILayer::UpdateLabels()
 	}
 
 	m_labels[Signal] = L"Output Signal = " + m_pSample->GetDisplayCurve();
-	m_labels[HDRSupport] = L"HDR Support = ";
+	m_labels[HDRSupport] = L"Current Output HDR Support = ";
 	m_labels[HDRSupport] += m_pSample->GetHDRSupport() ? L"true" : L"false";
 
 	m_ui[Format].text = m_labels[Format];
 	m_ui[Signal].text = m_labels[Signal];
 	m_ui[HDRSupport].text = m_labels[HDRSupport];
+
+    float MaxOutputNits = D3D12HDR::HDRMetaDataPool[m_pSample->GetHDRMetaDataPoolIndex()][0];
+    float MinOutputNits = D3D12HDR::HDRMetaDataPool[m_pSample->GetHDRMetaDataPoolIndex()][1];
+    float MaxCLL = D3D12HDR::HDRMetaDataPool[m_pSample->GetHDRMetaDataPoolIndex()][2];
+    float MaxFALL = D3D12HDR::HDRMetaDataPool[m_pSample->GetHDRMetaDataPoolIndex()][3];
+
+    wchar_t buffer[256];
+    swprintf_s(buffer, 256, L"M\tToggle HDR Meta Data\t MaxOutputNits:%3.3f\t MinOutputNits:%3.3f\t MaxCLL:%3.3f\t MaxFALL:%3.3f", MaxOutputNits, MinOutputNits, MaxCLL, MaxFALL);
+
+    m_ui[MetaData].text = buffer;
 }
 
 // Render the UI.
@@ -252,4 +263,5 @@ void UILayer::Resize()
 	m_ui[ChangeFormat] = { m_labels[ChangeFormat], D2D1::RectF(smallFontSize, height - fontSize * 5.0f, width, height), m_smallTextFormat.Get() };
 	m_ui[ChangeCurve] = { m_labels[ChangeCurve], D2D1::RectF(smallFontSize, height - fontSize * 3.0f, width, height), m_smallTextFormat.Get() };
 	m_ui[HideUI] = { m_labels[HideUI], D2D1::RectF(smallFontSize, height - fontSize * 2.0f, width, height), m_smallTextFormat.Get() };
+    m_ui[MetaData] = { m_labels[MetaData], D2D1::RectF(smallFontSize, height - fontSize * 1.0f, width, height), m_smallTextFormat.Get() };
 }

--- a/Samples/Desktop/D3D12HDR/src/UILayer.h
+++ b/Samples/Desktop/D3D12HDR/src/UILayer.h
@@ -43,6 +43,7 @@ private:
 		ChangeFormat,
 		ChangeCurve,
 		HideUI,
+        MetaData,
 		StringsCount
 	};
 

--- a/Samples/Desktop/D3D12HDR/src/Win32Application.cpp
+++ b/Samples/Desktop/D3D12HDR/src/Win32Application.cpp
@@ -175,12 +175,61 @@ LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wP
 	case WM_SIZE:
 		if (pSample)
 		{
+			RECT windowRect = {};
+			GetWindowRect(hWnd, &windowRect);
+			pSample->SetWindowBounds(windowRect.left, windowRect.top, windowRect.right, windowRect.bottom);			
+			
 			RECT clientRect = {};
 			GetClientRect(hWnd, &clientRect);
 			pSample->OnSizeChanged(clientRect.right - clientRect.left, clientRect.bottom - clientRect.top, wParam == SIZE_MINIMIZED);
 		}
 		return 0;
 
+	case WM_MOVE:
+		if (pSample)
+		{
+			RECT windowRect = {};
+			GetWindowRect(hWnd, &windowRect);
+			pSample->SetWindowBounds(windowRect.left, windowRect.top, windowRect.right, windowRect.bottom);
+			
+			int xPos = (int)(short) LOWORD(lParam);
+			int yPos = (int)(short) HIWORD(lParam);
+			pSample->OnWindowMoved(xPos, yPos);
+		}
+		return 0;
+		
+    case WM_DISPLAYCHANGE:
+        if (pSample)
+        {
+            pSample->OnDisplayChanged();
+        }
+        return 0;		
+		
+    case WM_MOUSEMOVE:
+        if (pSample && static_cast<UINT8>(wParam)== MK_LBUTTON)
+        {
+            UINT x = LOWORD(lParam);
+            UINT y = HIWORD(lParam);
+            pSample->OnMouseMove(x, y);
+        }
+		return 0;
+		
+	case WM_LBUTTONDOWN:
+		{
+			UINT x = LOWORD(lParam);
+			UINT y = HIWORD(lParam);
+			pSample->OnLeftButtonDown(x, y);
+		}
+		return 0;
+	
+	case WM_LBUTTONUP:
+		{
+			UINT x = LOWORD(lParam);
+			UINT y = HIWORD(lParam);
+			pSample->OnLeftButtonUp(x, y);
+		}
+		return 0;
+		
 	case WM_DESTROY:
 		PostQuitMessage(0);
 		return 0;

--- a/Samples/Desktop/D3D12HDR/src/color.hlsli
+++ b/Samples/Desktop/D3D12HDR/src/color.hlsli
@@ -12,7 +12,7 @@
 // These values must match the DisplayCurve enum in D3D12HDR.h.
 #define DISPLAY_CURVE_SRGB      0
 #define DISPLAY_CURVE_ST2084    1
-#define DISPLAY_CURVE_LINEAR      2
+#define DISPLAY_CURVE_LINEAR    2
 
 float3 xyYToRec709(float2 xy, float Y = 1.0)
 {
@@ -78,8 +78,7 @@ float3 Rec2020ToRec709(float3 color)
 	return mul(conversion, color);
 }
 
-
-float3 ApplyST2084(float3 color)
+float3 LinearToST2084(float3 color)
 {
 	float m1 = 2610.0 / 4096.0 / 4;
 	float m2 = 2523.0 / 4096.0 * 128;

--- a/Samples/Desktop/D3D12HDR/src/gradientPS.hlsl
+++ b/Samples/Desktop/D3D12HDR/src/gradientPS.hlsl
@@ -15,5 +15,5 @@
 float4 PSMain(PSInput input) : SV_TARGET
 {
 	// This draws a perceptual gradient rather than a linear gradient.
-	return float4(pow(abs(input.color.rgb), 2.0), input.color.a);
+	return float4(pow(abs(input.color.rgb), 2.2), input.color.a);
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.vcxproj
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12HelloBundles</RootNamespace>
     <ProjectName>D3D12HelloBundles</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.vcxproj
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12HelloConstBuffers</RootNamespace>
     <ProjectName>D3D12HelloConstBuffers</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/D3D12HelloFrameBuffering.vcxproj
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/D3D12HelloFrameBuffering.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12HelloFrameBuffering</RootNamespace>
     <ProjectName>D3D12HelloFrameBuffering</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.vcxproj
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12HelloTexture</RootNamespace>
     <ProjectName>D3D12HelloTexture</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.vcxproj
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12HelloTriangle</RootNamespace>
     <ProjectName>D3D12HelloTriangle</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.vcxproj
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12HelloWindow</RootNamespace>
     <ProjectName>D3D12HelloWindow</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/D3D12HeterogeneousMultiadapter.vcxproj
+++ b/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/D3D12HeterogeneousMultiadapter.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12HeterogeneousMultiadapter</RootNamespace>
     <ProjectName>D3D12HeterogeneousMultiadapter</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12LinkedGpus/src/D3DX12AffinityLayer/D3DX12AffinityLayer.vcxproj
+++ b/Samples/Desktop/D3D12LinkedGpus/src/D3DX12AffinityLayer/D3DX12AffinityLayer.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{B2283BA1-603B-4360-AE99-7A3F5912BC42}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3DX12AffinityLayer</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/D3D12LinkedGpus.vcxproj
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/D3D12LinkedGpus.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12LinkedGpus</RootNamespace>
     <ProjectName>D3D12LinkedGpus</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/DXSample.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/DXSample.cpp
@@ -17,6 +17,7 @@ using namespace Microsoft::WRL;
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_windowBounds{0,0,0,0},
 	m_title(name),
 	m_aspectRatio(0.0f),
 	m_useWarpDevice(false)
@@ -120,4 +121,12 @@ void DXSample::CheckTearingSupport()
 	}
 
 	m_tearingSupport = SUCCEEDED(hr) && allowTearing;
+}
+
+void DXSample::SetWindowBounds(int left, int top, int right, int bottom)
+{
+    m_windowBounds.left = static_cast<LONG>(left);
+    m_windowBounds.top = static_cast<LONG>(top);
+    m_windowBounds.right = static_cast<LONG>(right);
+    m_windowBounds.bottom = static_cast<LONG>(bottom);
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/DXSample.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/DXSample.h
@@ -27,17 +27,24 @@ public:
 	virtual void OnDestroy() = 0;
 
 	// Samples override the event handlers to handle specific messages.
-	virtual void OnKeyDown(UINT8 /*key*/)   {}
-	virtual void OnKeyUp(UINT8 /*key*/)     {}
-
+	virtual void OnKeyDown(UINT8 /*key*/) {}
+	virtual void OnKeyUp(UINT8 /*key*/) {}
+	virtual void OnWindowMoved(int /*x*/, int /*y*/) {}
+	virtual void OnMouseMove(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnLeftButtonDown(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnLeftButtonUp(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnDisplayChanged() {}
+	
 	// Accessors.
 	UINT GetWidth() const           { return m_width; }
 	UINT GetHeight() const          { return m_height; }
 	const WCHAR* GetTitle() const   { return m_title.c_str(); }
-	bool GetTearingSupport()        { return m_tearingSupport; }
+	bool GetTearingSupport() const  { return m_tearingSupport; }
+	RECT GetWindowsBounds() const   { return m_windowBounds; }
 
 	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 	void UpdateForSizeChange(UINT clientWidth, UINT clientHeight);
+	void SetWindowBounds(int left, int top, int right, int bottom);
 
 protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
@@ -50,6 +57,9 @@ protected:
 	UINT m_height;
 	float m_aspectRatio;
 
+	// Window Bounds
+	RECT m_windowBounds;
+	
 	// Whether or not tearing is available for fullscreen borderless windowed mode.
 	bool m_tearingSupport;
 

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/Win32Application.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/Win32Application.cpp
@@ -175,12 +175,61 @@ LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wP
 	case WM_SIZE:
 		if (pSample)
 		{
+			RECT windowRect = {};
+			GetWindowRect(hWnd, &windowRect);
+			pSample->SetWindowBounds(windowRect.left, windowRect.top, windowRect.right, windowRect.bottom);			
+			
 			RECT clientRect = {};
 			GetClientRect(hWnd, &clientRect);
 			pSample->OnSizeChanged(clientRect.right - clientRect.left, clientRect.bottom - clientRect.top, wParam == SIZE_MINIMIZED);
 		}
 		return 0;
 
+	case WM_MOVE:
+		if (pSample)
+		{
+			RECT windowRect = {};
+			GetWindowRect(hWnd, &windowRect);
+			pSample->SetWindowBounds(windowRect.left, windowRect.top, windowRect.right, windowRect.bottom);
+			
+			int xPos = (int)(short) LOWORD(lParam);
+			int yPos = (int)(short) HIWORD(lParam);
+			pSample->OnWindowMoved(xPos, yPos);
+		}
+		return 0;
+		
+    case WM_DISPLAYCHANGE:
+        if (pSample)
+        {
+            pSample->OnDisplayChanged();
+        }
+        return 0;		
+		
+    case WM_MOUSEMOVE:
+        if (pSample && static_cast<UINT8>(wParam)== MK_LBUTTON)
+        {
+            UINT x = LOWORD(lParam);
+            UINT y = HIWORD(lParam);
+            pSample->OnMouseMove(x, y);
+        }
+		return 0;
+		
+	case WM_LBUTTONDOWN:
+		{
+			UINT x = LOWORD(lParam);
+			UINT y = HIWORD(lParam);
+			pSample->OnLeftButtonDown(x, y);
+		}
+		return 0;
+	
+	case WM_LBUTTONUP:
+		{
+			UINT x = LOWORD(lParam);
+			UINT y = HIWORD(lParam);
+			pSample->OnLeftButtonUp(x, y);
+		}
+		return 0;
+		
 	case WM_DESTROY:
 		PostQuitMessage(0);
 		return 0;

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/D3D12LinkedGpusAffinity.vcxproj
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/D3D12LinkedGpusAffinity.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12LinkedGpusAffinity</RootNamespace>
     <ProjectName>D3D12LinkedGpusAffinity</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.cpp
@@ -17,6 +17,7 @@ using namespace Microsoft::WRL;
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_windowBounds{0,0,0,0},
 	m_title(name),
 	m_aspectRatio(0.0f),
 	m_useWarpDevice(false)
@@ -120,4 +121,12 @@ void DXSample::CheckTearingSupport()
 	}
 
 	m_tearingSupport = SUCCEEDED(hr) && allowTearing;
+}
+
+void DXSample::SetWindowBounds(int left, int top, int right, int bottom)
+{
+    m_windowBounds.left = static_cast<LONG>(left);
+    m_windowBounds.top = static_cast<LONG>(top);
+    m_windowBounds.right = static_cast<LONG>(right);
+    m_windowBounds.bottom = static_cast<LONG>(bottom);
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.h
@@ -27,17 +27,24 @@ public:
 	virtual void OnDestroy() = 0;
 
 	// Samples override the event handlers to handle specific messages.
-	virtual void OnKeyDown(UINT8 /*key*/)   {}
-	virtual void OnKeyUp(UINT8 /*key*/)     {}
-
+	virtual void OnKeyDown(UINT8 /*key*/) {}
+	virtual void OnKeyUp(UINT8 /*key*/) {}
+	virtual void OnWindowMoved(int /*x*/, int /*y*/) {}
+	virtual void OnMouseMove(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnLeftButtonDown(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnLeftButtonUp(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnDisplayChanged() {}
+	
 	// Accessors.
 	UINT GetWidth() const           { return m_width; }
 	UINT GetHeight() const          { return m_height; }
 	const WCHAR* GetTitle() const   { return m_title.c_str(); }
-	bool GetTearingSupport()        { return m_tearingSupport; }
+	bool GetTearingSupport() const  { return m_tearingSupport; }
+	RECT GetWindowsBounds() const   { return m_windowBounds; }
 
 	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 	void UpdateForSizeChange(UINT clientWidth, UINT clientHeight);
+	void SetWindowBounds(int left, int top, int right, int bottom);
 
 protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
@@ -50,6 +57,9 @@ protected:
 	UINT m_height;
 	float m_aspectRatio;
 
+	// Window Bounds
+	RECT m_windowBounds;
+	
 	// Whether or not tearing is available for fullscreen borderless windowed mode.
 	bool m_tearingSupport;
 

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/Win32Application.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/Win32Application.cpp
@@ -175,12 +175,61 @@ LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wP
 	case WM_SIZE:
 		if (pSample)
 		{
+			RECT windowRect = {};
+			GetWindowRect(hWnd, &windowRect);
+			pSample->SetWindowBounds(windowRect.left, windowRect.top, windowRect.right, windowRect.bottom);			
+			
 			RECT clientRect = {};
 			GetClientRect(hWnd, &clientRect);
 			pSample->OnSizeChanged(clientRect.right - clientRect.left, clientRect.bottom - clientRect.top, wParam == SIZE_MINIMIZED);
 		}
 		return 0;
 
+	case WM_MOVE:
+		if (pSample)
+		{
+			RECT windowRect = {};
+			GetWindowRect(hWnd, &windowRect);
+			pSample->SetWindowBounds(windowRect.left, windowRect.top, windowRect.right, windowRect.bottom);
+			
+			int xPos = (int)(short) LOWORD(lParam);
+			int yPos = (int)(short) HIWORD(lParam);
+			pSample->OnWindowMoved(xPos, yPos);
+		}
+		return 0;
+		
+    case WM_DISPLAYCHANGE:
+        if (pSample)
+        {
+            pSample->OnDisplayChanged();
+        }
+        return 0;		
+		
+    case WM_MOUSEMOVE:
+        if (pSample && static_cast<UINT8>(wParam)== MK_LBUTTON)
+        {
+            UINT x = LOWORD(lParam);
+            UINT y = HIWORD(lParam);
+            pSample->OnMouseMove(x, y);
+        }
+		return 0;
+		
+	case WM_LBUTTONDOWN:
+		{
+			UINT x = LOWORD(lParam);
+			UINT y = HIWORD(lParam);
+			pSample->OnLeftButtonDown(x, y);
+		}
+		return 0;
+	
+	case WM_LBUTTONUP:
+		{
+			UINT x = LOWORD(lParam);
+			UINT y = HIWORD(lParam);
+			pSample->OnLeftButtonUp(x, y);
+		}
+		return 0;
+		
 	case WM_DESTROY:
 		PostQuitMessage(0);
 		return 0;

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/D3D12SingleGpu.vcxproj
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/D3D12SingleGpu.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12SingleGpu</RootNamespace>
     <ProjectName>D3D12SingleGpu</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/DXSample.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/DXSample.cpp
@@ -17,6 +17,7 @@ using namespace Microsoft::WRL;
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_windowBounds{0,0,0,0},
 	m_title(name),
 	m_aspectRatio(0.0f),
 	m_useWarpDevice(false)
@@ -120,4 +121,12 @@ void DXSample::CheckTearingSupport()
 	}
 
 	m_tearingSupport = SUCCEEDED(hr) && allowTearing;
+}
+
+void DXSample::SetWindowBounds(int left, int top, int right, int bottom)
+{
+    m_windowBounds.left = static_cast<LONG>(left);
+    m_windowBounds.top = static_cast<LONG>(top);
+    m_windowBounds.right = static_cast<LONG>(right);
+    m_windowBounds.bottom = static_cast<LONG>(bottom);
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/DXSample.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/DXSample.h
@@ -27,17 +27,24 @@ public:
 	virtual void OnDestroy() = 0;
 
 	// Samples override the event handlers to handle specific messages.
-	virtual void OnKeyDown(UINT8 /*key*/)   {}
-	virtual void OnKeyUp(UINT8 /*key*/)     {}
-
+	virtual void OnKeyDown(UINT8 /*key*/) {}
+	virtual void OnKeyUp(UINT8 /*key*/) {}
+	virtual void OnWindowMoved(int /*x*/, int /*y*/) {}
+	virtual void OnMouseMove(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnLeftButtonDown(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnLeftButtonUp(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnDisplayChanged() {}
+	
 	// Accessors.
 	UINT GetWidth() const           { return m_width; }
 	UINT GetHeight() const          { return m_height; }
 	const WCHAR* GetTitle() const   { return m_title.c_str(); }
-	bool GetTearingSupport()        { return m_tearingSupport; }
+	bool GetTearingSupport() const  { return m_tearingSupport; }
+	RECT GetWindowsBounds() const   { return m_windowBounds; }
 
 	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 	void UpdateForSizeChange(UINT clientWidth, UINT clientHeight);
+	void SetWindowBounds(int left, int top, int right, int bottom);
 
 protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
@@ -50,6 +57,9 @@ protected:
 	UINT m_height;
 	float m_aspectRatio;
 
+	// Window Bounds
+	RECT m_windowBounds;
+	
 	// Whether or not tearing is available for fullscreen borderless windowed mode.
 	bool m_tearingSupport;
 

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/Win32Application.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/Win32Application.cpp
@@ -175,12 +175,61 @@ LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wP
 	case WM_SIZE:
 		if (pSample)
 		{
+			RECT windowRect = {};
+			GetWindowRect(hWnd, &windowRect);
+			pSample->SetWindowBounds(windowRect.left, windowRect.top, windowRect.right, windowRect.bottom);			
+			
 			RECT clientRect = {};
 			GetClientRect(hWnd, &clientRect);
 			pSample->OnSizeChanged(clientRect.right - clientRect.left, clientRect.bottom - clientRect.top, wParam == SIZE_MINIMIZED);
 		}
 		return 0;
 
+	case WM_MOVE:
+		if (pSample)
+		{
+			RECT windowRect = {};
+			GetWindowRect(hWnd, &windowRect);
+			pSample->SetWindowBounds(windowRect.left, windowRect.top, windowRect.right, windowRect.bottom);
+			
+			int xPos = (int)(short) LOWORD(lParam);
+			int yPos = (int)(short) HIWORD(lParam);
+			pSample->OnWindowMoved(xPos, yPos);
+		}
+		return 0;
+		
+    case WM_DISPLAYCHANGE:
+        if (pSample)
+        {
+            pSample->OnDisplayChanged();
+        }
+        return 0;		
+		
+    case WM_MOUSEMOVE:
+        if (pSample && static_cast<UINT8>(wParam)== MK_LBUTTON)
+        {
+            UINT x = LOWORD(lParam);
+            UINT y = HIWORD(lParam);
+            pSample->OnMouseMove(x, y);
+        }
+		return 0;
+		
+	case WM_LBUTTONDOWN:
+		{
+			UINT x = LOWORD(lParam);
+			UINT y = HIWORD(lParam);
+			pSample->OnLeftButtonDown(x, y);
+		}
+		return 0;
+	
+	case WM_LBUTTONUP:
+		{
+			UINT x = LOWORD(lParam);
+			UINT y = HIWORD(lParam);
+			pSample->OnLeftButtonUp(x, y);
+		}
+		return 0;
+		
 	case WM_DESTROY:
 		PostQuitMessage(0);
 		return 0;

--- a/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.vcxproj
+++ b/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12Multithreading</RootNamespace>
     <ProjectName>D3D12Multithreading</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12PipelineStateCache/src/D3D12PipelineStateCache.vcxproj
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/D3D12PipelineStateCache.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12nBodyGravity</RootNamespace>
     <ProjectName>D3D12PipelineStateCache</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12PredicationQueries/src/D3D12PredicationQueries.vcxproj
+++ b/Samples/Desktop/D3D12PredicationQueries/src/D3D12PredicationQueries.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12PredicationQueries</RootNamespace>
     <ProjectName>D3D12PredicationQueries</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12ReservedResources/src/D3D12ReservedResources.vcxproj
+++ b/Samples/Desktop/D3D12ReservedResources/src/D3D12ReservedResources.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12ReservedResources</RootNamespace>
     <ProjectName>D3D12ReservedResources</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12Residency/src/D3D12Residency.vcxproj
+++ b/Samples/Desktop/D3D12Residency/src/D3D12Residency.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12Residency</RootNamespace>
     <ProjectName>D3D12Residency</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.vcxproj
+++ b/Samples/Desktop/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12SM6WaveIntrinsics</RootNamespace>
     <ProjectName>D3D12SM6WaveIntrinsics</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12SM6WaveIntrinsics/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12SM6WaveIntrinsics/src/DXSample.cpp
@@ -17,6 +17,7 @@ using namespace Microsoft::WRL;
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_windowBounds{0,0,0,0},
 	m_title(name),
 	m_aspectRatio(0.0f),
 	m_useWarpDevice(false)
@@ -120,4 +121,12 @@ void DXSample::CheckTearingSupport()
 	}
 
 	m_tearingSupport = SUCCEEDED(hr) && allowTearing;
+}
+
+void DXSample::SetWindowBounds(int left, int top, int right, int bottom)
+{
+    m_windowBounds.left = static_cast<LONG>(left);
+    m_windowBounds.top = static_cast<LONG>(top);
+    m_windowBounds.right = static_cast<LONG>(right);
+    m_windowBounds.bottom = static_cast<LONG>(bottom);
 }

--- a/Samples/Desktop/D3D12SM6WaveIntrinsics/src/DXSample.h
+++ b/Samples/Desktop/D3D12SM6WaveIntrinsics/src/DXSample.h
@@ -33,15 +33,18 @@ public:
 	virtual void OnMouseMove(UINT /*x*/, UINT /*y*/) {}
 	virtual void OnLeftButtonDown(UINT /*x*/, UINT /*y*/) {}
 	virtual void OnLeftButtonUp(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnDisplayChanged() {}
 	
 	// Accessors.
 	UINT GetWidth() const           { return m_width; }
 	UINT GetHeight() const          { return m_height; }
 	const WCHAR* GetTitle() const   { return m_title.c_str(); }
-	bool GetTearingSupport()        { return m_tearingSupport; }
+	bool GetTearingSupport() const  { return m_tearingSupport; }
+	RECT GetWindowsBounds() const   { return m_windowBounds; }
 
 	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 	void UpdateForSizeChange(UINT clientWidth, UINT clientHeight);
+	void SetWindowBounds(int left, int top, int right, int bottom);
 
 protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
@@ -54,6 +57,9 @@ protected:
 	UINT m_height;
 	float m_aspectRatio;
 
+	// Window Bounds
+	RECT m_windowBounds;
+	
 	// Whether or not tearing is available for fullscreen borderless windowed mode.
 	bool m_tearingSupport;
 

--- a/Samples/Desktop/D3D12SM6WaveIntrinsics/src/Win32Application.cpp
+++ b/Samples/Desktop/D3D12SM6WaveIntrinsics/src/Win32Application.cpp
@@ -175,6 +175,10 @@ LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wP
 	case WM_SIZE:
 		if (pSample)
 		{
+			RECT windowRect = {};
+			GetWindowRect(hWnd, &windowRect);
+			pSample->SetWindowBounds(windowRect.left, windowRect.top, windowRect.right, windowRect.bottom);			
+			
 			RECT clientRect = {};
 			GetClientRect(hWnd, &clientRect);
 			pSample->OnSizeChanged(clientRect.right - clientRect.left, clientRect.bottom - clientRect.top, wParam == SIZE_MINIMIZED);
@@ -184,11 +188,22 @@ LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wP
 	case WM_MOVE:
 		if (pSample)
 		{
+			RECT windowRect = {};
+			GetWindowRect(hWnd, &windowRect);
+			pSample->SetWindowBounds(windowRect.left, windowRect.top, windowRect.right, windowRect.bottom);
+			
 			int xPos = (int)(short) LOWORD(lParam);
 			int yPos = (int)(short) HIWORD(lParam);
 			pSample->OnWindowMoved(xPos, yPos);
 		}
 		return 0;
+		
+    case WM_DISPLAYCHANGE:
+        if (pSample)
+        {
+            pSample->OnDisplayChanged();
+        }
+        return 0;		
 		
     case WM_MOUSEMOVE:
         if (pSample && static_cast<UINT8>(wParam)== MK_LBUTTON)

--- a/Samples/Desktop/D3D12SmallResources/src/D3D12SmallResources.vcxproj
+++ b/Samples/Desktop/D3D12SmallResources/src/D3D12SmallResources.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12SmallResources</RootNamespace>
     <ProjectName>D3D12SmallResources</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12nBodyGravity/src/D3D12nBodyGravity.vcxproj
+++ b/Samples/Desktop/D3D12nBodyGravity/src/D3D12nBodyGravity.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12nBodyGravity</RootNamespace>
     <ProjectName>D3D12nBodyGravity</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/UWP/D3D1211On12/src/D3D1211On12.vcxproj
+++ b/Samples/UWP/D3D1211On12/src/D3D1211On12.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12Bundles/src/D3D12Bundles.vcxproj
+++ b/Samples/UWP/D3D12Bundles/src/D3D12Bundles.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12DepthBoundsTest/src/D3D12DepthBoundsTest.vcxproj
+++ b/Samples/UWP/D3D12DepthBoundsTest/src/D3D12DepthBoundsTest.vcxproj
@@ -27,14 +27,14 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{2869AA54-4B40-44B1-99E6-8D9F41C46C4B}</ProjectGuid>
+    <ProjectGuid>{2928DC97-642B-40EF-B963-04AF0B74CCE9}</ProjectGuid>
     <Keyword>DirectXApp</Keyword>
     <RootNamespace>D3D12DepthBoundsTest</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12DynamicIndexing/src/D3D12DynamicIndexing.vcxproj
+++ b/Samples/UWP/D3D12DynamicIndexing/src/D3D12DynamicIndexing.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.vcxproj
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12Fullscreen/src/D3D12Fullscreen.cpp
+++ b/Samples/UWP/D3D12Fullscreen/src/D3D12Fullscreen.cpp
@@ -882,3 +882,7 @@ void D3D12Fullscreen::UpdateTitle()
 	swprintf_s(updatedTitle, L"( %u x %u ) scaled to ( %u x %u )", m_resolutionOptions[m_resolutionIndex].Width, m_resolutionOptions[m_resolutionIndex].Height, m_width, m_height);
 	SetCustomWindowText(updatedTitle);
 }
+
+void D3D12Fullscreen::OnWindowMoved(int, int)
+{
+}

--- a/Samples/UWP/D3D12Fullscreen/src/D3D12Fullscreen.h
+++ b/Samples/UWP/D3D12Fullscreen/src/D3D12Fullscreen.h
@@ -33,6 +33,7 @@ protected:
 	virtual void OnUpdate();
 	virtual void OnRender();
 	virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
+    virtual void OnWindowMoved(int, int);
 	virtual void OnDestroy();
 	virtual void OnKeyDown(UINT8 key);
 

--- a/Samples/UWP/D3D12Fullscreen/src/D3D12Fullscreen.vcxproj
+++ b/Samples/UWP/D3D12Fullscreen/src/D3D12Fullscreen.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12Fullscreen/src/DXSample.cpp
+++ b/Samples/UWP/D3D12Fullscreen/src/DXSample.cpp
@@ -17,6 +17,7 @@ using namespace Microsoft::WRL;
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_windowBounds{0,0,0,0},
 	m_title(name),
 	m_aspectRatio(0.0f),
 	m_useWarpDevice(false)
@@ -121,4 +122,12 @@ void DXSample::CheckTearingSupport()
 	}
 
 	m_tearingSupport = SUCCEEDED(hr) && allowTearing;
+}
+
+void DXSample::SetWindowBounds(int left, int top, int right, int bottom)
+{
+    m_windowBounds.left = static_cast<LONG>(left);
+    m_windowBounds.top = static_cast<LONG>(top);
+    m_windowBounds.right = static_cast<LONG>(right);
+    m_windowBounds.bottom = static_cast<LONG>(bottom);
 }

--- a/Samples/UWP/D3D12Fullscreen/src/DXSample.h
+++ b/Samples/UWP/D3D12Fullscreen/src/DXSample.h
@@ -26,17 +26,24 @@ public:
 	virtual void OnDestroy() = 0;
 
 	// Samples override the event handlers to handle specific messages.
-	virtual void OnKeyDown(UINT8 /*key*/)   {}
-	virtual void OnKeyUp(UINT8 /*key*/)     {}
-
+	virtual void OnKeyDown(UINT8 /*key*/) {}
+	virtual void OnKeyUp(UINT8 /*key*/) {}
+	virtual void OnWindowMoved(int /*x*/, int /*y*/) {}
+	virtual void OnMouseMove(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnLeftButtonDown(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnLeftButtonUp(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnDisplayChanged() {}
+	
 	// Accessors.
 	UINT GetWidth() const           { return m_width; }
 	UINT GetHeight() const          { return m_height; }
 	const WCHAR* GetTitle() const   { return m_title.c_str(); }
-	bool GetTearingSupport()        { return m_tearingSupport; }
+	bool GetTearingSupport() const  { return m_tearingSupport; }
+	RECT GetWindowsBounds() const   { return m_windowBounds; }
 
 	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 	void UpdateForSizeChange(UINT clientWidth, UINT clientHeight);
+	void SetWindowBounds(int left, int top, int right, int bottom);
 
 protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
@@ -49,6 +56,9 @@ protected:
 	UINT m_height;
 	float m_aspectRatio;
 
+	// Window Bounds
+	RECT m_windowBounds;
+	
 	// Whether or not tearing is available for fullscreen borderless windowed mode.
 	bool m_tearingSupport;
 

--- a/Samples/UWP/D3D12Fullscreen/src/View.cpp
+++ b/Samples/UWP/D3D12Fullscreen/src/View.cpp
@@ -14,9 +14,18 @@
 
 using namespace Windows::Foundation;
 
+inline int ConvertToPixels(float dimension, float dpi)
+{
+	return static_cast<int>(dimension * dpi / 96.0f + 0.5f);
+}
+
 View::View(UINT_PTR pSample) :
 	m_pSample(reinterpret_cast<DXSample*>(pSample)),
-	m_windowClosed(false)
+	m_windowClosed(false),
+	m_windowResizing(false),
+	m_windowVisible(true),
+	m_logicalWidth(0),
+	m_logicalHeight(0)
 {
 }
 
@@ -30,17 +39,34 @@ void View::Initialize(CoreApplicationView^ applicationView)
 
 void View::SetWindow(CoreWindow^ window)
 {
+	m_logicalWidth = window->Bounds.Width;
+	m_logicalHeight = window->Bounds.Height;
+
 	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
 	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
 	window->SizeChanged += ref new TypedEventHandler<CoreWindow^, WindowSizeChangedEventArgs^>(this, &View::OnSizeChanged);
 	window->VisibilityChanged += ref new TypedEventHandler<CoreWindow^, VisibilityChangedEventArgs^>(this, &View::OnVisibilityChanged);
 	window->Closed += ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &View::OnClosed);
+	window->PointerMoved += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerMoved);
+	window->PointerPressed += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerPressed);
+	window->PointerReleased += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerReleased);
+
+	try
+	{
+		window->ResizeStarted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeStarted);
+		window->ResizeCompleted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeCompleted);
+	}
+	catch (Exception^ e)
+	{
+		// Requires Windows 10 Creators Update (10.0.15063) or later.
+	}
 
 	// For simplicity, this sample ignores a number of events on CoreWindow that a
 	// typical app should subscribe to.
 
 	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
 	displayInformation->DpiChanged += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDpiChanged);
+	displayInformation->DisplayContentsInvalidated += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDisplayContentsInvalidated);
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -92,18 +118,35 @@ void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 
 void View::OnSizeChanged(CoreWindow^ /*window*/, WindowSizeChangedEventArgs^ args)
 {
-	UpdateWindowSize(args->Size.Width, args->Size.Height);
+	m_logicalWidth = args->Size.Width;
+	m_logicalHeight = args->Size.Height;
+
+	if (!m_windowResizing)
+	{
+		UpdateWindowSize();
+	}
+}
+
+void View::OnResizeStarted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
+{
+	m_windowResizing = true;
+}
+
+void View::OnResizeCompleted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
+{
+	m_windowResizing = false;
+	UpdateWindowSize();
 }
 
 void View::OnDpiChanged(DisplayInformation^ /*sender*/, Object^ /*args*/)
 {
-	CoreWindow^ window = CoreWindow::GetForCurrentThread();
-	UpdateWindowSize(window->Bounds.Width, window->Bounds.Height);
+	UpdateWindowSize();
 }
 
-void View::OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args)
+void View::OnVisibilityChanged(CoreWindow^ /*window*/, VisibilityChangedEventArgs^ args)
 {
-	UpdateWindowSize(window->Bounds.Width, window->Bounds.Height, args->Visible);
+	m_windowVisible = args->Visible;
+	UpdateWindowSize();
 }
 
 void View::OnClosed(CoreWindow^ /*window*/, CoreWindowEventArgs^ /*args*/)
@@ -111,14 +154,53 @@ void View::OnClosed(CoreWindow^ /*window*/, CoreWindowEventArgs^ /*args*/)
 	m_windowClosed = true;
 }
 
-inline UINT ConvertToPixels(float dimension, float dpi)
-{
-	return static_cast<UINT>(dimension * dpi / 96.0f);
-}
-
-void View::UpdateWindowSize(float width, float height, bool visible)
+void View::OnPointerMoved(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
 	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
 	float dpi = displayInformation->LogicalDpi;
-	m_pSample->OnSizeChanged(ConvertToPixels(width, dpi), ConvertToPixels(height, dpi), !visible);
+	m_pSample->OnMouseMove(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+}
+
+void View::OnPointerPressed(CoreWindow^ /*window*/, PointerEventArgs^ args)
+{
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonDown(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
+}
+
+void View::OnPointerReleased(CoreWindow^ /*window*/, PointerEventArgs^ args)
+{
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonUp(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
+}
+
+void View::UpdateWindowSize()
+{
+	CoreWindow^ window = CoreWindow::GetForCurrentThread();
+	Windows::Foundation::Rect windowBounds = window->Bounds;
+
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	float dpi = displayInformation->LogicalDpi;
+	
+	m_pSample->SetWindowBounds(
+		ConvertToPixels(windowBounds.Left, dpi),
+		ConvertToPixels(windowBounds.Top, dpi),
+		ConvertToPixels(windowBounds.Right, dpi),
+		ConvertToPixels(windowBounds.Bottom, dpi));
+		
+	m_pSample->OnSizeChanged(ConvertToPixels(m_logicalWidth, dpi), ConvertToPixels(m_logicalHeight, dpi), !m_windowVisible);
+}
+
+void View::OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args)
+{
+	m_pSample->OnDisplayChanged();
 }

--- a/Samples/UWP/D3D12Fullscreen/src/View.h
+++ b/Samples/UWP/D3D12Fullscreen/src/View.h
@@ -37,12 +37,22 @@ private:
 	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ args);
 	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ args);
 	void OnSizeChanged(CoreWindow^ window, WindowSizeChangedEventArgs^ args);
+	void OnResizeStarted(CoreWindow^ window, Object^ args);
+	void OnResizeCompleted(CoreWindow^ window, Object^ args);
 	void OnDpiChanged(DisplayInformation^ sender, Object^ args);
 	void OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args);
 	void OnClosed(CoreWindow^ window, CoreWindowEventArgs^ args);
-
-	void UpdateWindowSize(float width, float height, bool windowVisible = true);
+	void OnPointerMoved(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerPressed(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerReleased(CoreWindow^ window, PointerEventArgs^ args);
+	void OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args);
+	
+	void UpdateWindowSize();
 
 	DXSample* m_pSample;
 	bool m_windowClosed;
+	bool m_windowResizing;
+	bool m_windowVisible;
+	float m_logicalWidth;
+	float m_logicalHeight;
 };

--- a/Samples/UWP/D3D12HDR/src/D3D12HDR.cpp
+++ b/Samples/UWP/D3D12HDR/src/D3D12HDR.cpp
@@ -23,25 +23,35 @@
 #include "presentPS.hlsl.h"
 
 const float D3D12HDR::ClearColor[4] = { 0.0f, 0.0f, 0.0f, 1.0f };
+const float D3D12HDR::HDRMetaDataPool[4][4] =
+{
+    // MaxOutputNits, MinOutputNits, MaxCLL, MaxFALL
+    // These values are made up for testing. You need to figure out those numbers for your app.
+    { 1000.0f, 0.001f, 2000.0f, 500.0f },
+    { 500.0f, 0.001f, 2000.0f, 500.0f },
+    { 500.0f, 0.100f, 500.0f, 100.0f },
+    { 2000.0f, 1.000f, 2000.0f, 1000.0f }
+};
 
 D3D12HDR::D3D12HDR(UINT width, UINT height, std::wstring name) :
-	DXSample(width, height, name),
-	m_frameIndex(0),
-	m_viewport(),
-	m_scissorRect(0,0,width,height),
-	m_swapChainFormats{ DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_R10G10B10A2_UNORM, DXGI_FORMAT_R16G16B16A16_FLOAT },
-	m_currentSwapChainColorSpace(DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709),
-	m_currentSwapChainBitDepth(_8),
-	m_swapChainFormatChanged(false),
-	m_intermediateRenderTargetFormat(DXGI_FORMAT_R16G16B16A16_FLOAT),
-	m_rtvDescriptorSize(0),
-	m_srvDescriptorSize(0),
-	m_dxgiFactoryFlags(0),
-	m_rootConstants{},
-	m_updateVertexBuffer(true),
-	m_fenceValues{},
-	m_windowVisible(true),
-	m_windowedMode(true)
+    DXSample(width, height, name),
+    m_frameIndex(0),
+    m_viewport(),
+    m_scissorRect(0, 0, width, height),
+    m_swapChainFormats{ DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_R10G10B10A2_UNORM, DXGI_FORMAT_R16G16B16A16_FLOAT },
+    m_currentSwapChainColorSpace(DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709),
+    m_currentSwapChainBitDepth(_8),
+    m_swapChainFormatChanged(false),
+    m_intermediateRenderTargetFormat(DXGI_FORMAT_R16G16B16A16_FLOAT),
+    m_rtvDescriptorSize(0),
+    m_srvDescriptorSize(0),
+    m_dxgiFactoryFlags(0),
+    m_rootConstants{},
+    m_updateVertexBuffer(true),
+    m_fenceValues{},
+    m_windowVisible(true),
+    m_windowedMode(true),
+    m_in_sizechanging(false)
 {
 	// Alias the root constants so that we can easily set them as either floats or UINTs.
 	m_rootConstantsF = reinterpret_cast<float*>(m_rootConstants);
@@ -71,12 +81,12 @@ void D3D12HDR::LoadPipeline()
 	}
 #endif
 
-	ThrowIfFailed(CreateDXGIFactory2(m_dxgiFactoryFlags, IID_PPV_ARGS(&m_factory)));
+	ThrowIfFailed(CreateDXGIFactory2(m_dxgiFactoryFlags, IID_PPV_ARGS(&m_dxgiFactory)));
 
 	if (m_useWarpDevice)
 	{
 		ComPtr<IDXGIAdapter> warpAdapter;
-		ThrowIfFailed(m_factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+		ThrowIfFailed(m_dxgiFactory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
 		ThrowIfFailed(D3D12CreateDevice(
 			warpAdapter.Get(),
@@ -87,7 +97,7 @@ void D3D12HDR::LoadPipeline()
 	else
 	{
 		ComPtr<IDXGIAdapter1> hardwareAdapter;
-		GetHardwareAdapter(m_factory.Get(), &hardwareAdapter);
+		GetHardwareAdapter(m_dxgiFactory.Get(), &hardwareAdapter);
 
 		ThrowIfFailed(D3D12CreateDevice(
 			hardwareAdapter.Get(),
@@ -118,7 +128,7 @@ void D3D12HDR::LoadPipeline()
 	swapChainDesc.Flags = m_tearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
 
 	ComPtr<IDXGISwapChain1> swapChain;
-	ThrowIfFailed(m_factory->CreateSwapChainForCoreWindow(
+	ThrowIfFailed(m_dxgiFactory->CreateSwapChainForCoreWindow(
 		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
 		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
 		&swapChainDesc,
@@ -127,10 +137,12 @@ void D3D12HDR::LoadPipeline()
 		));
 
 	ThrowIfFailed(swapChain.As(&m_swapChain));
-	UpdateSwapChainFormat();
-
-	// Initialize ST.2084 support to match the display's support.
-	m_enableST2084 = m_hdrSupport;
+    
+    // Check display HDR support and initialize ST.2084 support to match the display's support.
+    CheckDisplayHDRSupport();
+    m_enableST2084 = m_hdrSupport;
+    EnsureSwapChainColorSpace(m_currentSwapChainBitDepth, m_enableST2084);
+    SetHDRMetaData(HDRMetaDataPool[m_hdrMetaDataPoolIdx][0], HDRMetaDataPool[m_hdrMetaDataPoolIdx][1], HDRMetaDataPool[m_hdrMetaDataPoolIdx][2], HDRMetaDataPool[m_hdrMetaDataPoolIdx][3]);
 
 	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
@@ -556,6 +568,10 @@ void D3D12HDR::UpdateVertexBuffer()
 // Update frame-based values.
 void D3D12HDR::OnUpdate()
 {
+    if (m_enableUI)
+    {
+        m_uiLayer->UpdateLabels();
+    }
 }
 
 // Render the scene.
@@ -578,7 +594,6 @@ void D3D12HDR::OnRender()
 		ThrowIfFailed(m_swapChain->Present(1, 0));
 
 		MoveToNextFrame();
-		UpdateSwapChainFormat();	// Check for HDR support changes on the display.
 	}
 }
 
@@ -710,51 +725,28 @@ void D3D12HDR::RenderScene()
 	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 }
 
+
+void D3D12HDR::OnWindowMoved(int xPos, int yPos)
+{
+    UNREFERENCED_PARAMETER(xPos);
+    UNREFERENCED_PARAMETER(yPos);
+}
+
 void D3D12HDR::OnSizeChanged(UINT width, UINT height, bool minimized)
 {
-	if (!m_swapChain)
-	{
-		return;
-	}
+    // Update the width, height, and aspect ratio member variables.
+    UpdateForSizeChange(width, height);
 
-	// Determine if the swap buffers and other resources need to be resized or not.
-	if ((width != m_width || height != m_height || m_swapChainFormatChanged) && !minimized)
-	{
-		// Flush all current GPU commands.
-		WaitForGpu();
+    // For UWP, dragging a window across monitors will also trigger resize event. 
+    // An app could be moved from a HDR monitor to another SDR monitor or vice versa so we can verify the monitor HDR support again here.
+    CheckDisplayHDRSupport();
 
-		// Release the resources holding references to the swap chain (requirement of
-		// IDXGISwapChain::ResizeBuffers) and reset the frame fence values to the
-		// current fence value.
-		for (UINT n = 0; n < FrameCount; n++)
-		{
-			m_renderTargets[n].Reset();
-			m_fenceValues[n] = m_fenceValues[m_frameIndex];
-		}
-		if (m_enableUI)
-		{
-			m_uiLayer->ReleaseResources();
-		}
+    // Update the size of swapchain buffers.
+    UpdateSwapChainBuffer(width, height, GetBackBufferFormat());
 
-		// Resize the swap chain to the desired dimensions.
-		DXGI_SWAP_CHAIN_DESC1 desc = {};
-		m_swapChain->GetDesc1(&desc);
-		ThrowIfFailed(m_swapChain->ResizeBuffers(FrameCount, width, height, m_swapChainFormats[m_currentSwapChainBitDepth], desc.Flags));
-
-		EnsureSwapChainColorSpace();
-
-		// Reset the frame index to the current back buffer index.
-		m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
-
-		// Update the width, height, and aspect ratio member variables.
-		UpdateForSizeChange(width, height);
-		m_swapChainFormatChanged = false;
-
-		LoadSizeDependentResources();
-	}
-
-	m_windowVisible = !minimized;
+    m_windowVisible = !minimized;
 }
+
 
 void D3D12HDR::OnDestroy()
 {
@@ -769,67 +761,76 @@ void D3D12HDR::OnKeyDown(UINT8 key)
 {
 	switch (key)
 	{
-	// Instrument the Space Bar to toggle between fullscreen states.
-	// The CoreWindow will fire a SizeChanged event once the window is in the
-	// fullscreen state. At that point, the IDXGISwapChain should be resized
-	// to match the new window size.
-	case VK_SPACE:
-	{
-		auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-		if (applicationView->IsFullScreenMode)
-		{
-			applicationView->ExitFullScreenMode();
-		}
-		else
-		{
-			applicationView->TryEnterFullScreenMode();
-		}
-		break;
-	}
+	    // Instrument the Space Bar to toggle between fullscreen states.
+	    // The CoreWindow will fire a SizeChanged event once the window is in the
+	    // fullscreen state. At that point, the IDXGISwapChain should be resized
+	    // to match the new window size.
+	    case VK_SPACE:
+	    {
+		    auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+		    if (applicationView->IsFullScreenMode)
+		    {
+			    applicationView->ExitFullScreenMode();
+		    }
+		    else
+		    {
+			    applicationView->TryEnterFullScreenMode();
+		    }
+		    break;
+	    }
 
-	case VK_PRIOR:	// Page Up
-		m_currentSwapChainBitDepth = static_cast<SwapChainBitDepth>((m_currentSwapChainBitDepth - 1 + SwapChainBitDepthCount) % SwapChainBitDepthCount);
-		m_swapChainFormatChanged = true;
-		OnSizeChanged(m_width, m_height, false);
-		if (m_enableUI)
-		{
-			m_uiLayer->UpdateLabels();
-		}
-		break;
-		
-	case VK_NEXT:	// Page Down
-		m_currentSwapChainBitDepth = static_cast<SwapChainBitDepth>((m_currentSwapChainBitDepth + 1) % SwapChainBitDepthCount);
-		m_swapChainFormatChanged = true;
-		OnSizeChanged(m_width, m_height, false);
-		if (m_enableUI)
-		{
-			m_uiLayer->UpdateLabels();
-		}
-		break;
+	    case VK_PRIOR:	// Page Up
+        {
+            m_currentSwapChainBitDepth = static_cast<SwapChainBitDepth>((m_currentSwapChainBitDepth - 1 + SwapChainBitDepthCount) % SwapChainBitDepthCount);
+            DXGI_FORMAT newFormat = m_swapChainFormats[m_currentSwapChainBitDepth];
+            UpdateSwapChainBuffer(m_width, m_height, newFormat);
+            SetHDRMetaData(HDRMetaDataPool[m_hdrMetaDataPoolIdx][0], HDRMetaDataPool[m_hdrMetaDataPoolIdx][1], HDRMetaDataPool[m_hdrMetaDataPoolIdx][2], HDRMetaDataPool[m_hdrMetaDataPoolIdx][3]);
+            break;
+        }
 
-	case 'H':
-		m_enableST2084 = !m_enableST2084;
-		if (m_currentSwapChainBitDepth == _10)
-		{
-			m_swapChainFormatChanged = true;
-			OnSizeChanged(m_width, m_height, false);
-		}
-		if (m_enableUI)
-		{
-			m_uiLayer->UpdateLabels();
-		}
-		break;
+	    case VK_NEXT:	// Page Down
+        {
+            m_currentSwapChainBitDepth = static_cast<SwapChainBitDepth>((m_currentSwapChainBitDepth + 1) % SwapChainBitDepthCount);
+            DXGI_FORMAT newFormat = m_swapChainFormats[m_currentSwapChainBitDepth];
+            UpdateSwapChainBuffer(m_width, m_height, newFormat);
+            SetHDRMetaData(HDRMetaDataPool[m_hdrMetaDataPoolIdx][0], HDRMetaDataPool[m_hdrMetaDataPoolIdx][1], HDRMetaDataPool[m_hdrMetaDataPoolIdx][2], HDRMetaDataPool[m_hdrMetaDataPoolIdx][3]);
+            break;
+        }
 
-	case 'U':
-		m_enableUI = !m_enableUI;
-		if (m_enableUI)
-		{
-			m_uiLayer = std::make_shared<UILayer>(this);
-		}
-		else
-		{
-			m_uiLayer.reset();
-		}
+	    case 'H':
+        {
+            m_enableST2084 = !m_enableST2084;
+            if (m_currentSwapChainBitDepth == _10)
+            {
+                EnsureSwapChainColorSpace(m_currentSwapChainBitDepth, m_enableST2084);
+                SetHDRMetaData(HDRMetaDataPool[m_hdrMetaDataPoolIdx][0], HDRMetaDataPool[m_hdrMetaDataPoolIdx][1], HDRMetaDataPool[m_hdrMetaDataPoolIdx][2], HDRMetaDataPool[m_hdrMetaDataPoolIdx][3]);
+            }
+
+            break;
+        }
+
+	    case 'U':
+        {
+            m_enableUI = !m_enableUI;
+            if (m_enableUI)
+            {
+                m_uiLayer = std::make_shared<UILayer>(this);
+            }
+            else
+            {
+                m_uiLayer.reset();
+            }
+
+            break;
+        }
+
+        case 'M':
+        {
+            // Switch meta data value for testing. TV should adjust the content based on the metadata we sent.
+            m_hdrMetaDataPoolIdx = (m_hdrMetaDataPoolIdx + 1) % 4;
+            SetHDRMetaData(HDRMetaDataPool[m_hdrMetaDataPoolIdx][0], HDRMetaDataPool[m_hdrMetaDataPoolIdx][1], HDRMetaDataPool[m_hdrMetaDataPoolIdx][2], HDRMetaDataPool[m_hdrMetaDataPoolIdx][3]);
+            break;
+        }
 	}
 }
 
@@ -871,68 +872,233 @@ void D3D12HDR::MoveToNextFrame()
 	m_fenceValues[m_frameIndex] = currentFenceValue + 1;
 }
 
-// Detect HDR support on the display and update the swap chain if necessary.
-void D3D12HDR::UpdateSwapChainFormat()
+
+// DirectX supports two combinations of swapchain pixel formats and colorspaces for HDR content.
+// Option 1: FP16 + DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709
+// Option 2: R10G10B10A2 + DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020
+// Calling this function to ensure the correct color space for the different pixel formats.
+void D3D12HDR::EnsureSwapChainColorSpace(SwapChainBitDepth swapChainBitDepth, bool enableST2084)
 {
-	static bool checkSupport = true;
+    DXGI_COLOR_SPACE_TYPE colorSpace = DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
+    switch (swapChainBitDepth)
+    {
+    case _8:
+        m_rootConstants[DisplayCurve] = sRGB;
+        break;
 
-	// Output information is cached on the DXGI Factory. If it is stale we need to create
-	// a new factory and re-enumerate the displays.
-	if (!m_factory->IsCurrent())
-	{
-		ThrowIfFailed(CreateDXGIFactory2(m_dxgiFactoryFlags, IID_PPV_ARGS(&m_factory)));
-		checkSupport = true;
-	}
+    case _10:
+        colorSpace = enableST2084 ? DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020 : DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
+        m_rootConstants[DisplayCurve] = enableST2084 ? ST2084 : sRGB;
+        break;
 
-	if (checkSupport)
-	{
-		// Get information about the display we are presenting to.
-		ComPtr<IDXGIOutput> output;
-		ComPtr<IDXGIOutput6> output6;
+    case _16:
+        colorSpace = DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709;
+        m_rootConstants[DisplayCurve] = None;
+        break;
+    }
 
-		ThrowIfFailed(m_swapChain->GetContainingOutput(&output));
-		if (SUCCEEDED(output.As(&output6)))
-		{
-			DXGI_OUTPUT_DESC1 outputDesc;
-			ThrowIfFailed(output6->GetDesc1(&outputDesc));
-
-			// If the display supports HDR, then we'll enable high color.
-			m_hdrSupport = (outputDesc.ColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020);
-
-			EnsureSwapChainColorSpace();
-		}
-		checkSupport = false;
-	}
+    if (m_currentSwapChainColorSpace != colorSpace)
+    {
+        UINT colorSpaceSupport = 0;
+        if (SUCCEEDED(m_swapChain->CheckColorSpaceSupport(colorSpace, &colorSpaceSupport)) &&
+            ((colorSpaceSupport & DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG_PRESENT) == DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG_PRESENT))
+        {
+            ThrowIfFailed(m_swapChain->SetColorSpace1(colorSpace));
+            m_currentSwapChainColorSpace = colorSpace;
+        }
+    }
 }
 
-void D3D12HDR::EnsureSwapChainColorSpace()
+// Set HDR meta data for output display to master the content and the luminance values of the content.
+// An app should estimate and set appropriate metadata based on its contents.
+// For demo purpose, we simply made up a few set of metadata for you to experience the effect of appling meta data.
+// Please see details in https://msdn.microsoft.com/en-us/library/windows/desktop/mt732700(v=vs.85).aspx.
+void D3D12HDR::SetHDRMetaData(float MaxOutputNits /*=1000.0f*/, float MinOutputNits /*=0.001f*/, float MaxCLL /*=2000.0f*/, float MaxFALL /*=500.0f*/)
 {
-	DXGI_COLOR_SPACE_TYPE colorSpace = DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
-	switch (m_currentSwapChainBitDepth)
-	{
-	case _8:
-		m_rootConstants[DisplayCurve] = sRGB;
-		break;
+    if (!m_swapChain)
+    {
+        return;
+    }
 
-	case _10:
-		colorSpace = m_enableST2084 ? DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020 : DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
-		m_rootConstants[DisplayCurve] = m_enableST2084 ? ST2084 : sRGB;
-		break;
+    // Clean the hdr metadata if the display doesn't support HDR
+    if (!m_hdrSupport)
+    {
+        ThrowIfFailed(m_swapChain->SetHDRMetaData(DXGI_HDR_METADATA_TYPE_NONE, 0, nullptr));
+		return;
+    }
 
-	case _16:
-		colorSpace = DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709;
-		m_rootConstants[DisplayCurve] = None;
-		break;
-	}
+    static const DisplayChromacities DisplayChromacityList[] =
+    {
+        { 0.64000f, 0.33000f, 0.30000f, 0.60000f, 0.15000f, 0.06000f, 0.31270f, 0.32900f }, // Display Gamut Rec709 
+        { 0.70800f, 0.29200f, 0.17000f, 0.79700f, 0.13100f, 0.04600f, 0.31270f, 0.32900f }, // Display Gamut Rec2020
+    };
 
-	if (m_currentSwapChainColorSpace != colorSpace)
-	{
-		UINT colorSpaceSupport = 0;
-		if (SUCCEEDED(m_swapChain->CheckColorSpaceSupport(colorSpace, &colorSpaceSupport)) &&
-			((colorSpaceSupport & DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG_PRESENT) == DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG_PRESENT))
-		{
-			ThrowIfFailed(m_swapChain->SetColorSpace1(colorSpace));
-			m_currentSwapChainColorSpace = colorSpace;
-		}
-	}
+    // Select the chromaticity based on HDR format of the DWM.
+    int selectedChroma = 0;
+    if (m_currentSwapChainBitDepth == _16 && m_currentSwapChainColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709)
+    {
+        selectedChroma = 0;
+    }
+    else if (m_currentSwapChainBitDepth == _10 && m_currentSwapChainColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020)
+    {
+        selectedChroma = 1;
+    }
+    else
+    {
+        // Reset the metadata since this is not a supported HDR format.
+        ThrowIfFailed(m_swapChain->SetHDRMetaData(DXGI_HDR_METADATA_TYPE_NONE, 0, nullptr));
+        return;
+    }
+
+    // Set HDR meta data
+    const DisplayChromacities& Chroma = DisplayChromacityList[selectedChroma];
+    DXGI_HDR_METADATA_HDR10 HDR10MetaData = {};
+    HDR10MetaData.RedPrimary[0] = static_cast<UINT16>(Chroma.RedX * 50000.0f);
+    HDR10MetaData.RedPrimary[1] = static_cast<UINT16>(Chroma.RedY * 50000.0f);
+    HDR10MetaData.GreenPrimary[0] = static_cast<UINT16>(Chroma.GreenX * 50000.0f);
+    HDR10MetaData.GreenPrimary[1] = static_cast<UINT16>(Chroma.GreenY * 50000.0f);
+    HDR10MetaData.BluePrimary[0] = static_cast<UINT16>(Chroma.BlueX * 50000.0f);
+    HDR10MetaData.BluePrimary[1] = static_cast<UINT16>(Chroma.BlueY * 50000.0f);
+    HDR10MetaData.WhitePoint[0] = static_cast<UINT16>(Chroma.WhiteX * 50000.0f);
+    HDR10MetaData.WhitePoint[1] = static_cast<UINT16>(Chroma.WhiteY * 50000.0f);
+    HDR10MetaData.MaxMasteringLuminance = static_cast<UINT>(MaxOutputNits * 10000.0f);
+    HDR10MetaData.MinMasteringLuminance = static_cast<UINT>(MinOutputNits * 10000.0f);
+    HDR10MetaData.MaxContentLightLevel = static_cast<UINT16>(MaxCLL);
+    HDR10MetaData.MaxFrameAverageLightLevel = static_cast<UINT16>(MaxFALL);
+    ThrowIfFailed(m_swapChain->SetHDRMetaData(DXGI_HDR_METADATA_TYPE_HDR10, sizeof(DXGI_HDR_METADATA_HDR10), &HDR10MetaData));
+}
+
+
+void D3D12HDR::UpdateSwapChainBuffer(UINT width, UINT height, DXGI_FORMAT format)
+{
+    if (!m_swapChain)
+    {
+        return;
+    }
+
+
+    // Flush all current GPU commands.
+    WaitForGpu();
+
+    // Release the resources holding references to the swap chain (requirement of
+    // IDXGISwapChain::ResizeBuffers) and reset the frame fence values to the
+    // current fence value.
+    for (UINT n = 0; n < FrameCount; n++)
+    {
+        m_renderTargets[n].Reset();
+        m_fenceValues[n] = m_fenceValues[m_frameIndex];
+    }
+    if (m_enableUI)
+    {
+        m_uiLayer->ReleaseResources();
+    }
+
+    // Resize the swap chain to the desired dimensions.
+    DXGI_SWAP_CHAIN_DESC1 desc = {};
+    m_swapChain->GetDesc1(&desc);
+    ThrowIfFailed(m_swapChain->ResizeBuffers(FrameCount, width, height, format, desc.Flags));
+
+    EnsureSwapChainColorSpace(m_currentSwapChainBitDepth, m_enableST2084);
+
+    // Reset the frame index to the current back buffer index.
+    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+
+    // Update the width, height, and aspect ratio member variables.
+    UpdateForSizeChange(width, height);
+
+    LoadSizeDependentResources();
+}
+
+
+// To detect HDR support, we will need to check the color space in the primary DXGI output associated with the app at
+// this point in time (using window/display intersection). 
+void D3D12HDR::CheckDisplayHDRSupport()
+{
+    // If the display's advanced color state has changed (e.g. HDR display plug/unplug, or OS HDR setting on/off), 
+    // then this app's DXGI factory is invalidated and must be created anew in order to retrieve up-to-date display information. 
+    if (m_dxgiFactory->IsCurrent() == false)
+    {
+        ThrowIfFailed(
+            CreateDXGIFactory2(0, IID_PPV_ARGS(&m_dxgiFactory))
+        );
+    }
+
+    // First, the method must determine the app's current display. 
+    // We don't recommend using IDXGISwapChain::GetContainingOutput method to do that because of two reasons:
+    //    1. Swap chains created with CreateSwapChainForComposition do not support this method.
+    //    2. Swap chains will return a stale dxgi output once DXGIFactory::IsCurrent() is false. In addition, 
+    //       we don't recommend re-creating swapchain to resolve the stale dxgi output because it will cause a short 
+    //       period of black screen.
+    // Instead, we suggest enumerating through the bounds of all dxgi outputs and determine which one has the greatest 
+    // intersection with the app window bounds. Then, use the DXGI output found in previous step to determine if the 
+    // app is on a HDR capable display. 
+
+    // Get window bound of the app
+    Windows::Foundation::Rect windowBounds = Windows::Foundation::Rect(
+        static_cast<float>(m_windowBounds.left),
+        static_cast<float>(m_windowBounds.top),
+        static_cast<float>(m_windowBounds.right - m_windowBounds.left),
+        static_cast<float>(m_windowBounds.bottom - m_windowBounds.top)
+    );
+
+    // Retrieve the current default adapter.
+    ComPtr<IDXGIAdapter1> dxgiAdapter;
+    ThrowIfFailed(m_dxgiFactory->EnumAdapters1(0, &dxgiAdapter));
+
+    // Iterate through the DXGI outputs associated with the DXGI adapter,
+    // and find the output whose bounds have the greatest overlap with the
+    // app window (i.e. the output for which the intersection area is the
+    // greatest).
+
+    UINT i = 0;
+    ComPtr<IDXGIOutput> currentOutput;
+    ComPtr<IDXGIOutput> bestOutput;
+    float bestIntersectArea = -1;
+
+    while (dxgiAdapter->EnumOutputs(i, &currentOutput) != DXGI_ERROR_NOT_FOUND)
+    {
+        DXGI_OUTPUT_DESC desc;
+        ThrowIfFailed(currentOutput->GetDesc(&desc));
+        RECT r = desc.DesktopCoordinates;
+        Windows::Foundation::Rect outputBounds = Windows::Foundation::Rect(
+            (float)r.left,
+            (float)r.top,
+            (float)(r.right - r.left),
+            (float)(r.bottom - r.top)
+        );
+
+        if (windowBounds.IntersectsWith(outputBounds))
+        {
+            Windows::Foundation::Rect intersectBounds = windowBounds;
+            intersectBounds.Intersect(outputBounds);
+
+            float intersectArea = intersectBounds.Width * intersectBounds.Height;
+
+            if (intersectArea > bestIntersectArea)
+            {
+                bestOutput = currentOutput;
+                bestIntersectArea = intersectArea;
+            }
+        }
+
+        i++;
+    }
+
+    // Having determined the output (display) upon which the app is primarily being 
+    // rendered, retrieve the HDR capabilities of that display by checking the color space.
+    ComPtr<IDXGIOutput6> output6;
+    ThrowIfFailed(bestOutput.As(&output6));
+
+    DXGI_OUTPUT_DESC1 desc1;
+    ThrowIfFailed(output6->GetDesc1(&desc1));
+
+    m_hdrSupport = (desc1.ColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020);
+}
+
+
+void D3D12HDR::OnDisplayChanged()
+{
+    // Changing display setting or plugging/unplugging HDR displays could raise a WM_DISPLAYCHANGE message (win32) or OnDisplayContentsInvalidated event(uwp). 
+    // Re-check the HDR support while receiving them.
+    CheckDisplayHDRSupport();
 }

--- a/Samples/UWP/D3D12HDR/src/D3D12HDR.sln
+++ b/Samples/UWP/D3D12HDR/src/D3D12HDR.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "D3D12HDR", "D3D12HDR.vcxproj", "{C5DBC19D-6528-4EC1-8BDB-73B191B5AA9D}"
 EndProject

--- a/Samples/UWP/D3D12HDR/src/D3D12HDR.vcxproj
+++ b/Samples/UWP/D3D12HDR/src/D3D12HDR.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.15063.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12HDR/src/DXSample.cpp
+++ b/Samples/UWP/D3D12HDR/src/DXSample.cpp
@@ -17,6 +17,7 @@ using namespace Microsoft::WRL;
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_windowBounds{0,0,0,0},
 	m_title(name),
 	m_aspectRatio(0.0f),
 	m_useWarpDevice(false)
@@ -121,4 +122,12 @@ void DXSample::CheckTearingSupport()
 	}
 
 	m_tearingSupport = SUCCEEDED(hr) && allowTearing;
+}
+
+void DXSample::SetWindowBounds(int left, int top, int right, int bottom)
+{
+    m_windowBounds.left = static_cast<LONG>(left);
+    m_windowBounds.top = static_cast<LONG>(top);
+    m_windowBounds.right = static_cast<LONG>(right);
+    m_windowBounds.bottom = static_cast<LONG>(bottom);
 }

--- a/Samples/UWP/D3D12HDR/src/DXSample.h
+++ b/Samples/UWP/D3D12HDR/src/DXSample.h
@@ -26,17 +26,24 @@ public:
 	virtual void OnDestroy() = 0;
 
 	// Samples override the event handlers to handle specific messages.
-	virtual void OnKeyDown(UINT8 /*key*/)   {}
-	virtual void OnKeyUp(UINT8 /*key*/)     {}
-
+	virtual void OnKeyDown(UINT8 /*key*/) {}
+	virtual void OnKeyUp(UINT8 /*key*/) {}
+	virtual void OnWindowMoved(int /*x*/, int /*y*/) {}
+	virtual void OnMouseMove(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnLeftButtonDown(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnLeftButtonUp(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnDisplayChanged() {}
+	
 	// Accessors.
 	UINT GetWidth() const           { return m_width; }
 	UINT GetHeight() const          { return m_height; }
 	const WCHAR* GetTitle() const   { return m_title.c_str(); }
-	bool GetTearingSupport()        { return m_tearingSupport; }
+	bool GetTearingSupport() const  { return m_tearingSupport; }
+	RECT GetWindowsBounds() const   { return m_windowBounds; }
 
 	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 	void UpdateForSizeChange(UINT clientWidth, UINT clientHeight);
+	void SetWindowBounds(int left, int top, int right, int bottom);
 
 protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
@@ -49,6 +56,9 @@ protected:
 	UINT m_height;
 	float m_aspectRatio;
 
+	// Window Bounds
+	RECT m_windowBounds;
+	
 	// Whether or not tearing is available for fullscreen borderless windowed mode.
 	bool m_tearingSupport;
 

--- a/Samples/UWP/D3D12HDR/src/UILayer.cpp
+++ b/Samples/UWP/D3D12HDR/src/UILayer.cpp
@@ -20,7 +20,7 @@ UILayer::UILayer(D3D12HDR* pSample) :
 
 	m_labels[Format] = L"Back Buffer Format";
 	m_labels[Signal] = L"Output Signal";
-	m_labels[HDRSupport] = L"HDR Support";
+	m_labels[HDRSupport] = L"Current Output HDR Support";
 	m_labels[StandardGradient] = L"SDR Gradient [0,1]";
 	m_labels[BrightGradient] = L"HDR Gradient [0,9]";
 	m_labels[Rec709] = L"Rec 709";
@@ -28,6 +28,7 @@ UILayer::UILayer(D3D12HDR* pSample) :
 	m_labels[ChangeFormat] = L"PgUp/PgDn\tChange back buffer format";
 	m_labels[ChangeCurve] = L"H\tToggle between sRGB and ST.2084 (10-bit swap chain only)";
 	m_labels[HideUI] = L"U\tToggle UI Visibility";
+    m_labels[MetaData] = L"M\tToggle HDR Meta Data";
 
 	Initialize();
 }
@@ -135,12 +136,22 @@ void UILayer::UpdateLabels()
 	}
 
 	m_labels[Signal] = L"Output Signal = " + m_pSample->GetDisplayCurve();
-	m_labels[HDRSupport] = L"HDR Support = ";
+	m_labels[HDRSupport] = L"Current Output HDR Support = ";
 	m_labels[HDRSupport] += m_pSample->GetHDRSupport() ? L"true" : L"false";
 
 	m_ui[Format].text = m_labels[Format];
 	m_ui[Signal].text = m_labels[Signal];
 	m_ui[HDRSupport].text = m_labels[HDRSupport];
+
+    float MaxOutputNits = D3D12HDR::HDRMetaDataPool[m_pSample->GetHDRMetaDataPoolIndex()][0];
+    float MinOutputNits = D3D12HDR::HDRMetaDataPool[m_pSample->GetHDRMetaDataPoolIndex()][1];
+    float MaxCLL = D3D12HDR::HDRMetaDataPool[m_pSample->GetHDRMetaDataPoolIndex()][2];
+    float MaxFALL = D3D12HDR::HDRMetaDataPool[m_pSample->GetHDRMetaDataPoolIndex()][3];
+
+    wchar_t buffer[256];
+    swprintf_s(buffer, 256, L"M\tToggle HDR Meta Data\t MaxOutputNits:%3.3f\t MinOutputNits:%3.3f\t MaxCLL:%3.3f\t MaxFALL:%3.3f", MaxOutputNits, MinOutputNits, MaxCLL, MaxFALL);
+
+    m_ui[MetaData].text = buffer;
 }
 
 // Render the UI.
@@ -252,4 +263,5 @@ void UILayer::Resize()
 	m_ui[ChangeFormat] = { m_labels[ChangeFormat], D2D1::RectF(smallFontSize, height - fontSize * 5.0f, width, height), m_smallTextFormat.Get() };
 	m_ui[ChangeCurve] = { m_labels[ChangeCurve], D2D1::RectF(smallFontSize, height - fontSize * 3.0f, width, height), m_smallTextFormat.Get() };
 	m_ui[HideUI] = { m_labels[HideUI], D2D1::RectF(smallFontSize, height - fontSize * 2.0f, width, height), m_smallTextFormat.Get() };
+    m_ui[MetaData] = { m_labels[MetaData], D2D1::RectF(smallFontSize, height - fontSize * 1.0f, width, height), m_smallTextFormat.Get() };
 }

--- a/Samples/UWP/D3D12HDR/src/UILayer.h
+++ b/Samples/UWP/D3D12HDR/src/UILayer.h
@@ -43,6 +43,7 @@ private:
 		ChangeFormat,
 		ChangeCurve,
 		HideUI,
+        MetaData,
 		StringsCount
 	};
 

--- a/Samples/UWP/D3D12HDR/src/View.cpp
+++ b/Samples/UWP/D3D12HDR/src/View.cpp
@@ -14,9 +14,18 @@
 
 using namespace Windows::Foundation;
 
+inline int ConvertToPixels(float dimension, float dpi)
+{
+	return static_cast<int>(dimension * dpi / 96.0f + 0.5f);
+}
+
 View::View(UINT_PTR pSample) :
 	m_pSample(reinterpret_cast<DXSample*>(pSample)),
-	m_windowClosed(false)
+	m_windowClosed(false),
+	m_windowResizing(false),
+	m_windowVisible(true),
+	m_logicalWidth(0),
+	m_logicalHeight(0)
 {
 }
 
@@ -30,17 +39,34 @@ void View::Initialize(CoreApplicationView^ applicationView)
 
 void View::SetWindow(CoreWindow^ window)
 {
+	m_logicalWidth = window->Bounds.Width;
+	m_logicalHeight = window->Bounds.Height;
+
 	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
 	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
 	window->SizeChanged += ref new TypedEventHandler<CoreWindow^, WindowSizeChangedEventArgs^>(this, &View::OnSizeChanged);
 	window->VisibilityChanged += ref new TypedEventHandler<CoreWindow^, VisibilityChangedEventArgs^>(this, &View::OnVisibilityChanged);
 	window->Closed += ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &View::OnClosed);
+	window->PointerMoved += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerMoved);
+	window->PointerPressed += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerPressed);
+	window->PointerReleased += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerReleased);
+
+	try
+	{
+		window->ResizeStarted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeStarted);
+		window->ResizeCompleted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeCompleted);
+	}
+	catch (Exception^ e)
+	{
+		// Requires Windows 10 Creators Update (10.0.15063) or later.
+	}
 
 	// For simplicity, this sample ignores a number of events on CoreWindow that a
 	// typical app should subscribe to.
 
 	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
 	displayInformation->DpiChanged += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDpiChanged);
+	displayInformation->DisplayContentsInvalidated += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDisplayContentsInvalidated);
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -92,18 +118,35 @@ void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 
 void View::OnSizeChanged(CoreWindow^ /*window*/, WindowSizeChangedEventArgs^ args)
 {
-	UpdateWindowSize(args->Size.Width, args->Size.Height);
+	m_logicalWidth = args->Size.Width;
+	m_logicalHeight = args->Size.Height;
+
+	if (!m_windowResizing)
+	{
+		UpdateWindowSize();
+	}
+}
+
+void View::OnResizeStarted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
+{
+	m_windowResizing = true;
+}
+
+void View::OnResizeCompleted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
+{
+	m_windowResizing = false;
+	UpdateWindowSize();
 }
 
 void View::OnDpiChanged(DisplayInformation^ /*sender*/, Object^ /*args*/)
 {
-	CoreWindow^ window = CoreWindow::GetForCurrentThread();
-	UpdateWindowSize(window->Bounds.Width, window->Bounds.Height);
+	UpdateWindowSize();
 }
 
-void View::OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args)
+void View::OnVisibilityChanged(CoreWindow^ /*window*/, VisibilityChangedEventArgs^ args)
 {
-	UpdateWindowSize(window->Bounds.Width, window->Bounds.Height, args->Visible);
+	m_windowVisible = args->Visible;
+	UpdateWindowSize();
 }
 
 void View::OnClosed(CoreWindow^ /*window*/, CoreWindowEventArgs^ /*args*/)
@@ -111,14 +154,53 @@ void View::OnClosed(CoreWindow^ /*window*/, CoreWindowEventArgs^ /*args*/)
 	m_windowClosed = true;
 }
 
-inline UINT ConvertToPixels(float dimension, float dpi)
-{
-	return static_cast<UINT>(dimension * dpi / 96.0f);
-}
-
-void View::UpdateWindowSize(float width, float height, bool visible)
+void View::OnPointerMoved(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
 	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
 	float dpi = displayInformation->LogicalDpi;
-	m_pSample->OnSizeChanged(ConvertToPixels(width, dpi), ConvertToPixels(height, dpi), !visible);
+	m_pSample->OnMouseMove(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+}
+
+void View::OnPointerPressed(CoreWindow^ /*window*/, PointerEventArgs^ args)
+{
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonDown(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
+}
+
+void View::OnPointerReleased(CoreWindow^ /*window*/, PointerEventArgs^ args)
+{
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonUp(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
+}
+
+void View::UpdateWindowSize()
+{
+	CoreWindow^ window = CoreWindow::GetForCurrentThread();
+	Windows::Foundation::Rect windowBounds = window->Bounds;
+
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	float dpi = displayInformation->LogicalDpi;
+	
+	m_pSample->SetWindowBounds(
+		ConvertToPixels(windowBounds.Left, dpi),
+		ConvertToPixels(windowBounds.Top, dpi),
+		ConvertToPixels(windowBounds.Right, dpi),
+		ConvertToPixels(windowBounds.Bottom, dpi));
+		
+	m_pSample->OnSizeChanged(ConvertToPixels(m_logicalWidth, dpi), ConvertToPixels(m_logicalHeight, dpi), !m_windowVisible);
+}
+
+void View::OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args)
+{
+	m_pSample->OnDisplayChanged();
 }

--- a/Samples/UWP/D3D12HDR/src/View.h
+++ b/Samples/UWP/D3D12HDR/src/View.h
@@ -37,12 +37,22 @@ private:
 	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ args);
 	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ args);
 	void OnSizeChanged(CoreWindow^ window, WindowSizeChangedEventArgs^ args);
+	void OnResizeStarted(CoreWindow^ window, Object^ args);
+	void OnResizeCompleted(CoreWindow^ window, Object^ args);
 	void OnDpiChanged(DisplayInformation^ sender, Object^ args);
 	void OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args);
 	void OnClosed(CoreWindow^ window, CoreWindowEventArgs^ args);
-
-	void UpdateWindowSize(float width, float height, bool windowVisible = true);
+	void OnPointerMoved(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerPressed(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerReleased(CoreWindow^ window, PointerEventArgs^ args);
+	void OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args);
+	
+	void UpdateWindowSize();
 
 	DXSample* m_pSample;
 	bool m_windowClosed;
+	bool m_windowResizing;
+	bool m_windowVisible;
+	float m_logicalWidth;
+	float m_logicalHeight;
 };

--- a/Samples/UWP/D3D12HDR/src/color.hlsli
+++ b/Samples/UWP/D3D12HDR/src/color.hlsli
@@ -12,7 +12,7 @@
 // These values must match the DisplayCurve enum in D3D12HDR.h.
 #define DISPLAY_CURVE_SRGB      0
 #define DISPLAY_CURVE_ST2084    1
-#define DISPLAY_CURVE_LINEAR      2
+#define DISPLAY_CURVE_LINEAR    2
 
 float3 xyYToRec709(float2 xy, float Y = 1.0)
 {
@@ -78,8 +78,7 @@ float3 Rec2020ToRec709(float3 color)
 	return mul(conversion, color);
 }
 
-
-float3 ApplyST2084(float3 color)
+float3 LinearToST2084(float3 color)
 {
 	float m1 = 2610.0 / 4096.0 / 4;
 	float m2 = 2523.0 / 4096.0 * 128;

--- a/Samples/UWP/D3D12HDR/src/gradientPS.hlsl
+++ b/Samples/UWP/D3D12HDR/src/gradientPS.hlsl
@@ -15,5 +15,5 @@
 float4 PSMain(PSInput input) : SV_TARGET
 {
 	// This draws a perceptual gradient rather than a linear gradient.
-	return float4(pow(abs(input.color.rgb), 2.0), input.color.a);
+	return float4(pow(abs(input.color.rgb), 2.2), input.color.a);
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.vcxproj
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.vcxproj
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/D3D12HelloFrameBuffering.vcxproj
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/D3D12HelloFrameBuffering.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.vcxproj
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.vcxproj
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.vcxproj
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/D3D12HeterogeneousMultiadapter.vcxproj
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/D3D12HeterogeneousMultiadapter.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12LinkedGpus/src/D3DX12AffinityLayer/D3DX12AffinityLayer.vcxproj
+++ b/Samples/UWP/D3D12LinkedGpus/src/D3DX12AffinityLayer/D3DX12AffinityLayer.vcxproj
@@ -35,7 +35,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/D3D12LinkedGpus.vcxproj
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/D3D12LinkedGpus.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/DXSample.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/DXSample.cpp
@@ -17,6 +17,7 @@ using namespace Microsoft::WRL;
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_windowBounds{0,0,0,0},
 	m_title(name),
 	m_aspectRatio(0.0f),
 	m_useWarpDevice(false)
@@ -121,4 +122,12 @@ void DXSample::CheckTearingSupport()
 	}
 
 	m_tearingSupport = SUCCEEDED(hr) && allowTearing;
+}
+
+void DXSample::SetWindowBounds(int left, int top, int right, int bottom)
+{
+    m_windowBounds.left = static_cast<LONG>(left);
+    m_windowBounds.top = static_cast<LONG>(top);
+    m_windowBounds.right = static_cast<LONG>(right);
+    m_windowBounds.bottom = static_cast<LONG>(bottom);
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/DXSample.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/DXSample.h
@@ -26,17 +26,24 @@ public:
 	virtual void OnDestroy() = 0;
 
 	// Samples override the event handlers to handle specific messages.
-	virtual void OnKeyDown(UINT8 /*key*/)   {}
-	virtual void OnKeyUp(UINT8 /*key*/)     {}
-
+	virtual void OnKeyDown(UINT8 /*key*/) {}
+	virtual void OnKeyUp(UINT8 /*key*/) {}
+	virtual void OnWindowMoved(int /*x*/, int /*y*/) {}
+	virtual void OnMouseMove(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnLeftButtonDown(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnLeftButtonUp(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnDisplayChanged() {}
+	
 	// Accessors.
 	UINT GetWidth() const           { return m_width; }
 	UINT GetHeight() const          { return m_height; }
 	const WCHAR* GetTitle() const   { return m_title.c_str(); }
-	bool GetTearingSupport()        { return m_tearingSupport; }
+	bool GetTearingSupport() const  { return m_tearingSupport; }
+	RECT GetWindowsBounds() const   { return m_windowBounds; }
 
 	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 	void UpdateForSizeChange(UINT clientWidth, UINT clientHeight);
+	void SetWindowBounds(int left, int top, int right, int bottom);
 
 protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
@@ -49,6 +56,9 @@ protected:
 	UINT m_height;
 	float m_aspectRatio;
 
+	// Window Bounds
+	RECT m_windowBounds;
+	
 	// Whether or not tearing is available for fullscreen borderless windowed mode.
 	bool m_tearingSupport;
 

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/View.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/View.cpp
@@ -14,9 +14,18 @@
 
 using namespace Windows::Foundation;
 
+inline int ConvertToPixels(float dimension, float dpi)
+{
+	return static_cast<int>(dimension * dpi / 96.0f + 0.5f);
+}
+
 View::View(UINT_PTR pSample) :
 	m_pSample(reinterpret_cast<DXSample*>(pSample)),
-	m_windowClosed(false)
+	m_windowClosed(false),
+	m_windowResizing(false),
+	m_windowVisible(true),
+	m_logicalWidth(0),
+	m_logicalHeight(0)
 {
 }
 
@@ -30,17 +39,34 @@ void View::Initialize(CoreApplicationView^ applicationView)
 
 void View::SetWindow(CoreWindow^ window)
 {
+	m_logicalWidth = window->Bounds.Width;
+	m_logicalHeight = window->Bounds.Height;
+
 	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
 	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
 	window->SizeChanged += ref new TypedEventHandler<CoreWindow^, WindowSizeChangedEventArgs^>(this, &View::OnSizeChanged);
 	window->VisibilityChanged += ref new TypedEventHandler<CoreWindow^, VisibilityChangedEventArgs^>(this, &View::OnVisibilityChanged);
 	window->Closed += ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &View::OnClosed);
+	window->PointerMoved += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerMoved);
+	window->PointerPressed += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerPressed);
+	window->PointerReleased += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerReleased);
+
+	try
+	{
+		window->ResizeStarted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeStarted);
+		window->ResizeCompleted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeCompleted);
+	}
+	catch (Exception^ e)
+	{
+		// Requires Windows 10 Creators Update (10.0.15063) or later.
+	}
 
 	// For simplicity, this sample ignores a number of events on CoreWindow that a
 	// typical app should subscribe to.
 
 	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
 	displayInformation->DpiChanged += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDpiChanged);
+	displayInformation->DisplayContentsInvalidated += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDisplayContentsInvalidated);
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -92,18 +118,35 @@ void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 
 void View::OnSizeChanged(CoreWindow^ /*window*/, WindowSizeChangedEventArgs^ args)
 {
-	UpdateWindowSize(args->Size.Width, args->Size.Height);
+	m_logicalWidth = args->Size.Width;
+	m_logicalHeight = args->Size.Height;
+
+	if (!m_windowResizing)
+	{
+		UpdateWindowSize();
+	}
+}
+
+void View::OnResizeStarted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
+{
+	m_windowResizing = true;
+}
+
+void View::OnResizeCompleted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
+{
+	m_windowResizing = false;
+	UpdateWindowSize();
 }
 
 void View::OnDpiChanged(DisplayInformation^ /*sender*/, Object^ /*args*/)
 {
-	CoreWindow^ window = CoreWindow::GetForCurrentThread();
-	UpdateWindowSize(window->Bounds.Width, window->Bounds.Height);
+	UpdateWindowSize();
 }
 
-void View::OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args)
+void View::OnVisibilityChanged(CoreWindow^ /*window*/, VisibilityChangedEventArgs^ args)
 {
-	UpdateWindowSize(window->Bounds.Width, window->Bounds.Height, args->Visible);
+	m_windowVisible = args->Visible;
+	UpdateWindowSize();
 }
 
 void View::OnClosed(CoreWindow^ /*window*/, CoreWindowEventArgs^ /*args*/)
@@ -111,14 +154,53 @@ void View::OnClosed(CoreWindow^ /*window*/, CoreWindowEventArgs^ /*args*/)
 	m_windowClosed = true;
 }
 
-inline UINT ConvertToPixels(float dimension, float dpi)
-{
-	return static_cast<UINT>(dimension * dpi / 96.0f);
-}
-
-void View::UpdateWindowSize(float width, float height, bool visible)
+void View::OnPointerMoved(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
 	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
 	float dpi = displayInformation->LogicalDpi;
-	m_pSample->OnSizeChanged(ConvertToPixels(width, dpi), ConvertToPixels(height, dpi), !visible);
+	m_pSample->OnMouseMove(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+}
+
+void View::OnPointerPressed(CoreWindow^ /*window*/, PointerEventArgs^ args)
+{
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonDown(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
+}
+
+void View::OnPointerReleased(CoreWindow^ /*window*/, PointerEventArgs^ args)
+{
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonUp(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
+}
+
+void View::UpdateWindowSize()
+{
+	CoreWindow^ window = CoreWindow::GetForCurrentThread();
+	Windows::Foundation::Rect windowBounds = window->Bounds;
+
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	float dpi = displayInformation->LogicalDpi;
+	
+	m_pSample->SetWindowBounds(
+		ConvertToPixels(windowBounds.Left, dpi),
+		ConvertToPixels(windowBounds.Top, dpi),
+		ConvertToPixels(windowBounds.Right, dpi),
+		ConvertToPixels(windowBounds.Bottom, dpi));
+		
+	m_pSample->OnSizeChanged(ConvertToPixels(m_logicalWidth, dpi), ConvertToPixels(m_logicalHeight, dpi), !m_windowVisible);
+}
+
+void View::OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args)
+{
+	m_pSample->OnDisplayChanged();
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/View.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/View.h
@@ -37,12 +37,22 @@ private:
 	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ args);
 	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ args);
 	void OnSizeChanged(CoreWindow^ window, WindowSizeChangedEventArgs^ args);
+	void OnResizeStarted(CoreWindow^ window, Object^ args);
+	void OnResizeCompleted(CoreWindow^ window, Object^ args);
 	void OnDpiChanged(DisplayInformation^ sender, Object^ args);
 	void OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args);
 	void OnClosed(CoreWindow^ window, CoreWindowEventArgs^ args);
-
-	void UpdateWindowSize(float width, float height, bool windowVisible = true);
+	void OnPointerMoved(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerPressed(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerReleased(CoreWindow^ window, PointerEventArgs^ args);
+	void OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args);
+	
+	void UpdateWindowSize();
 
 	DXSample* m_pSample;
 	bool m_windowClosed;
+	bool m_windowResizing;
+	bool m_windowVisible;
+	float m_logicalWidth;
+	float m_logicalHeight;
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/D3D12LinkedGpusAffinity.vcxproj
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/D3D12LinkedGpusAffinity.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.cpp
@@ -17,6 +17,7 @@ using namespace Microsoft::WRL;
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_windowBounds{0,0,0,0},
 	m_title(name),
 	m_aspectRatio(0.0f),
 	m_useWarpDevice(false)
@@ -121,4 +122,12 @@ void DXSample::CheckTearingSupport()
 	}
 
 	m_tearingSupport = SUCCEEDED(hr) && allowTearing;
+}
+
+void DXSample::SetWindowBounds(int left, int top, int right, int bottom)
+{
+    m_windowBounds.left = static_cast<LONG>(left);
+    m_windowBounds.top = static_cast<LONG>(top);
+    m_windowBounds.right = static_cast<LONG>(right);
+    m_windowBounds.bottom = static_cast<LONG>(bottom);
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.h
@@ -26,17 +26,24 @@ public:
 	virtual void OnDestroy() = 0;
 
 	// Samples override the event handlers to handle specific messages.
-	virtual void OnKeyDown(UINT8 /*key*/)   {}
-	virtual void OnKeyUp(UINT8 /*key*/)     {}
-
+	virtual void OnKeyDown(UINT8 /*key*/) {}
+	virtual void OnKeyUp(UINT8 /*key*/) {}
+	virtual void OnWindowMoved(int /*x*/, int /*y*/) {}
+	virtual void OnMouseMove(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnLeftButtonDown(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnLeftButtonUp(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnDisplayChanged() {}
+	
 	// Accessors.
 	UINT GetWidth() const           { return m_width; }
 	UINT GetHeight() const          { return m_height; }
 	const WCHAR* GetTitle() const   { return m_title.c_str(); }
-	bool GetTearingSupport()        { return m_tearingSupport; }
+	bool GetTearingSupport() const  { return m_tearingSupport; }
+	RECT GetWindowsBounds() const   { return m_windowBounds; }
 
 	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 	void UpdateForSizeChange(UINT clientWidth, UINT clientHeight);
+	void SetWindowBounds(int left, int top, int right, int bottom);
 
 protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
@@ -49,6 +56,9 @@ protected:
 	UINT m_height;
 	float m_aspectRatio;
 
+	// Window Bounds
+	RECT m_windowBounds;
+	
 	// Whether or not tearing is available for fullscreen borderless windowed mode.
 	bool m_tearingSupport;
 

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/View.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/View.cpp
@@ -14,9 +14,18 @@
 
 using namespace Windows::Foundation;
 
+inline int ConvertToPixels(float dimension, float dpi)
+{
+	return static_cast<int>(dimension * dpi / 96.0f + 0.5f);
+}
+
 View::View(UINT_PTR pSample) :
 	m_pSample(reinterpret_cast<DXSample*>(pSample)),
-	m_windowClosed(false)
+	m_windowClosed(false),
+	m_windowResizing(false),
+	m_windowVisible(true),
+	m_logicalWidth(0),
+	m_logicalHeight(0)
 {
 }
 
@@ -30,17 +39,34 @@ void View::Initialize(CoreApplicationView^ applicationView)
 
 void View::SetWindow(CoreWindow^ window)
 {
+	m_logicalWidth = window->Bounds.Width;
+	m_logicalHeight = window->Bounds.Height;
+
 	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
 	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
 	window->SizeChanged += ref new TypedEventHandler<CoreWindow^, WindowSizeChangedEventArgs^>(this, &View::OnSizeChanged);
 	window->VisibilityChanged += ref new TypedEventHandler<CoreWindow^, VisibilityChangedEventArgs^>(this, &View::OnVisibilityChanged);
 	window->Closed += ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &View::OnClosed);
+	window->PointerMoved += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerMoved);
+	window->PointerPressed += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerPressed);
+	window->PointerReleased += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerReleased);
+
+	try
+	{
+		window->ResizeStarted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeStarted);
+		window->ResizeCompleted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeCompleted);
+	}
+	catch (Exception^ e)
+	{
+		// Requires Windows 10 Creators Update (10.0.15063) or later.
+	}
 
 	// For simplicity, this sample ignores a number of events on CoreWindow that a
 	// typical app should subscribe to.
 
 	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
 	displayInformation->DpiChanged += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDpiChanged);
+	displayInformation->DisplayContentsInvalidated += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDisplayContentsInvalidated);
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -92,18 +118,35 @@ void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 
 void View::OnSizeChanged(CoreWindow^ /*window*/, WindowSizeChangedEventArgs^ args)
 {
-	UpdateWindowSize(args->Size.Width, args->Size.Height);
+	m_logicalWidth = args->Size.Width;
+	m_logicalHeight = args->Size.Height;
+
+	if (!m_windowResizing)
+	{
+		UpdateWindowSize();
+	}
+}
+
+void View::OnResizeStarted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
+{
+	m_windowResizing = true;
+}
+
+void View::OnResizeCompleted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
+{
+	m_windowResizing = false;
+	UpdateWindowSize();
 }
 
 void View::OnDpiChanged(DisplayInformation^ /*sender*/, Object^ /*args*/)
 {
-	CoreWindow^ window = CoreWindow::GetForCurrentThread();
-	UpdateWindowSize(window->Bounds.Width, window->Bounds.Height);
+	UpdateWindowSize();
 }
 
-void View::OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args)
+void View::OnVisibilityChanged(CoreWindow^ /*window*/, VisibilityChangedEventArgs^ args)
 {
-	UpdateWindowSize(window->Bounds.Width, window->Bounds.Height, args->Visible);
+	m_windowVisible = args->Visible;
+	UpdateWindowSize();
 }
 
 void View::OnClosed(CoreWindow^ /*window*/, CoreWindowEventArgs^ /*args*/)
@@ -111,14 +154,53 @@ void View::OnClosed(CoreWindow^ /*window*/, CoreWindowEventArgs^ /*args*/)
 	m_windowClosed = true;
 }
 
-inline UINT ConvertToPixels(float dimension, float dpi)
-{
-	return static_cast<UINT>(dimension * dpi / 96.0f);
-}
-
-void View::UpdateWindowSize(float width, float height, bool visible)
+void View::OnPointerMoved(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
 	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
 	float dpi = displayInformation->LogicalDpi;
-	m_pSample->OnSizeChanged(ConvertToPixels(width, dpi), ConvertToPixels(height, dpi), !visible);
+	m_pSample->OnMouseMove(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+}
+
+void View::OnPointerPressed(CoreWindow^ /*window*/, PointerEventArgs^ args)
+{
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonDown(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
+}
+
+void View::OnPointerReleased(CoreWindow^ /*window*/, PointerEventArgs^ args)
+{
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonUp(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
+}
+
+void View::UpdateWindowSize()
+{
+	CoreWindow^ window = CoreWindow::GetForCurrentThread();
+	Windows::Foundation::Rect windowBounds = window->Bounds;
+
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	float dpi = displayInformation->LogicalDpi;
+	
+	m_pSample->SetWindowBounds(
+		ConvertToPixels(windowBounds.Left, dpi),
+		ConvertToPixels(windowBounds.Top, dpi),
+		ConvertToPixels(windowBounds.Right, dpi),
+		ConvertToPixels(windowBounds.Bottom, dpi));
+		
+	m_pSample->OnSizeChanged(ConvertToPixels(m_logicalWidth, dpi), ConvertToPixels(m_logicalHeight, dpi), !m_windowVisible);
+}
+
+void View::OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args)
+{
+	m_pSample->OnDisplayChanged();
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/View.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/View.h
@@ -37,12 +37,22 @@ private:
 	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ args);
 	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ args);
 	void OnSizeChanged(CoreWindow^ window, WindowSizeChangedEventArgs^ args);
+	void OnResizeStarted(CoreWindow^ window, Object^ args);
+	void OnResizeCompleted(CoreWindow^ window, Object^ args);
 	void OnDpiChanged(DisplayInformation^ sender, Object^ args);
 	void OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args);
 	void OnClosed(CoreWindow^ window, CoreWindowEventArgs^ args);
-
-	void UpdateWindowSize(float width, float height, bool windowVisible = true);
+	void OnPointerMoved(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerPressed(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerReleased(CoreWindow^ window, PointerEventArgs^ args);
+	void OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args);
+	
+	void UpdateWindowSize();
 
 	DXSample* m_pSample;
 	bool m_windowClosed;
+	bool m_windowResizing;
+	bool m_windowVisible;
+	float m_logicalWidth;
+	float m_logicalHeight;
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/D3D12SingleGpu.vcxproj
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/D3D12SingleGpu.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/DXSample.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/DXSample.cpp
@@ -17,6 +17,7 @@ using namespace Microsoft::WRL;
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_windowBounds{0,0,0,0},
 	m_title(name),
 	m_aspectRatio(0.0f),
 	m_useWarpDevice(false)
@@ -121,4 +122,12 @@ void DXSample::CheckTearingSupport()
 	}
 
 	m_tearingSupport = SUCCEEDED(hr) && allowTearing;
+}
+
+void DXSample::SetWindowBounds(int left, int top, int right, int bottom)
+{
+    m_windowBounds.left = static_cast<LONG>(left);
+    m_windowBounds.top = static_cast<LONG>(top);
+    m_windowBounds.right = static_cast<LONG>(right);
+    m_windowBounds.bottom = static_cast<LONG>(bottom);
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/DXSample.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/DXSample.h
@@ -26,17 +26,24 @@ public:
 	virtual void OnDestroy() = 0;
 
 	// Samples override the event handlers to handle specific messages.
-	virtual void OnKeyDown(UINT8 /*key*/)   {}
-	virtual void OnKeyUp(UINT8 /*key*/)     {}
-
+	virtual void OnKeyDown(UINT8 /*key*/) {}
+	virtual void OnKeyUp(UINT8 /*key*/) {}
+	virtual void OnWindowMoved(int /*x*/, int /*y*/) {}
+	virtual void OnMouseMove(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnLeftButtonDown(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnLeftButtonUp(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnDisplayChanged() {}
+	
 	// Accessors.
 	UINT GetWidth() const           { return m_width; }
 	UINT GetHeight() const          { return m_height; }
 	const WCHAR* GetTitle() const   { return m_title.c_str(); }
-	bool GetTearingSupport()        { return m_tearingSupport; }
+	bool GetTearingSupport() const  { return m_tearingSupport; }
+	RECT GetWindowsBounds() const   { return m_windowBounds; }
 
 	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 	void UpdateForSizeChange(UINT clientWidth, UINT clientHeight);
+	void SetWindowBounds(int left, int top, int right, int bottom);
 
 protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
@@ -49,6 +56,9 @@ protected:
 	UINT m_height;
 	float m_aspectRatio;
 
+	// Window Bounds
+	RECT m_windowBounds;
+	
 	// Whether or not tearing is available for fullscreen borderless windowed mode.
 	bool m_tearingSupport;
 

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/View.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/View.cpp
@@ -14,9 +14,18 @@
 
 using namespace Windows::Foundation;
 
+inline int ConvertToPixels(float dimension, float dpi)
+{
+	return static_cast<int>(dimension * dpi / 96.0f + 0.5f);
+}
+
 View::View(UINT_PTR pSample) :
 	m_pSample(reinterpret_cast<DXSample*>(pSample)),
-	m_windowClosed(false)
+	m_windowClosed(false),
+	m_windowResizing(false),
+	m_windowVisible(true),
+	m_logicalWidth(0),
+	m_logicalHeight(0)
 {
 }
 
@@ -30,17 +39,34 @@ void View::Initialize(CoreApplicationView^ applicationView)
 
 void View::SetWindow(CoreWindow^ window)
 {
+	m_logicalWidth = window->Bounds.Width;
+	m_logicalHeight = window->Bounds.Height;
+
 	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
 	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
 	window->SizeChanged += ref new TypedEventHandler<CoreWindow^, WindowSizeChangedEventArgs^>(this, &View::OnSizeChanged);
 	window->VisibilityChanged += ref new TypedEventHandler<CoreWindow^, VisibilityChangedEventArgs^>(this, &View::OnVisibilityChanged);
 	window->Closed += ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &View::OnClosed);
+	window->PointerMoved += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerMoved);
+	window->PointerPressed += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerPressed);
+	window->PointerReleased += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerReleased);
+
+	try
+	{
+		window->ResizeStarted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeStarted);
+		window->ResizeCompleted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeCompleted);
+	}
+	catch (Exception^ e)
+	{
+		// Requires Windows 10 Creators Update (10.0.15063) or later.
+	}
 
 	// For simplicity, this sample ignores a number of events on CoreWindow that a
 	// typical app should subscribe to.
 
 	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
 	displayInformation->DpiChanged += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDpiChanged);
+	displayInformation->DisplayContentsInvalidated += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDisplayContentsInvalidated);
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -92,18 +118,35 @@ void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 
 void View::OnSizeChanged(CoreWindow^ /*window*/, WindowSizeChangedEventArgs^ args)
 {
-	UpdateWindowSize(args->Size.Width, args->Size.Height);
+	m_logicalWidth = args->Size.Width;
+	m_logicalHeight = args->Size.Height;
+
+	if (!m_windowResizing)
+	{
+		UpdateWindowSize();
+	}
+}
+
+void View::OnResizeStarted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
+{
+	m_windowResizing = true;
+}
+
+void View::OnResizeCompleted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
+{
+	m_windowResizing = false;
+	UpdateWindowSize();
 }
 
 void View::OnDpiChanged(DisplayInformation^ /*sender*/, Object^ /*args*/)
 {
-	CoreWindow^ window = CoreWindow::GetForCurrentThread();
-	UpdateWindowSize(window->Bounds.Width, window->Bounds.Height);
+	UpdateWindowSize();
 }
 
-void View::OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args)
+void View::OnVisibilityChanged(CoreWindow^ /*window*/, VisibilityChangedEventArgs^ args)
 {
-	UpdateWindowSize(window->Bounds.Width, window->Bounds.Height, args->Visible);
+	m_windowVisible = args->Visible;
+	UpdateWindowSize();
 }
 
 void View::OnClosed(CoreWindow^ /*window*/, CoreWindowEventArgs^ /*args*/)
@@ -111,14 +154,53 @@ void View::OnClosed(CoreWindow^ /*window*/, CoreWindowEventArgs^ /*args*/)
 	m_windowClosed = true;
 }
 
-inline UINT ConvertToPixels(float dimension, float dpi)
-{
-	return static_cast<UINT>(dimension * dpi / 96.0f);
-}
-
-void View::UpdateWindowSize(float width, float height, bool visible)
+void View::OnPointerMoved(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
 	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
 	float dpi = displayInformation->LogicalDpi;
-	m_pSample->OnSizeChanged(ConvertToPixels(width, dpi), ConvertToPixels(height, dpi), !visible);
+	m_pSample->OnMouseMove(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+}
+
+void View::OnPointerPressed(CoreWindow^ /*window*/, PointerEventArgs^ args)
+{
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonDown(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
+}
+
+void View::OnPointerReleased(CoreWindow^ /*window*/, PointerEventArgs^ args)
+{
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonUp(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
+}
+
+void View::UpdateWindowSize()
+{
+	CoreWindow^ window = CoreWindow::GetForCurrentThread();
+	Windows::Foundation::Rect windowBounds = window->Bounds;
+
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	float dpi = displayInformation->LogicalDpi;
+	
+	m_pSample->SetWindowBounds(
+		ConvertToPixels(windowBounds.Left, dpi),
+		ConvertToPixels(windowBounds.Top, dpi),
+		ConvertToPixels(windowBounds.Right, dpi),
+		ConvertToPixels(windowBounds.Bottom, dpi));
+		
+	m_pSample->OnSizeChanged(ConvertToPixels(m_logicalWidth, dpi), ConvertToPixels(m_logicalHeight, dpi), !m_windowVisible);
+}
+
+void View::OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args)
+{
+	m_pSample->OnDisplayChanged();
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/View.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/View.h
@@ -37,12 +37,22 @@ private:
 	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ args);
 	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ args);
 	void OnSizeChanged(CoreWindow^ window, WindowSizeChangedEventArgs^ args);
+	void OnResizeStarted(CoreWindow^ window, Object^ args);
+	void OnResizeCompleted(CoreWindow^ window, Object^ args);
 	void OnDpiChanged(DisplayInformation^ sender, Object^ args);
 	void OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args);
 	void OnClosed(CoreWindow^ window, CoreWindowEventArgs^ args);
-
-	void UpdateWindowSize(float width, float height, bool windowVisible = true);
+	void OnPointerMoved(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerPressed(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerReleased(CoreWindow^ window, PointerEventArgs^ args);
+	void OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args);
+	
+	void UpdateWindowSize();
 
 	DXSample* m_pSample;
 	bool m_windowClosed;
+	bool m_windowResizing;
+	bool m_windowVisible;
+	float m_logicalWidth;
+	float m_logicalHeight;
 };

--- a/Samples/UWP/D3D12PipelineStateCache/src/D3D12PipelineStateCache.vcxproj
+++ b/Samples/UWP/D3D12PipelineStateCache/src/D3D12PipelineStateCache.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12PredicationQueries/src/D3D12PredicationQueries.vcxproj
+++ b/Samples/UWP/D3D12PredicationQueries/src/D3D12PredicationQueries.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12ReservedResources/src/D3D12ReservedResources.vcxproj
+++ b/Samples/UWP/D3D12ReservedResources/src/D3D12ReservedResources.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12Residency/src/D3D12Residency.vcxproj
+++ b/Samples/UWP/D3D12Residency/src/D3D12Residency.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.vcxproj
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.vcxproj.filters
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.vcxproj.filters
@@ -111,10 +111,6 @@
     <CustomBuild Include="magnify.hlsl">
       <Filter>Assets\Shaders</Filter>
     </CustomBuild>
-  </ItemGroup>
-  <ItemGroup>
-    <FxCompile Include="wave.hlsl">
-      <Filter>Assets\Shaders</Filter>
-    </FxCompile>
+    <CustomBuild Include="wave.hlsl" />
   </ItemGroup>
 </Project>

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/DXSample.cpp
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/DXSample.cpp
@@ -17,6 +17,7 @@ using namespace Microsoft::WRL;
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
 	m_width(width),
 	m_height(height),
+	m_windowBounds{0,0,0,0},
 	m_title(name),
 	m_aspectRatio(0.0f),
 	m_useWarpDevice(false)
@@ -121,4 +122,12 @@ void DXSample::CheckTearingSupport()
 	}
 
 	m_tearingSupport = SUCCEEDED(hr) && allowTearing;
+}
+
+void DXSample::SetWindowBounds(int left, int top, int right, int bottom)
+{
+    m_windowBounds.left = static_cast<LONG>(left);
+    m_windowBounds.top = static_cast<LONG>(top);
+    m_windowBounds.right = static_cast<LONG>(right);
+    m_windowBounds.bottom = static_cast<LONG>(bottom);
 }

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/DXSample.h
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/DXSample.h
@@ -32,15 +32,18 @@ public:
 	virtual void OnMouseMove(UINT /*x*/, UINT /*y*/) {}
 	virtual void OnLeftButtonDown(UINT /*x*/, UINT /*y*/) {}
 	virtual void OnLeftButtonUp(UINT /*x*/, UINT /*y*/) {}
+	virtual void OnDisplayChanged() {}
 	
 	// Accessors.
 	UINT GetWidth() const           { return m_width; }
 	UINT GetHeight() const          { return m_height; }
 	const WCHAR* GetTitle() const   { return m_title.c_str(); }
-	bool GetTearingSupport()        { return m_tearingSupport; }
+	bool GetTearingSupport() const  { return m_tearingSupport; }
+	RECT GetWindowsBounds() const   { return m_windowBounds; }
 
 	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 	void UpdateForSizeChange(UINT clientWidth, UINT clientHeight);
+	void SetWindowBounds(int left, int top, int right, int bottom);
 
 protected:
 	std::wstring GetAssetFullPath(LPCWSTR assetName);
@@ -53,6 +56,9 @@ protected:
 	UINT m_height;
 	float m_aspectRatio;
 
+	// Window Bounds
+	RECT m_windowBounds;
+	
 	// Whether or not tearing is available for fullscreen borderless windowed mode.
 	bool m_tearingSupport;
 

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/View.h
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/View.h
@@ -37,15 +37,22 @@ private:
 	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ args);
 	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ args);
 	void OnSizeChanged(CoreWindow^ window, WindowSizeChangedEventArgs^ args);
+	void OnResizeStarted(CoreWindow^ window, Object^ args);
+	void OnResizeCompleted(CoreWindow^ window, Object^ args);
 	void OnDpiChanged(DisplayInformation^ sender, Object^ args);
 	void OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args);
 	void OnClosed(CoreWindow^ window, CoreWindowEventArgs^ args);
 	void OnPointerMoved(CoreWindow^ window, PointerEventArgs^ args);
 	void OnPointerPressed(CoreWindow^ window, PointerEventArgs^ args);
 	void OnPointerReleased(CoreWindow^ window, PointerEventArgs^ args);
+	void OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args);
 	
-	void UpdateWindowSize(float width, float height, bool windowVisible = true);
+	void UpdateWindowSize();
 
 	DXSample* m_pSample;
 	bool m_windowClosed;
+	bool m_windowResizing;
+	bool m_windowVisible;
+	float m_logicalWidth;
+	float m_logicalHeight;
 };

--- a/Samples/UWP/D3D12SmallResources/src/D3D12SmallResources.vcxproj
+++ b/Samples/UWP/D3D12SmallResources/src/D3D12SmallResources.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/UWP/D3D12nBodyGravity/src/D3D12nBodyGravity.vcxproj
+++ b/Samples/UWP/D3D12nBodyGravity/src/D3D12nBodyGravity.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>


### PR DESCRIPTION
…e HDR, Fullscreen, LinkedGPUs, SM6WaveIntrinsics samples with latest changes.

Notable updates:
- Resizable UWP samples (e.g the Fullscreen sample) now use the new Resize events
- HDR sample updates to handle multi-mon scenarios and send HDR metadata