### PR TITLE
Updating the Fallback to use a new version of the DxrFallbackCompiler

### DIFF
--- a/Libraries/D3D12RaytracingFallback/developerguide.md
+++ b/Libraries/D3D12RaytracingFallback/developerguide.md
@@ -12,7 +12,7 @@ This path is used when the Fallback Layer detects that the OS + GPU have support
 This path is used when the Fallback Layer detects the OS + GPU do *not* support the DirectX Raytracing API. Instead, it will use the DirectCompute API to emulate Raytracing capabilities. It is expected that this path with be slower than the DXR API path due to lack of fixed-function/driver-optimizations.
 
 ## Fallback Layer Integration
-For use in a project outside of the samples, the Fallback Layer is a stand-alone static lib in FallbackLayer/(debug|release)/FallbackLayer.lib that can be compiled into other DX projects. In addition, some Fallback Layer logic exists in the Dxil Compiler, and so projects should also always use the DxCompiler.dll bundles with the Fallback Layer.
+For use in a project outside of the samples, the Fallback Layer is a stand-alone static lib in FallbackLayer/(debug|release)/FallbackLayer.lib that can be compiled into other DX projects. In addition, some Fallback Layer logic exists in the Dxil Compiler Repo, and so projects should also always use the DxrFallbackCompiler.dll bundled with the Fallback Layer.
 
 ## Fallback Layer Interface differences
 This is an outline of the major concepts that differ from DXR.

--- a/Libraries/D3D12RaytracingFallback/developerguide.md
+++ b/Libraries/D3D12RaytracingFallback/developerguide.md
@@ -188,8 +188,8 @@ All raytracing shaders are expected to be contained within a single DXIL library
 * #### No Export Renames
 Export renames for state objects are not supported
 
-* #### D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS for update/compact are ignored
-Updating Acceleration Structures is implemented as a full rebuild of the Acceleration Structure and does not offer any performance benefit.
+* #### D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS for compaction are ignored
+Both D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_COMPACTION and D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_MINIMIZE_MEMORY are ignored by the Fallback Layer
 
 * #### D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_COMPACT is ignored
 
@@ -197,15 +197,15 @@ Compacting Acceleration Structures is treated as a normal copy and will not redu
 
 * #### No Support for Subobjects Specified in HLSL
 
-* #### Hard-coded Pipeline-state stack size
-The stack size passed by `SetPipelineStackSize` is ignored and uses a hard-coded stack size.
+* #### App-provided Pipeline-state stack size
+The stack size passed by `SetPipelineStackSize` is ignored and the Fallback instead uses a worst-case calculated stack size based on the max recursion count provided in the state object
 
 * #### Only one AccelerationStructure can be bound per call to DispatchRays()
 
 * #### Use of the Shader Record is thrown off when using an empty ray payload
 
-* #### D3D12_RAYTRACING_GEOMETRY_FLAG_OPAQUE  is ignored
-As a result, the `RAY_FLAG_CULL_OPAQUE`/`RAY_FLAG_CULL_NON_OPAQUE` flags will have no effect either        
+* #### D3D12_RAYTRACING_GEOMETRY_FLAG_OPAQUE doesn't prevent Any-Hit invocation from getting called on geometry using Intersection Shaders
+Note: On regular triangle geometry, all opaque/non-opaque flags should still work as expected
 
 * #### Intersection Shader doesn't respect D3D12_RAYTRACING_INSTANCE_FLAG_FORCE_OPAQUE/D3D12_RAYTRACING_INSTANCE_FLAG_FORCE_NON_OPAQUE
 The invocation of an AnyHit shader after a ReportHit() call from an Intersection shader will not correctly respond based on the use of the instance flags
@@ -222,7 +222,6 @@ Initial development is expected to focus on some of the major functional gaps ou
 There is also a significant opportunity left for performance. As of this release, little time has been afforded for performance, and it's expected that optimizations here could greatly multiply performance. Some examples of performance work are listed below. 
 
 Performance opportunities:
-* Treelet re-ordering 
 * Optimize for NO_DUPLICATE_ANY_HIT  (Triangle spatial splitting)
 * Compressed-wide BVH nodes
 * Use ExecuteIndirect with *simple* StateObjects 
@@ -237,10 +236,6 @@ Functional work includes resolving gaps already laid out in *Known Issues & Limi
 ### Performance work:
 #### Add Triangle Splitting
 Implement triangle splitting for better handling of large-thin triangles that sabotage the use of AABBs: [reference](http://www.nvidia.com/docs/IO/77714/sbvh.pdf)
-
-
-#### AABB refitting (support for quick Acceleration Structure updates)
-Meshes that are being animated every frame but have only small, localized changes do not require that a whole new Acceleration Structure be built from scratch, and can request the Acceleration Structure only be updated. The Fallback does not support this path, but a fast path could be added where the BVH hierarchy is not rebuilt, and only the corresponding AABBs for each shifted triangle are updated.
 
 #### Multiple triangles per leaf node
 Currently there is only ever 1 triangle per leaf node. In some cases, the cost of traversing each leaf's individual bounding box may outweigh the cost of simply having an encompassing bounding box that contains a list of many triangles. A Surface Area Heuristic-style check should be used to determine when to combine triangles

--- a/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.cpp
@@ -27,145 +27,6 @@ namespace FallbackLayer
         ThrowFailure(hr, L"Failed to compile the shader");
     }
 
-
-    void DxilShaderPatcher::ReplaceDxilBlobPart(
-        const void * originalShaderBytecode,
-        SIZE_T originalShaderLength,
-        IDxcBlob * pNewDxilBlob,
-        IDxcBlob** ppNewShaderOut)
-    {
-        CComPtr<IDxcBlob> pNewContainer;
-
-        // Use the container assembler to build a new container from the recently-modified DXIL bitcode. This container will
-        // contain new copies of things like input signature etc., which will supersede the ones from the original
-        // compiled shader's container.
-        {
-            CComPtr<IDxcOperationResult> pAssembleResult;
-            ThrowInternalFailure(m_pAssembler->AssembleToContainer(pNewDxilBlob, &pAssembleResult));
-
-            CComPtr<IDxcBlobEncoding> pAssembleErrors;
-            ThrowInternalFailure(pAssembleResult->GetErrorBuffer(&pAssembleErrors));
-
-            if (pAssembleErrors && pAssembleErrors->GetBufferSize() != 0)
-            {
-                OutputDebugStringW(static_cast<LPCWSTR>(pAssembleErrors->GetBufferPointer()));
-                ThrowFailure(E_FAIL, L"Failed to assemble a DXC Container");
-            }
-
-            ThrowInternalFailure(pAssembleResult->GetResult(&pNewContainer));
-        }
-
-        // Now copy over the blobs from the original container that won't have been invalidated by changing the shader
-        // code itself, using the container reflection API
-        {
-            // Wrap the original code in a container blob
-            CComPtr<IDxcBlobEncoding> pContainer;
-            ThrowFailure(m_pLibrary->CreateBlobWithEncodingFromPinned(
-                static_cast<LPBYTE>(const_cast<void*>(originalShaderBytecode)),
-                static_cast<UINT32>(originalShaderLength),
-                CP_ACP,
-                &pContainer),
-                L"Failed to create a blob for the provided shader");
-
-            // Load the reflector from the original shader
-            ThrowInternalFailure(m_pContainerReflection->Load(pContainer));
-
-            UINT32 partIndex;
-
-            if (SUCCEEDED(m_pContainerReflection->FindFirstPartKind(hlsl::DFCC_PrivateData, &partIndex)))
-            {
-                CComPtr<IDxcBlob> pPart;
-                ThrowInternalFailure(m_pContainerReflection->GetPartContent(partIndex, &pPart));
-
-                ThrowInternalFailure(m_pContainerBuilder->Load(pNewContainer));
-
-                ThrowInternalFailure(m_pContainerBuilder->AddPart(hlsl::DFCC_PrivateData, pPart));
-
-                CComPtr<IDxcOperationResult> pBuildResult;
-
-                ThrowInternalFailure(m_pContainerBuilder->SerializeContainer(&pBuildResult));
-
-                CComPtr<IDxcBlobEncoding> pBuildErrors;
-                ThrowInternalFailure(pBuildResult->GetErrorBuffer(&pBuildErrors));
-
-                if (pBuildErrors && pBuildErrors->GetBufferSize() != 0)
-                {
-                    OutputDebugStringW(reinterpret_cast<LPCWSTR>(pBuildErrors->GetBufferPointer()));
-                    ThrowFailure(E_FAIL, L"Failed to serialize DXC container");
-                }
-
-                ThrowInternalFailure(pBuildResult->GetResult(&pNewContainer));
-                pNewContainer.Release();
-            }
-        }
-
-        *ppNewShaderOut = pNewContainer.Detach();
-    }
-
-    HRESULT DxilShaderPatcher::DxilGetBlobPartImpl(
-        _In_reads_bytes_(SrcDataSize) LPCVOID pSrcData,
-        _In_ SIZE_T SrcDataSize,
-        _In_ DxilFourCC targetFourCC,
-        _Out_ const UINT **ppTargetBlobStart,
-        _Out_ IDxcBlob **ppTargetBlob)
-    {
-        if (SrcDataSize < sizeof(DxilContainerHeader))
-        {
-            return E_INVALIDARG;
-        }
-
-        const BYTE* pSourceBytes = reinterpret_cast<const BYTE*>(pSrcData);
-        const DxilContainerHeader* pContainerHeader = reinterpret_cast<const DxilContainerHeader*>(pSourceBytes);
-
-        // According to DxilContainer.h the container header is followed by uint32_t PartOffset[PartCount] containing offsets to each DxilPartHeader.
-        const UINT32* pPartOffsets = reinterpret_cast<const UINT32*>(pSourceBytes + sizeof(DxilContainerHeader));
-
-        for (uint32_t i = 0; i < pContainerHeader->PartCount; ++i)
-        {
-            const DxilPartHeader* pDxilPartHeader = reinterpret_cast<const DxilPartHeader*>(pSourceBytes + pPartOffsets[i]);
-            if (pDxilPartHeader->PartFourCC == (UINT)targetFourCC)
-            {
-                // Create a dxc blob from the source data.
-                CComPtr<IDxcBlobEncoding> pSource;
-                HRESULT hr = m_pLibrary->CreateBlobWithEncodingFromPinned((LPBYTE)pSrcData, static_cast<UINT32>(SrcDataSize), CP_ACP, &pSource);
-                if (FAILED(hr)) return hr;
-
-                // Determine the part offset.
-                DxilProgramHeader *pDxilProgramHeader = (DxilProgramHeader*)(pDxilPartHeader + 1);
-                const char* pBitcode = reinterpret_cast<const char *>(&pDxilProgramHeader->BitcodeHeader) + pDxilProgramHeader->BitcodeHeader.BitcodeOffset;
-                UINT32 bitcodeLength = pDxilProgramHeader->BitcodeHeader.BitcodeSize;
-                UINT32 bitcodeOffset = (UINT32)(pBitcode - (const char *)pSrcData);
-
-                if (ppTargetBlobStart != nullptr)
-                {
-                    *ppTargetBlobStart = (UINT*)pDxilProgramHeader;
-                }
-
-                if (ppTargetBlob != nullptr)
-                {
-                    return m_pLibrary->CreateBlobFromBlob(pSource, bitcodeOffset, bitcodeLength, ppTargetBlob);
-                }
-
-                return S_OK;
-            }
-        }
-
-        return E_FAIL;
-    }
-
-    void DxilShaderPatcher::GetDxilBlobPart(
-        _In_reads_bytes_(SrcDataSize) const void * pSrcData,
-        _In_ SIZE_T SrcDataSize,
-        _Out_ IDxcBlob **ppTargetBlob)
-    {
-        ThrowInternalFailure(DxilGetBlobPartImpl(
-            pSrcData,
-            SrcDataSize,
-            hlsl::DFCC_DXIL,
-            nullptr,
-            ppTargetBlob));
-    }
-
     void DxilShaderPatcher::LinkCollection(UINT maxAttributeSize, const std::vector<DxilLibraryInfo> &dxilLibraries, const std::vector<LPCWSTR>& exportNames, std::vector<DxcShaderInfo>& shaderInfo, IDxcBlob** ppOutputBlob)
     {
         CComPtr<IDxcDxrFallbackCompiler> pFallbackCompiler;
@@ -189,6 +50,7 @@ namespace FallbackLayer
 
         shaderInfo.resize(exportNames.size());
         CComPtr<IDxcOperationResult> pResult;
+        pFallbackCompiler->SetDebugOutput(2);
         pFallbackCompiler->Compile(pLibBlobPtrs.data(), (UINT32)pLibBlobPtrs.size(), exportNames.data(), shaderInfo.data(), (UINT32)exportNames.size(), maxAttributeSize, &pResult);
 
         VerifyResult(pResult);
@@ -205,6 +67,7 @@ namespace FallbackLayer
 
         shaderInfo.resize(exportNames.size());
         CComPtr<IDxcOperationResult> pResult;
+        pFallbackCompiler->SetDebugOutput(2);
         pFallbackCompiler->Link(L"main", &pLinkedBlob, 1, exportNames.data(), shaderInfo.data(), (UINT32)exportNames.size(), maxAttributeSize, stackSize, &pResult);
 
         VerifyResult(pResult);
@@ -229,38 +92,22 @@ namespace FallbackLayer
 
     void DxilShaderPatcher::PatchShaderBindingTables(const BYTE *pShaderBytecode, UINT bytecodeLength, ShaderInfo *pShaderInfo, IDxcBlob** ppOutputBlob)
     {
-        CComPtr<IDxcBlob> pShaderBlob;
-        GetDxilBlobPart(pShaderBytecode, bytecodeLength, &pShaderBlob);
+        CComPtr<IDxcDxrFallbackCompiler> pFallbackCompiler;
+        ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcDxrFallbackCompiler, &pFallbackCompiler),
+            L"Failed to create an instance of the Fallback Compiler. This suggest a version of DxCompiler.dll "
+            L"is being used that doesn't match up with the Fallback layer. Verify that the DxCompiler.dll is from "
+            L"same package as the Fallback.");
 
         CComPtr<IDxcOperationResult> pResult;
-        CComPtr<IDxcBlob> pPatchedBlob;
-        CComPtr<IDxcBlobEncoding> pErrorMessage;
+        CComPtr<IDxcBlobEncoding> pShaderBlob;
+        ThrowInternalFailure(m_pLibrary->CreateBlobWithEncodingFromPinned(
+            static_cast<LPBYTE>((void *)pShaderBytecode),
+            static_cast<UINT32>(bytecodeLength),
+            CP_ACP,
+            &pShaderBlob));
+        pFallbackCompiler->PatchShaderBindingTables(pShaderBlob, pShaderInfo, &pResult);
 
-        wchar_t dxilPatchShaderRecordString[200];
-        ThrowFailure(StringCchPrintfW(dxilPatchShaderRecordString, _countof(dxilPatchShaderRecordString),
-            L"-hlsl-dxil-patch-shader-record-bindings,root-signature=%p",
-            pShaderInfo));
-
-        std::vector<LPCWSTR> arguments;
-        arguments.push_back(dxilPatchShaderRecordString);
-        HRESULT hr = m_pOptimizer->RunOptimizer(pShaderBlob, arguments.data(), (UINT32)arguments.size(), &pPatchedBlob, &pErrorMessage);
-
-#if SPEW_SHADERS
-        CComPtr<IDxcBlobEncoding> pShaderText;
-        m_pCompiler->Disassemble(pPatchedBlob, &pShaderText);
-        OutputDebugStringA((char *)pShaderText->GetBufferPointer());
-#endif
-
-        if (FAILED(hr))
-        {
-            std::wstring ret;
-            auto pChars = reinterpret_cast<const std::wstring::value_type *>(pErrorMessage->GetBufferPointer());
-            ret.assign(pChars, pChars + pErrorMessage->GetBufferSize());
-            OutputDebugString(ret.c_str());
-
-            ThrowFailure(hr, L"Failed to apply shader record bindings from the local root signature");
-        }
-
-        ReplaceDxilBlobPart(pShaderBytecode, bytecodeLength, pPatchedBlob, ppOutputBlob);
+        VerifyResult(pResult);
+        ThrowInternalFailure(pResult->GetResult(ppOutputBlob));
     }
 }

--- a/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.cpp
@@ -166,7 +166,7 @@ namespace FallbackLayer
             ppTargetBlob));
     }
 
-    void DxilShaderPatcher::LinkShaders(UINT stackSize, const std::vector<DxilLibraryInfo> &dxilLibraries, const std::vector<LPCWSTR>& exportNames, std::vector<FallbackLayer::StateIdentifier>& shaderIdentifiers, IDxcBlob** ppOutputBlob)
+    void DxilShaderPatcher::LinkShaders(UINT stackSize, const std::vector<DxilLibraryInfo> &dxilLibraries, const std::vector<LPCWSTR>& exportNames, std::vector<DxcShaderInfo>& shaderInfo, IDxcBlob** ppOutputBlob)
     {
         CComPtr<IDxcDxrFallbackCompiler> pFallbackCompiler;
         ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcDxrFallbackCompiler, &pFallbackCompiler),
@@ -187,9 +187,9 @@ namespace FallbackLayer
           pLibBlobPtrs[i] = pLibBlobs[i];
         }
 
-        shaderIdentifiers.resize(exportNames.size());
+        shaderInfo.resize(exportNames.size());
         CComPtr<IDxcOperationResult> pResult;
-        pFallbackCompiler->Compile(L"main", pLibBlobPtrs.data(), (UINT32)pLibBlobPtrs.size(), exportNames.data(), (int*)shaderIdentifiers.data(), (UINT32)exportNames.size(), stackSize, &pResult);
+        pFallbackCompiler->Compile(L"main", pLibBlobPtrs.data(), (UINT32)pLibBlobPtrs.size(), exportNames.data(), shaderInfo.data(), (UINT32)exportNames.size(), stackSize, &pResult);
 
         VerifyResult(pResult);
         ThrowInternalFailure(pResult->GetResult(ppOutputBlob));

--- a/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.cpp
@@ -31,8 +31,8 @@ namespace FallbackLayer
     {
         CComPtr<IDxcDxrFallbackCompiler> pFallbackCompiler;
         ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcDxrFallbackCompiler, &pFallbackCompiler),
-            L"Failed to create an instance of the Fallback Compiler. This suggest a version of DxCompiler.dll "
-            L"is being used that doesn't match up with the Fallback layer. Verify that the DxCompiler.dll is from "
+            L"Failed to create an instance of the Fallback Compiler. This suggest a version of DxrFallbackCompiler.dll "
+            L"is being used that doesn't match up with the Fallback layer. Verify that the DxrFallbackCompiler.dll is from "
             L"same package as the Fallback.");
 
         std::vector<DxcShaderBytecode> pLibBlobPtrs(dxilLibraries.size());
@@ -53,8 +53,8 @@ namespace FallbackLayer
     {
         CComPtr<IDxcDxrFallbackCompiler> pFallbackCompiler;
         ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcDxrFallbackCompiler, &pFallbackCompiler),
-            L"Failed to create an instance of the Fallback Compiler. This suggest a version of DxCompiler.dll "
-            L"is being used that doesn't match up with the Fallback layer. Verify that the DxCompiler.dll is from "
+            L"Failed to create an instance of the Fallback Compiler. This suggest a version of DxrFallbackCompiler.dll "
+            L"is being used that doesn't match up with the Fallback layer. Verify that the DxrFallbackCompiler.dll is from "
             L"same package as the Fallback.");
 
         shaderInfo.resize(exportNames.size());
@@ -85,8 +85,8 @@ namespace FallbackLayer
     {
         CComPtr<IDxcDxrFallbackCompiler> pFallbackCompiler;
         ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcDxrFallbackCompiler, &pFallbackCompiler),
-            L"Failed to create an instance of the Fallback Compiler. This suggest a version of DxCompiler.dll "
-            L"is being used that doesn't match up with the Fallback layer. Verify that the DxCompiler.dll is from "
+            L"Failed to create an instance of the Fallback Compiler. This suggest a version of DxrFallbackCompiler.dll "
+            L"is being used that doesn't match up with the Fallback layer. Verify that the DxrFallbackCompiler.dll is from "
             L"same package as the Fallback.");
 
         CComPtr<IDxcOperationResult> pResult;

--- a/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.cpp
@@ -35,22 +35,14 @@ namespace FallbackLayer
             L"is being used that doesn't match up with the Fallback layer. Verify that the DxCompiler.dll is from "
             L"same package as the Fallback.");
 
-        std::vector<CComPtr<IDxcBlobEncoding>> pLibBlobs(dxilLibraries.size());
-        std::vector<IDxcBlob*> pLibBlobPtrs(dxilLibraries.size());
+        std::vector<DxcShaderBytecode> pLibBlobPtrs(dxilLibraries.size());
         for (size_t i = 0; i < dxilLibraries.size(); ++i)
         {
-
-            ThrowInternalFailure(m_pLibrary->CreateBlobWithEncodingFromPinned(
-                static_cast<LPBYTE>(dxilLibraries[i].pByteCode),
-                static_cast<UINT32>(dxilLibraries[i].BytecodeLength),
-                CP_ACP,
-                &pLibBlobs[i]));
-            pLibBlobPtrs[i] = pLibBlobs[i];
+            pLibBlobPtrs[i] = { (LPBYTE)dxilLibraries[i].pByteCode, (UINT32)dxilLibraries[i].BytecodeLength };
         }
 
         shaderInfo.resize(exportNames.size());
         CComPtr<IDxcOperationResult> pResult;
-        pFallbackCompiler->SetDebugOutput(2);
         pFallbackCompiler->Compile(pLibBlobPtrs.data(), (UINT32)pLibBlobPtrs.size(), exportNames.data(), shaderInfo.data(), (UINT32)exportNames.size(), maxAttributeSize, &pResult);
 
         VerifyResult(pResult);
@@ -67,7 +59,6 @@ namespace FallbackLayer
 
         shaderInfo.resize(exportNames.size());
         CComPtr<IDxcOperationResult> pResult;
-        pFallbackCompiler->SetDebugOutput(2);
         pFallbackCompiler->Link(L"main", &pLinkedBlob, 1, exportNames.data(), shaderInfo.data(), (UINT32)exportNames.size(), maxAttributeSize, stackSize, &pResult);
 
         VerifyResult(pResult);
@@ -99,13 +90,8 @@ namespace FallbackLayer
             L"same package as the Fallback.");
 
         CComPtr<IDxcOperationResult> pResult;
-        CComPtr<IDxcBlobEncoding> pShaderBlob;
-        ThrowInternalFailure(m_pLibrary->CreateBlobWithEncodingFromPinned(
-            static_cast<LPBYTE>((void *)pShaderBytecode),
-            static_cast<UINT32>(bytecodeLength),
-            CP_ACP,
-            &pShaderBlob));
-        pFallbackCompiler->PatchShaderBindingTables(pShaderBlob, pShaderInfo, &pResult);
+        DxcShaderBytecode shaderBytecode = { (LPBYTE)pShaderBytecode, bytecodeLength };
+        pFallbackCompiler->PatchShaderBindingTables(pShaderInfo->ExportName, &shaderBytecode, pShaderInfo, &pResult);
 
         VerifyResult(pResult);
         ThrowInternalFailure(pResult->GetResult(ppOutputBlob));

--- a/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.cpp
@@ -166,7 +166,7 @@ namespace FallbackLayer
             ppTargetBlob));
     }
 
-    void DxilShaderPatcher::LinkShaders(UINT stackSize, const std::vector<DxilLibraryInfo> &dxilLibraries, const std::vector<LPCWSTR>& exportNames, std::vector<DxcShaderInfo>& shaderInfo, IDxcBlob** ppOutputBlob)
+    void DxilShaderPatcher::LinkShaders(UINT maxAttributeSize, UINT stackSize, const std::vector<DxilLibraryInfo> &dxilLibraries, const std::vector<LPCWSTR>& exportNames, std::vector<DxcShaderInfo>& shaderInfo, IDxcBlob** ppOutputBlob)
     {
         CComPtr<IDxcDxrFallbackCompiler> pFallbackCompiler;
         ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcDxrFallbackCompiler, &pFallbackCompiler),
@@ -189,7 +189,7 @@ namespace FallbackLayer
 
         shaderInfo.resize(exportNames.size());
         CComPtr<IDxcOperationResult> pResult;
-        pFallbackCompiler->Compile(L"main", pLibBlobPtrs.data(), (UINT32)pLibBlobPtrs.size(), exportNames.data(), shaderInfo.data(), (UINT32)exportNames.size(), stackSize, &pResult);
+        pFallbackCompiler->Compile(L"main", pLibBlobPtrs.data(), (UINT32)pLibBlobPtrs.size(), exportNames.data(), shaderInfo.data(), (UINT32)exportNames.size(), maxAttributeSize, stackSize, &pResult);
 
         VerifyResult(pResult);
         ThrowInternalFailure(pResult->GetResult(ppOutputBlob));

--- a/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.cpp
@@ -169,7 +169,7 @@ namespace FallbackLayer
     void DxilShaderPatcher::LinkShaders(UINT stackSize, const std::vector<DxilLibraryInfo> &dxilLibraries, const std::vector<LPCWSTR>& exportNames, std::vector<FallbackLayer::StateIdentifier>& shaderIdentifiers, IDxcBlob** ppOutputBlob)
     {
         CComPtr<IDxcDxrFallbackCompiler> pFallbackCompiler;
-        ThrowFailure(dxcSupport.CreateInstance(CLSID_DxcDxrFallbackCompiler, &pFallbackCompiler), 
+        ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcDxrFallbackCompiler, &pFallbackCompiler),
             L"Failed to create an instance of the Fallback Compiler. This suggest a version of DxCompiler.dll "
             L"is being used that doesn't match up with the Fallback layer. Verify that the DxCompiler.dll is from "
             L"same package as the Fallback.");
@@ -213,12 +213,6 @@ namespace FallbackLayer
 
     void DxilShaderPatcher::PatchShaderBindingTables(const BYTE *pShaderBytecode, UINT bytecodeLength, ShaderInfo *pShaderInfo, IDxcBlob** ppOutputBlob)
     {
-        dxc::DxcDllSupport dxcSupport;
-        ThrowFailure(dxcSupport.Initialize(), 
-            L"Failed to load DxCompiler.dll, verify this executable is in the executable directory."
-            L" The Fallback Layer is sensitive to the DxCompiler.dll version, make sure the"
-            L" DxCompiler.dll is the correct version packaged with the Fallback");
-
         CComPtr<IDxcBlob> pShaderBlob;
         GetDxilBlobPart(pShaderBytecode, bytecodeLength, &pShaderBlob);
 

--- a/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.h
+++ b/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.h
@@ -46,7 +46,8 @@ namespace FallbackLayer
 
         void PatchShaderBindingTables(const BYTE *pShaderBytecode, UINT bytecodeLength, ShaderInfo *pShaderInfo, IDxcBlob** ppOutputBlob);
         
-        void LinkShaders(UINT maxAttributeSize, UINT stackSize, const std::vector<DxilLibraryInfo> &dxilLibraries, const std::vector<LPCWSTR>& exportNames, std::vector<DxcShaderInfo>& shaderInfo, IDxcBlob** ppOutputBlob);
+        void LinkCollection(UINT maxAttributeSize, const std::vector<DxilLibraryInfo> &dxilLibraries, const std::vector<LPCWSTR>& exportNames, std::vector<DxcShaderInfo>& shaderInfo, IDxcBlob** ppOutputBlob);
+        void LinkStateObject(UINT maxAttributeSize, UINT stackSize, IDxcBlob* pLinkedBlob, const std::vector<LPCWSTR>& exportNames, std::vector<DxcShaderInfo>& shaderInfo, IDxcBlob** ppOutputBlob);
 
         IDxcValidator &GetValidator() { return *m_pValidator; }
     private:

--- a/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.h
+++ b/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.h
@@ -33,15 +33,8 @@ namespace FallbackLayer
               L" DxCompiler.dll is the correct version packaged with the Fallback");
 
             ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcLibrary, &m_pLibrary), L"Failed to load a DXC library instance");
-            ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcOptimizer, &m_pOptimizer), L"Failed to load a DXC Optimizer instance");
-            ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcAssembler, &m_pAssembler), L"Failed to load a DXC Assembler instance");
-            ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcContainerBuilder, &m_pContainerBuilder), L"Failed to load a DXC ContainerBuilder instance");
-            ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcContainerReflection, &m_pContainerReflection), L"Failed to load a DXC ContainterReflection instance");
             ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcValidator, &m_pValidator), L"Failed to load a DXC Validator instance");
 
-#ifdef DEBUG
-            //ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcCompiler, &m_pCompiler));
-#endif
         }
 
         void PatchShaderBindingTables(const BYTE *pShaderBytecode, UINT bytecodeLength, ShaderInfo *pShaderInfo, IDxcBlob** ppOutputBlob);
@@ -53,32 +46,10 @@ namespace FallbackLayer
     private:
         void VerifyResult(IDxcOperationResult *pResult);
 
-        // These DXIL helper functions were shamelessly stolen from PIX
-        void ReplaceDxilBlobPart(
-            const void * originalShaderBytecode,
-            SIZE_T originalShaderLength,
-            IDxcBlob * pNewDxilBlob,
-            IDxcBlob** ppNewShaderOut);
-
-        HRESULT DxilGetBlobPartImpl(
-            _In_reads_bytes_(SrcDataSize) LPCVOID pSrcData,
-            _In_ SIZE_T SrcDataSize,
-            _In_ hlsl::DxilFourCC targetFourCC,
-            _Out_ const UINT **ppTargetBlobStart,
-            _Out_ IDxcBlob **ppTargetBlob);
-
-        void GetDxilBlobPart(
-            _In_reads_bytes_(SrcDataSize) const void * pSrcData,
-            _In_ SIZE_T SrcDataSize,
-            _Out_ IDxcBlob **ppTargetBlob);
-
         dxc::DxcDxrFallbackDllSupport dxcDxrFallbackSupport;
 
         CComPtr<IDxcOptimizer> m_pOptimizer;
         CComPtr<IDxcLibrary> m_pLibrary;
-        CComPtr<IDxcAssembler> m_pAssembler;
-        CComPtr<IDxcContainerBuilder> m_pContainerBuilder;
-        CComPtr<IDxcContainerReflection> m_pContainerReflection;
         CComPtr<IDxcValidator> m_pValidator;
 
 #ifdef DEBUG

--- a/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.h
+++ b/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.h
@@ -31,10 +31,6 @@ namespace FallbackLayer
               L"Failed to load DxCompiler.dll, verify this executable is in the executable directory."
               L" The Fallback Layer is sensitive to the DxCompiler.dll version, make sure the"
               L" DxCompiler.dll is the correct version packaged with the Fallback");
-
-            ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcLibrary, &m_pLibrary), L"Failed to load a DXC library instance");
-            ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcValidator, &m_pValidator), L"Failed to load a DXC Validator instance");
-
         }
 
         void PatchShaderBindingTables(const BYTE *pShaderBytecode, UINT bytecodeLength, ShaderInfo *pShaderInfo, IDxcBlob** ppOutputBlob);
@@ -42,15 +38,10 @@ namespace FallbackLayer
         void LinkCollection(UINT maxAttributeSize, const std::vector<DxilLibraryInfo> &dxilLibraries, const std::vector<LPCWSTR>& exportNames, std::vector<DxcShaderInfo>& shaderInfo, IDxcBlob** ppOutputBlob);
         void LinkStateObject(UINT maxAttributeSize, UINT stackSize, IDxcBlob* pLinkedBlob, const std::vector<LPCWSTR>& exportNames, std::vector<DxcShaderInfo>& shaderInfo, IDxcBlob** ppOutputBlob);
 
-        IDxcValidator &GetValidator() { return *m_pValidator; }
     private:
         void VerifyResult(IDxcOperationResult *pResult);
 
         dxc::DxcDxrFallbackDllSupport dxcDxrFallbackSupport;
-
-        CComPtr<IDxcOptimizer> m_pOptimizer;
-        CComPtr<IDxcLibrary> m_pLibrary;
-        CComPtr<IDxcValidator> m_pValidator;
 
 #ifdef DEBUG
         CComPtr<IDxcCompiler> m_pCompiler;

--- a/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.h
+++ b/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.h
@@ -27,17 +27,17 @@ namespace FallbackLayer
     public:
         DxilShaderPatcher()
         {
-            ThrowFailure(dxcSupport.Initialize(), 
-                L"Failed to load DxCompiler.dll, verify this executable is in the executable directory."
-                L" The Fallback Layer is sensitive to the DxCompiler.dll version, make sure the" 
-                L" DxCompiler.dll is the correct version packaged with the Fallback");
+            ThrowFailure(dxcDxrFallbackSupport.Initialize(),
+              L"Failed to load DxCompiler.dll, verify this executable is in the executable directory."
+              L" The Fallback Layer is sensitive to the DxCompiler.dll version, make sure the"
+              L" DxCompiler.dll is the correct version packaged with the Fallback");
 
-            ThrowFailure(dxcSupport.CreateInstance(CLSID_DxcLibrary, &m_pLibrary), L"Failed to load a DXC library instance");
-            ThrowFailure(dxcSupport.CreateInstance(CLSID_DxcOptimizer, &m_pOptimizer), L"Failed to load a DXC Optimizer instance");
-            ThrowFailure(dxcSupport.CreateInstance(CLSID_DxcAssembler, &m_pAssembler), L"Failed to load a DXC Assembler instance");
-            ThrowFailure(dxcSupport.CreateInstance(CLSID_DxcContainerBuilder, &m_pContainerBuilder), L"Failed to load a DXC ContainerBuilder instance");
-            ThrowFailure(dxcSupport.CreateInstance(CLSID_DxcContainerReflection, &m_pContainerReflection), L"Failed to load a DXC ContainterReflection instance");
-            ThrowFailure(dxcSupport.CreateInstance(CLSID_DxcValidator, &m_pValidator), L"Failed to load a DXC Validator instance");
+            ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcLibrary, &m_pLibrary), L"Failed to load a DXC library instance");
+            ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcOptimizer, &m_pOptimizer), L"Failed to load a DXC Optimizer instance");
+            ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcAssembler, &m_pAssembler), L"Failed to load a DXC Assembler instance");
+            ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcContainerBuilder, &m_pContainerBuilder), L"Failed to load a DXC ContainerBuilder instance");
+            ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcContainerReflection, &m_pContainerReflection), L"Failed to load a DXC ContainterReflection instance");
+            ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcValidator, &m_pValidator), L"Failed to load a DXC Validator instance");
 
 #ifdef DEBUG
             ThrowFailure(dxcSupport.CreateInstance(CLSID_DxcCompiler, &m_pCompiler));
@@ -71,7 +71,7 @@ namespace FallbackLayer
             _In_ SIZE_T SrcDataSize,
             _Out_ IDxcBlob **ppTargetBlob);
 
-        dxc::DxcDllSupport dxcSupport;
+        dxc::DxcDxrFallbackDllSupport dxcDxrFallbackSupport;
 
         CComPtr<IDxcOptimizer> m_pOptimizer;
         CComPtr<IDxcLibrary> m_pLibrary;

--- a/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.h
+++ b/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.h
@@ -28,9 +28,9 @@ namespace FallbackLayer
         DxilShaderPatcher()
         {
             ThrowFailure(dxcDxrFallbackSupport.Initialize(),
-              L"Failed to load DxCompiler.dll, verify this executable is in the executable directory."
-              L" The Fallback Layer is sensitive to the DxCompiler.dll version, make sure the"
-              L" DxCompiler.dll is the correct version packaged with the Fallback");
+              L"Failed to load DxrFallbackCompiler.dll, verify this executable is in the executable directory."
+              L" The Fallback Layer is sensitive to the DxrFallbackCompiler.dll version, make sure the"
+              L" DxrFallbackCompiler.dll is the correct version packaged with the Fallback");
         }
 
         void PatchShaderBindingTables(const BYTE *pShaderBytecode, UINT bytecodeLength, ShaderInfo *pShaderInfo, IDxcBlob** ppOutputBlob);

--- a/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.h
+++ b/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.h
@@ -46,7 +46,7 @@ namespace FallbackLayer
 
         void PatchShaderBindingTables(const BYTE *pShaderBytecode, UINT bytecodeLength, ShaderInfo *pShaderInfo, IDxcBlob** ppOutputBlob);
         
-        void LinkShaders(UINT stackSize, const std::vector<DxilLibraryInfo> &dxilLibraries, const std::vector<LPCWSTR>& exportNames, std::vector<DxcShaderInfo>& shaderInfo, IDxcBlob** ppOutputBlob);
+        void LinkShaders(UINT maxAttributeSize, UINT stackSize, const std::vector<DxilLibraryInfo> &dxilLibraries, const std::vector<LPCWSTR>& exportNames, std::vector<DxcShaderInfo>& shaderInfo, IDxcBlob** ppOutputBlob);
 
         IDxcValidator &GetValidator() { return *m_pValidator; }
     private:

--- a/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.h
+++ b/Libraries/D3D12RaytracingFallback/src/DxilShaderPatcher.h
@@ -40,13 +40,13 @@ namespace FallbackLayer
             ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcValidator, &m_pValidator), L"Failed to load a DXC Validator instance");
 
 #ifdef DEBUG
-            ThrowFailure(dxcSupport.CreateInstance(CLSID_DxcCompiler, &m_pCompiler));
+            //ThrowFailure(dxcDxrFallbackSupport.CreateInstance(CLSID_DxcCompiler, &m_pCompiler));
 #endif
         }
 
         void PatchShaderBindingTables(const BYTE *pShaderBytecode, UINT bytecodeLength, ShaderInfo *pShaderInfo, IDxcBlob** ppOutputBlob);
         
-        void LinkShaders(UINT stackSize, const std::vector<DxilLibraryInfo> &dxilLibraries, const std::vector<LPCWSTR>& exportNames, std::vector<FallbackLayer::StateIdentifier>& shaderIdentifiers, IDxcBlob** ppOutputBlob);
+        void LinkShaders(UINT stackSize, const std::vector<DxilLibraryInfo> &dxilLibraries, const std::vector<LPCWSTR>& exportNames, std::vector<DxcShaderInfo>& shaderInfo, IDxcBlob** ppOutputBlob);
 
         IDxcValidator &GetValidator() { return *m_pValidator; }
     private:

--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayer.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayer.cpp
@@ -374,9 +374,9 @@ namespace FallbackLayer
             case D3D12_STATE_SUBOBJECT_TYPE_RAYTRACING_SHADER_CONFIG:
             {
                 D3D12_RAYTRACING_SHADER_CONFIG & shaderConfig = *(D3D12_RAYTRACING_SHADER_CONFIG*)subObject.pDesc;
-                rayTracingStateObject.m_collection.m_maxAttributeSizeInBytes = (UINT)max(
-                    rayTracingStateObject.m_collection.m_maxAttributeSizeInBytes,
-                    shaderConfig.MaxAttributeSizeInBytes);
+                rayTracingStateObject.m_collection.m_maxAttributeSizeInBytes = (UINT)std::max(
+                    (UINT)rayTracingStateObject.m_collection.m_maxAttributeSizeInBytes,
+                    (UINT)shaderConfig.MaxAttributeSizeInBytes);
                 break;
             }
             case D3D12_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE:

--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayer.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayer.cpp
@@ -332,7 +332,6 @@ namespace FallbackLayer
         switch (type)
         {
         case D3D12_STATE_SUBOBJECT_TYPE_LOCAL_ROOT_SIGNATURE:
-        case D3D12_STATE_SUBOBJECT_TYPE_RAYTRACING_SHADER_CONFIG:
             return true;
         default:
             return false;
@@ -341,8 +340,6 @@ namespace FallbackLayer
 
     void RaytracingDevice::ProcessShaderAssociation(const D3D12_STATE_SUBOBJECT &subObject, ShaderAssociations &shaderAssociation)
     {
-        assert(IsShaderAssociationField(subObject.Type));
-
         switch (subObject.Type)
         {
         case D3D12_STATE_SUBOBJECT_TYPE_LOCAL_ROOT_SIGNATURE:
@@ -374,6 +371,14 @@ namespace FallbackLayer
         {
             switch (subObject.Type)
             {
+            case D3D12_STATE_SUBOBJECT_TYPE_RAYTRACING_SHADER_CONFIG:
+            {
+                D3D12_RAYTRACING_SHADER_CONFIG & shaderConfig = *(D3D12_RAYTRACING_SHADER_CONFIG*)subObject.pDesc;
+                rayTracingStateObject.m_collection.m_maxAttributeSizeInBytes = (UINT)max(
+                    rayTracingStateObject.m_collection.m_maxAttributeSizeInBytes,
+                    shaderConfig.MaxAttributeSizeInBytes);
+                break;
+            }
             case D3D12_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE:
             {
                 ID3D12RootSignature** ppRootSignatureDesc = (ID3D12RootSignature**)subObject.pDesc;

--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayer.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayer.cpp
@@ -622,6 +622,12 @@ namespace FallbackLayer
         return m_spProgram->GetShaderIdentifier(pExportName);
     }
 
+    UINT64 STDMETHODCALLTYPE RaytracingStateObject::GetShaderStackSize(LPCWSTR pExportName)
+    {
+        return m_spProgram->GetShaderStackSize(pExportName);
+    }
+
+
     UINT STDMETHODCALLTYPE RaytracingDevice::GetShaderIdentifierSize(void)
     {
         return sizeof(ShaderIdentifier);

--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayer.h
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayer.h
@@ -87,11 +87,7 @@ namespace FallbackLayer
         virtual ~RaytracingStateObject() {}
 
         virtual void *STDMETHODCALLTYPE GetShaderIdentifier(LPCWSTR pExportName);
-        virtual UINT64 STDMETHODCALLTYPE GetShaderStackSize(_In_  LPCWSTR pExportName)
-        {
-            UNREFERENCED_PARAMETER(pExportName);
-            return 0;
-        }
+        virtual UINT64 STDMETHODCALLTYPE GetShaderStackSize(_In_  LPCWSTR pExportName);
 
         virtual UINT64 STDMETHODCALLTYPE GetPipelineStackSize(void)
         {

--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/FallbackLayerUnitTests.vcxproj
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/FallbackLayerUnitTests.vcxproj
@@ -113,7 +113,8 @@
       <AdditionalDependencies>dxgi.lib;d3d12.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(SolutionDir)..\tools\x64\dxcompiler.dll" "$(SolutionDir)\$(Platform)\$(Configuration)"</Command>
+      <Command>copy "$(SolutionDir)..\tools\x64\dxcompiler.dll" "$(SolutionDir)\$(Platform)\$(Configuration)"
+copy "$(SolutionDir)..\tools\x64\dxrfallbackcompiler.dll" "$(SolutionDir)\$(Platform)\$(Configuration)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -131,7 +132,8 @@
       <AdditionalDependencies>dxgi.lib;d3d12.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>copy $(SolutionDir)..\DxilCompiler\$(Platform)\dxcompiler.dll  $(SolutionDir)..\ModelViewer\$(Platform)\$(Configuration)</Command>
+      <Command>copy "$(SolutionDir)..\tools\x64\dxcompiler.dll" "$(SolutionDir)\$(Platform)\$(Configuration)"
+copy "$(SolutionDir)..\tools\x64\dxrfallbackcompiler.dll" "$(SolutionDir)\$(Platform)\$(Configuration)"</Command>
     </PostBuildEvent>
     <FxCompile>
       <VariableName>g_p%(Filename)</VariableName>
@@ -155,7 +157,8 @@
       <AdditionalDependencies>dxgi.lib;d3d12.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(SolutionDir)..\tools\x64\dxcompiler.dll" "$(SolutionDir)\$(Platform)\$(Configuration)"</Command>
+      <Command>copy "$(SolutionDir)..\tools\x64\dxcompiler.dll" "$(SolutionDir)\$(Platform)\$(Configuration)"
+copy "$(SolutionDir)..\tools\x64\dxrfallbackcompiler.dll" "$(SolutionDir)\$(Platform)\$(Configuration)"</Command>
     </PostBuildEvent>
     <FxCompile>
       <VariableName>g_p%(Filename)</VariableName>
@@ -183,7 +186,8 @@
       <AdditionalDependencies>dxgi.lib;d3d12.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>copy $(SolutionDir)..\DxilCompiler\$(Platform)\dxcompiler.dll  $(SolutionDir)..\ModelViewer\$(Platform)\$(Configuration)</Command>
+      <Command>copy "$(SolutionDir)..\tools\x64\dxcompiler.dll" "$(SolutionDir)\$(Platform)\$(Configuration)"
+copy "$(SolutionDir)..\tools\x64\dxrfallbackcompiler.dll" "$(SolutionDir)\$(Platform)\$(Configuration)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/FallbackLayerUnitTests.vcxproj.filters
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/FallbackLayerUnitTests.vcxproj.filters
@@ -193,17 +193,6 @@
     <FxCompile Include="ReadDataTexture1DArray.hlsl" />
     <FxCompile Include="ReadDataTexture2D.hlsl" />
     <FxCompile Include="ReadDataTexture2DArray.hlsl" />
-    <FxCompile Include="ReadDataRWBuffer.hlsl" />
-    <FxCompile Include="ReadDataRWByteAddressBuffer.hlsl" />
-    <FxCompile Include="ReadDataRWTexture1D.hlsl" />
-    <FxCompile Include="ReadDataRWTexture1DArray.hlsl" />
-    <FxCompile Include="ReadDataRWTexture2D.hlsl" />
-    <FxCompile Include="ReadDataRWTexture2DArray.hlsl" />
-    <FxCompile Include="ReadDataRWTexture3D.hlsl" />
-    <FxCompile Include="ReadDataTexture1D.hlsl" />
-    <FxCompile Include="ReadDataTexture1DArray.hlsl" />
-    <FxCompile Include="ReadDataTexture2D.hlsl" />
-    <FxCompile Include="ReadDataTexture2DArray.hlsl" />
     <FxCompile Include="ReadData*.hlsl">
       <Filter>Shaders</Filter>
     </FxCompile>
@@ -260,6 +249,17 @@
     <FxCompile Include="SimpleRaygen.hlsl">
       <Filter>Shaders</Filter>
     </FxCompile>
+    <FxCompile Include="ReadData*.hlsl" />
+    <FxCompile Include="ReadData*.hlsl" />
+    <FxCompile Include="ReadData*.hlsl" />
+    <FxCompile Include="ReadData*.hlsl" />
+    <FxCompile Include="ReadData*.hlsl" />
+    <FxCompile Include="ReadData*.hlsl" />
+    <FxCompile Include="ReadData*.hlsl" />
+    <FxCompile Include="ReadData*.hlsl" />
+    <FxCompile Include="ReadData*.hlsl" />
+    <FxCompile Include="ReadData*.hlsl" />
+    <FxCompile Include="ReadData*.hlsl" />
     <FxCompile Include="ReadData*.hlsl" />
     <FxCompile Include="ReadData*.hlsl" />
     <FxCompile Include="ReadData*.hlsl" />

--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/fallbacklayerunittests.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/fallbacklayerunittests.cpp
@@ -2175,9 +2175,6 @@ namespace FallbackLayerUnitTests
         void InitializeDxcComponents()
         {
             ThrowFailure(m_dxcSupport.Initialize());
-
-            ThrowFailure(m_dxcSupport.CreateInstance(CLSID_DxcLibrary, &m_pLibrary));
-            ThrowFailure(m_dxcSupport.CreateInstance(CLSID_DxcCompiler, &m_pCompiler));
         }
 
         void InitializeDescriptorHeaps()
@@ -2225,8 +2222,10 @@ namespace FallbackLayerUnitTests
         {
             m_shaderPatcher.PatchShaderBindingTables(pShaderBytecode, bytecodeLength, pShaderInfo, ppOutputBlob);
 
+            CComPtr<IDxcValidator> pValidator;
             CComPtr<IDxcOperationResult> pResult;
-            m_shaderPatcher.GetValidator().Validate(*ppOutputBlob, DxcValidatorFlags_Default, &pResult);
+            m_dxcSupport.CreateInstance(CLSID_DxcValidator, &pValidator);
+            pValidator->Validate(*ppOutputBlob, DxcValidatorFlags_Default, &pResult);
 
             HRESULT hr;
             AssertSucceeded(pResult->GetStatus(&hr));
@@ -2258,8 +2257,6 @@ namespace FallbackLayerUnitTests
         FallbackLayer::DxilShaderPatcher m_shaderPatcher;
 
         dxc::DxcDllSupport m_dxcSupport;
-        CComPtr<IDxcCompiler> m_pCompiler;
-        CComPtr<IDxcLibrary> m_pLibrary;
     };
 
 #include "CompiledShaders/SimpleRaytracing.h"

--- a/Libraries/D3D12RaytracingFallback/src/RayTracingProgram.h
+++ b/Libraries/D3D12RaytracingFallback/src/RayTracingProgram.h
@@ -40,6 +40,7 @@ namespace FallbackLayer
             const D3D12_FALLBACK_DISPATCH_RAYS_DESC &desc) = 0;
 
         virtual ShaderIdentifier *GetShaderIdentifier(LPCWSTR pExportName) = 0;
+        virtual UINT64 GetShaderStackSize(LPCWSTR pExportName) = 0;
 
         virtual void SetPredispatchCallback(std::function<void(ID3D12GraphicsCommandList *, UINT)> callback) = 0;
     };

--- a/Libraries/D3D12RaytracingFallback/src/RayTracingProgramFactory.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/RayTracingProgramFactory.cpp
@@ -118,6 +118,7 @@ namespace FallbackLayer
         {
             IsUsingIntersection = true;
         }
+        m_maxAttributeSizeInBytes = max(m_maxAttributeSizeInBytes, collection.m_maxAttributeSizeInBytes);
     }
 
 }

--- a/Libraries/D3D12RaytracingFallback/src/RayTracingProgramFactory.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/RayTracingProgramFactory.cpp
@@ -118,7 +118,7 @@ namespace FallbackLayer
         {
             IsUsingIntersection = true;
         }
-        m_maxAttributeSizeInBytes = max(m_maxAttributeSizeInBytes, collection.m_maxAttributeSizeInBytes);
+        m_maxAttributeSizeInBytes = (UINT)std::max(m_maxAttributeSizeInBytes, collection.m_maxAttributeSizeInBytes);
     }
 
 }

--- a/Libraries/D3D12RaytracingFallback/src/RayTracingProgramFactory.h
+++ b/Libraries/D3D12RaytracingFallback/src/RayTracingProgramFactory.h
@@ -25,6 +25,7 @@ namespace FallbackLayer
         void CombineCollection(const StateObjectCollection &collection);
 
         UINT64 m_pipelineStackSize = 0;
+        UINT m_maxAttributeSizeInBytes = 0;
         UINT m_nodeMask = 0;
         std::vector<D3D12_DXIL_LIBRARY_DESC> m_dxilLibraries;
         std::unordered_map<std::wstring, D3D12_HIT_GROUP_DESC> m_hitGroups;

--- a/Libraries/D3D12RaytracingFallback/src/UberShaderRayTracingProgram.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/UberShaderRayTracingProgram.cpp
@@ -158,7 +158,7 @@ namespace FallbackLayer
         m_DxilShaderPatcher.LinkCollection(stateObjectCollection.m_maxAttributeSizeInBytes, librariesInfo, exportNames, shaderInfo, &pCollectionBlob);
 
         UINT traceRayStackSize = shaderInfo[exportNames.size() - 1].StackSize;
-        for (size_t i = 0; i < exportNames.size(); ++i)
+        for (size_t i = 0; i < exportNames.size() - 1; ++i)
         {
             auto &shader = shaderInfo[i];
             bool isRaygen = shader.Type == ShaderType::Raygen;

--- a/Libraries/D3D12RaytracingFallback/src/UberShaderRayTracingProgram.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/UberShaderRayTracingProgram.cpp
@@ -165,11 +165,11 @@ namespace FallbackLayer
             UINT shaderStackSize = shader.StackSize;
             if (isRaygen)
             {
-                shaderStackSize += traceRayStackSize;
                 m_largestRayGenStackSize = std::max(shaderStackSize, m_largestRayGenStackSize);
             }
             else if (shader.Type == ShaderType::Miss)
             {
+                shaderStackSize += traceRayStackSize;
                 m_largestNonRayGenStackSize = std::max(shaderStackSize, m_largestNonRayGenStackSize);
             }
 
@@ -189,7 +189,7 @@ namespace FallbackLayer
             UINT shaderStackSize = (UINT)std::max(std::max(
                 GetShaderStackSize(closestHitName), GetShaderStackSize(anyHitName)), GetShaderStackSize(intersectionName));
 
-            m_largestNonRayGenStackSize = std::max(shaderStackSize, m_largestNonRayGenStackSize);
+            m_largestNonRayGenStackSize = std::max(shaderStackSize + traceRayStackSize, m_largestNonRayGenStackSize);
             auto hitGroupName = hitGroupMapEntry.first;
             m_ExportNameToShaderData[hitGroupName] = { shaderId, shaderStackSize };
         }

--- a/Libraries/D3D12RaytracingFallback/src/UberShaderRayTracingProgram.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/UberShaderRayTracingProgram.cpp
@@ -153,9 +153,9 @@ namespace FallbackLayer
         }
 
         // Link shaders just to get the stack sizes (very bad)
-        CComPtr<IDxcBlob> pUnusedBlob;
+        CComPtr<IDxcBlob> pCollectionBlob;
         std::vector<DxcShaderInfo> shaderInfo;
-        m_DxilShaderPatcher.LinkShaders(stateObjectCollection.m_maxAttributeSizeInBytes, 0, librariesInfo, exportNames, shaderInfo, &pUnusedBlob);
+        m_DxilShaderPatcher.LinkCollection(stateObjectCollection.m_maxAttributeSizeInBytes, librariesInfo, exportNames, shaderInfo, &pCollectionBlob);
 
         UINT traceRayStackSize = shaderInfo[exportNames.size() - 1].StackSize;
         for (size_t i = 0; i < exportNames.size(); ++i)
@@ -196,7 +196,7 @@ namespace FallbackLayer
 
         UINT stackSize = stateObjectCollection.m_config.MaxTraceRecursionDepth * m_largestNonRayGenStackSize + m_largestRayGenStackSize;
         CComPtr<IDxcBlob> pLinkedBlob;
-        m_DxilShaderPatcher.LinkShaders(stateObjectCollection.m_maxAttributeSizeInBytes, stackSize, librariesInfo, exportNames, shaderInfo, &pLinkedBlob);
+        m_DxilShaderPatcher.LinkStateObject(stateObjectCollection.m_maxAttributeSizeInBytes, stackSize, pCollectionBlob, exportNames, shaderInfo, &pLinkedBlob);
 
         CompilePSO(
             pDevice, 

--- a/Libraries/D3D12RaytracingFallback/src/UberShaderRayTracingProgram.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/UberShaderRayTracingProgram.cpp
@@ -23,22 +23,29 @@ namespace FallbackLayer
         ThrowInternalFailure(pDevice->CreateComputePipelineState(&psoDesc, IID_PPV_ARGS(ppPipelineState)));
     }
 
+    UINT64 UberShaderRaytracingProgram::GetShaderStackSize(LPCWSTR pExportName)
+    {
+        auto shaderData = GetShaderData(pExportName);
+        return shaderData ? shaderData->stackSize : 0;
+    }
+
+    UberShaderRaytracingProgram::ShaderData *UberShaderRaytracingProgram::GetShaderData(LPCWSTR pExportName)
+    {
+      if (pExportName)
+      {
+        auto &shaderData = m_ExportNameToShaderData.find(pExportName);
+        if (shaderData != m_ExportNameToShaderData.end())
+        {
+          return &shaderData->second;
+        }
+      }
+      return nullptr;
+    }
+
     StateIdentifier UberShaderRaytracingProgram::GetStateIdentfier(LPCWSTR pExportName)
     {
-        StateIdentifier id = 0;
-        if (pExportName)
-        {
-            auto shaderIdentifier = m_ExportNameToShaderIdentifier.find(pExportName);
-            if (shaderIdentifier != m_ExportNameToShaderIdentifier.end())
-            {
-                id = shaderIdentifier->second.StateId;
-            }
-            else
-            {
-                ThrowFailure(E_INVALIDARG, L"Hit group is referring to a shader name that wasn't found in the state object");
-            }
-        }
-        return id;
+        auto shaderData = GetShaderData(pExportName);
+        return shaderData ? shaderData->stateIdentifier.StateId : (StateIdentifier)0u;
     }
 
 
@@ -145,22 +152,28 @@ namespace FallbackLayer
             librariesInfo.emplace_back((void *)g_pStateMachineLib, ARRAYSIZE(g_pStateMachineLib));
         }
 
-        std::vector<FallbackLayer::StateIdentifier> stateIdentifiers;
-        CComPtr<IDxcBlob> pLinkedBlob;
-        UINT stackSize = (UINT)stateObjectCollection.m_pipelineStackSize;
-        if (stackSize == 0 && (stateObjectCollection.IsUsingAnyHit || stateObjectCollection.IsUsingIntersection))
-        {
-            // TODO: The stack size used by the traversal shader is high when it's split by a continuation from the
-            // Intersection shader or the Anyhit. Currently setting a higher hard-coded value, this can go-away
-            // once API-specified stack-sizes are supported
-            stackSize = 2048;
-        }
+        // Link shaders just to get the stack sizes (very bad)
+        CComPtr<IDxcBlob> pUnusedBlob;
+        std::vector<DxcShaderInfo> shaderInfo;
+        m_DxilShaderPatcher.LinkShaders(0, librariesInfo, exportNames, shaderInfo, &pUnusedBlob);
 
-        m_DxilShaderPatcher.LinkShaders(stackSize, librariesInfo, exportNames, stateIdentifiers, &pLinkedBlob);
-
+        UINT traceRayStackSize = shaderInfo[exportNames.size() - 1].StackSize;
         for (size_t i = 0; i < exportNames.size(); ++i)
         {
-            m_ExportNameToShaderIdentifier[exportNames[i]] = { stateIdentifiers[i], 0 };
+            auto &shader = shaderInfo[i];
+            bool isRaygen = shader.Type == ShaderType::Raygen;
+            UINT shaderStackSize = shader.StackSize;
+            if (isRaygen)
+            {
+                shaderStackSize += traceRayStackSize;
+                m_largestRayGenStackSize = std::max(shaderStackSize, m_largestNonRayGenStackSize);
+            }
+            else if (shader.Type == ShaderType::Miss)
+            {
+                m_largestNonRayGenStackSize = std::max(shaderStackSize, m_largestNonRayGenStackSize);
+            }
+
+            m_ExportNameToShaderData[exportNames[i]] = { {shader.Identifier, 0}, shaderStackSize };
         }
 
         for (auto &hitGroupMapEntry : stateObjectCollection.m_hitGroups)
@@ -173,10 +186,17 @@ namespace FallbackLayer
             shaderId.StateId = GetStateIdentfier(closestHitName);
             shaderId.AnyHitId = GetStateIdentfier(anyHitName);
             shaderId.IntersectionShaderId = GetStateIdentfier(intersectionName);
+            UINT shaderStackSize = (UINT)std::max(std::max(
+                GetShaderStackSize(closestHitName), GetShaderStackSize(anyHitName)), GetShaderStackSize(intersectionName));
 
+            m_largestNonRayGenStackSize = std::max(shaderStackSize, m_largestNonRayGenStackSize);
             auto hitGroupName = hitGroupMapEntry.first;
-            m_ExportNameToShaderIdentifier[hitGroupName] = shaderId;
+            m_ExportNameToShaderData[hitGroupName] = { shaderId, shaderStackSize };
         }
+
+        UINT stackSize = stateObjectCollection.m_config.MaxTraceRecursionDepth * m_largestNonRayGenStackSize + m_largestRayGenStackSize;
+        CComPtr<IDxcBlob> pLinkedBlob;
+        m_DxilShaderPatcher.LinkShaders(stackSize, librariesInfo, exportNames, shaderInfo, &pLinkedBlob);
 
         CompilePSO(
             pDevice, 
@@ -197,15 +217,15 @@ namespace FallbackLayer
 
     ShaderIdentifier *UberShaderRaytracingProgram::GetShaderIdentifier(LPCWSTR pExportName)
     {
-        auto pEntry = m_ExportNameToShaderIdentifier.find(pExportName);
-        if (pEntry == m_ExportNameToShaderIdentifier.end())
+        auto pEntry = m_ExportNameToShaderData.find(pExportName);
+        if (pEntry == m_ExportNameToShaderData.end())
         {
             return nullptr;
         }
         else
         {
             // Handing out this pointer is safe because the map is read-only at this point
-            return &pEntry->second;
+            return &pEntry->second.stateIdentifier;
         }
     }
 

--- a/Libraries/D3D12RaytracingFallback/src/UberShaderRayTracingProgram.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/UberShaderRayTracingProgram.cpp
@@ -155,7 +155,7 @@ namespace FallbackLayer
         // Link shaders just to get the stack sizes (very bad)
         CComPtr<IDxcBlob> pUnusedBlob;
         std::vector<DxcShaderInfo> shaderInfo;
-        m_DxilShaderPatcher.LinkShaders(0, librariesInfo, exportNames, shaderInfo, &pUnusedBlob);
+        m_DxilShaderPatcher.LinkShaders(stateObjectCollection.m_maxAttributeSizeInBytes, 0, librariesInfo, exportNames, shaderInfo, &pUnusedBlob);
 
         UINT traceRayStackSize = shaderInfo[exportNames.size() - 1].StackSize;
         for (size_t i = 0; i < exportNames.size(); ++i)
@@ -166,7 +166,7 @@ namespace FallbackLayer
             if (isRaygen)
             {
                 shaderStackSize += traceRayStackSize;
-                m_largestRayGenStackSize = std::max(shaderStackSize, m_largestNonRayGenStackSize);
+                m_largestRayGenStackSize = std::max(shaderStackSize, m_largestRayGenStackSize);
             }
             else if (shader.Type == ShaderType::Miss)
             {
@@ -196,7 +196,7 @@ namespace FallbackLayer
 
         UINT stackSize = stateObjectCollection.m_config.MaxTraceRecursionDepth * m_largestNonRayGenStackSize + m_largestRayGenStackSize;
         CComPtr<IDxcBlob> pLinkedBlob;
-        m_DxilShaderPatcher.LinkShaders(stackSize, librariesInfo, exportNames, shaderInfo, &pLinkedBlob);
+        m_DxilShaderPatcher.LinkShaders(stateObjectCollection.m_maxAttributeSizeInBytes, stackSize, librariesInfo, exportNames, shaderInfo, &pLinkedBlob);
 
         CompilePSO(
             pDevice, 

--- a/Libraries/D3D12RaytracingFallback/src/UberShaderRayTracingProgram.h
+++ b/Libraries/D3D12RaytracingFallback/src/UberShaderRayTracingProgram.h
@@ -25,6 +25,7 @@ namespace FallbackLayer
             const D3D12_FALLBACK_DISPATCH_RAYS_DESC &desc);
 
         virtual ShaderIdentifier *GetShaderIdentifier(LPCWSTR pExportName);
+        virtual UINT64 GetShaderStackSize(LPCWSTR pExportName);
 
         virtual void SetPredispatchCallback(std::function<void(ID3D12GraphicsCommandList *, UINT)> callback)
         {
@@ -35,9 +36,19 @@ namespace FallbackLayer
         StateIdentifier GetStateIdentfier(LPCWSTR pExportName);
 
         DxilShaderPatcher &m_DxilShaderPatcher;
+        struct ShaderData
+        {
+          ShaderIdentifier stateIdentifier;
+          UINT stackSize;
+        };
 
-        std::unordered_map<std::wstring, ShaderIdentifier> m_ExportNameToShaderIdentifier;
+        ShaderData *GetShaderData(LPCWSTR pExportName);
+
+        std::unordered_map<std::wstring, ShaderData> m_ExportNameToShaderData;
         CComPtr<ID3D12PipelineState> m_pRayTracePSO;
         UINT m_patchRootSignatureParameterStart;
+
+        UINT m_largestNonRayGenStackSize = 0;
+        UINT m_largestRayGenStackSize = 0;
     };
 }

--- a/Libraries/D3D12RaytracingFallback/src/dxc/dxcapi.h
+++ b/Libraries/D3D12RaytracingFallback/src/dxc/dxcapi.h
@@ -1,13 +1,3 @@
-//*********************************************************
-//
-// Copyright (c) Microsoft. All rights reserved.
-// This code is licensed under the MIT License (MIT).
-// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
-// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
-// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
-// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
-//
-//*********************************************************
 
 ///////////////////////////////////////////////////////////////////////////////
 //                                                                           //
@@ -320,29 +310,6 @@ IDxcVersionInfo : public IUnknown {
   virtual HRESULT STDMETHODCALLTYPE GetFlags(_Out_ UINT32 *pFlags) = 0;
 };
 
-struct __declspec(uuid("76bb3c85-006d-4b72-9e10-63cd97df57f0"))
-IDxcDxrFallbackCompiler : public IUnknown {
-
-  // If set to true then shaders not listed in pShaderNames in Compile() but 
-  // called by shaders in pShaderNames are added to the megakernel, otherwise
-  // these are consider errors.
-  virtual HRESULT STDMETHODCALLTYPE SetFindCalledShaders(bool val) = 0;
-
-  virtual HRESULT STDMETHODCALLTYPE SetDebugOutput(int val) = 0;
-
-  // Compiles the compute shader and produces a shader blob 
-  virtual HRESULT STDMETHODCALLTYPE Compile(
-    _In_ const LPCWSTR pEntryName,                          // Name of entry function
-    _In_count_(libCount) IDxcBlob **pLibs,                  // Array of libraries containing shaders
-    UINT32 libCount,                                        // Number of libraries containing shaders
-    _In_count_(shaderCount) const LPCWSTR *pShaderNames,    // Array of shader names to compile
-    _Out_ int* pShaderIdentifiers,                          // Array of generated shader identifiers
-    UINT32 shaderCount,                                     // Number of shaders to compile
-    UINT32 stackSizeInBytes,                                // Continuation stack size. Use 0 for default.
-    _COM_Outptr_ IDxcOperationResult **ppResult             // Compiler output status, buffer, and errors
-  ) = 0;
-};
-
 // {73e22d93-e6ce-47f3-b5bf-f0664f39c1b0}
 __declspec(selectany) extern const CLSID CLSID_DxcCompiler = {
   0x73e22d93,
@@ -413,13 +380,5 @@ __declspec(selectany) extern const GUID CLSID_DxcContainerBuilder = {
   0x411f,
   0x4574,  
   { 0xb4, 0xd0, 0x87, 0x41, 0xe2, 0x52, 0x40, 0xd2 }
-};
-
-// {76bb3c85-006d-4b72-9e10-63cd97df57f0}
-__declspec(selectany) extern const GUID CLSID_DxcDxrFallbackCompiler = {
-  0x76bb3c85,
-  0x006d,
-  0x4b72,  
-  { 0x9e, 0x10, 0x63, 0xcd, 0x97, 0xdf, 0x57, 0xf0 }
 };
 #endif

--- a/Libraries/D3D12RaytracingFallback/src/dxc/dxcdxrfallbackcompiler.h
+++ b/Libraries/D3D12RaytracingFallback/src/dxc/dxcdxrfallbackcompiler.h
@@ -51,8 +51,9 @@ struct __declspec(uuid("76bb3c85-006d-4b72-9e10-63cd97df57f0"))
     _In_count_(libCount) IDxcBlob **pLibs,                  // Array of libraries containing shaders
     UINT32 libCount,                                        // Number of libraries containing shaders
     _In_count_(shaderCount) const LPCWSTR *pShaderNames,    // Array of shader names to compile
-    _Out_writes_(shaderCount) DxcShaderInfo *pShaderInfo,      // Array of shaderInfo corresponding to pShaderNames
+    _Out_writes_(shaderCount) DxcShaderInfo *pShaderInfo,   // Array of shaderInfo corresponding to pShaderNames
     UINT32 shaderCount,                                     // Number of shaders to compile
+    UINT32 maxAttributeSize,
     UINT32 stackSizeInBytes,                                // Continuation stack size. Use 0 for default.
     _COM_Outptr_ IDxcOperationResult **ppResult             // Compiler output status, buffer, and errors
   ) = 0;

--- a/Libraries/D3D12RaytracingFallback/src/dxc/dxcdxrfallbackcompiler.h
+++ b/Libraries/D3D12RaytracingFallback/src/dxc/dxcdxrfallbackcompiler.h
@@ -42,6 +42,12 @@ struct __declspec(uuid("76bb3c85-006d-4b72-9e10-63cd97df57f0"))
 
   virtual HRESULT STDMETHODCALLTYPE SetDebugOutput(int val) = 0;
 
+  virtual HRESULT STDMETHODCALLTYPE PatchShaderBindingTables(
+      IDxcBlob *pShaderBlob,
+      void *pShaderInfo,
+      _COM_Outptr_ IDxcOperationResult **ppResult
+  ) = 0;
+
   // Compiles libs together to create a raytracing compute shader. One of the libs 
   // should be the fallback implementation lib that defines functions like 
   // Fallback_TraceRay(), Fallback_ReportHit(), etc. Fallback_TraceRay() should 

--- a/Libraries/D3D12RaytracingFallback/src/dxc/dxcdxrfallbackcompiler.h
+++ b/Libraries/D3D12RaytracingFallback/src/dxc/dxcdxrfallbackcompiler.h
@@ -47,15 +47,25 @@ struct __declspec(uuid("76bb3c85-006d-4b72-9e10-63cd97df57f0"))
   // Fallback_TraceRay(), Fallback_ReportHit(), etc. Fallback_TraceRay() should 
   // be one of the shader names so that it gets included in the compile. 
   virtual HRESULT STDMETHODCALLTYPE Compile(
-    _In_ const LPCWSTR pEntryName,                          // Name of entry function
     _In_count_(libCount) IDxcBlob **pLibs,                  // Array of libraries containing shaders
     UINT32 libCount,                                        // Number of libraries containing shaders
     _In_count_(shaderCount) const LPCWSTR *pShaderNames,    // Array of shader names to compile
     _Out_writes_(shaderCount) DxcShaderInfo *pShaderInfo,   // Array of shaderInfo corresponding to pShaderNames
     UINT32 shaderCount,                                     // Number of shaders to compile
     UINT32 maxAttributeSize,
-    UINT32 stackSizeInBytes,                                // Continuation stack size. Use 0 for default.
     _COM_Outptr_ IDxcOperationResult **ppResult             // Compiler output status, buffer, and errors
+  ) = 0;
+
+  virtual HRESULT STDMETHODCALLTYPE Link(
+      _In_ const LPCWSTR pEntryName,                          // Name of entry function, null if compiling a collection
+      _In_count_(libCount) IDxcBlob **pLibs,                  // Array of libraries containing shaders
+      UINT32 libCount,                                        // Number of libraries containing shaders
+      _In_count_(shaderCount) const LPCWSTR *pShaderNames,    // Array of shader names to compile
+      _In_count_(shaderCount) DxcShaderInfo *pShaderInfo,   // Array of shaderInfo corresponding to pShaderNames
+      UINT32 shaderCount,                                     // Number of shaders to compile
+      UINT32 maxAttributeSize,
+      UINT32 stackSizeInBytes,                                // Continuation stack size. Use 0 for default.
+      _COM_Outptr_ IDxcOperationResult **ppResult             // Compiler output status, buffer, and errors
   ) = 0;
 };
 

--- a/Libraries/D3D12RaytracingFallback/src/dxc/dxcdxrfallbackcompiler.h
+++ b/Libraries/D3D12RaytracingFallback/src/dxc/dxcdxrfallbackcompiler.h
@@ -14,6 +14,24 @@
 #define __DXC_DXR_FALLBACK_COMPILER_API__
 #include "dxcapi.h"
 
+enum class ShaderType : unsigned int
+{
+    Raygen,
+    AnyHit,
+    ClosestHit,
+    Intersection,
+    Miss,
+    Callable,
+    Lib,
+};
+
+struct DxcShaderInfo
+{
+    UINT32 Identifier;
+    UINT32 StackSize;
+    ShaderType Type;
+};
+
 struct __declspec(uuid("76bb3c85-006d-4b72-9e10-63cd97df57f0"))
   IDxcDxrFallbackCompiler : public IUnknown {
 
@@ -33,7 +51,7 @@ struct __declspec(uuid("76bb3c85-006d-4b72-9e10-63cd97df57f0"))
     _In_count_(libCount) IDxcBlob **pLibs,                  // Array of libraries containing shaders
     UINT32 libCount,                                        // Number of libraries containing shaders
     _In_count_(shaderCount) const LPCWSTR *pShaderNames,    // Array of shader names to compile
-    _Out_ int* pShaderIdentifiers,                          // Array of generated shader identifiers, one for each shader
+    _Out_writes_(shaderCount) DxcShaderInfo *pShaderInfo,      // Array of shaderInfo corresponding to pShaderNames
     UINT32 shaderCount,                                     // Number of shaders to compile
     UINT32 stackSizeInBytes,                                // Continuation stack size. Use 0 for default.
     _COM_Outptr_ IDxcOperationResult **ppResult             // Compiler output status, buffer, and errors

--- a/Libraries/D3D12RaytracingFallback/src/dxc/dxcdxrfallbackcompiler.h
+++ b/Libraries/D3D12RaytracingFallback/src/dxc/dxcdxrfallbackcompiler.h
@@ -1,0 +1,57 @@
+
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// dxcapi.h                                                                  //
+// Copyright (C) Microsoft Corporation. All rights reserved.                 //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+// Provides declarations for the DirectX Compiler API entry point.           //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef __DXC_DXR_FALLBACK_COMPILER_API__
+#define __DXC_DXR_FALLBACK_COMPILER_API__
+#include "dxcapi.h"
+
+struct __declspec(uuid("76bb3c85-006d-4b72-9e10-63cd97df57f0"))
+  IDxcDxrFallbackCompiler : public IUnknown {
+
+  // If set to true then shaders not listed in pShaderNames in Compile() but 
+  // called by shaders in pShaderNames are added to the final computer shader. 
+  // Otherwise these are considered errors. This is intended for testing purposes.
+  virtual HRESULT STDMETHODCALLTYPE SetFindCalledShaders(bool val) = 0;
+
+  virtual HRESULT STDMETHODCALLTYPE SetDebugOutput(int val) = 0;
+
+  // Compiles libs together to create a raytracing compute shader. One of the libs 
+  // should be the fallback implementation lib that defines functions like 
+  // Fallback_TraceRay(), Fallback_ReportHit(), etc. Fallback_TraceRay() should 
+  // be one of the shader names so that it gets included in the compile. 
+  virtual HRESULT STDMETHODCALLTYPE Compile(
+    _In_ const LPCWSTR pEntryName,                          // Name of entry function
+    _In_count_(libCount) IDxcBlob **pLibs,                  // Array of libraries containing shaders
+    UINT32 libCount,                                        // Number of libraries containing shaders
+    _In_count_(shaderCount) const LPCWSTR *pShaderNames,    // Array of shader names to compile
+    _Out_ int* pShaderIdentifiers,                          // Array of generated shader identifiers, one for each shader
+    UINT32 shaderCount,                                     // Number of shaders to compile
+    UINT32 stackSizeInBytes,                                // Continuation stack size. Use 0 for default.
+    _COM_Outptr_ IDxcOperationResult **ppResult             // Compiler output status, buffer, and errors
+  ) = 0;
+};
+
+// {76bb3c85-006d-4b72-9e10-63cd97df57f0}
+__declspec(selectany) extern const GUID CLSID_DxcDxrFallbackCompiler = {
+  0x76bb3c85,
+  0x006d,
+  0x4b72,
+{ 0x9e, 0x10, 0x63, 0xcd, 0x97, 0xdf, 0x57, 0xf0 }
+};
+
+typedef HRESULT(__stdcall *DxcCreateDxrFallbackCompilerProc)(
+  _In_ REFCLSID   rclsid,
+  _In_ REFIID     riid,
+  _Out_ LPVOID*   ppv
+  );
+
+#endif

--- a/Libraries/D3D12RaytracingFallback/src/dxc/dxcdxrfallbackcompiler.h
+++ b/Libraries/D3D12RaytracingFallback/src/dxc/dxcdxrfallbackcompiler.h
@@ -32,6 +32,12 @@ struct DxcShaderInfo
     ShaderType Type;
 };
 
+struct DxcShaderBytecode
+{
+    LPBYTE pShaderBytecode;
+    UINT32 shaderBytecodeSize;
+};
+
 struct __declspec(uuid("76bb3c85-006d-4b72-9e10-63cd97df57f0"))
   IDxcDxrFallbackCompiler : public IUnknown {
 
@@ -43,8 +49,9 @@ struct __declspec(uuid("76bb3c85-006d-4b72-9e10-63cd97df57f0"))
   virtual HRESULT STDMETHODCALLTYPE SetDebugOutput(int val) = 0;
 
   virtual HRESULT STDMETHODCALLTYPE PatchShaderBindingTables(
-      IDxcBlob *pShaderBlob,
-      void *pShaderInfo,
+      _In_ const LPCWSTR pEntryName,
+      _In_ DxcShaderBytecode *pShaderBytecode,
+      _In_ void *pShaderInfo,
       _COM_Outptr_ IDxcOperationResult **ppResult
   ) = 0;
 
@@ -53,7 +60,7 @@ struct __declspec(uuid("76bb3c85-006d-4b72-9e10-63cd97df57f0"))
   // Fallback_TraceRay(), Fallback_ReportHit(), etc. Fallback_TraceRay() should 
   // be one of the shader names so that it gets included in the compile. 
   virtual HRESULT STDMETHODCALLTYPE Compile(
-    _In_count_(libCount) IDxcBlob **pLibs,                  // Array of libraries containing shaders
+    _In_count_(libCount) DxcShaderBytecode *pLibs,                  // Array of libraries containing shaders
     UINT32 libCount,                                        // Number of libraries containing shaders
     _In_count_(shaderCount) const LPCWSTR *pShaderNames,    // Array of shader names to compile
     _Out_writes_(shaderCount) DxcShaderInfo *pShaderInfo,   // Array of shaderInfo corresponding to pShaderNames

--- a/Libraries/D3D12RaytracingFallback/src/dxc/dxcdxrfallbackcompiler.use.h
+++ b/Libraries/D3D12RaytracingFallback/src/dxc/dxcdxrfallbackcompiler.use.h
@@ -1,0 +1,137 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+//////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// dxcapi.use.h                                                              //
+// Copyright (C) Microsoft Corporation. All rights reserved.                 //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+// Provides support for DXC API users.                                       //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef __DXC_DXR_FALLBACK_API_USE_H__
+#define __DXC_DXR_FALLBACK_API_USE_H__
+
+#include "dxc/dxcapi.h"
+
+namespace dxc {
+
+// Helper class to dynamically load the dxcompiler or a compatible libraries.
+class DxcDxrFallbackDllSupport {
+protected:
+  HMODULE m_dll;
+  DxcCreateInstanceProc m_createFn;
+  DxcCreateInstance2Proc m_createFn2;
+
+  HRESULT InitializeInternal(LPCWSTR dllName, LPCSTR fnName) {
+    if (m_dll != nullptr) return S_OK;
+    m_dll = LoadLibraryW(dllName);
+
+    if (m_dll == nullptr) return HRESULT_FROM_WIN32(GetLastError());
+    m_createFn = (DxcCreateInstanceProc)GetProcAddress(m_dll, fnName);
+
+    if (m_createFn == nullptr) {
+      HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
+      FreeLibrary(m_dll);
+      m_dll = nullptr;
+      return hr;
+    }
+
+    // Only basic functions used to avoid requiring additional headers.
+    m_createFn2 = nullptr;
+    char fnName2[128];
+    size_t s = strlen(fnName);
+    if (s < sizeof(fnName2) - 2) {
+      memcpy(fnName2, fnName, s);
+      fnName2[s] = '2';
+      fnName2[s + 1] = '\0';
+      m_createFn2 = (DxcCreateInstance2Proc)GetProcAddress(m_dll, fnName2);
+    }
+
+    return S_OK;
+  }
+
+public:
+  DxcDxrFallbackDllSupport() : m_dll(nullptr), m_createFn(nullptr), m_createFn2(nullptr) {
+  }
+
+  DxcDxrFallbackDllSupport(DxcDxrFallbackDllSupport&& other) {
+    m_dll = other.m_dll; other.m_dll = nullptr;
+    m_createFn = other.m_createFn; other.m_createFn = nullptr;
+    m_createFn2 = other.m_createFn2; other.m_createFn2 = nullptr;
+  }
+
+  ~DxcDxrFallbackDllSupport() {
+    Cleanup();
+  }
+
+  HRESULT Initialize() {
+    return InitializeInternal(L"dxrfallbackcompiler.dll", "DxcCreateDxrFallbackCompiler");
+  }
+
+  HRESULT InitializeForDll(_In_z_ const wchar_t* dll, _In_z_ const char* entryPoint) {
+    return InitializeInternal(dll, entryPoint);
+  }
+
+  template <typename TInterface>
+  HRESULT CreateInstance(REFCLSID clsid, _Outptr_ TInterface** pResult) {
+    return CreateInstance(clsid, __uuidof(TInterface), (IUnknown**)pResult);
+  }
+
+  HRESULT CreateInstance(REFCLSID clsid, REFIID riid, _Outptr_ IUnknown **pResult) {
+    if (pResult == nullptr) return E_POINTER;
+    if (m_dll == nullptr) return E_FAIL;
+    HRESULT hr = m_createFn(clsid, riid, (LPVOID*)pResult);
+    return hr;
+  }
+
+  template <typename TInterface>
+  HRESULT CreateInstance2(IMalloc *pMalloc, REFCLSID clsid, _Outptr_ TInterface** pResult) {
+    return CreateInstance2(pMalloc, clsid, __uuidof(TInterface), (IUnknown**)pResult);
+  }
+
+  HRESULT CreateInstance2(IMalloc *pMalloc, REFCLSID clsid, REFIID riid, _Outptr_ IUnknown **pResult) {
+    if (pResult == nullptr) return E_POINTER;
+    if (m_dll == nullptr) return E_FAIL;
+    if (m_createFn2 == nullptr) return E_FAIL;
+    HRESULT hr = m_createFn2(pMalloc, clsid, riid, (LPVOID*)pResult);
+    return hr;
+  }
+
+  bool HasCreateWithMalloc() const {
+    return m_createFn2 != nullptr;
+  }
+
+  bool IsEnabled() const {
+    return m_dll != nullptr;
+  }
+
+  void Cleanup() {
+    if (m_dll != nullptr) {
+      m_createFn = nullptr;
+      m_createFn2 = nullptr;
+      FreeLibrary(m_dll);
+      m_dll = nullptr;
+    }
+  }
+
+  HMODULE Detach() {
+    HMODULE module = m_dll;
+    m_dll = nullptr;
+    return module;
+  }
+};
+
+} // namespace dxc
+
+#endif

--- a/Libraries/D3D12RaytracingFallback/src/pch.h
+++ b/Libraries/D3D12RaytracingFallback/src/pch.h
@@ -30,6 +30,8 @@
 #include "d3dx12.h"
 #include "dxc\dxcapi.h"
 #include "dxc\dxcapi.use.h"
+#include "dxc\dxcdxrfallbackcompiler.h"
+#include "dxc\dxcdxrfallbackcompiler.use.h"
 #include "dxc\hlsl\DxilContainer.h"
 #include "Util.h"
 

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/ModelViewer.cpp
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/ModelViewer.cpp
@@ -751,7 +751,7 @@ void InitializeRaytracingStateObjects(const Model &model, UINT numMeshes)
 
 void D3D12RaytracingMiniEngineSample::Startup( void )
 {
-    D3D12CreateRaytracingFallbackDevice(g_Device, CreateRaytracingFallbackDeviceFlags::None, 0, IID_PPV_ARGS(&g_pRaytracingDevice));
+    D3D12CreateRaytracingFallbackDevice(g_Device, CreateRaytracingFallbackDeviceFlags::ForceComputeFallback, 0, IID_PPV_ARGS(&g_pRaytracingDevice));
     g_SceneNormalBuffer.Create(L"Main Normal Buffer", g_SceneColorBuffer.GetWidth(), g_SceneColorBuffer.GetHeight(), 1, DXGI_FORMAT_R16G16B16A16_FLOAT);
 
     g_pRaytracingDescriptorHeap = std::unique_ptr<DescriptorHeapStack>(

--- a/Samples/Desktop/D3D12Raytracing/tools/x64/PostbuildCopy.bat
+++ b/Samples/Desktop/D3D12Raytracing/tools/x64/PostbuildCopy.bat
@@ -14,7 +14,7 @@ if %BuildVersion% GEQ 17093 if %BuildVersion% LEQ 17623 set UseRS4Binaries=1
 rem Copy Dxcompiler, needed regardless of whether it's using native DXR or the Fallback layer
 set outputDirectory=%1
 echo %1
-copy dxcompiler.dll %outputDirectory%
+copy dxrfallbackcompiler.dll %outputDirectory%
 
 if %UseRS4Binaries% NEQ 0 ( 
 	echo RS4-DXR compatible build detected, copying DXR D3D12 binaries

--- a/Samples/Desktop/D3D12Raytracing/tools/x64/PrebuildCheck.bat
+++ b/Samples/Desktop/D3D12Raytracing/tools/x64/PrebuildCheck.bat
@@ -24,6 +24,13 @@ if not exist dxc.exe (
    echo No dxc.exe found!
    set FILENOTFOUND=1
 )
+
+if not exist dxrfallbackcompiler.dll (
+   echo No dxrfallbackcompiler.dll found!
+   echo Note that if you were using an older version of the Raytracing samples, the Fallback Layer has been changed to require dxrfallbackcompiler.dll instead of dxcompiler.dll. This can be pulled from the below linked release
+   set FILENOTFOUND=1
+)
+
 echo Renaming dxc->fxc so that Visual Studio can natively work with HLSL files and still compile them to SM 6.1
 copy dxc.exe fxc.exe
 

--- a/Samples/Desktop/D3D12Raytracing/tools/x64/PrebuildCheck.bat
+++ b/Samples/Desktop/D3D12Raytracing/tools/x64/PrebuildCheck.bat
@@ -35,9 +35,7 @@ echo Renaming dxc->fxc so that Visual Studio can natively work with HLSL files a
 copy dxc.exe fxc.exe
 
 if %FILENOTFOUND% NEQ 0 (
-	echo Please go to https://github.com/Microsoft/DirectX-Graphics-Samples/releases and download latest "DirectX Raytracing Binary Release v1.2". 
-	echo Copy all the binaries to Samples\Desktop\D3D12Raytracing\tools\x64"
-	exit /b 1
+	goto :mismatch
 )
 
 if not exist version.txt (
@@ -45,14 +43,14 @@ if not exist version.txt (
 ) 
 
 set /p version=< version.txt
-if not "%version%"=="1.2-dxr" (
+if not "%version%"=="1.3-dxr" (
 	goto :mismatch
 )
 
 exit
 
 :mismatch
-	echo Stale binaries detected, please grab the v1.2-dxr binaries from https://github.com/Microsoft/DirectX-Graphics-Samples/releases/tag/v1.2-dxr 
+	echo Stale binaries detected, please grab the v1.3-dxr binaries from https://github.com/Microsoft/DirectX-Graphics-Samples/releases/tag/v1.3-dxr 
 	echo Copy all the binaries to Samples\Desktop\D3D12Raytracing\tools\x64"
 	exit /b 1
 )


### PR DESCRIPTION
The Fallback Compiler has been updated to be split off into it's own DxrFallbackCompiler.dll. The interfaces to the compiler are slightly different, the most notable difference is that stack sizes are now pre-calculated to the minimal amount needed based on the max recursion count specified. On some hardware affected by large alloca usage, this results in a large perf gains (~50%)

Also updating the developer guide with some of the latest Fallback Layer improvements