### PR TITLE
Fixes to incorrect Shader Record offset calculations, partial support for Root Views, and Root Signature Serialization fixes

### DIFF
--- a/Libraries/D3D12RaytracingFallback/Include/D3D12RaytracingFallback.h
+++ b/Libraries/D3D12RaytracingFallback/Include/D3D12RaytracingFallback.h
@@ -168,6 +168,7 @@ enum class CreateRaytracingFallbackDeviceFlags
 {
     None = 0x0,
     ForceComputeFallback = 0x1,
+    EnableRootDescriptorsInShaderRecords = 0x2
 };
 
 HRESULT D3D12CreateRaytracingFallbackDevice(

--- a/Libraries/D3D12RaytracingFallback/Include/D3D12RaytracingFallback.h
+++ b/Libraries/D3D12RaytracingFallback/Include/D3D12RaytracingFallback.h
@@ -164,7 +164,7 @@ public:
         _Always_(_Outptr_opt_result_maybenull_) ID3DBlob** ppErrorBlob) = 0;
 };
 
-enum class CreateRaytracingFallbackDeviceFlags
+enum CreateRaytracingFallbackDeviceFlags
 {
     None = 0x0,
     ForceComputeFallback = 0x1,
@@ -173,7 +173,7 @@ enum class CreateRaytracingFallbackDeviceFlags
 
 HRESULT D3D12CreateRaytracingFallbackDevice(
     _In_ ID3D12Device *pDevice, 
-    _In_ CreateRaytracingFallbackDeviceFlags Flags,
+    _In_ DWORD createRaytracingFallbackDeviceFlags,
     _In_ UINT NodeMask,
     _In_ REFIID riid,
     _COM_Outptr_opt_ void** ppDevice);

--- a/Libraries/D3D12RaytracingFallback/developerguide.md
+++ b/Libraries/D3D12RaytracingFallback/developerguide.md
@@ -174,8 +174,10 @@ The use of an AnyHit/Intersection shader require that the traversal code must st
 
 ## Known Issues & Limitations
 
-* #### No Local Root Signature Support for Root Descriptors
-Root descriptors are not currently supported. This is expected to be supported in the future, but it should be noted that these will require the use of `WRAPPED_GPU_POINTER`'s rather then being able to consume a `GPU_VIRTUAL_ADDRESS` directly
+* #### Limited Local Root Signature Support for Root Descriptors
+Root Descriptors are partially supported, however currently the offset in bytes portion of the pointer will always be ignored and it will only read from the start of the buffer. 
+
+In addition, to enable root descriptors in the first place, developers must pass in CreateRaytracingFallbackDeviceFlags::EnableRootDescriptorsInShaderRecords to D3D12CreateRaytracingFallbackDevice to enable this functionality.
 
 * #### No Callable shaders
 Callable shaders are not yet supported. 

--- a/Libraries/D3D12RaytracingFallback/src/D3D12RaytracingFallback.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/D3D12RaytracingFallback.cpp
@@ -12,7 +12,7 @@
 
 HRESULT D3D12CreateRaytracingFallbackDevice(
     _In_ ID3D12Device *pDevice, 
-    _In_ CreateRaytracingFallbackDeviceFlags flags, 
+    _In_ DWORD createRaytracingFallbackDeviceFlags, 
     _In_ UINT NodeMask,
     _In_ REFIID riid,
     _COM_Outptr_opt_ void** ppDevice)
@@ -26,9 +26,9 @@ HRESULT D3D12CreateRaytracingFallbackDevice(
     HRESULT hr = pDevice->QueryInterface(&pRaytracingDevice);
 
     const bool bSupportsNativeRaytracing = SUCCEEDED(hr) && pRaytracingDevice;
-    if (!bSupportsNativeRaytracing || ((UINT)flags & (UINT)CreateRaytracingFallbackDeviceFlags::ForceComputeFallback) != 0)
+    if (!bSupportsNativeRaytracing || ((UINT)createRaytracingFallbackDeviceFlags & (UINT)CreateRaytracingFallbackDeviceFlags::ForceComputeFallback) != 0)
     {
-        *ppDevice = new FallbackLayer::RaytracingDevice(pDevice, NodeMask, flags);
+        *ppDevice = new FallbackLayer::RaytracingDevice(pDevice, NodeMask, createRaytracingFallbackDeviceFlags);
     }
     else
     {

--- a/Libraries/D3D12RaytracingFallback/src/D3D12RaytracingFallback.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/D3D12RaytracingFallback.cpp
@@ -28,7 +28,7 @@ HRESULT D3D12CreateRaytracingFallbackDevice(
     const bool bSupportsNativeRaytracing = SUCCEEDED(hr) && pRaytracingDevice;
     if (!bSupportsNativeRaytracing || ((UINT)flags & (UINT)CreateRaytracingFallbackDeviceFlags::ForceComputeFallback) != 0)
     {
-        *ppDevice = new FallbackLayer::RaytracingDevice(pDevice, NodeMask);
+        *ppDevice = new FallbackLayer::RaytracingDevice(pDevice, NodeMask, flags);
     }
     else
     {

--- a/Libraries/D3D12RaytracingFallback/src/FallbackDxil.h
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackDxil.h
@@ -15,7 +15,7 @@
 // There's a driver issue on some hardware that has issues
 // starting a bindless table on any register but 0, so
 // make sure each bindless table has it's own register space
-#define FallbackLayerDescriptorHeapStartingSpaceOffset 1
+#define FallbackLayerDescriptorHeapSpaceOffset 1
 #define FallbackLayerNumDescriptorHeapSpacesPerView 10
 
 // CBVs
@@ -23,6 +23,11 @@
 #define FallbackLayerAccelerationStructureList 1
 
 #ifndef HLSL
+struct ViewKey {
+    unsigned int ViewType;
+    unsigned int StructuredStride;
+};
+
 struct ShaderInfo
 {
     const wchar_t *ExportName;
@@ -30,6 +35,12 @@ struct ShaderInfo
     unsigned int SrvCbvUavDescriptorSizeInBytes;
     unsigned int ShaderRecordIdentifierSizeInBytes;
     const D3D12_VERSIONED_ROOT_SIGNATURE_DESC *pRootSignatureDesc;
+
+    ViewKey *pSRVRegisterSpaceArray;
+    UINT *pNumSRVSpaces;
+
+    ViewKey *pUAVRegisterSpaceArray;
+    UINT *pNumUAVSpaces;
 };
 
 struct DispatchRaysConstants

--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayer.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayer.cpp
@@ -216,7 +216,7 @@ namespace FallbackLayer
                 }
 
                 auto range = TD3DX12_DESCRIPTOR_RANGE(
-                    descriptorType, UINT_MAX, FallbackLayerDescriptorHeapTable, FallbackLayerRegisterSpace + FallbackLayerDescriptorHeapStartingSpaceOffset);
+                    descriptorType, UINT_MAX, FallbackLayerDescriptorHeapTable, FallbackLayerRegisterSpace + FallbackLayerDescriptorHeapSpaceOffset);
                 range.OffsetInDescriptorsFromTableStart = 0;
                 __if_exists(TD3DX12_DESCRIPTOR_RANGE::Flags)
                 {

--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayer.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayer.cpp
@@ -15,7 +15,9 @@ namespace FallbackLayer
     GUID FallbackLayerBlobPrivateDataGUID = { 0xf0545791, 0x860b, 0x472e, 0x9c, 0xc5, 0x84, 0x2c, 0xf1, 0x4e, 0x37, 0x60 };
     GUID FallbackLayerPatchedParameterStartGUID = { 0xea063348, 0x974e, 0x4227, 0x82, 0x55, 0x34, 0x5e, 0x29, 0x14, 0xeb, 0x7f };
 
-    RaytracingDevice::RaytracingDevice(ID3D12Device *pDevice, UINT NodeMask) : m_pDevice(pDevice), m_RaytracingProgramFactory(pDevice), m_AccelerationStructureBuilderFactory(pDevice, NodeMask)
+    RaytracingDevice::RaytracingDevice(ID3D12Device *pDevice, UINT NodeMask, CreateRaytracingFallbackDeviceFlags flags) :
+        m_pDevice(pDevice), m_RaytracingProgramFactory(pDevice), m_AccelerationStructureBuilderFactory(pDevice, NodeMask),
+        m_flags(flags)
     {
         // Earlier builds of windows may not support checking shader model yet so this cannot 
         // catch non-Dxil drivers on older builds.
@@ -170,6 +172,7 @@ namespace FallbackLayer
     template <typename TD3D12_ROOT_SIGNATURE_DESC, typename TD3DX12_ROOT_PARAMETER, typename TD3DX12_DESCRIPTOR_RANGE>
     TD3D12_ROOT_SIGNATURE_DESC PatchRootSignature(
         _In_ const typename TD3D12_ROOT_SIGNATURE_DESC*pRootSignature,
+        _In_ bool localRootDescriptorsEnabled,
         _Out_ std::vector<TD3DX12_ROOT_PARAMETER> &patchedRootParameters,
         _Out_ std::vector<TD3DX12_DESCRIPTOR_RANGE> &patchedRanges,
         _Out_ TD3D12_ROOT_SIGNATURE_DESC &patchedRootSignatureDesc)
@@ -180,12 +183,18 @@ namespace FallbackLayer
         {
             for (UINT i = 0; i < pRootSignature->NumParameters; i++)
             {
-                if (pRootSignature->pParameters[i].ParameterType != D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS &&
-                   pRootSignature->pParameters[i].ParameterType != D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE)
+                if (!localRootDescriptorsEnabled &&
+                      (pRootSignature->pParameters[i].ParameterType == D3D12_ROOT_PARAMETER_TYPE_CBV ||
+                       pRootSignature->pParameters[i].ParameterType == D3D12_ROOT_PARAMETER_TYPE_UAV ||
+                       pRootSignature->pParameters[i].ParameterType == D3D12_ROOT_PARAMETER_TYPE_SRV))
                 {
                     ThrowFailure(E_INVALIDARG,
-                        L"Only D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS/D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE are currently " 
-                        "supported for local root signatures. For details, view the Fallback Layer readme.md");
+                        L"Root Views, i.e. D3D12_ROOT_PARAMETER_TYPE_(CBV|UAV|SRV), are not supported by the Fallback Layer by default. "
+                        "Support can be forced on by using CreateRaytracingFallbackDeviceFlags::EnableRootDescriptorsInShaderRecords, "
+                        "however there are 2 existing limitations to root descriptors: The first is that root descriptors must be bound "
+                        "using WRAPPED_GPU_POINTER rather than a GPU_VIRTUAL_ADDRESS. The second is that offsets added onto a WRAPPED_GPU_POINTER "
+                        "are ignored, so reads from the buffer will always start at the start of the buffer. "
+                        "Please see the developer guide for more details");
                 }
             }
         }
@@ -271,10 +280,10 @@ namespace FallbackLayer
         switch (pRootSignature->Version)
         {
         case D3D_ROOT_SIGNATURE_VERSION_1_0:
-            PatchRootSignature(&pRootSignature->Desc_1_0, patchedRootParameters, patchedRanges, patchedDesc.Desc_1_0);
+            PatchRootSignature(&pRootSignature->Desc_1_0, AreShaderRecordRootDescriptorsEnabled(), patchedRootParameters, patchedRanges, patchedDesc.Desc_1_0);
             break;
         case D3D_ROOT_SIGNATURE_VERSION_1_1:
-            PatchRootSignature(&pRootSignature->Desc_1_1, patchedRootParameters, patchedRanges, patchedDesc.Desc_1_1);
+            PatchRootSignature(&pRootSignature->Desc_1_1, AreShaderRecordRootDescriptorsEnabled(), patchedRootParameters, patchedRanges, patchedDesc.Desc_1_1);
             break;
         }
 
@@ -289,7 +298,7 @@ namespace FallbackLayer
         D3D12_ROOT_SIGNATURE_DESC patchedDesc;
         std::vector<CD3DX12_ROOT_PARAMETER> patchedRootParameters;
         std::vector<CD3DX12_DESCRIPTOR_RANGE> patchedRanges;
-        PatchRootSignature(pRootSignature, patchedRootParameters, patchedRanges, patchedDesc);
+        PatchRootSignature(pRootSignature, AreShaderRecordRootDescriptorsEnabled(), patchedRootParameters, patchedRanges, patchedDesc);
 
         if (patchedDesc.Flags & D3D12_ROOT_SIGNATURE_FLAG_LOCAL_ROOT_SIGNATURE)
         {

--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayer.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayer.cpp
@@ -15,9 +15,9 @@ namespace FallbackLayer
     GUID FallbackLayerBlobPrivateDataGUID = { 0xf0545791, 0x860b, 0x472e, 0x9c, 0xc5, 0x84, 0x2c, 0xf1, 0x4e, 0x37, 0x60 };
     GUID FallbackLayerPatchedParameterStartGUID = { 0xea063348, 0x974e, 0x4227, 0x82, 0x55, 0x34, 0x5e, 0x29, 0x14, 0xeb, 0x7f };
 
-    RaytracingDevice::RaytracingDevice(ID3D12Device *pDevice, UINT NodeMask, CreateRaytracingFallbackDeviceFlags flags) :
+    RaytracingDevice::RaytracingDevice(ID3D12Device *pDevice, UINT NodeMask, DWORD createRaytracingFallbackDeviceFlags) :
         m_pDevice(pDevice), m_RaytracingProgramFactory(pDevice), m_AccelerationStructureBuilderFactory(pDevice, NodeMask),
-        m_flags(flags)
+        m_flags(createRaytracingFallbackDeviceFlags)
     {
         // Earlier builds of windows may not support checking shader model yet so this cannot 
         // catch non-Dxil drivers on older builds.
@@ -274,8 +274,12 @@ namespace FallbackLayer
         _Out_ ID3DBlob** ppBlob,
         _Always_(_Outptr_opt_result_maybenull_) ID3DBlob** ppErrorBlob)
     {
-        std::vector<CD3DX12_ROOT_PARAMETER1> patchedRootParameters;
-        std::vector<CD3DX12_DESCRIPTOR_RANGE1> patchedRanges;
+        std::vector<CD3DX12_ROOT_PARAMETER> patchedRootParameters;
+        std::vector<CD3DX12_DESCRIPTOR_RANGE> patchedRanges;
+
+        std::vector<CD3DX12_ROOT_PARAMETER1> patchedRootParameters1;
+        std::vector<CD3DX12_DESCRIPTOR_RANGE1> patchedRanges1;
+
         D3D12_VERSIONED_ROOT_SIGNATURE_DESC patchedDesc = *pRootSignature;
         switch (pRootSignature->Version)
         {
@@ -283,7 +287,7 @@ namespace FallbackLayer
             PatchRootSignature(&pRootSignature->Desc_1_0, AreShaderRecordRootDescriptorsEnabled(), patchedRootParameters, patchedRanges, patchedDesc.Desc_1_0);
             break;
         case D3D_ROOT_SIGNATURE_VERSION_1_1:
-            PatchRootSignature(&pRootSignature->Desc_1_1, AreShaderRecordRootDescriptorsEnabled(), patchedRootParameters, patchedRanges, patchedDesc.Desc_1_1);
+            PatchRootSignature(&pRootSignature->Desc_1_1, AreShaderRecordRootDescriptorsEnabled(), patchedRootParameters1, patchedRanges1, patchedDesc.Desc_1_1);
             break;
         }
 

--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayer.h
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayer.h
@@ -120,7 +120,7 @@ namespace FallbackLayer
     class RaytracingDevice : public ID3D12RaytracingFallbackDevice
     {
     public:
-        RaytracingDevice(ID3D12Device *pDevice, UINT NodeMask, CreateRaytracingFallbackDeviceFlags flags);
+        RaytracingDevice(ID3D12Device *pDevice, UINT NodeMask, DWORD createRaytracingFallbackDeviceFlags);
         virtual ~RaytracingDevice() {}
 
         virtual bool UsingRaytracingDriver();
@@ -177,7 +177,7 @@ namespace FallbackLayer
 
         bool AreShaderRecordRootDescriptorsEnabled()
         {
-            return (UINT)m_flags & (UINT)CreateRaytracingFallbackDeviceFlags::EnableRootDescriptorsInShaderRecords;
+            return m_flags & CreateRaytracingFallbackDeviceFlags::EnableRootDescriptorsInShaderRecords;
         }
 
     private:
@@ -188,7 +188,7 @@ namespace FallbackLayer
         CComPtr<ID3D12Device> m_pDevice;
         AccelerationStructureBuilderFactory m_AccelerationStructureBuilderFactory;
         RaytracingProgramFactory m_RaytracingProgramFactory;
-        CreateRaytracingFallbackDeviceFlags m_flags;
+        DWORD m_flags;
 
         COM_IMPLEMENTATION();
 

--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayer.h
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayer.h
@@ -120,7 +120,7 @@ namespace FallbackLayer
     class RaytracingDevice : public ID3D12RaytracingFallbackDevice
     {
     public:
-        RaytracingDevice(ID3D12Device *pDevice, UINT NodeMask);
+        RaytracingDevice(ID3D12Device *pDevice, UINT NodeMask, CreateRaytracingFallbackDeviceFlags flags);
         virtual ~RaytracingDevice() {}
 
         virtual bool UsingRaytracingDriver();
@@ -175,6 +175,11 @@ namespace FallbackLayer
             _Out_ ID3DBlob** ppBlob,
             _Always_(_Outptr_opt_result_maybenull_) ID3DBlob** ppErrorBlob);
 
+        bool AreShaderRecordRootDescriptorsEnabled()
+        {
+            return (UINT)m_flags & (UINT)CreateRaytracingFallbackDeviceFlags::EnableRootDescriptorsInShaderRecords;
+        }
+
     private:
         void ProcessSubObject(const D3D12_STATE_SUBOBJECT &subObject, RaytracingStateObject &rayTracingStateObject);
         void ProcessShaderAssociation(const D3D12_STATE_SUBOBJECT &subObject, ShaderAssociations &shaderAssociations);
@@ -183,6 +188,8 @@ namespace FallbackLayer
         CComPtr<ID3D12Device> m_pDevice;
         AccelerationStructureBuilderFactory m_AccelerationStructureBuilderFactory;
         RaytracingProgramFactory m_RaytracingProgramFactory;
+        CreateRaytracingFallbackDeviceFlags m_flags;
+
         COM_IMPLEMENTATION();
 
 #if ENABLE_ACCELERATION_STRUCTURE_VISUALIZATION

--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayer.vcxproj.filters
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayer.vcxproj.filters
@@ -156,6 +156,9 @@
     <FxCompile Include="*Lib.hlsl" />
     <FxCompile Include="*Lib.hlsl" />
     <FxCompile Include="*Lib.hlsl" />
+    <FxCompile Include="*Lib.hlsl" />
+    <FxCompile Include="*Lib.hlsl" />
+    <FxCompile Include="*Lib.hlsl" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AccelerationStructureBuilderFactory.cpp">

--- a/Libraries/D3D12RaytracingFallback/src/UberShaderBindings.h
+++ b/Libraries/D3D12RaytracingFallback/src/UberShaderBindings.h
@@ -64,5 +64,5 @@ cbuffer DebugVariables : CONSTANT_REGISTER_SPACE(DebugConstantRegister, Fallback
 };
 #endif
 #else
-static_assert(FallbackLayerDescriptorHeapRegisterSpace == FallbackLayerRegisterSpace + FallbackLayerDescriptorHeapStartingSpaceOffset, L"#define for FallbackLayerDescriptorHeapRegisterSpace is incorrect");
+static_assert(FallbackLayerDescriptorHeapRegisterSpace == FallbackLayerRegisterSpace + FallbackLayerDescriptorHeapSpaceOffset, L"#define for FallbackLayerDescriptorHeapRegisterSpace is incorrect");
 #endif

--- a/Libraries/D3D12RaytracingFallback/src/UberShaderRayTracingProgram.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/UberShaderRayTracingProgram.cpp
@@ -60,6 +60,12 @@ namespace FallbackLayer
 
         UINT cbvSrvUavHandleSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
         UINT samplerHandleSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
+        
+        ViewKey SRVViewsList[FallbackLayerNumDescriptorHeapSpacesPerView];
+        UINT SRVsUsed = 0;
+        ViewKey UAVViewsList[FallbackLayerNumDescriptorHeapSpacesPerView];
+        UINT UAVsUsed = 0;
+        
         for (UINT i = 0; i < numLibraries; i++)
         {
             auto &library = stateObjectCollection.m_dxilLibraries[i];
@@ -96,6 +102,10 @@ namespace FallbackLayer
                         CComPtr<ID3D12VersionedRootSignatureDeserializer> pDeserializer;
                         ShaderInfo shaderInfo;
                         shaderInfo.pRootSignatureDesc = GetDescFromRootSignature(pShaderAssociation->second.m_pRootSignature, pDeserializer);
+                        shaderInfo.pSRVRegisterSpaceArray = SRVViewsList;
+                        shaderInfo.pNumSRVSpaces = &SRVsUsed;
+                        shaderInfo.pUAVRegisterSpaceArray = UAVViewsList;
+                        shaderInfo.pNumUAVSpaces = &UAVsUsed;
 
                         if (GetNumParameters(*shaderInfo.pRootSignatureDesc) > 0)
                         {

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/ModelViewer.cpp
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/ModelViewer.cpp
@@ -272,9 +272,9 @@ int wmain(int argc, wchar_t** argv)
     }
 
     s_EnableVSync.Decrement();
-    TargetResolution = k1080p;
-    g_DisplayWidth = 1920;
-    g_DisplayHeight = 1080;
+    TargetResolution = k720p;
+    g_DisplayWidth = 1280;
+    g_DisplayHeight = 720;
     GameCore::RunApplication(D3D12RaytracingMiniEngineSample(), L"D3D12RaytracingMiniEngineSample"); 
     return 0;
 }

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/ModelViewer.cpp
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/ModelViewer.cpp
@@ -272,9 +272,9 @@ int wmain(int argc, wchar_t** argv)
     }
 
     s_EnableVSync.Decrement();
-    TargetResolution = k720p;
-    g_DisplayWidth = 1280;
-    g_DisplayHeight = 720;
+    TargetResolution = k1080p;
+    g_DisplayWidth = 1920;
+    g_DisplayHeight = 1080;
     GameCore::RunApplication(D3D12RaytracingMiniEngineSample(), L"D3D12RaytracingMiniEngineSample"); 
     return 0;
 }

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/ModelViewer_VS15.vcxproj.filters
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/ModelViewer_VS15.vcxproj.filters
@@ -144,12 +144,6 @@
     <FxCompile Include="RayGenerationShaderLib.hlsl" />
     <FxCompile Include="RayGenerationShaderSSRLib.hlsl" />
     <FxCompile Include="RayGenerationShadowsLib.hlsl" />
-    <FxCompile Include="hitShaderLib.hlsl" />
-    <FxCompile Include="missShaderLib.hlsl" />
-    <FxCompile Include="missShadowsLib.hlsl" />
-    <FxCompile Include="RayGenerationShaderLib.hlsl" />
-    <FxCompile Include="RayGenerationShaderSSRLib.hlsl" />
-    <FxCompile Include="RayGenerationShadowsLib.hlsl" />
     <FxCompile Include="*Lib.hlsl">
       <Filter>Shaders</Filter>
     </FxCompile>
@@ -171,6 +165,12 @@
     <FxCompile Include="*Lib.hlsl">
       <Filter>Shaders</Filter>
     </FxCompile>
+    <FxCompile Include="*Lib.hlsl" />
+    <FxCompile Include="*Lib.hlsl" />
+    <FxCompile Include="*Lib.hlsl" />
+    <FxCompile Include="*Lib.hlsl" />
+    <FxCompile Include="*Lib.hlsl" />
+    <FxCompile Include="*Lib.hlsl" />
     <FxCompile Include="*Lib.hlsl" />
     <FxCompile Include="*Lib.hlsl" />
     <FxCompile Include="*Lib.hlsl" />


### PR DESCRIPTION
Big chunk of Fallback Layer fixes/features:

- Rev'ing the Fallback Layer to work with a newer version of DxCompiler. This fixes multiple issues including invalid shader record alignment calculations and handling for multiple descriptor tables in a shader record that was causing failures to link
- New DxCompiler version enables partial support for root views, but offset in bytes is still not supported. To prevent use without knowledge of the short-comings, shielding the use of root descriptors behind an explicit flag to stop developers from using this without opt-in
- Fix to root signature serialization and unittests to catch future regressions
- ModelViewer had an invalid shader record offset calculation that was revealed after the DxCompiler fixes
