### PR TITLE
Fixed instance transform size calculation

### DIFF
--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/fallbacklayerunittests.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/fallbacklayerunittests.cpp
@@ -16,7 +16,7 @@ using namespace FallbackLayer;
 
 namespace FallbackLayerUnitTests
 {
-    const UINT FloatsPerMatrix = ARRAYSIZE(D3D12_RAYTRACING_FALLBACK_INSTANCE_DESC::Transform);
+    const UINT FloatsPerMatrix = sizeof(D3D12_RAYTRACING_FALLBACK_INSTANCE_DESC::Transform) / sizeof(float);
     bool IsFloatArrayEqual(float *pArray1, float *pArray2, unsigned int floatCount)
     {
         const float epsilon = 0.002f;


### PR DESCRIPTION
D3D12_RAYTRACING_FALLBACK_INSTANCE_DESC::Transform went from being a float[12] to a float[3][4], breaking the use of ARRAYSIZE to calculate the number of floats in the matrix.

This fixes all the AccelerationStructure and LBVHBuilder unit tests. 