### PR TITLE
Adding a missing "globallycoherent" specifier that caused TDRs on some devices

### DIFF
--- a/Libraries/D3D12RaytracingFallback/src/ConstructAABBBindings.h
+++ b/Libraries/D3D12RaytracingFallback/src/ConstructAABBBindings.h
@@ -33,7 +33,7 @@ struct InputConstants
 #define InputConstantsRegister 0
 
 #ifdef HLSL
-RWByteAddressBuffer outputBVH : UAV_REGISTER(OutputBVHRegister);
+globallycoherent RWByteAddressBuffer outputBVH : UAV_REGISTER(OutputBVHRegister);
 RWByteAddressBuffer scratchMemory : UAV_REGISTER(ScratchBufferRegister);
 RWByteAddressBuffer childNodesProcessedCounter : UAV_REGISTER(ChildNodesProcessedBufferRegister);
 RWStructuredBuffer<uint> mortonCodes : UAV_REGISTER(MortonCodesBufferRegister);

--- a/Libraries/D3D12RaytracingFallback/src/TreeletReorder.hlsl
+++ b/Libraries/D3D12RaytracingFallback/src/TreeletReorder.hlsl
@@ -67,8 +67,6 @@ bool IsLeaf(uint nodeIndex)
 [numthreads(THREAD_GROUP_1D_WIDTH, 1, 1)]
 void main( uint3 DTid : SV_DispatchThreadID )
 {
-    uint unused;
-
     if (DTid.x >= Constants.NumberOfElements) return;
 
     const uint NumberOfInternalNodes = GetNumInternalNodes(Constants.NumberOfElements);

--- a/Libraries/D3D12RaytracingFallback/src/TreeletReorderBindings.h
+++ b/Libraries/D3D12RaytracingFallback/src/TreeletReorderBindings.h
@@ -36,7 +36,7 @@ struct InputConstants
 // These need to be UAVs despite being read-only because the fallback layer only gets a 
 // GPU VA and the API doesn't allow any way to transition that GPU VA from UAV->SRV
 
-RWStructuredBuffer<HierarchyNode> hierarchyBuffer : UAV_REGISTER(HierarchyBufferRegister);
+globallycoherent RWStructuredBuffer<HierarchyNode> hierarchyBuffer : UAV_REGISTER(HierarchyBufferRegister);
 RWByteAddressBuffer NumTrianglesBuffer : UAV_REGISTER(NumTrianglesBufferRegister);
 globallycoherent RWStructuredBuffer<AABB> AABBBuffer : UAV_REGISTER(AABBBufferRegister);
 RWStructuredBuffer<Primitive> InputBuffer : UAV_REGISTER(ElementBufferRegister);

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/ModelViewer.cpp
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/ModelViewer.cpp
@@ -261,10 +261,11 @@ int wmain(int argc, wchar_t** argv)
             {
                 DXGI_ADAPTER_DESC1 desc;
                 pAdapter->GetDesc1(&desc);
-                if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
-                    continue;
-
-                validDeviceFound = SUCCEEDED(D3D12CreateDevice(pAdapter, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&pDevice)));
+                if ((desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE) == 0)
+                {
+                    validDeviceFound = SUCCEEDED(D3D12CreateDevice(pAdapter, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&pDevice)));
+                }
+                pAdapter = nullptr;
             }
             if (validDeviceFound) break;
         }


### PR DESCRIPTION
Adding the globallycoherent tag on resources that depended on writes from other waves after a device barrier. Fixes a TDR that was happening on some devices.

Also bundling in a fix where a CComPtr's &operator would be used with non-null contents on RS5 builds.