### PR TITLE
Make MiniEngine core compatible with /W4/WX

### DIFF
--- a/MiniEngine/Core/BitonicSort.cpp
+++ b/MiniEngine/Core/BitonicSort.cpp
@@ -217,7 +217,7 @@ void TestBitonicSort(uint32_t ListSize, bool b64Bit, bool bAscending)
     Ctx.Finish(true);
 
     typedef uint32_t Args[3];
-    Args* iArgs = (Args*)IndirectArgs.Map();
+    IndirectArgs.Map();
     BufferPtr = ReadbackList.Map();
 
     // Scan through all items to ensure they are sorted in the proper order and that

--- a/MiniEngine/Core/BufferManager.cpp
+++ b/MiniEngine/Core/BufferManager.cpp
@@ -230,11 +230,14 @@ void Graphics::InitializeRenderingBuffers( uint32_t bufferWidth, uint32_t buffer
     InitContext.Finish();
 }
 
+#pragma warning(push)
+#pragma warning(disable : 4100)	// NativeWidth is not referenced, but retaining for clarity
 void Graphics::ResizeDisplayDependentBuffers(uint32_t NativeWidth, uint32_t NativeHeight)
 {
     g_OverlayBuffer.Create( L"UI Overlay", g_DisplayWidth, g_DisplayHeight, 1, DXGI_FORMAT_R8G8B8A8_UNORM );
     g_HorizontalBuffer.Create( L"Bicubic Intermediate", g_DisplayWidth, NativeHeight, 1, DefaultHdrColorFormat );
 }
+#pragma warning(pop)
 
 void Graphics::DestroyRenderingBuffers()
 {

--- a/MiniEngine/Core/BufferManager.cpp
+++ b/MiniEngine/Core/BufferManager.cpp
@@ -231,7 +231,7 @@ void Graphics::InitializeRenderingBuffers( uint32_t bufferWidth, uint32_t buffer
 }
 
 #pragma warning(push)
-#pragma warning(disable : 4100)	// NativeWidth is not referenced, but retaining for clarity
+#pragma warning(disable : 4100)   // NativeWidth is not referenced, but retaining for clarity
 void Graphics::ResizeDisplayDependentBuffers(uint32_t NativeWidth, uint32_t NativeHeight)
 {
     g_OverlayBuffer.Create( L"UI Overlay", g_DisplayWidth, g_DisplayHeight, 1, DXGI_FORMAT_R8G8B8A8_UNORM );

--- a/MiniEngine/Core/CommandContext.cpp
+++ b/MiniEngine/Core/CommandContext.cpp
@@ -526,7 +526,8 @@ void CommandContext::ReadbackTexture2D(GpuResource& ReadbackBuffer, PixelBuffer&
 {
     // The footprint may depend on the device of the resource, but we assume there is only one device.
     D3D12_PLACED_SUBRESOURCE_FOOTPRINT PlacedFootprint;
-    g_Device->GetCopyableFootprints(&SrcBuffer.GetResource()->GetDesc(), 0, 1, 0, &PlacedFootprint, nullptr, nullptr, nullptr);
+	D3D12_RESOURCE_DESC SrcResourceDesc = SrcBuffer.GetResource()->GetDesc();
+    g_Device->GetCopyableFootprints(&SrcResourceDesc, 0, 1, 0, &PlacedFootprint, nullptr, nullptr, nullptr);
 
     // This very short command list only issues one API call and will be synchronized so we can immediately read
     // the buffer contents.
@@ -534,9 +535,9 @@ void CommandContext::ReadbackTexture2D(GpuResource& ReadbackBuffer, PixelBuffer&
 
     Context.TransitionResource(SrcBuffer, D3D12_RESOURCE_STATE_COPY_SOURCE, true);
 
-    Context.m_CommandList->CopyTextureRegion(
-        &CD3DX12_TEXTURE_COPY_LOCATION(ReadbackBuffer.GetResource(), PlacedFootprint), 0, 0, 0,
-        &CD3DX12_TEXTURE_COPY_LOCATION(SrcBuffer.GetResource(), 0), nullptr);
+	CD3DX12_TEXTURE_COPY_LOCATION ReadbackCopyLocation(ReadbackBuffer.GetResource(), PlacedFootprint);
+	CD3DX12_TEXTURE_COPY_LOCATION SrcCopyLocation(SrcBuffer.GetResource(), 0);
+    Context.m_CommandList->CopyTextureRegion(&ReadbackCopyLocation, 0, 0, 0, &SrcCopyLocation, nullptr);
 
     Context.Finish(true);
 }

--- a/MiniEngine/Core/CommandContext.cpp
+++ b/MiniEngine/Core/CommandContext.cpp
@@ -526,7 +526,7 @@ void CommandContext::ReadbackTexture2D(GpuResource& ReadbackBuffer, PixelBuffer&
 {
     // The footprint may depend on the device of the resource, but we assume there is only one device.
     D3D12_PLACED_SUBRESOURCE_FOOTPRINT PlacedFootprint;
-	D3D12_RESOURCE_DESC SrcResourceDesc = SrcBuffer.GetResource()->GetDesc();
+    D3D12_RESOURCE_DESC SrcResourceDesc = SrcBuffer.GetResource()->GetDesc();
     g_Device->GetCopyableFootprints(&SrcResourceDesc, 0, 1, 0, &PlacedFootprint, nullptr, nullptr, nullptr);
 
     // This very short command list only issues one API call and will be synchronized so we can immediately read
@@ -535,8 +535,8 @@ void CommandContext::ReadbackTexture2D(GpuResource& ReadbackBuffer, PixelBuffer&
 
     Context.TransitionResource(SrcBuffer, D3D12_RESOURCE_STATE_COPY_SOURCE, true);
 
-	CD3DX12_TEXTURE_COPY_LOCATION ReadbackCopyLocation(ReadbackBuffer.GetResource(), PlacedFootprint);
-	CD3DX12_TEXTURE_COPY_LOCATION SrcCopyLocation(SrcBuffer.GetResource(), 0);
+    CD3DX12_TEXTURE_COPY_LOCATION ReadbackCopyLocation(ReadbackBuffer.GetResource(), PlacedFootprint);
+    CD3DX12_TEXTURE_COPY_LOCATION SrcCopyLocation(SrcBuffer.GetResource(), 0);
     Context.m_CommandList->CopyTextureRegion(&ReadbackCopyLocation, 0, 0, 0, &SrcCopyLocation, nullptr);
 
     Context.Finish(true);

--- a/MiniEngine/Core/DepthBuffer.cpp
+++ b/MiniEngine/Core/DepthBuffer.cpp
@@ -45,7 +45,7 @@ void DepthBuffer::Create( const std::wstring& Name, uint32_t Width, uint32_t Hei
     Create(Name, Width, Height, Format);
 }
 
-void DepthBuffer::Create( const std::wstring& Name, uint32_t Width, uint32_t Height, uint32_t Samples, DXGI_FORMAT Format, EsramAllocator& Allocator )
+void DepthBuffer::Create( const std::wstring& Name, uint32_t Width, uint32_t Height, uint32_t Samples, DXGI_FORMAT Format, EsramAllocator& )
 {
     Create(Name, Width, Height, Samples, Format);
 }

--- a/MiniEngine/Core/GameCore.h
+++ b/MiniEngine/Core/GameCore.h
@@ -52,7 +52,7 @@ namespace GameCore
 #define CREATE_APPLICATION( app_class ) \
     MAIN_FUNCTION() \
     { \
-		app_class app; \
+        app_class app; \
         GameCore::RunApplication( static_cast<IGameApp&>(app), L#app_class ); \
         return 0; \
     }

--- a/MiniEngine/Core/GameCore.h
+++ b/MiniEngine/Core/GameCore.h
@@ -44,7 +44,7 @@ namespace GameCore
 }
 
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-    #define MAIN_FUNCTION()  int wmain(int argc, wchar_t** argv)
+    #define MAIN_FUNCTION()  int wmain(int, wchar_t**)
 #else
     #define MAIN_FUNCTION()  [Platform::MTAThread] int main(Platform::Array<Platform::String^>^)
 #endif

--- a/MiniEngine/Core/GameCore.h
+++ b/MiniEngine/Core/GameCore.h
@@ -52,6 +52,7 @@ namespace GameCore
 #define CREATE_APPLICATION( app_class ) \
     MAIN_FUNCTION() \
     { \
-        GameCore::RunApplication( app_class(), L#app_class ); \
+		app_class app; \
+        GameCore::RunApplication( static_cast<IGameApp&>(app), L#app_class ); \
         return 0; \
     }

--- a/MiniEngine/Core/ReadbackBuffer.cpp
+++ b/MiniEngine/Core/ReadbackBuffer.cpp
@@ -63,11 +63,15 @@ void ReadbackBuffer::Create( const std::wstring& name, uint32_t NumElements, uin
 void* ReadbackBuffer::Map(void)
 {
     void* Memory;
-    m_pResource->Map(0, &CD3DX12_RANGE(0, m_BufferSize), &Memory);
+
+	CD3DX12_RANGE Range(0, m_BufferSize);
+    m_pResource->Map(0, &Range, &Memory);
+
     return Memory;
 }
 
 void ReadbackBuffer::Unmap(void)
 {
-    m_pResource->Unmap(0, &CD3DX12_RANGE(0, 0));
+	CD3DX12_RANGE Range(0, 0);
+    m_pResource->Unmap(0, &Range);
 }

--- a/MiniEngine/Core/ReadbackBuffer.cpp
+++ b/MiniEngine/Core/ReadbackBuffer.cpp
@@ -64,7 +64,7 @@ void* ReadbackBuffer::Map(void)
 {
     void* Memory;
 
-	CD3DX12_RANGE Range(0, m_BufferSize);
+    CD3DX12_RANGE Range(0, m_BufferSize);
     m_pResource->Map(0, &Range, &Memory);
 
     return Memory;
@@ -72,6 +72,6 @@ void* ReadbackBuffer::Map(void)
 
 void ReadbackBuffer::Unmap(void)
 {
-	CD3DX12_RANGE Range(0, 0);
+    CD3DX12_RANGE Range(0, 0);
     m_pResource->Unmap(0, &Range);
 }

--- a/MiniEngine/ModelConverter/IndexOptimizePostTransform.cpp
+++ b/MiniEngine/ModelConverter/IndexOptimizePostTransform.cpp
@@ -252,7 +252,7 @@ void OptimizeFaces(const IndexType* indexList, uint32_t indexCount, IndexType* n
                 || sortFunc(indexSorted[i - 1], indexSorted[i]))
             {
                 // it's not a duplicate
-                vertexRemap[indexSorted[i]] = uniqueVertexCount;
+                vertexRemap[indexSorted[i]] = static_cast<IndexType>(uniqueVertexCount);
                 uniqueVertexCount++;
             }
             else

--- a/MiniEngine/ModelConverter/ModelAssimp.cpp
+++ b/MiniEngine/ModelConverter/ModelAssimp.cpp
@@ -230,35 +230,35 @@ bool AssimpModel::LoadAssimp(const char *filename)
 
         // just store everything as float. Can quantize in Model::optimize()
         dstMesh->attribsEnabled |= attrib_mask_position;
-        dstMesh->attrib[attrib_position].offset = dstMesh->vertexStride;
+        dstMesh->attrib[attrib_position].offset = static_cast<uint16_t>(dstMesh->vertexStride);
         dstMesh->attrib[attrib_position].normalized = 0;
         dstMesh->attrib[attrib_position].components = 3;
         dstMesh->attrib[attrib_position].format = attrib_format_float;
         dstMesh->vertexStride += sizeof(float) * 3;
 
         dstMesh->attribsEnabled |= attrib_mask_texcoord0;
-        dstMesh->attrib[attrib_texcoord0].offset = dstMesh->vertexStride;
+        dstMesh->attrib[attrib_texcoord0].offset = static_cast<uint16_t>(dstMesh->vertexStride);
         dstMesh->attrib[attrib_texcoord0].normalized = 0;
         dstMesh->attrib[attrib_texcoord0].components = 2;
         dstMesh->attrib[attrib_texcoord0].format = attrib_format_float;
         dstMesh->vertexStride += sizeof(float) * 2;
 
         dstMesh->attribsEnabled |= attrib_mask_normal;
-        dstMesh->attrib[attrib_normal].offset = dstMesh->vertexStride;
+        dstMesh->attrib[attrib_normal].offset = static_cast<uint16_t>(dstMesh->vertexStride);
         dstMesh->attrib[attrib_normal].normalized = 0;
         dstMesh->attrib[attrib_normal].components = 3;
         dstMesh->attrib[attrib_normal].format = attrib_format_float;
         dstMesh->vertexStride += sizeof(float) * 3;
 
         dstMesh->attribsEnabled |= attrib_mask_tangent;
-        dstMesh->attrib[attrib_tangent].offset = dstMesh->vertexStride;
+        dstMesh->attrib[attrib_tangent].offset = static_cast<uint16_t>(dstMesh->vertexStride);
         dstMesh->attrib[attrib_tangent].normalized = 0;
         dstMesh->attrib[attrib_tangent].components = 3;
         dstMesh->attrib[attrib_tangent].format = attrib_format_float;
         dstMesh->vertexStride += sizeof(float) * 3;
 
         dstMesh->attribsEnabled |= attrib_mask_bitangent;
-        dstMesh->attrib[attrib_bitangent].offset = dstMesh->vertexStride;
+        dstMesh->attrib[attrib_bitangent].offset = static_cast<uint16_t>(dstMesh->vertexStride);
         dstMesh->attrib[attrib_bitangent].normalized = 0;
         dstMesh->attrib[attrib_bitangent].components = 3;
         dstMesh->attrib[attrib_bitangent].format = attrib_format_float;
@@ -266,7 +266,7 @@ bool AssimpModel::LoadAssimp(const char *filename)
 
         // depth-only
         dstMesh->attribsEnabledDepth |= attrib_mask_position;
-        dstMesh->attribDepth[attrib_position].offset = dstMesh->vertexStrideDepth;
+        dstMesh->attribDepth[attrib_position].offset = static_cast<uint16_t>(dstMesh->vertexStrideDepth);
         dstMesh->attribDepth[attrib_position].normalized = 0;
         dstMesh->attribDepth[attrib_position].components = 3;
         dstMesh->attribDepth[attrib_position].format = attrib_format_float;
@@ -390,13 +390,13 @@ bool AssimpModel::LoadAssimp(const char *filename)
         {
             assert(srcMesh->mFaces[f].mNumIndices == 3);
 
-            *dstIndex++ = srcMesh->mFaces[f].mIndices[0];
-            *dstIndex++ = srcMesh->mFaces[f].mIndices[1];
-            *dstIndex++ = srcMesh->mFaces[f].mIndices[2];
+            *dstIndex++ = static_cast<uint16_t>(srcMesh->mFaces[f].mIndices[0]);
+            *dstIndex++ = static_cast<uint16_t>(srcMesh->mFaces[f].mIndices[1]);
+            *dstIndex++ = static_cast<uint16_t>(srcMesh->mFaces[f].mIndices[2]);
 
-            *dstIndexDepth++ = srcMesh->mFaces[f].mIndices[0];
-            *dstIndexDepth++ = srcMesh->mFaces[f].mIndices[1];
-            *dstIndexDepth++ = srcMesh->mFaces[f].mIndices[2];
+            *dstIndexDepth++ = static_cast<uint16_t>(srcMesh->mFaces[f].mIndices[0]);
+            *dstIndexDepth++ = static_cast<uint16_t>(srcMesh->mFaces[f].mIndices[1]);
+            *dstIndexDepth++ = static_cast<uint16_t>(srcMesh->mFaces[f].mIndices[2]);
         }
     }
 

--- a/MiniEngine/ModelConverter/ModelConvert.cpp
+++ b/MiniEngine/ModelConverter/ModelConvert.cpp
@@ -105,7 +105,7 @@ void PrintModelStats(const Model *model)
     {
         const Model::Material *material = model->m_pMaterial + materialIndex;
 
-        printf("material %u\n", materialIndex);
+        printf("material %u: %s\n", materialIndex, material->name);
     }
     printf("\n");
 }

--- a/MiniEngine/ModelConverter/ModelOptimize.cpp
+++ b/MiniEngine/ModelConverter/ModelOptimize.cpp
@@ -66,7 +66,7 @@ void AssimpModel::OptimizeRemoveDuplicateVertices(bool depth)
         uint16_t *indexArray = (uint16_t*)((depth ? m_pIndexDataDepth : m_pIndexData) + mesh->indexDataByteOffset);
         for (unsigned int n = 0; n < indexCount; n++)
         {
-            indexArray[n] = vertexRemap[indexArray[n]];
+            indexArray[n] = static_cast<uint16_t>(vertexRemap[indexArray[n]]);
         }
 
         delete [] vertexRemap;
@@ -149,7 +149,7 @@ void AssimpModel::OptimizePreTransform(bool depth)
                 vertexRemap[index] = reorderedCount;
                 reorderedCount++;
             }
-            indexArray[n] = vertexRemap[index];
+            indexArray[n] = static_cast<uint16_t>(vertexRemap[index]);
         }
 
         delete [] vertexRemap;

--- a/MiniEngine/ModelViewer/ModelViewer.cpp
+++ b/MiniEngine/ModelViewer/ModelViewer.cpp
@@ -135,7 +135,6 @@ void ModelViewer::Startup( void )
 
     DXGI_FORMAT ColorFormat = g_SceneColorBuffer.GetFormat();
     DXGI_FORMAT DepthFormat = g_SceneDepthBuffer.GetFormat();
-	DXGI_FORMAT ShadowFormat = g_ShadowBuffer.GetFormat();
 
     D3D12_INPUT_ELEMENT_DESC vertElem[] =
     {

--- a/MiniEngine/ModelViewer/ModelViewer.cpp
+++ b/MiniEngine/ModelViewer/ModelViewer.cpp
@@ -135,7 +135,7 @@ void ModelViewer::Startup( void )
 
     DXGI_FORMAT ColorFormat = g_SceneColorBuffer.GetFormat();
     DXGI_FORMAT DepthFormat = g_SceneDepthBuffer.GetFormat();
-    DXGI_FORMAT ShadowFormat = g_ShadowBuffer.GetFormat();
+	DXGI_FORMAT ShadowFormat = g_ShadowBuffer.GetFormat();
 
     D3D12_INPUT_ELEMENT_DESC vertElem[] =
     {
@@ -442,7 +442,7 @@ void ModelViewer::RenderScene( void )
         gfxContext.SetDynamicConstantBufferView(1, sizeof(psConstants), &psConstants);
 
         {
-            ScopedTimer _prof(L"Opaque", gfxContext);
+            ScopedTimer _prof_opaque(L"Opaque", gfxContext);
             gfxContext.TransitionResource(g_SceneDepthBuffer, D3D12_RESOURCE_STATE_DEPTH_WRITE, true);
             gfxContext.ClearDepth(g_SceneDepthBuffer);
 
@@ -457,7 +457,7 @@ void ModelViewer::RenderScene( void )
         }
 
         {
-            ScopedTimer _prof(L"Cutout", gfxContext);
+            ScopedTimer _prof_cutout(L"Cutout", gfxContext);
             gfxContext.SetPipelineState(m_CutoutDepthPSO);
             RenderObjects(gfxContext, m_ViewProjMatrix, kCutout );
         }
@@ -477,7 +477,7 @@ void ModelViewer::RenderScene( void )
         pfnSetupGraphicsState();
 
         {
-            ScopedTimer _prof(L"Render Shadow Map", gfxContext);
+            ScopedTimer _prof_sm(L"Render Shadow Map", gfxContext);
 
             m_SunShadow.UpdateMatrix(-m_SunDirection, Vector3(0, -500.0f, 0), Vector3(ShadowDimX, ShadowDimY, ShadowDimZ),
                 (uint32_t)g_ShadowBuffer.GetWidth(), (uint32_t)g_ShadowBuffer.GetHeight(), 16);
@@ -500,7 +500,7 @@ void ModelViewer::RenderScene( void )
         }
 
         {
-            ScopedTimer _prof(L"Render Color", gfxContext);
+            ScopedTimer _prof_col(L"Render Color", gfxContext);
 
             gfxContext.TransitionResource(g_SSAOFullScreen, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
 

--- a/MiniEngine/ModelViewer/ModelViewer.cpp
+++ b/MiniEngine/ModelViewer/ModelViewer.cpp
@@ -424,7 +424,7 @@ void ModelViewer::RenderScene( void )
     psConstants.FrameIndexMod2 = FrameIndex;
 
     // Set the default state for command lists
-    auto& pfnSetupGraphicsState = [&](void)
+    auto pfnSetupGraphicsState = [&](void)
     {
         gfxContext.SetRootSignature(m_RootSig);
         gfxContext.SetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);

--- a/MiniEngine/Tools/SDFFontCreator/SDFFontCreator.cpp
+++ b/MiniEngine/Tools/SDFFontCreator/SDFFontCreator.cpp
@@ -274,8 +274,8 @@ uint32_t UnwrapUVs(uint32_t textureWidth)
         }
 
         // The actual character UVs don't include the border pixels
-		g_glyphs[i].u = static_cast<uint16_t>(x);
-		g_glyphs[i].v = static_cast<uint16_t>(y);
+        g_glyphs[i].u = static_cast<uint16_t>(x);
+        g_glyphs[i].v = static_cast<uint16_t>(y);
 
         x += deltaX + glyphBorder;
     }
@@ -445,8 +445,8 @@ void CompileFont(const string& outputName)
             if (wc >= L'0' && wc <= L'9')
             {
                 int extraSpace = numberWidth - g_glyphs[i].width;
-				g_glyphs[i].bearing = static_cast<uint16_t>(extraSpace) / 2U;
-				g_glyphs[i].advance = static_cast<uint16_t>(numberWidth);
+                g_glyphs[i].bearing = static_cast<uint16_t>(extraSpace) / 2U;
+                g_glyphs[i].advance = static_cast<uint16_t>(numberWidth);
             }
         }
     }

--- a/MiniEngine/Tools/SDFFontCreator/SDFFontCreator.cpp
+++ b/MiniEngine/Tools/SDFFontCreator/SDFFontCreator.cpp
@@ -397,7 +397,7 @@ void WritePreviewBMP(const string& fileName, const uint8_t* heightMap, uint32_t 
     file.close();
 }
 
-void CompileFont(const string& inputFile, uint32_t size, const string& outputName)
+void CompileFont(const string& outputName)
 {
     // Figure out how many threads to create, and then spawn them.  Leave their parameters blank.  We'll fill them in
     // before they're read.
@@ -682,7 +682,7 @@ void main( int argc, const char** argv )
                 g_glyphs[g_numGlyphs++].c = *it;
         }
 
-        CompileFont(inputFile, size, outputName);
+        CompileFont(outputName);
 
         printf("\nComplete!\n");
         //printf("Elapsed Time: %g sec\n", t.getElapsed());

--- a/MiniEngine/Tools/SDFFontCreator/SDFFontCreator.cpp
+++ b/MiniEngine/Tools/SDFFontCreator/SDFFontCreator.cpp
@@ -274,8 +274,8 @@ uint32_t UnwrapUVs(uint32_t textureWidth)
         }
 
         // The actual character UVs don't include the border pixels
-        g_glyphs[i].u = x;
-        g_glyphs[i].v = y;
+		g_glyphs[i].u = static_cast<uint16_t>(x);
+		g_glyphs[i].v = static_cast<uint16_t>(y);
 
         x += deltaX + glyphBorder;
     }
@@ -283,7 +283,7 @@ uint32_t UnwrapUVs(uint32_t textureWidth)
     return (y + rowSize + glyphBorder) / 16;
 }
 
-void PaintCharacters( float* distanceMap, uint32_t width, uint32_t height )
+void PaintCharacters( float* distanceMap, uint32_t width, uint32_t /*height*/ )
 {
     int32_t i = -1;
     while ((i = _InterlockedExchangeAdd((volatile long*)&g_nextGlyphIdx, 1)) < g_numGlyphs)
@@ -445,8 +445,8 @@ void CompileFont(const string& outputName)
             if (wc >= L'0' && wc <= L'9')
             {
                 int extraSpace = numberWidth - g_glyphs[i].width;
-                g_glyphs[i].bearing = extraSpace / 2;
-                g_glyphs[i].advance = numberWidth;
+				g_glyphs[i].bearing = static_cast<uint16_t>(extraSpace) / 2U;
+				g_glyphs[i].advance = static_cast<uint16_t>(numberWidth);
             }
         }
     }
@@ -552,7 +552,6 @@ void main( int argc, const char** argv )
     string characterSet = "ASCII";
     uint32_t size = 32;
     bool extendedASCII = false;
-    bool verbose = true;
     
     try
     {
@@ -574,9 +573,9 @@ void main( int argc, const char** argv )
             else if (strcmp("-character_set", argv[arg]) == 0)
                 characterSet = argv[++arg];
             else if (strcmp("-border", argv[arg]) == 0)
-                g_borderSize = atoi(argv[++arg]);
+                g_borderSize = static_cast<uint16_t>(atoi(argv[++arg]));
             else if (strcmp("-radius", argv[arg]) == 0)
-                g_maxDistance = atoi(argv[++arg]);
+                g_maxDistance = static_cast<uint16_t>(atoi(argv[++arg]));
             else
                 throw exception("Invalid option");
         }

--- a/MiniEngine/Tools/Scripts/ProjectTemplates/Main.cpp
+++ b/MiniEngine/Tools/Scripts/ProjectTemplates/Main.cpp
@@ -41,7 +41,7 @@ void TEMPLATE_NAME::Cleanup( void )
     // Free up resources in an orderly fashion
 }
 
-void TEMPLATE_NAME::Update( float deltaT )
+void TEMPLATE_NAME::Update( float /* deltaT */)
 {
     ScopedTimer _prof(L"Update State");
 


### PR DESCRIPTION
Address all warnings to allow compilation of all MiniEngine components under /W4/WX.

I have tried to make changes as minimal as possible and there are no functional effects.  Commits split by warning type to make the changes a little clearer