### PR TITLE
Removing no longer used Raytracing semantics

### DIFF
--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/ReadRootConstants.hlsl
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/ReadRootConstants.hlsl
@@ -29,7 +29,7 @@ cbuffer Constants : register(b2)
 }
 
 [shader("miss")]
-void miss(inout EmptyPayload payload : SV_RayPayload)
+void miss(inout EmptyPayload payload)
 {
     outputBuffer.Store4(0, asuint(color0));
     outputBuffer.Store4(16, asuint(color1));

--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/SharedReadData.hlsli
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/SharedReadData.hlsli
@@ -14,7 +14,7 @@ float4 ReadData();
 RWByteAddressBuffer outputBuffer : register(u0);
 
 [shader("miss")]
-void miss(inout EmptyPayload payload : SV_RayPayload)
+void miss(inout EmptyPayload payload)
 {
     float4 color0 = ReadData();
     outputBuffer.Store4(0, asuint(color0));

--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/SimpleRayTracing.hlsl
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/SimpleRayTracing.hlsl
@@ -45,13 +45,13 @@ void RayGen()
 }
 
 [shader("miss")]
-void Miss(inout MyPayload payload : SV_RayPayload)
+void Miss(inout MyPayload payload)
 {
     RenderTarget[DispatchRaysIndex()] = float4(1, 0, 0, 1);
 }
 
 [shader("closesthit")]
-void Hit(inout MyPayload payload : SV_RayPayload, in BuiltInTriangleIntersectionAttributes attr : SV_IntersectionAttributes)
+void Hit(inout MyPayload payload, in BuiltInTriangleIntersectionAttributes attr)
 {
     RenderTarget[DispatchRaysIndex()] = float4(1, 0, 1, 1);
 }

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingHelloWorld/Raytracing.hlsl
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingHelloWorld/Raytracing.hlsl
@@ -67,14 +67,14 @@ void MyRaygenShader()
 }
 
 [shader("closesthit")]
-void MyClosestHitShader(inout RayPayload payload : SV_RayPayload, in MyAttributes attr : SV_IntersectionAttributes)
+void MyClosestHitShader(inout RayPayload payload, in MyAttributes attr)
 {
     float3 barycentrics = float3(1 - attr.barycentrics.x - attr.barycentrics.y, attr.barycentrics.x, attr.barycentrics.y);
     payload.color = float4(barycentrics, 1);
 }
 
 [shader("miss")]
-void MyMissShader(inout RayPayload payload : SV_RayPayload)
+void MyMissShader(inout RayPayload payload)
 {
     payload.color = float4(0, 0, 0, 1);
 }

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/DiffuseHitShaderLib.hlsl
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/DiffuseHitShaderLib.hlsl
@@ -219,7 +219,7 @@ void CalculateUVDerivatives(float3 normal, float3 dpdu, float3 dpdv, float3 p, f
 }
 
 [shader("closesthit")]
-void Hit(inout RayPayload payload : SV_RayPayload, in BuiltInTriangleIntersectionAttributes attr : SV_IntersectionAttributes)
+void Hit(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
 {
     payload.RayHitT = RayTCurrent();
     if (payload.SkipShading)

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/hitShaderLib.hlsl
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/hitShaderLib.hlsl
@@ -13,7 +13,7 @@
 #include "ModelViewerRaytracing.h"
 
 [shader("closesthit")]
-void Hit(inout RayPayload payload : SV_RayPayload, in BuiltInTriangleIntersectionAttributes attr : SV_IntersectionAttributes)
+void Hit(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
 {
     payload.RayHitT = RayTCurrent();
     if (!payload.SkipShading)

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/missShaderLib.hlsl
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/missShaderLib.hlsl
@@ -13,7 +13,7 @@
 #include "ModelViewerRaytracing.h"
 
 [shader("miss")]
-void Miss(inout RayPayload payload : SV_RayPayload)
+void Miss(inout RayPayload payload)
 {
     if (!payload.SkipShading)
     {

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/missShadowsLib.hlsl
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/missShadowsLib.hlsl
@@ -13,7 +13,7 @@
 #include "ModelViewerRaytracing.h"
 
 [shader("miss")]
-void Miss(inout RayPayload payload : SV_RayPayload)
+void Miss(inout RayPayload payload)
 {
     // Do nothing
 }

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingProceduralGeometry/Raytracing.hlsl
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingProceduralGeometry/Raytracing.hlsl
@@ -153,7 +153,7 @@ void MyRaygenShader()
 // 
 
 [shader("closesthit")]
-void MyClosestHitShader_Triangle(inout RayPayload rayPayload : SV_RayPayload, in BuiltInTriangleIntersectionAttributes attr : SV_IntersectionAttributes)
+void MyClosestHitShader_Triangle(inout RayPayload rayPayload, in BuiltInTriangleIntersectionAttributes attr)
 {
     // Get the base index of the triangle's first 16 bit index.
     uint indexSizeInBytes = 2;
@@ -187,7 +187,7 @@ void MyClosestHitShader_Triangle(inout RayPayload rayPayload : SV_RayPayload, in
 }
 
 [shader("closesthit")]
-void MyClosestHitShader_AABB(inout RayPayload rayPayload : SV_RayPayload, in ProceduralPrimitiveAttributes attr : SV_IntersectionAttributes)
+void MyClosestHitShader_AABB(inout RayPayload rayPayload, in ProceduralPrimitiveAttributes attr)
 {
     float t = RayTCurrent();
     float3 hitPosition = HitWorldPosition();
@@ -223,7 +223,7 @@ void MyClosestHitShader_AABB(inout RayPayload rayPayload : SV_RayPayload, in Pro
 
 
 [shader("miss")]
-void MyMissShader(inout RayPayload rayPayload : SV_RayPayload)
+void MyMissShader(inout RayPayload rayPayload)
 {
     //float4 background = float4(0, 0, 0, 1.0f); //float4(0.8, 0.9, 1.0, 1.0f); //
     float4 background = float4(0.05f, 0.3f, 0.5f, 1.0f); //float4(0.8, 0.9, 1.0, 1.0f); //
@@ -232,7 +232,7 @@ void MyMissShader(inout RayPayload rayPayload : SV_RayPayload)
 
 
 [shader("miss")]
-void MyMissShader_ShadowRay(inout ShadowRayPayload rayPayload : SV_RayPayload)
+void MyMissShader_ShadowRay(inout ShadowRayPayload rayPayload)
 {
     rayPayload.hit = false;
 }

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/Raytracing.hlsl
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/Raytracing.hlsl
@@ -129,7 +129,7 @@ void MyRaygenShader()
 }
 
 [shader("closesthit")]
-void MyClosestHitShader(inout RayPayload payload : SV_RayPayload, in MyAttributes attr : SV_IntersectionAttributes)
+void MyClosestHitShader(inout RayPayload payload, in MyAttributes attr)
 {
     float3 hitPosition = HitWorldPosition();
 
@@ -161,7 +161,7 @@ void MyClosestHitShader(inout RayPayload payload : SV_RayPayload, in MyAttribute
 }
 
 [shader("miss")]
-void MyMissShader(inout RayPayload payload : SV_RayPayload)
+void MyMissShader(inout RayPayload payload)
 {
     float4 background = float4(0.0f, 0.2f, 0.4f, 1.0f);
     payload.color = background;


### PR DESCRIPTION
SV_RayPayload and SV_IntersectionAttributes are remnants from an older DXR spec and not actually meaningful semantic names since this is inferred by the ordering (ray payloads are the first parameter, attributes the second). The existing semantics were just being ignored by the compiler