### PR TITLE
NullResources and handle unset descriptors

### DIFF
--- a/MiniEngine/Core/Core_VS15.vcxproj
+++ b/MiniEngine/Core/Core_VS15.vcxproj
@@ -403,6 +403,15 @@
     <ClCompile>
       <AdditionalIncludeDirectories>..\Packages\zlib-vc140-static-64.1.2.11\lib\native\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
+    <FxCompile>
+      <AllResourcesBound Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</AllResourcesBound>
+    </FxCompile>
+    <FxCompile>
+      <AllResourcesBound Condition="'$(Configuration)|$(Platform)'=='Profile|x64'">true</AllResourcesBound>
+    </FxCompile>
+    <FxCompile>
+      <AllResourcesBound Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</AllResourcesBound>
+    </FxCompile>
   </ItemDefinitionGroup>
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\Packages\WinPixEventRuntime.1.0.170918004\build\WinPixEventRuntime.targets" Condition="Exists('..\Packages\WinPixEventRuntime.1.0.170918004\build\WinPixEventRuntime.targets')" />

--- a/MiniEngine/Core/DynamicDescriptorHeap.cpp
+++ b/MiniEngine/Core/DynamicDescriptorHeap.cpp
@@ -30,46 +30,46 @@ namespace {
     {
       using namespace Graphics;
 
-      D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
-      uavDesc.Format = DXGI_FORMAT_R8_UINT;
-      uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE1D;
+      D3D12_UNORDERED_ACCESS_VIEW_DESC UAVDesc = {};
+      UAVDesc.Format = DXGI_FORMAT_R8_UINT;
+      UAVDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE1D;
 
-      mUavNullDescriptor = AllocateDescriptor(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-      g_Device->CreateUnorderedAccessView(nullptr, nullptr, &uavDesc, mUavNullDescriptor);
+      m_UavNullDescriptor = AllocateDescriptor(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+      g_Device->CreateUnorderedAccessView(nullptr, nullptr, &UAVDesc, m_UavNullDescriptor);
 
-      D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-      srvDesc.Format = DXGI_FORMAT_R8_UINT;
-      srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE1D;
-      srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+      D3D12_SHADER_RESOURCE_VIEW_DESC SRVDesc = {};
+      SRVDesc.Format = DXGI_FORMAT_R8_UINT;
+      SRVDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE1D;
+      SRVDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
 
-      mSrvNullDescriptor = AllocateDescriptor(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-      g_Device->CreateShaderResourceView(nullptr, &srvDesc, mSrvNullDescriptor);
+      m_SrvNullDescriptor = AllocateDescriptor(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+      g_Device->CreateShaderResourceView(nullptr, &SRVDesc, m_SrvNullDescriptor);
 
-      mCbvNullDescriptor = AllocateDescriptor(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-      g_Device->CreateConstantBufferView(nullptr, mCbvNullDescriptor);
+      m_CbvNullDescriptor = AllocateDescriptor(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+      g_Device->CreateConstantBufferView(nullptr, m_CbvNullDescriptor);
 
-      D3D12_SAMPLER_DESC samplerDesc = {};
-      samplerDesc.AddressU = samplerDesc.AddressV = samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-      mSamplerNullDescriptor = AllocateDescriptor(D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
-      g_Device->CreateSampler(&samplerDesc, mSamplerNullDescriptor);
+      D3D12_SAMPLER_DESC SamplerDesc = {};
+      SamplerDesc.AddressU = SamplerDesc.AddressV = SamplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+      m_SamplerNullDescriptor = AllocateDescriptor(D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
+      g_Device->CreateSampler(&SamplerDesc, m_SamplerNullDescriptor);
     }
 
     const D3D12_CPU_DESCRIPTOR_HANDLE& GetType(const D3D12_DESCRIPTOR_RANGE_TYPE& type) {
       if (type == D3D12_DESCRIPTOR_RANGE_TYPE_SRV)
-        return mSrvNullDescriptor;
+        return m_SrvNullDescriptor;
       else if (type == D3D12_DESCRIPTOR_RANGE_TYPE_UAV)
-        return mUavNullDescriptor;
+        return m_UavNullDescriptor;
       else if (type == D3D12_DESCRIPTOR_RANGE_TYPE_CBV)
-        return mCbvNullDescriptor;
+        return m_CbvNullDescriptor;
       else
-        return mSamplerNullDescriptor;
+        return m_SamplerNullDescriptor;
     }
 
   private:
-    D3D12_CPU_DESCRIPTOR_HANDLE mSrvNullDescriptor;
-    D3D12_CPU_DESCRIPTOR_HANDLE mUavNullDescriptor;
-    D3D12_CPU_DESCRIPTOR_HANDLE mCbvNullDescriptor;
-    D3D12_CPU_DESCRIPTOR_HANDLE mSamplerNullDescriptor;
+    D3D12_CPU_DESCRIPTOR_HANDLE m_SrvNullDescriptor;
+    D3D12_CPU_DESCRIPTOR_HANDLE m_UavNullDescriptor;
+    D3D12_CPU_DESCRIPTOR_HANDLE m_CbvNullDescriptor;
+    D3D12_CPU_DESCRIPTOR_HANDLE m_SamplerNullDescriptor;
   };
 
   DefaultResources sm_DefaultResources;

--- a/MiniEngine/Core/DynamicDescriptorHeap.cpp
+++ b/MiniEngine/Core/DynamicDescriptorHeap.cpp
@@ -24,6 +24,58 @@ using namespace Graphics;
 // DynamicDescriptorHeap Implementation
 //
 
+namespace {
+  struct DefaultResources {
+    void CreateDefaultResources()
+    {
+      using namespace Graphics;
+
+      D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
+      uavDesc.Format = DXGI_FORMAT_R8_UINT;
+      uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE1D;
+
+      mUavNullDescriptor = AllocateDescriptor(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+      g_Device->CreateUnorderedAccessView(nullptr, nullptr, &uavDesc, mUavNullDescriptor);
+
+      D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+      srvDesc.Format = DXGI_FORMAT_R8_UINT;
+      srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE1D;
+      srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+
+      mSrvNullDescriptor = AllocateDescriptor(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+      g_Device->CreateShaderResourceView(nullptr, &srvDesc, mSrvNullDescriptor);
+
+      mCbvNullDescriptor = AllocateDescriptor(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+      g_Device->CreateConstantBufferView(nullptr, mCbvNullDescriptor);
+
+      D3D12_SAMPLER_DESC samplerDesc = {};
+      samplerDesc.AddressU = samplerDesc.AddressV = samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+      mSamplerNullDescriptor = AllocateDescriptor(D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
+      g_Device->CreateSampler(&samplerDesc, mSamplerNullDescriptor);
+    }
+
+    const D3D12_CPU_DESCRIPTOR_HANDLE& GetType(const D3D12_DESCRIPTOR_RANGE_TYPE& type) {
+      if (type == D3D12_DESCRIPTOR_RANGE_TYPE_SRV)
+        return mSrvNullDescriptor;
+      else if (type == D3D12_DESCRIPTOR_RANGE_TYPE_UAV)
+        return mUavNullDescriptor;
+      else if (type == D3D12_DESCRIPTOR_RANGE_TYPE_CBV)
+        return mCbvNullDescriptor;
+      else
+        return mSamplerNullDescriptor;
+    }
+
+  private:
+    D3D12_CPU_DESCRIPTOR_HANDLE mSrvNullDescriptor;
+    D3D12_CPU_DESCRIPTOR_HANDLE mUavNullDescriptor;
+    D3D12_CPU_DESCRIPTOR_HANDLE mCbvNullDescriptor;
+    D3D12_CPU_DESCRIPTOR_HANDLE mSamplerNullDescriptor;
+  };
+
+  DefaultResources sm_DefaultResources;
+
+}
+
 std::mutex DynamicDescriptorHeap::sm_Mutex;
 std::vector<Microsoft::WRL::ComPtr<ID3D12DescriptorHeap>> DynamicDescriptorHeap::sm_DescriptorHeapPool[2];
 std::queue<std::pair<uint64_t, ID3D12DescriptorHeap*>> DynamicDescriptorHeap::sm_RetiredDescriptorHeaps[2];
@@ -96,6 +148,9 @@ DynamicDescriptorHeap::DynamicDescriptorHeap(CommandContext& OwningContext, D3D1
     m_CurrentHeapPtr = nullptr;
     m_CurrentOffset = 0;
     m_DescriptorSize = Graphics::g_Device->GetDescriptorHandleIncrementSize(HeapType);
+
+    static std::once_flag init;
+    std::call_once(init, [&]() { sm_DefaultResources.CreateDefaultResources(); });
 }
 
 DynamicDescriptorHeap::~DynamicDescriptorHeap()
@@ -262,6 +317,57 @@ void DynamicDescriptorHeap::CopyAndBindStagedTables( DescriptorHandleCache& Hand
     HandleCache.CopyAndBindStaleTables(m_DescriptorType, m_DescriptorSize, Allocate(NeededSize), CmdList, SetFunc);
 }
 
+void DynamicDescriptorHeap::DescriptorHandleCache::SetDefaults() {
+  unsigned long TableParams = m_RootDescriptorTablesBitMap;
+  unsigned long RootIndex;
+  while (_BitScanForward(&RootIndex, TableParams)) {
+    TableParams ^= (1 << RootIndex);
+    DescriptorTableCache &RootDescTable = m_RootDescriptorTable[RootIndex];
+
+    if (RootDescTable.TableSize == 0u)
+      continue;
+
+    uint32_t TableMask = ((1 << RootDescTable.TableSize) - 1);
+    if (RootDescTable.AssignedHandlesBitMap == TableMask)
+      continue;
+
+    if (RootDescTable.Type != D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE)
+      continue;
+
+    uint64_t SetHandles = (uint64_t)m_RootDescriptorTable[RootIndex].AssignedHandlesBitMap;
+    auto SrcHandles = RootDescTable.TableStart;
+
+    if (RootDescTable.RangeType >= D3D12_DESCRIPTOR_RANGE_TYPE_SRV && RootDescTable.RangeType <= D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER)
+    {
+      auto& NullResource = sm_DefaultResources.GetType(RootDescTable.RangeType);
+      uint32_t InverseTableMask = ~TableMask;
+
+      unsigned long UnsetCount;
+      uint32_t Offset = 0;
+      while (_BitScanForward64(&UnsetCount, SetHandles ^ InverseTableMask) && Offset < RootDescTable.TableSize) {
+        SetHandles >>= UnsetCount;
+        InverseTableMask >>= UnsetCount;
+
+        if (UnsetCount > 0) {
+          std::vector<D3D12_CPU_DESCRIPTOR_HANDLE> null_resources(UnsetCount, NullResource);
+          StageDescriptorHandles(RootIndex, Offset, UnsetCount, null_resources.data());
+          Offset += UnsetCount;
+        }
+
+        // Skip already set ones
+        unsigned long DescriptorCount;
+        _BitScanForward64(&DescriptorCount, ~SetHandles);
+        if (DescriptorCount > 0) {
+          SetHandles >>= DescriptorCount;
+          InverseTableMask >>= DescriptorCount;
+          Offset += DescriptorCount;
+        }
+      }
+
+    }
+  }
+}
+
 void DynamicDescriptorHeap::UnbindAllValid( void )
 {
     m_GraphicsHandleCache.UnbindAllValid();
@@ -336,7 +442,8 @@ void DynamicDescriptorHeap::DescriptorHandleCache::ParseRootSignature( D3D12_DES
         RootDescriptorTable.AssignedHandlesBitMap = 0;
         RootDescriptorTable.TableStart = m_HandleCache + CurrentOffset;
         RootDescriptorTable.TableSize = TableSize;
-
+        RootDescriptorTable.Type = RootSig[RootIndex].GetType();
+        RootDescriptorTable.RangeType = RootSig[RootIndex].GetRangeType();
         CurrentOffset += TableSize;
     }
 

--- a/MiniEngine/Core/DynamicDescriptorHeap.h
+++ b/MiniEngine/Core/DynamicDescriptorHeap.h
@@ -68,12 +68,14 @@ public:
     // Upload any new descriptors in the cache to the shader-visible heap.
     inline void CommitGraphicsRootDescriptorTables( ID3D12GraphicsCommandList* CmdList )
     {
+        m_GraphicsHandleCache.SetDefaults();
         if (m_GraphicsHandleCache.m_StaleRootParamsBitMap != 0)
             CopyAndBindStagedTables(m_GraphicsHandleCache, CmdList, &ID3D12GraphicsCommandList::SetGraphicsRootDescriptorTable);
     }
 
     inline void CommitComputeRootDescriptorTables( ID3D12GraphicsCommandList* CmdList )
     {
+        m_ComputeHandleCache.SetDefaults();
         if (m_ComputeHandleCache.m_StaleRootParamsBitMap != 0)
             CopyAndBindStagedTables(m_ComputeHandleCache, CmdList, &ID3D12GraphicsCommandList::SetComputeRootDescriptorTable);
     }
@@ -107,6 +109,8 @@ private:
         uint32_t AssignedHandlesBitMap;
         D3D12_CPU_DESCRIPTOR_HANDLE* TableStart;
         uint32_t TableSize;
+        D3D12_ROOT_PARAMETER_TYPE Type;
+        D3D12_DESCRIPTOR_RANGE_TYPE RangeType;
     };
 
     struct DescriptorHandleCache
@@ -136,6 +140,7 @@ private:
         DescriptorTableCache m_RootDescriptorTable[kMaxNumDescriptorTables];
         D3D12_CPU_DESCRIPTOR_HANDLE m_HandleCache[kMaxNumDescriptors];
 
+        void SetDefaults(void);
         void UnbindAllValid();
         void StageDescriptorHandles( UINT RootIndex, UINT Offset, UINT NumHandles, const D3D12_CPU_DESCRIPTOR_HANDLE Handles[] );
         void ParseRootSignature( D3D12_DESCRIPTOR_HEAP_TYPE Type, const RootSignature& RootSig );

--- a/MiniEngine/Core/GraphicsCore.cpp
+++ b/MiniEngine/Core/GraphicsCore.cpp
@@ -393,7 +393,7 @@ void Graphics::Initialize(void)
             // This occurs when there are uninitialized descriptors in a descriptor table, even when a
             // shader does not access the missing descriptors.  I find this is common when switching
             // shader permutations and not wanting to change much code to reorder resources.
-            D3D12_MESSAGE_ID_INVALID_DESCRIPTOR_HANDLE,
+            //D3D12_MESSAGE_ID_INVALID_DESCRIPTOR_HANDLE,
 
             // Triggered when a shader does not export all color components of a render target, such as
             // when only writing RGB to an R10G10B10A2 buffer, ignoring alpha.
@@ -402,7 +402,7 @@ void Graphics::Initialize(void)
             // This occurs when a descriptor table is unbound even when a shader does not access the missing
             // descriptors.  This is common with a root signature shared between disparate shaders that
             // don't all need the same types of resources.
-            D3D12_MESSAGE_ID_COMMAND_LIST_DESCRIPTOR_TABLE_NOT_SET,
+           // D3D12_MESSAGE_ID_COMMAND_LIST_DESCRIPTOR_TABLE_NOT_SET,
 
             // RESOURCE_BARRIER_DUPLICATE_SUBRESOURCE_TRANSITIONS
             (D3D12_MESSAGE_ID)1008,

--- a/MiniEngine/Core/RootSignature.h
+++ b/MiniEngine/Core/RootSignature.h
@@ -99,6 +99,17 @@ public:
 
     const D3D12_ROOT_PARAMETER& operator() ( void ) const { return m_RootParam; }
         
+  D3D12_DESCRIPTOR_RANGE_TYPE GetRangeType(void) const {
+    if(m_RootParam.ParameterType == D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE) {
+      auto& range = m_RootParam.DescriptorTable.pDescriptorRanges[0];
+      return range.RangeType;
+    }
+    return (D3D12_DESCRIPTOR_RANGE_TYPE)-1;
+  }
+
+  D3D12_ROOT_PARAMETER_TYPE GetType(void) const {
+    return m_RootParam.ParameterType;
+  }
 
 protected:
 

--- a/MiniEngine/ModelViewer/ModelViewer_VS15.vcxproj
+++ b/MiniEngine/ModelViewer/ModelViewer_VS15.vcxproj
@@ -183,6 +183,15 @@
       <AdditionalDependencies>zlibstatic.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/nodefaultlib:LIBCMT %(AdditionalOptions)</AdditionalOptions>
     </Link>
+    <FxCompile>
+      <AllResourcesBound Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</AllResourcesBound>
+    </FxCompile>
+    <FxCompile>
+      <AllResourcesBound Condition="'$(Configuration)|$(Platform)'=='Profile|x64'">true</AllResourcesBound>
+    </FxCompile>
+    <FxCompile>
+      <AllResourcesBound Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</AllResourcesBound>
+    </FxCompile>
   </ItemDefinitionGroup>
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\Packages\WinPixEventRuntime.1.0.170918004\build\WinPixEventRuntime.targets" Condition="Exists('..\Packages\WinPixEventRuntime.1.0.170918004\build\WinPixEventRuntime.targets')" />


### PR DESCRIPTION
Some nice benefits to dealing with unassigned descriptors gracefully. For one i get my debug output window back without resorting to hiding errors and we get a wopping 1fps performance gain from /all_resources_bound.

Let me know if you need/want any changes