### PR TITLE
Resolving several more compiler warnings

### DIFF
--- a/Libraries/D3D12RaytracingFallback/src/CpuBVH2Builder.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/CpuBVH2Builder.cpp
@@ -122,6 +122,7 @@ namespace FallbackLayer
             const AABB& box,
             UINT32 maxDimension)
     {
+        UNREFERENCED_PARAMETER(maxDimension);
         assert(maxDimension < 3);
         const UINT32 nodeIndex = (UINT32)bvh.m_nodes.size();
 
@@ -665,7 +666,7 @@ namespace FallbackLayer
 
 void BuildRaytracingAccelerationStructureOnCpu(
     _In_  const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC *pDesc,
-    _Outptr_ void *pData)
+    _Out_ void *pData)
 {
     FallbackLayer::BVH bvh;
     FallbackLayer::BuildUniformBVH(pDesc->NumDescs, pDesc->pGeometryDescs, bvh);

--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayer.vcxproj
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayer.vcxproj
@@ -54,7 +54,15 @@
     <Import Project="PropertySheets\VS15.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <IncludePath>$(ProjectDir)..\include;$(SolutionDir)..\Build_VS15\$(Platform)\$(Configuration)\Output\$(ProjectName);$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Profile|x64'">
+    <IncludePath>$(ProjectDir)..\include;$(SolutionDir)..\Build_VS15\$(Platform)\$(Configuration)\Output\$(ProjectName);$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IncludePath>$(ProjectDir)..\include;$(SolutionDir)..\Build_VS15\$(Platform)\$(Configuration)\Output\$(ProjectName);$(IncludePath)</IncludePath>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>

--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayer.vcxproj.filters
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayer.vcxproj.filters
@@ -150,6 +150,12 @@
     <FxCompile Include="CalculateSceneAABBFromPrimitives.hlsl">
       <Filter>Shaders</Filter>
     </FxCompile>
+    <FxCompile Include="*Lib.hlsl" />
+    <FxCompile Include="*Lib.hlsl" />
+    <FxCompile Include="*Lib.hlsl" />
+    <FxCompile Include="*Lib.hlsl" />
+    <FxCompile Include="*Lib.hlsl" />
+    <FxCompile Include="*Lib.hlsl" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AccelerationStructureBuilderFactory.cpp">

--- a/Libraries/D3D12RaytracingFallback/src/RaytracingCompatibilityDebug.h
+++ b/Libraries/D3D12RaytracingFallback/src/RaytracingCompatibilityDebug.h
@@ -21,4 +21,4 @@ void VisualizeAccelerationStructureLevel(ID3D12RaytracingFallbackDevice *pDevice
 
 void BuildRaytracingAccelerationStructureOnCpu(
     _In_  const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC *pDesc,
-    _Outptr_ void *pData);
+    _Out_ void *pData);

--- a/Libraries/D3D12RaytracingFallback/src/Util.h
+++ b/Libraries/D3D12RaytracingFallback/src/Util.h
@@ -31,14 +31,14 @@ inline void ThrowFailure(HRESULT hr, LPCWSTR errorString = nullptr)
 template <typename T>
 T DivideAndRoundUp(T dividend, T divisor) { return (dividend - 1) / divisor + 1; }
 
-__forceinline uint8_t Log2(uint64_t value)
+__forceinline uint8_t Log2(uint32_t value)
 {
     unsigned long mssb; // most significant set bit
     unsigned long lssb; // least significant set bit
 
                         // If perfect power of two (only one set bit), return index of bit.  Otherwise round up
                         // fractional log by adding 1 to most signicant set bit's index.
-    if (BitScanReverse64(&mssb, value) > 0 && BitScanForward64(&lssb, value) > 0)
+    if (BitScanReverse(&mssb, value) > 0 && BitScanForward(&lssb, value) > 0)
         return uint8_t(mssb + (mssb == lssb ? 0 : 1));
     else
         return 0;

--- a/Libraries/D3D12RaytracingFallback/src/pch.h
+++ b/Libraries/D3D12RaytracingFallback/src/pch.h
@@ -26,8 +26,8 @@
 #include <deque>
 #include <string>
 #include <strsafe.h>
-#include "..\include\d3d12_1.h"
-#include "..\include\d3dx12.h"
+#include "d3d12_1.h"
+#include "d3dx12.h"
 #include "dxc\dxcapi.h"
 #include "dxc\dxcapi.use.h"
 #include "dxc\hlsl\DxilContainer.h"
@@ -35,7 +35,7 @@
 
 #include "FallbackDebug.h"
 
-#include "..\include\D3D12RaytracingFallback.h"
+#include "D3D12RaytracingFallback.h"
 #include "RaytracingCompatibilityDebug.h"
 #include "ComObject.h"
 


### PR DESCRIPTION
Fixing the include paths, cleaning up SAL, and modifying the Log2 function so that the Fallback can compile more universally across architectures