### PR TITLE
Update.gitignore to exclude fallback layer unit test binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 /Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/dxcompiler.dll
 /Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample
+/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/x64/


### PR DESCRIPTION
Binaries built out of the fallback layer unit tests don't belong in the repo.