### PR TITLE
Add missing export keyword for lib_6_3 compatibility

### DIFF
--- a/Libraries/D3D12RaytracingFallback/src/DebugLog.hlsli
+++ b/Libraries/D3D12RaytracingFallback/src/DebugLog.hlsli
@@ -28,17 +28,17 @@ void LogNoData(uint EntryType)
     Log(uint4(EntryType, 0, 0, 0));
 }
 
-void LogTraceRayStart()
+export void LogTraceRayStart()
 {
     LogNoData(TRACE_RAY_BEGIN);
 }
 
-void LogTraceRayEnd()
+export void LogTraceRayEnd()
 {
     LogNoData(TRACE_RAY_END);
 }
 
-void LogInt(int val)
+export void LogInt(int val)
 {
     Log(uint4(LOG_INT, val, 0, 0));
 }

--- a/Libraries/D3D12RaytracingFallback/src/TraverseFunction.hlsli
+++ b/Libraries/D3D12RaytracingFallback/src/TraverseFunction.hlsli
@@ -133,7 +133,7 @@ bool IsOpaque(bool geomOpaque, uint instanceFlags, uint rayFlags)
     return opaque;
 }
 
-int Fallback_ReportHit(float tHit, uint hitKind)
+export int Fallback_ReportHit(float tHit, uint hitKind)
 {
     if (tHit < RayTMin() || Fallback_RayTCurrent() <= tHit)
         return 0;

--- a/Libraries/D3D12RaytracingFallback/src/TraverseShader.hlsli
+++ b/Libraries/D3D12RaytracingFallback/src/TraverseShader.hlsli
@@ -19,7 +19,7 @@
 #include "TraverseFunction.hlsli"
 
 SHADER_internal
-void Fallback_TraceRay(
+export void Fallback_TraceRay(
     uint rayFlags,
     uint instanceInclusionMask,
     uint rayContributionToHitGroupIndex,


### PR DESCRIPTION
In a previous commit, this branch was updated to target lib_6_3 from lib_6_1.
6_3 differs from 6_1 in that it doesn’t export all functions by default. You need to either use ‘export’ (the keyword) or use the -default-linkage option. This change adds the 'export' keyword where necessary.