### PR TITLE
Fix warning in the D3DX12.H that happens at /W4

### DIFF
--- a/Libraries/D3DX12/d3dx12.h
+++ b/Libraries/D3DX12/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;


### PR DESCRIPTION
The current version of the D3DX12.H header generates a warning at a normal default of Warning Level 4 which is strongly encouraged for projects.

    d3dx12.h(2184): warning C4324: 'CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT<CD3DX12_BLEND_DESC,D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_BLEND,CD3DX12_DEFAULT>': structure was padded due to alignment specifier
    d3dx12.h(2297): note: see reference to class template instantiation 'CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT<CD3DX12_BLEND_DESC,D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_BLEND,CD3DX12_DEFAULT>' being compiled
    d3dx12.h(2184): warning C4324: 'CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT<CD3DX12_DEPTH_STENCIL_DESC1,D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL1,CD3DX12_DEFAULT>': structure was padded due to alignment specifier
    d3dx12.h(2298): note: see reference to class template instantiation 'CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT<CD3DX12_DEPTH_STENCIL_DESC1,D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL1,CD3DX12_DEFAULT>' being compiled
    d3dx12.h(2184): warning C4324: 'CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT<DXGI_SAMPLE_DESC,D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_SAMPLE_DESC,DefaultSampleDesc>': structure was padded due to alignment specifier
    d3dx12.h(2302): note: see reference to class template instantiation 'CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT<DXGI_SAMPLE_DESC,D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_SAMPLE_DESC,DefaultSampleDesc>' being compiled