### PR TITLE
Batch of Fallback Layer Fixes

### DIFF
--- a/Libraries/D3D12RaytracingFallback/src/ComObject.h
+++ b/Libraries/D3D12RaytracingFallback/src/ComObject.h
@@ -37,3 +37,35 @@ public:                                                                        \
     }                                                                          \
 private:                                                                       \
     UINT m_ReferenceCount = 1;                                                 
+
+#define COM_IMPLEMENTATION_WITH_QUERYINTERFACE(pParentObject)                  \
+public:                                                                        \
+    virtual HRESULT STDMETHODCALLTYPE QueryInterface(                          \
+        REFIID riid,                                                           \
+        void **ppvObject)                                                      \
+    {                                                                          \
+        if (riid == __uuidof(*pParentObject))                                  \
+        {                                                                      \
+            pParentObject->AddRef();                                           \
+            *ppvObject = pParentObject;                                        \
+            return S_OK;                                                       \
+        }                                                                      \
+        return pParentObject->QueryInterface(riid, ppvObject);                 \
+    }                                                                          \
+                                                                               \
+    virtual ULONG STDMETHODCALLTYPE AddRef(void)                               \
+    {                                                                          \
+        return InterlockedIncrement(&m_ReferenceCount);                        \
+    }                                                                          \
+                                                                               \
+    virtual ULONG STDMETHODCALLTYPE Release(void)                              \
+    {                                                                          \
+        ULONG currentRefCount = InterlockedDecrement(&m_ReferenceCount);       \
+        if (currentRefCount == 0)                                              \
+        {                                                                      \
+            delete this;                                                       \
+        }                                                                      \
+        return currentRefCount;                                                \
+    }                                                                          \
+private:                                                                       \
+    UINT m_ReferenceCount = 1;                                                 

--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayer.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayer.cpp
@@ -231,7 +231,7 @@ namespace FallbackLayer
                 {
                     if (range.RangeType != D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER)
                     {
-                        range.Flags = D3D12_DESCRIPTOR_RANGE_FLAG_DATA_VOLATILE;
+                        range.Flags = D3D12_DESCRIPTOR_RANGE_FLAG_DATA_VOLATILE | D3D12_DESCRIPTOR_RANGE_FLAG_DESCRIPTORS_VOLATILE;
                     }
                 }
 

--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayer.h
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayer.h
@@ -78,7 +78,7 @@ namespace FallbackLayer
         ID3D12DescriptorHeap *m_pBoundDescriptorHeaps[DescriptorHeapType::NumTypes] = {};
         ATL::CComPtr<ID3D12GraphicsCommandList> m_pCommandList;
         RaytracingDevice &m_device;
-        COM_IMPLEMENTATION();
+        COM_IMPLEMENTATION_WITH_QUERYINTERFACE(m_pCommandList.p);
     };
 
     class RaytracingStateObject : public ID3D12RaytracingFallbackStateObject
@@ -190,7 +190,7 @@ namespace FallbackLayer
         RaytracingProgramFactory m_RaytracingProgramFactory;
         DWORD m_flags;
 
-        COM_IMPLEMENTATION();
+        COM_IMPLEMENTATION_WITH_QUERYINTERFACE(m_pDevice.p)
 
 #if ENABLE_ACCELERATION_STRUCTURE_VISUALIZATION
     public:

--- a/Libraries/D3D12RaytracingFallback/src/NativeRayTracing.h
+++ b/Libraries/D3D12RaytracingFallback/src/NativeRayTracing.h
@@ -48,7 +48,7 @@ public:
 private:
     CComPtr<ID3D12StateObjectPropertiesPrototype> m_pStateObjectInfo;
     CComPtr<ID3D12StateObjectPrototype> m_pStateObject;
-    COM_IMPLEMENTATION();
+    COM_IMPLEMENTATION_WITH_QUERYINTERFACE(m_pStateObject.p);
 };
 
 class NativeRaytracingCommandList : public ID3D12RaytracingFallbackCommandList
@@ -129,7 +129,7 @@ public:
 private:
     CComPtr<ID3D12GraphicsCommandList> m_pCommandList;
     CComPtr<ID3D12CommandListRaytracingPrototype> m_pRaytracingCommandList;
-    COM_IMPLEMENTATION();
+    COM_IMPLEMENTATION_WITH_QUERYINTERFACE(m_pRaytracingCommandList.p);
 };
 
 class NativeRaytracingDevice : public ID3D12RaytracingFallbackDevice
@@ -247,5 +247,5 @@ public:
 private:
     CComPtr<ID3D12DeviceRaytracingPrototype> m_pRaytracingDevice;
     CComPtr<ID3D12Device> m_pDevice;
-    COM_IMPLEMENTATION();
+    COM_IMPLEMENTATION_WITH_QUERYINTERFACE(m_pDevice.p);
 };

--- a/Libraries/D3D12RaytracingFallback/src/TraverseFunction.hlsli
+++ b/Libraries/D3D12RaytracingFallback/src/TraverseFunction.hlsli
@@ -562,7 +562,6 @@ bool Traverse(
 
             {
                 MARK(4, 0);
-                // Leaf flag tells us whether to read the right index
                 if (IsLeaf(flags))
                 {
                     MARK(5, 0);


### PR DESCRIPTION
Fixing a batch of issues:

1. V1.1 Root Signatures require the D3D12_DESCRIPTOR_RANGE_FLAG_DESCRIPTORS_VOLATILE flag to be used with the injected descriptor table that spans the entire descriptor heap.
2. Fallback Layer objects can now be QI'd to get classes one might expect (like getting an ID3D12CommandList off of an ID3D12CommandListRaytracingPrototype).
3. Removed a stale traversal shader comment