### PR TITLE
Added macros to allow disabling treelet path. …

### DIFF
--- a/Libraries/D3D12RaytracingFallback/src/GpuBVH2Builder.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/GpuBVH2Builder.cpp
@@ -342,6 +342,7 @@ namespace FallbackLayer
 
         if (sceneType == SceneType::Triangles) 
         {
+#if ENABLE_TREELET_REORDERING
             m_treeletReorder.Optimize(
                 pCommandList,
                 numElements,
@@ -351,7 +352,8 @@ namespace FallbackLayer
                 outputElementBuffer,
                 baseTreeletsCountBuffer,
                 baseTreeletsIndexBuffer,
-                pDesc->Flags);
+                pDesc->Inputs.Flags);
+#endif
         }
     }
 

--- a/Libraries/D3D12RaytracingFallback/src/RayTracingHlslCompat.h
+++ b/Libraries/D3D12RaytracingFallback/src/RayTracingHlslCompat.h
@@ -12,6 +12,19 @@
 #define RAYTRACING_HLSL_COMPAT_H_INCLUDED
 #include "WaveDimensions.h"
 
+//*********----- AMD driver limitation workarounds ------******************
+//  
+// Set following to 0 to get MiniEngineSample to run on AMD.
+//
+// Enables an unroll in treelet. Fails to compile on AMD.
+#define USE_EXPLICIT_UNROLL_IN_FORMTREELET 1
+
+// Enables treelet BVH optimization. TDRs on AMD.
+#define ENABLE_TREELET_REORDERING 1
+//
+//*************************************************************************
+
+
 #define     TRAVERSAL_MAX_STACK_DEPTH       32
 
 #define     MAX_TRIS_IN_LEAF                1

--- a/Libraries/D3D12RaytracingFallback/src/TreeletReorder.hlsl
+++ b/Libraries/D3D12RaytracingFallback/src/TreeletReorder.hlsl
@@ -44,8 +44,10 @@ void FormTreelet(in uint groupThreadId)
         treeletToReorder[0] = hierarchyBuffer[nodeIndex].LeftChildIndex;
         treeletToReorder[1] = hierarchyBuffer[nodeIndex].RightChildIndex;
 
+#if USE_EXPLICIT_UNROLL_IN_FORMTREELET
         [unroll]
-        for (uint treeletSize = 2; treeletSize < FullTreeletSize; treeletSize++)
+#endif
+	for (uint treeletSize = 2; treeletSize < FullTreeletSize; treeletSize++)
         {
             float largestSurfaceArea = 0.0;
             uint nodeIndexToTraverse = 0;


### PR DESCRIPTION
Treelet path doesn't work on AMD currently. Set these macros to 0 to get MiniEngineSample to run on AMD.