### PR TITLE
Added support for opaque geometry flags

### DIFF
--- a/Libraries/D3D12RaytracingFallback/src/CpuBVH2Builder.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/CpuBVH2Builder.cpp
@@ -623,6 +623,7 @@ namespace FallbackLayer
                 PrimitiveMetaData metadata;
                 metadata.GeometryContributionToHitGroupIndex = i;
                 metadata.PrimitiveIndex = triangleIndex;
+                metadata.GeometryFlags = geometry.Flags;
                 primitiveMetaData[triangleIndex] = metadata;
 
                 // Next triangle

--- a/Libraries/D3D12RaytracingFallback/src/LoadPrimitivesBindings.h
+++ b/Libraries/D3D12RaytracingFallback/src/LoadPrimitivesBindings.h
@@ -29,6 +29,7 @@ struct LoadPrimitivesInputConstants
 
     // TODO: Consider inlining into separate shaders
     uint HasValidTransform; 
+    uint GeometryFlags;
 };
 
 // UAVs
@@ -61,6 +62,7 @@ void StorePrimitiveMetadata(uint globalPrimitiveIndex, uint localPrimitiveIndex)
     PrimitiveMetaData metaData;
     metaData.GeometryContributionToHitGroupIndex = Constants.GeometryContributionToHitGroupIndex;
     metaData.PrimitiveIndex = localPrimitiveIndex;
+    metaData.GeometryFlags = Constants.GeometryFlags;
     MetadataBuffer[globalPrimitiveIndex] = metaData;
 }
 #endif

--- a/Libraries/D3D12RaytracingFallback/src/LoadPrimitivesPass.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/LoadPrimitivesPass.cpp
@@ -101,6 +101,7 @@ namespace FallbackLayer
                 constants.ElementBufferStride = (UINT32)triangles.VertexBuffer.StrideInBytes;
                 constants.GeometryContributionToHitGroupIndex = elementIndex;
                 constants.HasValidTransform = (triangles.Transform != 0);
+                constants.GeometryFlags = geometryDesc.Flags;
 
                 pCommandList->SetComputeRoot32BitConstants(InputRootConstants, SizeOfInUint32(LoadPrimitivesInputConstants), &constants, 0);
                 pCommandList->SetComputeRootShaderResourceView(ElementBufferSRV, triangles.VertexBuffer.StartAddress);
@@ -138,6 +139,7 @@ namespace FallbackLayer
                 constants.PrimitiveOffset = numPrimitivesLoaded;
                 constants.ElementBufferStride = (UINT32)aabbs.AABBs.StrideInBytes;
                 constants.GeometryContributionToHitGroupIndex = elementIndex;
+                constants.GeometryFlags = geometryDesc.Flags;
 
                 pCommandList->SetComputeRoot32BitConstants(InputRootConstants, SizeOfInUint32(LoadPrimitivesInputConstants), &constants, 0);
                 pCommandList->SetComputeRootShaderResourceView(ElementBufferSRV, aabbs.AABBs.StartAddress);

--- a/Libraries/D3D12RaytracingFallback/src/RayTracingHlslCompat.h
+++ b/Libraries/D3D12RaytracingFallback/src/RayTracingHlslCompat.h
@@ -179,8 +179,9 @@ struct PrimitiveMetaData
 {
     uint GeometryContributionToHitGroupIndex;
     uint PrimitiveIndex;
+    uint GeometryFlags;
 };
-#define SizeOfPrimitiveMetaData (4 * 2)
+#define SizeOfPrimitiveMetaData (4 * 3)
 #ifndef HLSL
 static_assert(sizeof(PrimitiveMetaData) == SizeOfPrimitiveMetaData, L"Incorrect sizeof for PrimitiveMetaData");
 #endif


### PR DESCRIPTION
- Added `uint GeometryFlags` field to struct [`PrimitiveMetaData`](https://github.com/Microsoft/DirectX-Graphics-Samples/blob/5853f88d00c5dd06a88eca5a2e53a54fd3240075/Libraries/D3D12RaytracingFallback/src/LoadPrimitivesBindings.h#L32)

- Added unit test [`LoadTriangles`](https://github.com/Microsoft/DirectX-Graphics-Samples/blob/5853f88d00c5dd06a88eca5a2e53a54fd3240075/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/fallbacklayerunittests.cpp#L2773), which works very similarly to `LoadAABBs`, but instead loads triangle vertices and makes sure the flags field in the geometry description gets passed to the triangle's metadata.
