### PR TITLE
Use ProjectName macro to copy dll

### DIFF
--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingHelloWorld/D3D12RaytracingHelloWorld.vcxproj
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingHelloWorld/D3D12RaytracingHelloWorld.vcxproj
@@ -90,7 +90,7 @@
     </FxCompile>
     <PostBuildEvent>
       <Command>cd "$(SolutionDir)..\tools\x64\"
-PostbuildCopy.bat "$(SolutionDir)D3D12RaytracingHelloWorld\bin\$(Platform)\$(Configuration)\"</Command>
+PostbuildCopy.bat "$(SolutionDir)$(ProjectName)\bin\$(Platform)\$(Configuration)\"</Command>
       <Message>Sideloading DXR Fallback Compiler.</Message>
     </PostBuildEvent>
     <PreLinkEvent>
@@ -143,7 +143,7 @@ PrebuildCheck.bat</Command>
     </FxCompile>
     <PostBuildEvent>
       <Command>cd "$(SolutionDir)..\tools\x64\"
-PostbuildCopy.bat "$(SolutionDir)D3D12RaytracingHelloWorld\bin\$(Platform)\$(Configuration)\"</Command>
+PostbuildCopy.bat "$(SolutionDir)$(ProjectName)\bin\$(Platform)\$(Configuration)\"</Command>
       <Message>Sideloading DXR Fallback Compiler.</Message>
     </PostBuildEvent>
     <PreBuildEvent>

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/ModelViewer_VS15.vcxproj
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/ModelViewer_VS15.vcxproj
@@ -218,17 +218,17 @@
     </Link>
     <PostBuildEvent>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">cd "$(SolutionDir)..\tools\x64\"
-PostbuildCopy.bat "$(SolutionDir)D3D12RaytracingMiniEngineSample\"</Command>
+PostbuildCopy.bat "$(SolutionDir)$(ProjectName)\"</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Sideloading DXR Fallback Compiler.</Message>
     </PostBuildEvent>
     <PostBuildEvent>
       <Command Condition="'$(Configuration)|$(Platform)'=='Profile|x64'">cd "$(SolutionDir)..\tools\x64\"
-PostbuildCopy.bat "$(SolutionDir)D3D12RaytracingMiniEngineSample\"</Command>
+PostbuildCopy.bat "$(SolutionDir)$(ProjectName)\"</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Profile|x64'">Sideloading DXR Fallback Compiler.</Message>
     </PostBuildEvent>
     <PostBuildEvent>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">cd "$(SolutionDir)..\tools\x64\"
-PostbuildCopy.bat "$(SolutionDir)D3D12RaytracingMiniEngineSample\"</Command>
+PostbuildCopy.bat "$(SolutionDir)$(ProjectName)\"</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Sideloading DXR Fallback Compiler.</Message>
     </PostBuildEvent>
     <ProjectReference>

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingProceduralGeometry/D3D12RaytracingProceduralGeometry.vcxproj
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingProceduralGeometry/D3D12RaytracingProceduralGeometry.vcxproj
@@ -92,7 +92,7 @@
     </FxCompile>
     <PostBuildEvent>
       <Command>cd "$(SolutionDir)..\tools\x64\"
-PostbuildCopy.bat "$(SolutionDir)D3D12RaytracingProceduralGeometry\bin\$(Platform)\$(Configuration)\"</Command>
+PostbuildCopy.bat "$(SolutionDir)$(ProjectName)\bin\$(Platform)\$(Configuration)\"</Command>
       <Message>Sideloading DXR Fallback Compiler.</Message>
     </PostBuildEvent>
     <PreLinkEvent>
@@ -145,7 +145,7 @@ PrebuildCheck.bat</Command>
     </FxCompile>
     <PostBuildEvent>
       <Command>cd "$(SolutionDir)..\tools\x64\"
-PostbuildCopy.bat "$(SolutionDir)D3D12RaytracingProceduralGeometry\bin\$(Platform)\$(Configuration)\"</Command>
+PostbuildCopy.bat "$(SolutionDir)$(ProjectName)\bin\$(Platform)\$(Configuration)\"</Command>
       <Message>Sideloading DXR Fallback Compiler.</Message>
     </PostBuildEvent>
     <PreBuildEvent>

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/D3D12RaytracingSimpleLighting.vcxproj
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/D3D12RaytracingSimpleLighting.vcxproj
@@ -92,7 +92,7 @@
     </FxCompile>
     <PostBuildEvent>
       <Command>cd "$(SolutionDir)..\tools\x64\"
-PostbuildCopy.bat "$(SolutionDir)D3D12RaytracingSimpleLighting\bin\$(Platform)\$(Configuration)\"</Command>
+PostbuildCopy.bat "$(SolutionDir)$(ProjectName)\bin\$(Platform)\$(Configuration)\"</Command>
       <Message>Sideloading DXR Fallback Compiler.</Message>
     </PostBuildEvent>
     <PreLinkEvent>
@@ -145,7 +145,7 @@ PrebuildCheck.bat</Command>
     </FxCompile>
     <PostBuildEvent>
       <Command>cd "$(SolutionDir)..\tools\x64\"
-PostbuildCopy.bat "$(SolutionDir)D3D12RaytracingSimpleLighting\bin\$(Platform)\$(Configuration)\"</Command>
+PostbuildCopy.bat "$(SolutionDir)$(ProjectName)\bin\$(Platform)\$(Configuration)\"</Command>
       <Message>Sideloading DXR Fallback Compiler.</Message>
     </PostBuildEvent>
     <PreBuildEvent>


### PR DESCRIPTION
I think it is consistent to use `$(ProjectName)` to copy dxfallbackcompiler.dll into project's bin directory.
