### PR TITLE
Update samples for compatibility with latest DxCompiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 /Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/dxcompiler.dll
 /Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample
+/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/x64/

--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/SimpleRayTracing.hlsl
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/SimpleRayTracing.hlsl
@@ -28,7 +28,7 @@ struct MyPayload
 [shader("raygeneration")]
 void RayGen()
 {
-    float2 lerpValues = (float2(DispatchRaysIndex()) + 0.5) / DispatchRaysDimensions();
+    float2 lerpValues = (float2(DispatchRaysIndex().xy) + 0.5) / DispatchRaysDimensions().xy;
 
     float3 rayDir = float3(0.0, 0.0, 1);
     float3 origin = float3(
@@ -47,11 +47,11 @@ void RayGen()
 [shader("miss")]
 void Miss(inout MyPayload payload)
 {
-    RenderTarget[DispatchRaysIndex()] = float4(1, 0, 0, 1);
+    RenderTarget[DispatchRaysIndex().xy] = float4(1, 0, 0, 1);
 }
 
 [shader("closesthit")]
 void Hit(inout MyPayload payload, in BuiltInTriangleIntersectionAttributes attr)
 {
-    RenderTarget[DispatchRaysIndex()] = float4(1, 0, 1, 1);
+    RenderTarget[DispatchRaysIndex().xy] = float4(1, 0, 1, 1);
 }

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingHelloWorld/Raytracing.hlsl
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingHelloWorld/Raytracing.hlsl
@@ -57,12 +57,12 @@ void MyRaygenShader()
         TraceRay(Scene, RAY_FLAG_CULL_BACK_FACING_TRIANGLES, ~0, 0, 1, 0, ray, payload);
 
         // Write the raytraced color to the output texture.
-        RenderTarget[DispatchRaysIndex()] = payload.color;
+        RenderTarget[DispatchRaysIndex().xy] = payload.color;
     }
     else
     {
         // Render interpolated DispatchRaysIndex outside the stencil window
-        RenderTarget[DispatchRaysIndex()] = float4(lerpValues, 0, 1);
+        RenderTarget[DispatchRaysIndex().xy] = float4(lerpValues, 0, 1);
     }
 }
 

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/DiffuseHitShaderLib.hlsl
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/DiffuseHitShaderLib.hlsl
@@ -259,7 +259,7 @@ void Hit(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr
 
     float3 worldPosition = WorldRayOrigin() + WorldRayDirection() * RayTCurrent();
 
-    uint2 threadID = DispatchRaysIndex();
+    uint2 threadID = DispatchRaysIndex().xy;
     float3 ddxOrigin, ddxDir, ddyOrigin, ddyDir;
     GenerateCameraRay(uint2(threadID.x + 1, threadID.y), ddxOrigin, ddxDir);
     GenerateCameraRay(uint2(threadID.x, threadID.y + 1), ddyOrigin, ddyDir);
@@ -288,7 +288,7 @@ void Hit(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr
         normal = normalize(mul(normal, tbn));
     }
     
-    float3 outputColor = AmbientColor * diffuseColor * texSSAO[DispatchRaysIndex()];
+    float3 outputColor = AmbientColor * diffuseColor * texSSAO[DispatchRaysIndex().xy];
 
     float shadow = 1.0;
     if (UseShadowRays)
@@ -328,8 +328,8 @@ void Hit(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr
     // TODO: Should be passed in via material info
     if (IsReflection)
     {
-        outputColor = outputColor * 0.3 + g_screenOutput[DispatchRaysIndex()];
+        outputColor = outputColor * 0.3 + g_screenOutput[DispatchRaysIndex().xy];
     }
 
-    g_screenOutput[DispatchRaysIndex()] = float4(outputColor, 1);
+    g_screenOutput[DispatchRaysIndex().xy] = float4(outputColor, 1);
 }

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/RayGenerationShaderLib.hlsl
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/RayGenerationShaderLib.hlsl
@@ -17,7 +17,7 @@
 void RayGen()
 {
     float3 origin, direction;
-    GenerateCameraRay(DispatchRaysIndex(), origin, direction);
+    GenerateCameraRay(DispatchRaysIndex().xy, origin, direction);
 
     RayDesc rayDesc = { origin,
         0.0f,

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/RayGenerationShaderSSRLib.hlsl
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/RayGenerationShaderSSRLib.hlsl
@@ -18,7 +18,7 @@ Texture2D<float3>   normals  : register(t13);
 [shader("raygeneration")]
 void RayGen()
 {
-    uint2 DTid = DispatchRaysIndex();
+    uint2 DTid = DispatchRaysIndex().xy;
     float2 xy = DTid.xy + 0.5;
 
     // Screen position for the ray

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/RayGenerationShadowsLib.hlsl
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/RayGenerationShadowsLib.hlsl
@@ -17,7 +17,7 @@ Texture2D<float>    depth    : register(t1);
 [shader("raygeneration")]
 void RayGen()
 {
-    uint2 DTid = DispatchRaysIndex();
+    uint2 DTid = DispatchRaysIndex().xy;
     float2 xy = DTid.xy + 0.5;
 
     // Screen position for the ray
@@ -48,11 +48,11 @@ void RayGen()
 
     if (payload.RayHitT < FLT_MAX)
     {
-        g_screenOutput[DispatchRaysIndex()] = float4(0, 0, 0, 1);
+        g_screenOutput[DispatchRaysIndex().xy] = float4(0, 0, 0, 1);
     }
     else
     {
-        g_screenOutput[DispatchRaysIndex()] = float4(1, 1, 1, 1);
+        g_screenOutput[DispatchRaysIndex().xy] = float4(1, 1, 1, 1);
     }
 }
 

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/hitShaderLib.hlsl
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/hitShaderLib.hlsl
@@ -18,7 +18,7 @@ void Hit(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr
     payload.RayHitT = RayTCurrent();
     if (!payload.SkipShading)
     {
-        g_screenOutput[DispatchRaysIndex()] = float4(attr.barycentrics, 1, 1);
+        g_screenOutput[DispatchRaysIndex().xy] = float4(attr.barycentrics, 1, 1);
     }
 }
 

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/missShaderLib.hlsl
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/missShaderLib.hlsl
@@ -17,7 +17,7 @@ void Miss(inout RayPayload payload)
 {
     if (!payload.SkipShading)
     {
-        g_screenOutput[DispatchRaysIndex()] = float4(0, 0, 0, 1);
+        g_screenOutput[DispatchRaysIndex().xy] = float4(0, 0, 0, 1);
     }
 }
 

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingProceduralGeometry/Raytracing.hlsl
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingProceduralGeometry/Raytracing.hlsl
@@ -165,14 +165,14 @@ bool TraceShadowRayAndReportIfHit(in Ray ray, in UINT currentRayRecursionDepth)
 void MyRaygenShader()
 {
     // Generate a ray for a camera pixel corresponding to an index from the dispatched 2D grid.
-    Ray ray = GenerateCameraRay(DispatchRaysIndex(), g_sceneCB.cameraPosition.xyz, g_sceneCB.projectionToWorld);
+    Ray ray = GenerateCameraRay(DispatchRaysIndex().xy, g_sceneCB.cameraPosition.xyz, g_sceneCB.projectionToWorld);
  
     // Cast a ray into the scene and retrieve a shaded color.
     UINT currentRecursionDepth = 0;
     float4 color = TraceRadianceRay(ray, currentRecursionDepth);
 
     // Write the raytraced color to the output texture.
-    g_renderTarget[DispatchRaysIndex()] = color;
+    g_renderTarget[DispatchRaysIndex().xy] = color;
 }
 
 //***************************************************************************

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingProceduralGeometry/RaytracingShaderHelper.hlsli
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingProceduralGeometry/RaytracingShaderHelper.hlsli
@@ -102,7 +102,7 @@ float3 HitAttribute(float3 vertexAttribute[3], float2 barycentrics)
 inline Ray GenerateCameraRay(uint2 index, in float3 cameraPosition, in float4x4 projectionToWorld)
 {
     float2 xy = index + 0.5f; // center in the middle of the pixel.
-    float2 screenPos = xy / DispatchRaysDimensions() * 2.0 - 1.0;
+    float2 screenPos = xy / DispatchRaysDimensions().xy * 2.0 - 1.0;
 
     // Invert Y for DirectX-style coordinates.
     screenPos.y = -screenPos.y;
@@ -147,8 +147,8 @@ float2 TexCoords(in float3 position)
 void CalculateRayDifferentials(out float2 ddx_uv, out float2 ddy_uv, in float2 uv, in float3 hitPosition, in float3 surfaceNormal, in float3 cameraPosition, in float4x4 projectionToWorld)
 {
     // Compute ray differentials by intersecting the tangent plane to the  surface.
-    Ray ddx = GenerateCameraRay(DispatchRaysIndex() + uint2(1, 0), cameraPosition, projectionToWorld);
-    Ray ddy = GenerateCameraRay(DispatchRaysIndex() + uint2(0, 1), cameraPosition, projectionToWorld);
+    Ray ddx = GenerateCameraRay(DispatchRaysIndex().xy + uint2(1, 0), cameraPosition, projectionToWorld);
+    Ray ddy = GenerateCameraRay(DispatchRaysIndex().xy + uint2(0, 1), cameraPosition, projectionToWorld);
 
     // Compute ray differentials.
     float3 ddx_pos = ddx.origin - ddx.direction * dot(ddx.origin - hitPosition, surfaceNormal) / dot(ddx.direction, surfaceNormal);

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/Raytracing.hlsl
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/Raytracing.hlsl
@@ -79,7 +79,7 @@ float3 HitAttribute(float3 vertexAttribute[3], BuiltInTriangleIntersectionAttrib
 inline void GenerateCameraRay(uint2 index, out float3 origin, out float3 direction)
 {
     float2 xy = index + 0.5f; // center in the middle of the pixel.
-    float2 screenPos = xy / DispatchRaysDimensions() * 2.0 - 1.0;
+    float2 screenPos = xy / DispatchRaysDimensions().xy * 2.0 - 1.0;
 
     // Invert Y for DirectX-style coordinates.
     screenPos.y = -screenPos.y;
@@ -125,7 +125,7 @@ void MyRaygenShader()
     TraceRay(Scene, RAY_FLAG_CULL_BACK_FACING_TRIANGLES, ~0, 0, 1, 0, ray, payload);
 
     // Write the raytraced color to the output texture.
-    RenderTarget[DispatchRaysIndex()] = payload.color;
+    RenderTarget[DispatchRaysIndex().xy] = payload.color;
 }
 
 [shader("closesthit")]


### PR DESCRIPTION
The semantics for some things have changed to be a 3-component vector instead of a 2-component vector, and the samples will not build against the latest compiler tools until they have been updated accordingly.