### PR TITLE
Implemented AABB refitting on PERFORM_UPDATE

### DIFF
--- a/Libraries/D3D12RaytracingFallback/src/BottomLevelLoadTriangles.hlsli
+++ b/Libraries/D3D12RaytracingFallback/src/BottomLevelLoadTriangles.hlsli
@@ -98,8 +98,6 @@ void main( uint3 DTid : SV_DispatchThreadID )
     uint NumberOfAABBs = NumberOfInternalNodes + Constants.TotalPrimitiveCount;
 
     uint3 indicies = GetIndex(localTriangleIndex);
-    
-    uint globalTriangleIndex = localTriangleIndex + Constants.PrimitiveOffset;
 
     Triangle tri;
     tri.v0 = GetVertex(elementBuffer, indicies[0], Constants.ElementBufferStride);
@@ -120,6 +118,9 @@ void main( uint3 DTid : SV_DispatchThreadID )
         tri.v2 = TransformVertex(tri.v2, transform);
     }
 
-    PrimitiveBuffer[globalTriangleIndex] = CreateTrianglePrimitive(tri);
-    StorePrimitiveMetadata(globalTriangleIndex, localTriangleIndex);
+    uint globalTriangleIndex = localTriangleIndex + Constants.PrimitiveOffset;
+    uint outputIndex = GetOutputIndex(globalTriangleIndex);
+    
+    PrimitiveBuffer[outputIndex] = CreateTrianglePrimitive(tri);
+    StorePrimitiveMetadata(outputIndex, localTriangleIndex);
 }

--- a/Libraries/D3D12RaytracingFallback/src/ConstructAABBBindings.h
+++ b/Libraries/D3D12RaytracingFallback/src/ConstructAABBBindings.h
@@ -17,14 +17,15 @@
 struct InputConstants
 {
     uint NumberOfElements;
+    uint UpdateFlags;
 };
 
 // UAVs
 #define OutputBVHRegister 0
 #define ScratchBufferRegister 1
 #define ChildNodesProcessedBufferRegister 2
-#define MortonCodesBufferRegister 3
-#define HierarchyBufferRegister 4
+#define HierarchyBufferRegister 3
+#define AABBParentBufferRegister 4
 
 #define GlobalDescriptorHeapRegister 0
 #define GlobalDescriptorHeapRegisterSpace 1
@@ -32,12 +33,17 @@ struct InputConstants
 // CBVs
 #define InputConstantsRegister 0
 
+#define PREPARE_UPDATE_FLAG 0x1
+#define PERFORM_UPDATE_FLAG 0x2
+#define ShouldPrepareUpdate Constants.UpdateFlags & PREPARE_UPDATE_FLAG
+#define ShouldPerformUpdate Constants.UpdateFlags & PERFORM_UPDATE_FLAG
+
 #ifdef HLSL
 globallycoherent RWByteAddressBuffer outputBVH : UAV_REGISTER(OutputBVHRegister);
 RWByteAddressBuffer scratchMemory : UAV_REGISTER(ScratchBufferRegister);
 RWByteAddressBuffer childNodesProcessedCounter : UAV_REGISTER(ChildNodesProcessedBufferRegister);
-RWStructuredBuffer<uint> mortonCodes : UAV_REGISTER(MortonCodesBufferRegister);
 RWStructuredBuffer<HierarchyNode> hierarchyBuffer : UAV_REGISTER(HierarchyBufferRegister);
+RWStructuredBuffer<uint> aabbParentBuffer : UAV_REGISTER(AABBParentBufferRegister);
 RWByteAddressBuffer DescriptorHeapBufferTable[] : UAV_REGISTER_SPACE(GlobalDescriptorHeapRegister, GlobalDescriptorHeapRegisterSpace);
 
 cbuffer ConstructHierarchyConstants : CONSTANT_REGISTER(InputConstantsRegister)

--- a/Libraries/D3D12RaytracingFallback/src/ConstructAABBPass.h
+++ b/Libraries/D3D12RaytracingFallback/src/ConstructAABBPass.h
@@ -21,9 +21,11 @@ namespace FallbackLayer
             D3D12_GPU_VIRTUAL_ADDRESS outputVH,
             D3D12_GPU_VIRTUAL_ADDRESS scratchBuffer,
             D3D12_GPU_VIRTUAL_ADDRESS childNodesProcessedCountBuffer,
-            D3D12_GPU_VIRTUAL_ADDRESS mortonCodeBuffer,
             D3D12_GPU_VIRTUAL_ADDRESS hierarchyBuffer,
+            D3D12_GPU_VIRTUAL_ADDRESS outputAABBParentBuffer,
             D3D12_GPU_DESCRIPTOR_HANDLE globalDescriptorHeap,
+            const bool prepareUpdate,
+            const bool performUpdate,
             UINT numElements);
     private:
         enum RootParameterSlot
@@ -31,8 +33,8 @@ namespace FallbackLayer
             OutputBVHRootUAVParam = 0,
             ScratchUAVParam,
             HierarchyUAVParam,
+            AABBParentBufferParam,
             ChildNodesProcessedCountBufferParam,
-            MortonCodesBufferParam,
             InputRootConstants,
             GlobalDescriptorHeap,
             NumRootParameters,

--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/fallbacklayerunittests.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/fallbacklayerunittests.cpp
@@ -100,6 +100,62 @@ namespace FallbackLayerUnitTests
         D3D12_CPU_DESCRIPTOR_HANDLE m_descriptorHeapCpuBase;
     };
 
+    D3D12_RAYTRACING_GEOMETRY_DESC GetGeometryDesc(
+        const CpuGeometryDescriptor &geomDesc,
+        ID3D12Resource *pVertexBuffer = nullptr,
+        ID3D12Resource *pIndexBuffer = nullptr,
+        D3D12_GPU_VIRTUAL_ADDRESS transform = 0)
+    {
+        D3D12_RAYTRACING_GEOMETRY_DESC geometryDesc = {};
+        geometryDesc.Type = D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES;
+        geometryDesc.Triangles.IndexBuffer = pIndexBuffer ? pIndexBuffer->GetGPUVirtualAddress() : 0;
+        geometryDesc.Triangles.IndexCount = geomDesc.m_numIndicies;
+        geometryDesc.Triangles.IndexFormat = geomDesc.m_indexBufferFormat;
+        geometryDesc.Triangles.Transform = transform;
+        geometryDesc.Triangles.VertexFormat = DXGI_FORMAT_R32G32B32_FLOAT;
+        geometryDesc.Triangles.VertexCount = geomDesc.m_numVerticies;
+        geometryDesc.Triangles.VertexBuffer.StartAddress = pVertexBuffer ? pVertexBuffer->GetGPUVirtualAddress() : 0;
+        geometryDesc.Triangles.VertexBuffer.StrideInBytes = sizeof(float) * 3;
+
+        return geometryDesc;
+    }
+
+    void GenerateRandomTranformation(float *pMatrix)
+    {
+        // Identity matrix
+        ZeroMemory(pMatrix, sizeof(float) * FloatsPerMatrix);
+        pMatrix[0] = 1;
+        pMatrix[5] = 1;
+        pMatrix[10] = 1;
+
+        enum { Translation = 0, Rotation, Scale, NumTransformations };
+        uint tranformType = rand() % NumTransformations;
+
+        float rand0 = (rand() / (float)RAND_MAX) * 100.0f - 50.0f;
+        float rand1 = (rand() / (float)RAND_MAX) * 100.0f - 50.0f;
+        float rand2 = (rand() / (float)RAND_MAX) * 100.0f - 50.0f;
+
+        switch (tranformType)
+        {
+        case Translation:
+            pMatrix[3] = rand0;
+            pMatrix[7] = rand1;
+            pMatrix[11] = rand2;
+            break;
+        case Rotation:
+            pMatrix[0] = cos(rand0);
+            pMatrix[1] = sin(rand0);
+            pMatrix[4] = -sin(rand0);
+            pMatrix[5] = cos(rand0);
+            break;
+        case Scale:
+            pMatrix[0] = rand0;
+            pMatrix[5] = rand1;
+            pMatrix[10] = rand2;
+            break;
+        }
+    }
+
 #define ALIGN(alignment, num) (((num + alignment - 1) / alignment) * alignment)
 
     class BuilderWrapper
@@ -185,7 +241,8 @@ namespace FallbackLayerUnitTests
             UINT numGeoms,
             CComPtr<ID3D12Heap> &pHeap,
             CComPtr<ID3D12Resource> &pTopLevelResource,
-            D3D12_ELEMENTS_LAYOUT layoutToTest
+            D3D12_ELEMENTS_LAYOUT layoutToTest,
+            bool performUpdate = false
         )
         {
             ID3D12Device &device = m_d3d12Context.GetDevice();
@@ -202,10 +259,23 @@ namespace FallbackLayerUnitTests
                 totalSizeNeeded += ALIGN(D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT, prebuildInfo.ScratchDataSizeInBytes);
             }
 
+            D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS buildFlags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD;
+            if (performUpdate)
+            {
+                buildFlags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE;
+            }
+
             // Top level
             D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO topLevelPrebuildInfo;
             {
-                builder.GetRaytracingAccelerationStructurePrebuildInfo(&device, D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL, D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD, numGeoms, nullptr, &topLevelPrebuildInfo);
+                builder.GetRaytracingAccelerationStructurePrebuildInfo(
+                    &device,
+                    D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL,
+                    buildFlags,
+                    numGeoms,
+                    nullptr,
+                    &topLevelPrebuildInfo
+                );
                 totalSizeNeeded += ALIGN(D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT, topLevelPrebuildInfo.ResultDataMaxSizeInBytes);
                 totalSizeNeeded += ALIGN(D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT, topLevelPrebuildInfo.ScratchDataSizeInBytes);
             }
@@ -295,7 +365,7 @@ namespace FallbackLayerUnitTests
             topLevelDesc.DestAccelerationStructureData.SizeInBytes = pTopLevelResource->GetDesc().Width;
             topLevelDesc.ScratchAccelerationStructureData.StartAddress = pScratchResource->GetGPUVirtualAddress();
             topLevelDesc.ScratchAccelerationStructureData.SizeInBytes = pScratchResource->GetDesc().Width;
-            topLevelDesc.Flags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD;
+            topLevelDesc.Flags = buildFlags;
             topLevelDesc.NumDescs = numGeoms;
             topLevelDesc.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL;
             topLevelDesc.InstanceDescs = layoutToTest == D3D12_ELEMENTS_LAYOUT_ARRAY ?
@@ -303,6 +373,12 @@ namespace FallbackLayerUnitTests
                 pInstanceLocationList->GetGPUVirtualAddress();
             topLevelDesc.DescsLayout = layoutToTest;
             builder.BuildRaytracingAccelerationStructure(pCommandList, &topLevelDesc, &m_descriptorHeapStack.GetDescriptorHeap());
+
+            if (performUpdate)
+            {
+                topLevelDesc.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PERFORM_UPDATE;
+                builder.BuildRaytracingAccelerationStructure(pCommandList, &topLevelDesc, &m_descriptorHeapStack.GetDescriptorHeap());
+            }
 
             AssertSucceeded(pCommandList->Close());
             m_d3d12Context.ExecuteCommandList(pCommandList);
@@ -340,7 +416,8 @@ namespace FallbackLayerUnitTests
             CpuGeometryDescriptor *pCpuGeometryDescriptors, UINT numGeometry,
             ID3D12Resource **ppBottomLevelAccelerationStructure,
             D3D12_ELEMENTS_LAYOUT layoutToTest = D3D12_ELEMENTS_LAYOUT_ARRAY,
-            UINT offsetPointer = 0
+            UINT offsetPointer = 0,
+            D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS buildFlags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD
         )
         {
             ID3D12Device &device = m_d3d12Context.GetDevice();
@@ -362,7 +439,7 @@ namespace FallbackLayerUnitTests
                 geometryDescs[i] = GetGeometryDesc(desc, pVertexBuffer[i], pIndexBuffer[i], transformBuffers[i]->GetGPUVirtualAddress());
             }
 
-            D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO prebuildInfo = GetSizeNeededForBottomLevelHeap(device, builder, pCpuGeometryDescriptors, numGeometry);
+            D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO prebuildInfo = GetSizeNeededForBottomLevelHeap(device, builder, pCpuGeometryDescriptors, numGeometry, buildFlags);
 
             auto bottomLevelResourceDesc = CD3DX12_RESOURCE_DESC::Buffer(offsetPointer + prebuildInfo.ResultDataMaxSizeInBytes, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
             auto defaultHeapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
@@ -396,7 +473,7 @@ namespace FallbackLayerUnitTests
             bottomLevelDesc.DestAccelerationStructureData.SizeInBytes = (*ppBottomLevelAccelerationStructure)->GetDesc().Width;
             bottomLevelDesc.ScratchAccelerationStructureData.StartAddress = prebuildInfo.ScratchDataSizeInBytes > 0 ? pScratchMemory->GetGPUVirtualAddress() : 0;
             bottomLevelDesc.ScratchAccelerationStructureData.SizeInBytes = pScratchMemory->GetDesc().Width;
-            bottomLevelDesc.Flags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD;
+            bottomLevelDesc.Flags = buildFlags;
             bottomLevelDesc.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
             bottomLevelDesc.NumDescs = (UINT)geometryDescs.size();
             if (layoutToTest == D3D12_ELEMENTS_LAYOUT_ARRAY)
@@ -429,16 +506,18 @@ namespace FallbackLayerUnitTests
             BuilderWrapper &builder,
             CpuGeometryDescriptor &geometryDescriptor,
             ID3D12Resource **ppBottomLevelAccelerationStructure,
-            UINT offsetToPointer = 0)
+            UINT offsetToPointer = 0,
+            D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS buildFlags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD)
         {
-            BuildBottomLevelAccelerationStructure(builder, &geometryDescriptor, 1, ppBottomLevelAccelerationStructure, D3D12_ELEMENTS_LAYOUT_ARRAY, offsetToPointer);
+            BuildBottomLevelAccelerationStructure(builder, &geometryDescriptor, 1, ppBottomLevelAccelerationStructure, D3D12_ELEMENTS_LAYOUT_ARRAY, offsetToPointer, buildFlags);
         }
 
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO GetSizeNeededForBottomLevelHeap(
             ID3D12Device &device,
             BuilderWrapper &builder,
             const CpuGeometryDescriptor *pGeomDescs,
-            UINT geomCount)
+            UINT geomCount,
+            D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS buildFlags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD)
         {
             std::vector<D3D12_RAYTRACING_GEOMETRY_DESC> descs(geomCount);
             D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO prebuildInfo;
@@ -451,35 +530,14 @@ namespace FallbackLayerUnitTests
             builder.GetRaytracingAccelerationStructurePrebuildInfo(
                 &device,
                 D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL,
-                D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD,
+                buildFlags,
                 geomCount,
                 descs.data(),
                 &prebuildInfo);
             return prebuildInfo;
         }
     private:
-
-        D3D12_RAYTRACING_GEOMETRY_DESC GetGeometryDesc(
-            const CpuGeometryDescriptor &geomDesc,
-            ID3D12Resource *pVertexBuffer = nullptr,
-            ID3D12Resource *pIndexBuffer = nullptr,
-            D3D12_GPU_VIRTUAL_ADDRESS transform = 0)
-        {
-            D3D12_RAYTRACING_GEOMETRY_DESC geometryDesc = {};
-            geometryDesc.Type = D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES;
-            geometryDesc.Triangles.IndexBuffer = pIndexBuffer ? pIndexBuffer->GetGPUVirtualAddress() : 0;
-            geometryDesc.Triangles.IndexCount = geomDesc.m_numIndicies;
-            geometryDesc.Triangles.IndexFormat = geomDesc.m_indexBufferFormat;
-            geometryDesc.Triangles.Transform = transform;
-            geometryDesc.Triangles.VertexFormat = DXGI_FORMAT_R32G32B32_FLOAT;
-            geometryDesc.Triangles.VertexCount = geomDesc.m_numVerticies;
-            geometryDesc.Triangles.VertexBuffer.StartAddress = pVertexBuffer ? pVertexBuffer->GetGPUVirtualAddress() : 0;
-            geometryDesc.Triangles.VertexBuffer.StrideInBytes = sizeof(float) * 3;
-
-            return geometryDesc;
-        }
-
-        D3D12Context &m_d3d12Context;
+        D3D12Context & m_d3d12Context;
         DescriptorHeapStack &m_descriptorHeapStack;
     };
 
@@ -719,47 +777,12 @@ namespace FallbackLayerUnitTests
                 testCase);
         }
 
-        void GenerateRandomTranformation(float *pMatrix)
-        {
-            // Identity matrix
-            ZeroMemory(pMatrix, sizeof(float) * FloatsPerMatrix);
-            pMatrix[0] = 1;
-            pMatrix[5] = 1;
-            pMatrix[10] = 1;
-
-            enum { Translation = 0, Rotation, Scale, NumTransformations };
-            uint tranformType = rand() % NumTransformations;
-
-            float rand0 = (rand() / (float)RAND_MAX) * 100.0f - 50.0f;
-            float rand1 = (rand() / (float)RAND_MAX) * 100.0f - 50.0f;
-            float rand2 = (rand() / (float)RAND_MAX) * 100.0f - 50.0f;
-
-            switch (tranformType)
-            {
-            case Translation:
-                pMatrix[3] = rand0;
-                pMatrix[7] = rand1;
-                pMatrix[11] = rand2;
-                break;
-            case Rotation:
-                pMatrix[0] = cos(rand0);
-                pMatrix[1] = sin(rand0);
-                pMatrix[4] = -sin(rand0);
-                pMatrix[5] = cos(rand0);
-                break;
-            case Scale:
-                pMatrix[0] = rand0;
-                pMatrix[5] = rand1;
-                pMatrix[10] = rand2;
-                break;
-            }
-        }
-
         template <UINT numBottomLevels>
         void SimpleTopLevelGpuBVHBuilder(
             D3D12_ELEMENTS_LAYOUT layoutToTest,
             bool applyRandomInstanceTransforms,
-            bool testCopyAccelerationStructure = false) {
+            bool testCopyAccelerationStructure = false,
+            bool testWithUpdate = false) {
             const UINT referenceVertexArraySize = ARRAYSIZE(ReferenceVerticies0);
             const UINT referenceIndexArraySize = ARRAYSIZE(ReferenceIndices0);
 
@@ -830,7 +853,8 @@ namespace FallbackLayerUnitTests
                 ARRAYSIZE(geomDescs),
                 pHeap,
                 pTopLevelResource,
-                layoutToTest);
+                layoutToTest,
+                testWithUpdate);
 
             const UINT dataSize = (UINT)pTopLevelResource->GetDesc().Width;
 
@@ -886,6 +910,30 @@ namespace FallbackLayerUnitTests
         TEST_METHOD(TopLevelGpuBVHBuilderWithInstanceTransforms_ArrayOfPointersLayout)
         {
             SimpleTopLevelGpuBVHBuilder<50>(D3D12_ELEMENTS_LAYOUT_ARRAY_OF_POINTERS, true);
+        }
+
+        TEST_METHOD(SimpleTopLevelGpuBVHBuilderSingleBottomLevel_WithUpdate)
+        {
+            SimpleTopLevelGpuBVHBuilder<1>(D3D12_ELEMENTS_LAYOUT_ARRAY, false, true);
+        }
+
+        TEST_METHOD(SimpleTopLevelGpuBVHBuilder_ArrayLayout_WithUpdate) {
+            SimpleTopLevelGpuBVHBuilder<50>(D3D12_ELEMENTS_LAYOUT_ARRAY, false, true);
+        }
+
+        TEST_METHOD(SimpleTopLevelGpuBVHBuilder_ArrayOfPointersLayout_WithUpdate)
+        {
+            SimpleTopLevelGpuBVHBuilder<50>(D3D12_ELEMENTS_LAYOUT_ARRAY_OF_POINTERS, false, true);
+        }
+
+        TEST_METHOD(TopLevelGpuBVHBuilderWithInstanceTransforms_ArrayLayout_WithUpdate)
+        {
+            SimpleTopLevelGpuBVHBuilder<50>(D3D12_ELEMENTS_LAYOUT_ARRAY, true, true);
+        }
+
+        TEST_METHOD(TopLevelGpuBVHBuilderWithInstanceTransforms_ArrayOfPointersLayout_WithUpdate)
+        {
+            SimpleTopLevelGpuBVHBuilder<50>(D3D12_ELEMENTS_LAYOUT_ARRAY_OF_POINTERS, true, true);
         }
 
         TEST_METHOD(EmitRaytracingAccelerationStructurePostBuildInfoTest)
@@ -1003,6 +1051,253 @@ namespace FallbackLayerUnitTests
             }
         }
 
+        TEST_METHOD(UpdatesAllowedAllocateMemoryGpuBVHBuilder) {
+            ID3D12Device &device = m_d3d12Context.GetDevice();
+            std::unique_ptr<FallbackLayer::IAccelerationStructureBuilder> pBuilder =
+                std::unique_ptr<FallbackLayer::IAccelerationStructureBuilder>(
+                    new FallbackLayer::GpuBvh2Builder(&device, m_d3d12Context.GetTotalLaneCount(), 0));
+            InternalFallbackBuilder builderWrapper(pBuilder.get());
+
+            UINT numVertices = VERTEX_COUNT(ReferenceVerticies0);
+            UINT numTriangles = numVertices / 3;
+            UINT totalNumNodes = numTriangles + numTriangles - 1; // A binary tree with N leaves will always have N - 1 internal nodes
+            UINT updateExtraDataSize = (numTriangles * sizeof(UINT)) + (totalNumNodes * sizeof(UINT));
+
+            CpuGeometryDescriptor cpuGeomDesc = CpuGeometryDescriptor(ReferenceVerticies0, numVertices);
+            D3D12_RAYTRACING_GEOMETRY_DESC gpuGeomDesc = GetGeometryDesc(cpuGeomDesc);
+
+            D3D12_GET_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO_DESC bottomLevelDesc = {};
+            bottomLevelDesc.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
+            bottomLevelDesc.Flags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD;
+            bottomLevelDesc.NumDescs = 1;
+            bottomLevelDesc.pGeometryDescs = &gpuGeomDesc;
+            bottomLevelDesc.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
+
+            D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO infoNoUpdate = {};
+            pBuilder->GetRaytracingAccelerationStructurePrebuildInfo(&bottomLevelDesc, &infoNoUpdate);
+
+            // Turn on updates, make sure the memory gets allocated.
+            bottomLevelDesc.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE;
+
+            D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO infoWithUpdate = {};
+            pBuilder->GetRaytracingAccelerationStructurePrebuildInfo(&bottomLevelDesc, &infoWithUpdate);
+
+            Assert::AreEqual(infoNoUpdate.ScratchDataSizeInBytes, infoWithUpdate.ScratchDataSizeInBytes, L"Allowing update allocated scratch data.");
+            Assert::IsTrue(infoWithUpdate.ResultDataMaxSizeInBytes == infoNoUpdate.ResultDataMaxSizeInBytes + updateExtraDataSize, L"Data allocated for update doesn't match expected.");
+        }
+
+        TEST_METHOD(StoreSortResultForUpdate) {
+            ID3D12Device &device = m_d3d12Context.GetDevice();
+            std::unique_ptr<FallbackLayer::IAccelerationStructureBuilder> pBuilder =
+                std::unique_ptr<FallbackLayer::IAccelerationStructureBuilder>(
+                    new FallbackLayer::GpuBvh2Builder(&device, m_d3d12Context.GetTotalLaneCount(), 0));
+            InternalFallbackBuilder builderWrapper(pBuilder.get());
+
+            UINT numVertices = VERTEX_COUNT(ReferenceVerticies1);
+            UINT numTriangles = numVertices / 3;
+
+            CpuGeometryDescriptor geomDesc = CpuGeometryDescriptor(ReferenceVerticies1, VERTEX_COUNT(ReferenceVerticies1));
+
+            std::unique_ptr<BYTE[]> pData;
+            BuildBottomLevelAccelerationStructureAndGetCpuData(
+                builderWrapper,
+                &geomDesc,
+                1,
+                pData,
+                D3D12_ELEMENTS_LAYOUT_ARRAY,
+                D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD | D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE);
+
+            const BYTE *pOutputBVH = pData.get();
+            BVHOffsets offsets = *(BVHOffsets*)pOutputBVH;
+            AABBNode *pNodeArray = (AABBNode*)((BYTE *)pOutputBVH + offsets.offsetToBoxes);
+            Primitive *pPrimitiveArray = (Primitive*)((BYTE *)pOutputBVH + offsets.offsetToVertices);
+            UINT *pSortResults = (UINT *)((BYTE *)pOutputBVH + offsets.totalSize);
+
+            for (UINT i = 0; i < numTriangles; i++) {
+                UINT sortedIndex = pSortResults[i];
+                Triangle sortedTriangle = pPrimitiveArray[sortedIndex].triangle;
+                for (UINT vi = 0; vi < 3; vi++) {
+                    Assert::AreEqual(sortedTriangle.v[vi].x, ReferenceVerticies1[i * 9 + vi * 3 + 0], L"x not equal");
+                    Assert::AreEqual(sortedTriangle.v[vi].y, ReferenceVerticies1[i * 9 + vi * 3 + 1], L"y not equal");
+                    Assert::AreEqual(sortedTriangle.v[vi].z, ReferenceVerticies1[i * 9 + vi * 3 + 2], L"z not equal");
+                }
+            }
+        }
+
+        TEST_METHOD(StoreParentIndicesForUpdate) {
+            ID3D12Device &device = m_d3d12Context.GetDevice();
+            std::unique_ptr<FallbackLayer::IAccelerationStructureBuilder> pBuilder =
+                std::unique_ptr<FallbackLayer::IAccelerationStructureBuilder>(
+                    new FallbackLayer::GpuBvh2Builder(&device, m_d3d12Context.GetTotalLaneCount(), 0));
+            InternalFallbackBuilder builderWrapper(pBuilder.get());
+
+            UINT numVertices = VERTEX_COUNT(ReferenceVerticies1);
+            UINT numTriangles = numVertices / 3;
+            UINT totalNumNodes = numTriangles + numTriangles - 1; // A binary tree with N leaves will always have N - 1 internal nodes
+
+            CpuGeometryDescriptor geomDesc = CpuGeometryDescriptor(ReferenceVerticies1, VERTEX_COUNT(ReferenceVerticies1));
+
+            std::unique_ptr<BYTE[]> pData;
+            BuildBottomLevelAccelerationStructureAndGetCpuData(
+                builderWrapper,
+                &geomDesc,
+                1,
+                pData,
+                D3D12_ELEMENTS_LAYOUT_ARRAY,
+                D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD | D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE);
+
+            const BYTE *pOutputBVH = pData.get();
+            BVHOffsets offsets = *(BVHOffsets*)pOutputBVH;
+            AABBNode *pNodeArray = (AABBNode*)((BYTE *)pOutputBVH + offsets.offsetToBoxes);
+            Primitive *pPrimitiveArray = (Primitive*)((BYTE *)pOutputBVH + offsets.offsetToVertices);
+            UINT *pUpdateInfoCache = (UINT *)((BYTE *)pOutputBVH + offsets.totalSize); // sort results + parent indices
+            UINT *pParentIndexCache = pUpdateInfoCache + numTriangles;
+
+            for (UINT parentIndex = 0; parentIndex < totalNumNodes; parentIndex++) {
+                AABBNode parent = pNodeArray[parentIndex];
+                if (!parent.leaf)
+                {
+                    UINT leftChildIndex = parent.internalNode.leftNodeIndex;
+                    UINT rightChildIndex = parent.rightNodeIndex;
+                    Assert::IsTrue(pParentIndexCache[leftChildIndex] == parentIndex, L"Left child parent index incorrectly assigned.");
+                    Assert::IsTrue(pParentIndexCache[rightChildIndex] == parentIndex, L"Right child parent index incorrectly assigned.");
+                }
+            }
+        }
+
+        void BuildAndUpdateBottomLevelAccelerationStructure(
+            const float *startVertices,
+            const float *updatedVertices,
+            int numVertices)
+        {
+            ID3D12Device &device = m_d3d12Context.GetDevice();
+            std::unique_ptr<FallbackLayer::IAccelerationStructureBuilder> pBuilder =
+                std::unique_ptr<FallbackLayer::IAccelerationStructureBuilder>(
+                    new FallbackLayer::GpuBvh2Builder(&device, m_d3d12Context.GetTotalLaneCount(), 0));
+            InternalFallbackBuilder builderWrapper(pBuilder.get());
+
+            const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS buildFlags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD | D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE;
+
+            const UINT floatsPerVertex = 3;
+            const UINT verticesPerTriangle = 3;
+            const UINT floatsPerTriangle = verticesPerTriangle * floatsPerVertex;
+            UINT numFloats = numVertices * floatsPerVertex;
+            UINT numTriangles = numVertices / 3;
+            UINT totalNumNodes = numTriangles + numTriangles - 1; // A binary tree with N leaves will always have N - 1 internal nodes
+
+            CComPtr<ID3D12Resource> pVertexBuffer;
+            m_d3d12Context.CreateResourceWithInitialData(
+                startVertices,
+                sizeof(float) * numFloats,
+                &pVertexBuffer);
+
+            CComPtr<ID3D12Resource> pUpdatedVertexBuffer;
+            m_d3d12Context.CreateResourceWithInitialData(
+                updatedVertices,
+                sizeof(float) * numFloats,
+                &pUpdatedVertexBuffer);
+
+            D3D12_RAYTRACING_GEOMETRY_DESC geometryDesc = {};
+            geometryDesc.Type = D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES;
+            geometryDesc.Triangles.IndexBuffer = 0;
+            geometryDesc.Triangles.IndexCount = 0;
+            geometryDesc.Triangles.IndexFormat = DXGI_FORMAT_UNKNOWN;
+            geometryDesc.Triangles.Transform = 0;
+            geometryDesc.Triangles.VertexFormat = DXGI_FORMAT_R32G32B32_FLOAT;
+            geometryDesc.Triangles.VertexCount = numVertices;
+            geometryDesc.Triangles.VertexBuffer.StartAddress = pVertexBuffer->GetGPUVirtualAddress();
+            geometryDesc.Triangles.VertexBuffer.StrideInBytes = floatsPerVertex * sizeof(float);
+
+            auto heapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+
+            D3D12_GET_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO_DESC getPrebuildDesc = {};
+            getPrebuildDesc.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
+            getPrebuildDesc.NumDescs = 1;
+            getPrebuildDesc.pGeometryDescs = &geometryDesc;
+            getPrebuildDesc.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
+            getPrebuildDesc.Flags = buildFlags;
+
+            D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO prebuildInfo;
+            pBuilder->GetRaytracingAccelerationStructurePrebuildInfo(&getPrebuildDesc, &prebuildInfo);
+
+            CComPtr<ID3D12Resource> pBottomLevelResource;
+            D3D12_GPU_VIRTUAL_ADDRESS bottomLevelGpuVA;
+            auto accelerationStructureDesc = CD3DX12_RESOURCE_DESC::Buffer(prebuildInfo.ResultDataMaxSizeInBytes, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+            device.CreateCommittedResource(&heapProperties, D3D12_HEAP_FLAG_NONE, &accelerationStructureDesc, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&pBottomLevelResource));
+            bottomLevelGpuVA = pBottomLevelResource->GetGPUVirtualAddress();
+
+            CComPtr<ID3D12Resource> pScratchBufferResources[2];
+            auto scratchBufferDesc = CD3DX12_RESOURCE_DESC::Buffer(prebuildInfo.ScratchDataSizeInBytes, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+            device.CreateCommittedResource(&heapProperties, D3D12_HEAP_FLAG_NONE, &scratchBufferDesc, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&pScratchBufferResources[0]));
+            device.CreateCommittedResource(&heapProperties, D3D12_HEAP_FLAG_NONE, &scratchBufferDesc, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&pScratchBufferResources[1]));
+
+            CComPtr<ID3D12GraphicsCommandList> pCommandList;
+            m_d3d12Context.GetGraphicsCommandList(&pCommandList);
+
+            D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC bottomLevelDesc = {};
+            bottomLevelDesc.DestAccelerationStructureData.StartAddress = bottomLevelGpuVA;
+            bottomLevelDesc.DestAccelerationStructureData.SizeInBytes = prebuildInfo.ResultDataMaxSizeInBytes;
+            bottomLevelDesc.ScratchAccelerationStructureData.StartAddress = pScratchBufferResources[0]->GetGPUVirtualAddress();
+            bottomLevelDesc.ScratchAccelerationStructureData.SizeInBytes = prebuildInfo.ScratchDataSizeInBytes;
+            bottomLevelDesc.Flags = buildFlags;
+            bottomLevelDesc.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
+            bottomLevelDesc.NumDescs = 1;
+            bottomLevelDesc.pGeometryDescs = &geometryDesc;
+            bottomLevelDesc.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
+
+            pBuilder->BuildRaytracingAccelerationStructure(
+                pCommandList,
+                &bottomLevelDesc,
+                nullptr);
+
+            // Clear scratch buffer and signal perform update.
+            bottomLevelDesc.ScratchAccelerationStructureData.StartAddress = pScratchBufferResources[1]->GetGPUVirtualAddress();
+            bottomLevelDesc.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PERFORM_UPDATE;
+            geometryDesc.Triangles.VertexBuffer.StartAddress = pUpdatedVertexBuffer->GetGPUVirtualAddress();
+
+            
+            pBuilder->BuildRaytracingAccelerationStructure(
+                pCommandList,
+                &bottomLevelDesc,
+                nullptr);
+            
+            pCommandList->Close();
+            m_d3d12Context.ExecuteCommandList(pCommandList);
+            m_d3d12Context.WaitForGpuWork();
+
+            // Check AABBNode before & after, a little too similar
+            std::unique_ptr<BYTE[]> outputData = std::unique_ptr<BYTE[]>(new BYTE[(UINT)prebuildInfo.ResultDataMaxSizeInBytes]);
+            Assert::AreNotEqual(outputData.get(), (BYTE *)nullptr, L"Failed to allocate output data");
+
+            m_d3d12Context.ReadbackResource(pBottomLevelResource, outputData.get(), (UINT)prebuildInfo.ResultDataMaxSizeInBytes);
+
+            CpuGeometryDescriptor cpuGeomDescAfter = CpuGeometryDescriptor(updatedVertices, numVertices);
+
+            std::wstring errorMessage;
+            auto &validator = FallbackLayer::GetAccelerationStructureValidator(pBuilder->GetAccelerationStructureType());
+            if (!validator.VerifyBottomLevelOutput(&cpuGeomDescAfter, 1, outputData.get(), errorMessage))
+            {
+                Assert::Fail(errorMessage.c_str());
+            }
+        }
+
+        TEST_METHOD(RefitAABBsOnUpdate) {
+            const UINT numVertices = VERTEX_COUNT(ReferenceVerticies1);
+            // Scramble up the triangles
+            std::vector<float> UpdatedVertices(numVertices * 3);
+            for (UINT i = 0; i < UpdatedVertices.size(); i++)
+            {
+                UINT vertexIndex = i / 3;
+                UINT triangleIndex = vertexIndex / 3;
+                UpdatedVertices[i] = (((ReferenceVerticies1[i] + vertexIndex) * (vertexIndex % 2 == 0 ? -8 : 8))) * ((triangleIndex % 2 == 0) ? -12 : 12);
+            }
+
+            BuildAndUpdateBottomLevelAccelerationStructure(
+                ReferenceVerticies1,
+                UpdatedVertices.data(),
+                numVertices
+            );
+        }
 
     private:
 #define TEST_EPSILON 0.001
@@ -1139,11 +1434,12 @@ namespace FallbackLayerUnitTests
             CpuGeometryDescriptor *pGeomDescs,
             UINT numDescs,
             std::unique_ptr<BYTE[]> &outputData,
-            D3D12_ELEMENTS_LAYOUT layoutToTest = D3D12_ELEMENTS_LAYOUT_ARRAY)
+            D3D12_ELEMENTS_LAYOUT layoutToTest = D3D12_ELEMENTS_LAYOUT_ARRAY,
+            D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS buildFlags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD)
         {
             ID3D12Device &device = m_d3d12Context.GetDevice();
             CComPtr<ID3D12Resource> pResource;
-            m_pBuilderHelper->BuildBottomLevelAccelerationStructure(builder, pGeomDescs, numDescs, &pResource, layoutToTest);
+            m_pBuilderHelper->BuildBottomLevelAccelerationStructure(builder, pGeomDescs, numDescs, &pResource, layoutToTest, 0, buildFlags);
 
             outputData = std::unique_ptr<BYTE[]>(new BYTE[(UINT)pResource->GetDesc().Width]);
             Assert::AreNotEqual(outputData.get(), (BYTE *)nullptr, L"Failed to allocate output data");
@@ -2778,7 +3074,19 @@ namespace FallbackLayerUnitTests
             TestLoadPrimitives<Triangle>(TRIANGLE_TYPE);
         }
 
-        template <typename PrimitiveObjectType> void TestLoadPrimitives(UINT primitiveType) {
+        TEST_METHOD(LoadSortedAABBs)
+        {
+            TestLoadPrimitives<AABB>(PROCEDURAL_PRIMITIVE_TYPE, true);
+        }
+
+        TEST_METHOD(LoadSortedTriangles)
+        {
+            TestLoadPrimitives<Triangle>(TRIANGLE_TYPE, true);
+        }
+
+        template <typename PrimitiveObjectType>
+        void TestLoadPrimitives(UINT primitiveType, bool testCachedSort = false)
+        {
             const UINT primitivesPerGeometry = 4;
 
             D3D12_RAYTRACING_GEOMETRY_FLAGS geometryFlags[] =
@@ -2799,7 +3107,7 @@ namespace FallbackLayerUnitTests
             {
                 float fi = (float)(i * floatsPerPrimitive);
                 float f[floatsPerPrimitive];
-                for(UINT j = 0; j < floatsPerPrimitive; j++)
+                for (UINT j = 0; j < floatsPerPrimitive; j++)
                     f[j] = fi + j;
 
                 memcpy(&inputPrimitives[i], f, floatsPerPrimitive);
@@ -2814,6 +3122,19 @@ namespace FallbackLayerUnitTests
             CComPtr<ID3D12Resource> pInputPrimitiveBuffer;
             m_d3d12Context.CreateResourceWithInitialData(inputPrimitives.data(), inputPrimitives.size() * primitiveSizeBytes, &pInputPrimitiveBuffer);
 
+            UINT cachedSortIndices[totalPrimCount];
+            D3D12_GPU_VIRTUAL_ADDRESS cachedSortBuffer = 0;
+            CComPtr<ID3D12Resource> pCachedSortBuffer;
+            if (testCachedSort)
+            {
+                for (UINT i = 0; i < totalPrimCount; i++)
+                {
+                    cachedSortIndices[i] = (i + 1) % totalPrimCount;
+                }
+                m_d3d12Context.CreateResourceWithInitialData(cachedSortIndices, totalPrimCount * sizeof(UINT), &pCachedSortBuffer);
+                cachedSortBuffer = pCachedSortBuffer->GetGPUVirtualAddress();
+            }
+
             CComPtr<ID3D12Resource> pOutputBuffer, pOutputMetadataBuffer;
 
             D3D12_HEAP_PROPERTIES defaultHeapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
@@ -2823,22 +3144,22 @@ namespace FallbackLayerUnitTests
 
             auto outputMetadataBufferDesc = CD3DX12_RESOURCE_DESC::Buffer(inputPrimitives.size() * sizeof(PrimitiveMetaData), D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
             AssertSucceeded(d3d12Device.CreateCommittedResource(&defaultHeapProperties, D3D12_HEAP_FLAG_NONE, &outputMetadataBufferDesc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, nullptr, IID_PPV_ARGS(&pOutputMetadataBuffer)));
-            
+
             D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC trianglesDesc = {};
             D3D12_RAYTRACING_GEOMETRY_AABBS_DESC aabbsDesc = {};
-            switch(primitiveType) {
-                case TRIANGLE_TYPE:
-                    trianglesDesc.VertexFormat = DXGI_FORMAT_R32G32B32_FLOAT;
-                    trianglesDesc.VertexCount = primitivesPerGeometry * 3;
-                    trianglesDesc.VertexBuffer.StartAddress = pInputPrimitiveBuffer->GetGPUVirtualAddress();
-                    trianglesDesc.VertexBuffer.StrideInBytes = sizeof(float3);
-                    trianglesDesc.IndexFormat = DXGI_FORMAT_UNKNOWN;
-                    trianglesDesc.IndexBuffer = 0;
+            switch (primitiveType) {
+            case TRIANGLE_TYPE:
+                trianglesDesc.VertexFormat = DXGI_FORMAT_R32G32B32_FLOAT;
+                trianglesDesc.VertexCount = primitivesPerGeometry * 3;
+                trianglesDesc.VertexBuffer.StartAddress = pInputPrimitiveBuffer->GetGPUVirtualAddress();
+                trianglesDesc.VertexBuffer.StrideInBytes = sizeof(float3);
+                trianglesDesc.IndexFormat = DXGI_FORMAT_UNKNOWN;
+                trianglesDesc.IndexBuffer = 0;
                 break;
-                case PROCEDURAL_PRIMITIVE_TYPE:
-                    aabbsDesc.AABBCount = primitivesPerGeometry;
-                    aabbsDesc.AABBs.StartAddress = pInputPrimitiveBuffer->GetGPUVirtualAddress();
-                    aabbsDesc.AABBs.StrideInBytes = sizeof(AABB);
+            case PROCEDURAL_PRIMITIVE_TYPE:
+                aabbsDesc.AABBCount = primitivesPerGeometry;
+                aabbsDesc.AABBs.StartAddress = pInputPrimitiveBuffer->GetGPUVirtualAddress();
+                aabbsDesc.AABBs.StrideInBytes = sizeof(AABB);
                 break;
             }
 
@@ -2847,19 +3168,19 @@ namespace FallbackLayerUnitTests
             {
                 D3D12_RAYTRACING_GEOMETRY_DESC geometryDesc = {};
                 geometryDesc.Flags = geometryFlags[i];
-                switch(primitiveType) {
-                    case TRIANGLE_TYPE:
-                        geometryDesc.Type = D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES;
-                        geometryDesc.Triangles = trianglesDesc;
-                        geometryDesc.Triangles.VertexBuffer.StartAddress += i * geomDescStartAddrStride;
+                switch (primitiveType) {
+                case TRIANGLE_TYPE:
+                    geometryDesc.Type = D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES;
+                    geometryDesc.Triangles = trianglesDesc;
+                    geometryDesc.Triangles.VertexBuffer.StartAddress += i * geomDescStartAddrStride;
                     break;
-                    case PROCEDURAL_PRIMITIVE_TYPE:
-                        geometryDesc.Type = D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS;
-                        geometryDesc.AABBs = aabbsDesc;
-                        geometryDesc.AABBs.AABBs.StartAddress += i * geomDescStartAddrStride;
+                case PROCEDURAL_PRIMITIVE_TYPE:
+                    geometryDesc.Type = D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS;
+                    geometryDesc.AABBs = aabbsDesc;
+                    geometryDesc.AABBs.AABBs.StartAddress += i * geomDescStartAddrStride;
                     break;
                 }
-                
+
                 geometryDescs[i] = geometryDesc;
             }
 
@@ -2874,7 +3195,8 @@ namespace FallbackLayerUnitTests
                 buildDesc,
                 totalPrimCount,
                 pOutputBuffer->GetGPUVirtualAddress(),
-                pOutputMetadataBuffer->GetGPUVirtualAddress());
+                pOutputMetadataBuffer->GetGPUVirtualAddress(),
+                cachedSortBuffer);
 
             pCommandList->Close();
             m_d3d12Context.ExecuteCommandList(pCommandList);
@@ -2887,26 +3209,27 @@ namespace FallbackLayerUnitTests
 
             for (UINT i = 0; i < totalPrimCount; i++)
             {
+                const UINT sortedIndex = cachedSortBuffer ? cachedSortIndices[i] : i;
                 const UINT geometryDescIndex = i / primitivesPerGeometry;
                 const UINT targetGeomFlag = geometryFlags[geometryDescIndex];
                 void *pUnwrappedPrimitive;
 
-                switch(primitiveType) {
-                    case TRIANGLE_TYPE:
-                        pUnwrappedPrimitive = &outputPrimitives[i].triangle;
+                switch (primitiveType) {
+                case TRIANGLE_TYPE:
+                    pUnwrappedPrimitive = &outputPrimitives[sortedIndex].triangle;
                     break;
-                    
-                    case PROCEDURAL_PRIMITIVE_TYPE:
-                        pUnwrappedPrimitive = &outputPrimitives[i].aabb;
+
+                case PROCEDURAL_PRIMITIVE_TYPE:
+                    pUnwrappedPrimitive = &outputPrimitives[sortedIndex].aabb;
                     break;
                 }
 
                 Assert::IsTrue(outputPrimitives[i].PrimitiveType == primitiveType, L"Loaded primitive is not properly marked with specified Primitive Type");
-                Assert::IsTrue(memcmp(&outputPrimitives[i].triangle, &inputPrimitives[i], sizeof(inputPrimitives[i])) == 0, L"Loaded primitive does not match the input primitive");
+                Assert::IsTrue(memcmp(pUnwrappedPrimitive, &inputPrimitives[i], sizeof(inputPrimitives[i])) == 0, L"Loaded primitive does not match the input primitive");
                 if (targetGeomFlag)
-                    Assert::IsTrue(outputMetadata[i].GeometryFlags == targetGeomFlag, L"Loaded primitive does not have correct geometry flag set");
+                    Assert::IsTrue(outputMetadata[sortedIndex].GeometryFlags == targetGeomFlag, L"Loaded primitive does not have correct geometry flag set");
                 else
-                    Assert::IsTrue(outputMetadata[i].GeometryFlags == 0, L"Loaded primitive does not have geometry flags cleared");
+                    Assert::IsTrue(outputMetadata[sortedIndex].GeometryFlags == 0, L"Loaded primitive does not have geometry flags cleared");
             }
         }
 
@@ -3009,11 +3332,12 @@ namespace FallbackLayerUnitTests
             rearrangeTrianglePass.Rearrange(
                 pCommandList,
                 sceneType,
+                numElements,
                 pInputBuffer->GetGPUVirtualAddress(),
-                numElements, pIndexBuffer->GetGPUVirtualAddress(),
-                pOutputBuffer->GetGPUVirtualAddress(),
                 pMetadataBuffer->GetGPUVirtualAddress(),
-                pOutputMetadata->GetGPUVirtualAddress());
+                pIndexBuffer->GetGPUVirtualAddress(),
+                pOutputBuffer->GetGPUVirtualAddress(),
+                pOutputMetadata->GetGPUVirtualAddress(), 0);
 
             D3D12_RESOURCE_BARRIER uavToCopySourceBarrier[] =
             {

--- a/Libraries/D3D12RaytracingFallback/src/GpuBvh2Builder.h
+++ b/Libraries/D3D12RaytracingFallback/src/GpuBvh2Builder.h
@@ -79,6 +79,29 @@ namespace FallbackLayer
         PostBuildInfoQuery m_postBuildInfoQuery;
         GpuBvh2Copy m_copyPass;
 
+        struct GpuBVHBuffers {
+            D3D12_GPU_VIRTUAL_ADDRESS scratchElementBuffer;
+            D3D12_GPU_VIRTUAL_ADDRESS outputElementBuffer;
+            D3D12_GPU_VIRTUAL_ADDRESS scratchMetadataBuffer;
+            D3D12_GPU_VIRTUAL_ADDRESS outputMetadataBuffer;
+            D3D12_GPU_VIRTUAL_ADDRESS sceneAABBScratchMemory;
+            D3D12_GPU_VIRTUAL_ADDRESS sceneAABB;
+            D3D12_GPU_VIRTUAL_ADDRESS mortonCodeBuffer;
+            D3D12_GPU_VIRTUAL_ADDRESS indexBuffer;
+            D3D12_GPU_VIRTUAL_ADDRESS outputSortCacheBuffer;
+            D3D12_GPU_VIRTUAL_ADDRESS hierarchyBuffer;
+            D3D12_GPU_VIRTUAL_ADDRESS nodeCountBuffer;
+            D3D12_GPU_VIRTUAL_ADDRESS calculateAABBScratchBuffer;
+            D3D12_GPU_VIRTUAL_ADDRESS outputAABBParentBuffer;
+        };
+
+        void GpuBvh2Builder::LoadGpuBVHBuffers(
+            _In_  const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC *pDesc,
+            Level bvhLevel,
+            UINT numElements,
+            GpuBVHBuffers &buffers
+        );
+        
         void BuildTopLevelBVH(
             _In_  ID3D12GraphicsCommandList *pCommandList,
             _In_  const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC *pDesc,
@@ -88,6 +111,47 @@ namespace FallbackLayer
         void BuildBottomLevelBVH(
             _In_  ID3D12GraphicsCommandList *pCommandList,
             _In_  const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC *pDesc
+        );
+
+        void GpuBvh2Builder::BuildBVH(
+            _In_  ID3D12GraphicsCommandList *pCommandList,
+            _In_  const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC *pDesc,
+            Level bvhLevel,
+            SceneType sceneType,
+            UINT numElements,
+            D3D12_GPU_DESCRIPTOR_HANDLE globalDescriptorHeap
+        );
+
+        void GpuBvh2Builder::LoadBVHElements(
+            _In_ ID3D12GraphicsCommandList *pCommandList,
+            _In_  const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC *pDesc,
+            const SceneType sceneType,
+            const uint totalElements,
+            D3D12_GPU_VIRTUAL_ADDRESS elementBuffer,
+            D3D12_GPU_VIRTUAL_ADDRESS metadataBuffer,
+            D3D12_GPU_VIRTUAL_ADDRESS indexBuffer,
+            D3D12_GPU_VIRTUAL_ADDRESS sceneAABBScratchMemory,
+            D3D12_GPU_VIRTUAL_ADDRESS sceneAABB,
+            D3D12_GPU_DESCRIPTOR_HANDLE globalDescriptorHeap
+        );
+
+        void GpuBvh2Builder::BuildBVHHierarchy(
+            _In_ ID3D12GraphicsCommandList *pCommandList,
+            _In_  const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC *pDesc,
+            const SceneType sceneType,
+            const uint totalElements,
+            D3D12_GPU_VIRTUAL_ADDRESS scratchElementBuffer,
+            D3D12_GPU_VIRTUAL_ADDRESS outputElementBuffer,
+            D3D12_GPU_VIRTUAL_ADDRESS scratchMetadataBuffer,
+            D3D12_GPU_VIRTUAL_ADDRESS outputMetadataBuffer,
+            D3D12_GPU_VIRTUAL_ADDRESS sceneAABBScratchMemory,
+            D3D12_GPU_VIRTUAL_ADDRESS sceneAABB,
+            D3D12_GPU_VIRTUAL_ADDRESS mortonCodeBuffer,
+            D3D12_GPU_VIRTUAL_ADDRESS indexBuffer,
+            D3D12_GPU_VIRTUAL_ADDRESS outputSortCacheBuffer,
+            D3D12_GPU_VIRTUAL_ADDRESS hierarchyBuffer,
+            D3D12_GPU_VIRTUAL_ADDRESS nodeCountBuffer,
+            D3D12_GPU_DESCRIPTOR_HANDLE globalDescriptorHeap
         );
     };
 }

--- a/Libraries/D3D12RaytracingFallback/src/LoadInstancesBindings.h
+++ b/Libraries/D3D12RaytracingFallback/src/LoadInstancesBindings.h
@@ -18,12 +18,14 @@
 struct LoadInstancesConstants
 {
     uint NumberOfElements;
+    uint PerformUpdate;
 };
 
 // UAVs
 #define OutputBVHRegister 0
 #define DescriptorHeapBufferRegister 0
 #define DescriptorHeapBufferRegisterSpace 1
+#define CachedSortBufferRegister 3
 
 //SRVs 
 #define InstanceDescsRegister 0
@@ -35,6 +37,8 @@ struct LoadInstancesConstants
 
 #ifdef HLSL
 
+RWStructuredBuffer<uint> CachedSortBuffer : UAV_REGISTER(CachedSortBufferRegister);
+
 RWByteAddressBuffer outputBVH : UAV_REGISTER(OutputBVHRegister);
 RWByteAddressBuffer DescriptorHeapBufferTable[] : UAV_REGISTER_SPACE(DescriptorHeapBufferRegister, DescriptorHeapBufferRegisterSpace);
 
@@ -44,5 +48,14 @@ ByteAddressBuffer DescriptorHeapSRVBufferTable[] : SRV_REGISTER_SPACE(Descriptor
 cbuffer TopLevelConstants : CONSTANT_REGISTER(LoadInstancesConstantsRegister)
 {
     LoadInstancesConstants Constants;
-};
+}
+
+uint GetOutputIndex(uint inputIndex) 
+{
+    if (Constants.PerformUpdate)
+    {
+        return CachedSortBuffer[inputIndex];
+    }
+    return inputIndex;
+}
 #endif

--- a/Libraries/D3D12RaytracingFallback/src/LoadInstancesPass.h
+++ b/Libraries/D3D12RaytracingFallback/src/LoadInstancesPass.h
@@ -15,7 +15,13 @@ namespace FallbackLayer
     {
     public:
         LoadInstancesPass(ID3D12Device *pDevice, UINT nodeMask);
-        void LoadInstances(ID3D12GraphicsCommandList *pCommandList, D3D12_GPU_VIRTUAL_ADDRESS outputBVH, D3D12_GPU_VIRTUAL_ADDRESS instancesDesc, D3D12_ELEMENTS_LAYOUT instanceDescLayout, UINT numElements, D3D12_GPU_DESCRIPTOR_HANDLE descriptorHeapBase);
+        void LoadInstances(ID3D12GraphicsCommandList *pCommandList, 
+            D3D12_GPU_VIRTUAL_ADDRESS outputBVH, 
+            D3D12_GPU_VIRTUAL_ADDRESS instancesDesc, 
+            D3D12_ELEMENTS_LAYOUT instanceDescLayout, 
+            UINT numElements, 
+            D3D12_GPU_DESCRIPTOR_HANDLE descriptorHeapBase,
+            D3D12_GPU_VIRTUAL_ADDRESS cachedSortBuffer);
     private:
         enum RootParameterSlot
         {
@@ -23,6 +29,7 @@ namespace FallbackLayer
             InstanceDescsSRV,
             GlobalDescriptorHeap,
             Constants,
+            CachedSortBuffer,
             NumRootParameters,
         };
 

--- a/Libraries/D3D12RaytracingFallback/src/LoadPrimitivesBindings.h
+++ b/Libraries/D3D12RaytracingFallback/src/LoadPrimitivesBindings.h
@@ -30,11 +30,13 @@ struct LoadPrimitivesInputConstants
     // TODO: Consider inlining into separate shaders
     uint HasValidTransform; 
     uint GeometryFlags;
+    uint PerformUpdate;
 };
 
 // UAVs
 #define OutputPrimitiveBufferRegister 0
 #define OutputMetadataBufferRegister 1
+#define CachedSortBufferRegister 2
 
 //SRVs 
 #define ElementBufferRegister 0
@@ -48,6 +50,7 @@ struct LoadPrimitivesInputConstants
 
 RWStructuredBuffer<Primitive> PrimitiveBuffer : UAV_REGISTER(OutputPrimitiveBufferRegister);
 RWStructuredBuffer<PrimitiveMetaData> MetadataBuffer : UAV_REGISTER(OutputMetadataBufferRegister);
+RWStructuredBuffer<uint> CachedSortBuffer : UAV_REGISTER(CachedSortBufferRegister);
 
 ByteAddressBuffer elementBuffer : SRV_REGISTER(ElementBufferRegister);
 ByteAddressBuffer indexBuffer : SRV_REGISTER(IndexBufferRegister);
@@ -55,6 +58,15 @@ StructuredBuffer<float4> TransformBuffer : SRV_REGISTER(TransformRegister);
 cbuffer LoadPrimitivesConstants : CONSTANT_REGISTER(LoadInstancesConstantsRegister)
 {
     LoadPrimitivesInputConstants Constants;
+}
+
+uint GetOutputIndex(uint inputIndex) 
+{
+    if (Constants.PerformUpdate)
+    {
+        return CachedSortBuffer[inputIndex];
+    }
+    return inputIndex;
 }
 
 void StorePrimitiveMetadata(uint globalPrimitiveIndex, uint localPrimitiveIndex)

--- a/Libraries/D3D12RaytracingFallback/src/LoadPrimitivesPass.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/LoadPrimitivesPass.cpp
@@ -25,6 +25,7 @@ namespace FallbackLayer
         rootParameters[TransformsBuffer].InitAsShaderResourceView(TransformRegister);
         rootParameters[OutputBuffer].InitAsUnorderedAccessView(OutputPrimitiveBufferRegister);
         rootParameters[OutputMetadataBuffer].InitAsUnorderedAccessView(OutputMetadataBufferRegister);
+        rootParameters[CachedSortBuffer].InitAsUnorderedAccessView(CachedSortBufferRegister);
         rootParameters[InputRootConstants].InitAsConstants(SizeOfInUint32(LoadPrimitivesInputConstants), LoadInstancesConstantsRegister);
 
         auto rootSignatureDesc = CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC(ARRAYSIZE(rootParameters), rootParameters);
@@ -56,8 +57,11 @@ namespace FallbackLayer
         const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC &buildDesc, 
         const UINT totalPrimitiveCount,
         D3D12_GPU_VIRTUAL_ADDRESS outputTriangleBuffer,
-        D3D12_GPU_VIRTUAL_ADDRESS outputMetadataBuffer)
+        D3D12_GPU_VIRTUAL_ADDRESS outputMetadataBuffer,
+        D3D12_GPU_VIRTUAL_ADDRESS cachedSortBuffer)
     {
+        const bool performUpdate = cachedSortBuffer != 0;
+
         CComPtr<ID3D12Device> pDevice;
         pCommandList->GetDevice(IID_PPV_ARGS(&pDevice));
         pCommandList->SetComputeRootSignature(m_pRootSignature);
@@ -102,6 +106,7 @@ namespace FallbackLayer
                 constants.GeometryContributionToHitGroupIndex = elementIndex;
                 constants.HasValidTransform = (triangles.Transform != 0);
                 constants.GeometryFlags = geometryDesc.Flags;
+                constants.PerformUpdate = performUpdate;
 
                 pCommandList->SetComputeRoot32BitConstants(InputRootConstants, SizeOfInUint32(LoadPrimitivesInputConstants), &constants, 0);
                 pCommandList->SetComputeRootShaderResourceView(ElementBufferSRV, triangles.VertexBuffer.StartAddress);
@@ -140,11 +145,18 @@ namespace FallbackLayer
                 constants.ElementBufferStride = (UINT32)aabbs.AABBs.StrideInBytes;
                 constants.GeometryContributionToHitGroupIndex = elementIndex;
                 constants.GeometryFlags = geometryDesc.Flags;
+                constants.PerformUpdate = performUpdate;
 
                 pCommandList->SetComputeRoot32BitConstants(InputRootConstants, SizeOfInUint32(LoadPrimitivesInputConstants), &constants, 0);
                 pCommandList->SetComputeRootShaderResourceView(ElementBufferSRV, aabbs.AABBs.StartAddress);
                 pCommandList->SetPipelineState(m_pLoadProceduralGeometryPSO);
             }
+
+            if(performUpdate) 
+            {
+                pCommandList->SetComputeRootUnorderedAccessView(CachedSortBuffer, cachedSortBuffer);
+            }
+            
             pCommandList->SetComputeRootUnorderedAccessView(OutputBuffer, outputTriangleBuffer);
             pCommandList->SetComputeRootUnorderedAccessView(OutputMetadataBuffer, outputMetadataBuffer);
 

--- a/Libraries/D3D12RaytracingFallback/src/LoadPrimitivesPass.h
+++ b/Libraries/D3D12RaytracingFallback/src/LoadPrimitivesPass.h
@@ -19,7 +19,8 @@ namespace FallbackLayer
             const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC &buildDesc,
             UINT totalTriangleCount,
             D3D12_GPU_VIRTUAL_ADDRESS outputTriangleBuffer,
-            D3D12_GPU_VIRTUAL_ADDRESS outputMetadataBuffer);
+            D3D12_GPU_VIRTUAL_ADDRESS outputMetadataBuffer,
+            D3D12_GPU_VIRTUAL_ADDRESS cachedSortBuffer);
     private:
         enum RootParameterSlot
         {
@@ -29,6 +30,7 @@ namespace FallbackLayer
             ElementBufferSRV,
             InputRootConstants,
             TransformsBuffer,
+            CachedSortBuffer,
             NumRootParameters,
         };
 

--- a/Libraries/D3D12RaytracingFallback/src/LoadProceduralGeometry.hlsl
+++ b/Libraries/D3D12RaytracingFallback/src/LoadProceduralGeometry.hlsl
@@ -29,9 +29,11 @@ void main(uint3 DTid : SV_DispatchThreadID)
     {
         return;
     }
-    uint globalPrimitiveIndex = localPrimitiveIndex + Constants.PrimitiveOffset;
     AABB aabb = GetAABB(elementBuffer, localPrimitiveIndex, Constants.ElementBufferStride);
 
-    PrimitiveBuffer[globalPrimitiveIndex] = CreateProceduralGeometryPrimitive(aabb);
-    StorePrimitiveMetadata(globalPrimitiveIndex, localPrimitiveIndex);
+    uint globalPrimitiveIndex = localPrimitiveIndex + Constants.PrimitiveOffset;
+    uint outputIndex = GetOutputIndex(globalPrimitiveIndex);
+
+    PrimitiveBuffer[outputIndex] = CreateProceduralGeometryPrimitive(aabb);
+    StorePrimitiveMetadata(outputIndex, localPrimitiveIndex);
 }

--- a/Libraries/D3D12RaytracingFallback/src/RayTracingHelper.hlsli
+++ b/Libraries/D3D12RaytracingFallback/src/RayTracingHelper.hlsli
@@ -17,9 +17,6 @@
 
 // Hidden
 #define AABB_Min_Padding 0.001
-#define SizeOfFloat 4
-#define SizeOfUINT16 2
-#define SizeOfUINT32 4
 #define NumberOfFloatsPerVertex 3
 #define SizeOfVertex (NumberOfFloatsPerVertex * SizeOfFloat)
 #define NumberOfVerticesPerTriangle 3

--- a/Libraries/D3D12RaytracingFallback/src/RayTracingHlslCompat.h
+++ b/Libraries/D3D12RaytracingFallback/src/RayTracingHlslCompat.h
@@ -26,6 +26,10 @@
 #pragma pack(push, 1)
 #endif
 
+#define SizeOfFloat 4
+#define SizeOfUINT16 2
+#define SizeOfUINT32 4
+
 struct HierarchyNode
 {
     uint ParentIndex;
@@ -400,6 +404,23 @@ inline
 uint GetNumInternalNodes(uint numLeaves)
 {
     return numLeaves - 1;
+}
+
+inline
+uint GetOffsetFromSortedIndicesToAABBParents(uint numPrimitives) {
+    return SizeOfUINT32 * numPrimitives;
+}
+
+inline
+uint GetOffsetToBVHSortedIndices(uint numElements) {
+    uint totalNodes = numElements + GetNumInternalNodes(numElements);
+    return SizeOfBVHOffsets + SizeOfAABBNode * totalNodes + SizeOfBVHMetadata * numElements;
+}
+
+inline
+uint GetOffsetFromPrimitiveMetaDataToSortedIndices(uint numPrimitives)
+{
+    return SizeOfPrimitiveMetaData * numPrimitives;
 }
 
 inline

--- a/Libraries/D3D12RaytracingFallback/src/RearrangeBVHs.hlsl
+++ b/Libraries/D3D12RaytracingFallback/src/RearrangeBVHs.hlsl
@@ -24,6 +24,11 @@ void CopyBVHAABB(uint srcIndex, uint dstIndex)
     uint srcAddress = srcIndex * sizeInUint4s;
     uint dstAddress = dstIndex * sizeInUint4s;
 
+    if (Constants.UpdatesAllowed)
+    {
+        OutputIndexBuffer[srcIndex] = dstIndex;
+    }
+
     [unroll]
     for (uint i = 0; i < sizeInUint4s; i++)
     {
@@ -46,7 +51,7 @@ void CopyBVH(uint srcIndex, uint dstIndex)
 void main(uint3 DTid : SV_DispatchThreadID)
 {
     uint dstIndex = DTid.x;
-    if (dstIndex >= NumberOfTriangles) return;
+    if (dstIndex >= Constants.NumberOfTriangles) return;
 
     uint srcIndex = IndexBuffer[dstIndex];
     CopyBVH(srcIndex, dstIndex);

--- a/Libraries/D3D12RaytracingFallback/src/RearrangeElementsPass.h
+++ b/Libraries/D3D12RaytracingFallback/src/RearrangeElementsPass.h
@@ -20,23 +20,25 @@ namespace FallbackLayer
         void Rearrange(
             ID3D12GraphicsCommandList *pCommandList,
             SceneType sceneType,
-            D3D12_GPU_VIRTUAL_ADDRESS inputBuffer,
-            UINT numElements,
+            UINT numTriangles,
+            D3D12_GPU_VIRTUAL_ADDRESS inputElements,
+            D3D12_GPU_VIRTUAL_ADDRESS inputMetadataBuffer,
             D3D12_GPU_VIRTUAL_ADDRESS indexBuffer,
-            D3D12_GPU_VIRTUAL_ADDRESS outputBuffer,
-            D3D12_GPU_VIRTUAL_ADDRESS inputMetadataBuffer = 0,
-            D3D12_GPU_VIRTUAL_ADDRESS outputMetadataBuffer = 0
+            D3D12_GPU_VIRTUAL_ADDRESS outputTriangles,
+            D3D12_GPU_VIRTUAL_ADDRESS outputMetadataBuffer,
+            D3D12_GPU_VIRTUAL_ADDRESS outputIndexBuffer
         );
 
     private:
         enum RootParameterSlot
         {
             InputElements= 0,
+            InputMetadata,
             IndexBuffer,
-            NumTrianglesConstant,
             OutputElements,
             OutputMetadata,
-            InputMetadata,
+            OutputIndexBuffer,
+            InputRootConstants,
             NumParameters
         };
 

--- a/Libraries/D3D12RaytracingFallback/src/RearrangeTriangles.hlsl
+++ b/Libraries/D3D12RaytracingFallback/src/RearrangeTriangles.hlsl
@@ -20,13 +20,17 @@ void CopyPrimitive(uint srcIndex, uint dstIndex)
 {
     OutputTriangleBuffer[dstIndex] = InputTriangleBuffer[srcIndex];
     OutputMetadataBuffer[dstIndex] = InputMetadataBuffer[srcIndex];
+    if (Constants.UpdatesAllowed)
+    {
+    	OutputIndexBuffer[srcIndex] = dstIndex;
+    }
 }
 
 [numthreads(THREAD_GROUP_1D_WIDTH, 1, 1)]
 void main(uint3 DTid : SV_DispatchThreadID)
 {
     uint dstIndex = DTid.x;
-    if (dstIndex >= NumberOfTriangles) return;
+    if (dstIndex >= Constants.NumberOfTriangles) return;
     
     uint srcIndex = IndexBuffer[dstIndex];
     CopyPrimitive(srcIndex, dstIndex);

--- a/Libraries/D3D12RaytracingFallback/src/RearrangeTrianglesBindings.h
+++ b/Libraries/D3D12RaytracingFallback/src/RearrangeTrianglesBindings.h
@@ -18,23 +18,31 @@
 
 #define ElementsSummedPerThread 8
 
+struct InputConstants
+{
+    uint NumberOfTriangles;
+    uint UpdatesAllowed;
+};
+
 // UAVs
-#define InputElementBufferRegister 0
-#define IndexBufferRegister 1
-#define OutputElementBufferRegister 2
-#define InputMetadataBufferRegister 3
+#define InputElementBufferRegister   0
+#define InputMetadataBufferRegister  1
+#define IndexBufferRegister          2
+#define OutputElementBufferRegister  3
 #define OutputMetadataBufferRegister 4
+#define OutputIndexBufferRegister    5
 
 // CBVs
-#define NumberOfTrianglesConstantsRegister 0
+#define InputConstantsRegister 0
 
 #ifdef HLSL
 // These need to be UAVs despite being read-only because the fallback layer only gets a 
 // GPU VA and the API doesn't allow any way to transition that GPU VA from UAV->SRV
 RWStructuredBuffer<uint> IndexBuffer : UAV_REGISTER(IndexBufferRegister);
+RWStructuredBuffer<uint> OutputIndexBuffer : UAV_REGISTER(OutputIndexBufferRegister);
 
-cbuffer NumberOfTriangles : CONSTANT_REGISTER(NumberOfTrianglesConstantsRegister)
+cbuffer RearrangeElementsConstants : CONSTANT_REGISTER(InputConstantsRegister)
 {
-    uint NumberOfTriangles;
+    InputConstants Constants;
 }
 #endif

--- a/Libraries/D3D12RaytracingFallback/src/TopLevelLoadAABBs.hlsli
+++ b/Libraries/D3D12RaytracingFallback/src/TopLevelLoadAABBs.hlsli
@@ -64,6 +64,8 @@ void main(uint3 DTid : SV_DispatchThreadID)
         return;
     }
 
+    uint outputIndex = GetOutputIndex(instanceIndex);
+
     uint totalSizeOfAABBNodes = Constants.NumberOfElements * SizeOfAABBNode;
     const uint offsetToLeafNodeMetadata = totalSizeOfAABBNodes;
 
@@ -85,7 +87,7 @@ void main(uint3 DTid : SV_DispatchThreadID)
     AABB transformedBox = TransformAABB(box, ObjectToWorld);
 
     int leafFlag = IsLeafFlag | instanceIndex;
-    WriteBoxToBuffer(outputBVH, 0, instanceIndex, AABBtoBoundingBox(transformedBox), leafFlag);
+    WriteBoxToBuffer(outputBVH, 0, outputIndex, AABBtoBoundingBox(transformedBox), leafFlag);
     
     BVHMetadata metadata;
     metadata.instanceDesc = instanceDesc;
@@ -94,5 +96,5 @@ void main(uint3 DTid : SV_DispatchThreadID)
     metadata.ObjectToWorld[0] = ObjectToWorld[0];
     metadata.ObjectToWorld[1] = ObjectToWorld[1];
     metadata.ObjectToWorld[2] = ObjectToWorld[2];
-    StoreBVHMetadataToRawData(outputBVH, offsetToLeafNodeMetadata + instanceIndex * SizeOfBVHMetadata, metadata);
+    StoreBVHMetadataToRawData(outputBVH, offsetToLeafNodeMetadata + outputIndex * SizeOfBVHMetadata, metadata);
 }


### PR DESCRIPTION
Consider a character in a video game that typically stands around holding an axe, but occasionally throws the axe when made upset. While the axe is in the character’s hand, the AABB containing the character’s hand and the AABB containing the axe can share a larger AABB in the BVH. Once the character throws the axe, the BVH should rebuild to separate the hand and the axe, avoiding an ever-growing AABB as the axe travels away from the hand. However, while the character is standing with the axe, the BVH would not sacrifice raytracing performance per-frame if it did not update. In fact, by not fully rebuilding the BVH per-frame, and instead simply refitting AABBs to updated triangle positions without considering a new hierarchy, we should see significant performance wins that will allow the Fallback Layer to render animations smoothly.


