### PR TITLE
Workaround to enable several levels of recursion for anyhit/intersection shaders

### DIFF
--- a/Libraries/D3D12RaytracingFallback/src/UberShaderRayTracingProgram.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/UberShaderRayTracingProgram.cpp
@@ -137,7 +137,16 @@ namespace FallbackLayer
 
         std::vector<FallbackLayer::StateIdentifier> stateIdentifiers;
         CComPtr<IDxcBlob> pLinkedBlob;
-        m_DxilShaderPatcher.LinkShaders((UINT)stateObjectCollection.m_pipelineStackSize, librariesInfo, exportNames, stateIdentifiers, &pLinkedBlob);
+        UINT stackSize = (UINT)stateObjectCollection.m_pipelineStackSize;
+        if (stackSize == 0 && (stateObjectCollection.IsUsingAnyHit || stateObjectCollection.IsUsingIntersection))
+        {
+            // TODO: The stack size used by the traversal shader is high when it's split by a continuation from the
+            // Intersection shader or the Anyhit. Currently setting a higher hard-coded value, this can go-away
+            // once API-specified stack-sizes are supported
+            stackSize = 2048;
+        }
+
+        m_DxilShaderPatcher.LinkShaders(stackSize, librariesInfo, exportNames, stateIdentifiers, &pLinkedBlob);
 
         for (size_t i = 0; i < exportNames.size(); ++i)
         {


### PR DESCRIPTION
Adding a workaround in lieu of API-specified stack support (significant amount of dev required) to allow for the procedural geometry sample to run properly.

The underlying issue is using intersection shaders introduces a continuation with the Traversal shader, which introduces a large amount of live-values that wouldn't normally get hit in cases with no anyhit/intersection shaders