### PR TITLE
Samples to support device removal and GPU enumeration by preference

### DIFF
--- a/Samples/Desktop/D3D1211On12/src/D3D1211On12.cpp
+++ b/Samples/Desktop/D3D1211On12/src/D3D1211On12.cpp
@@ -13,388 +13,391 @@
 #include "D3D1211On12.h"
 
 D3D1211on12::D3D1211on12(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0),
-    m_fenceValues{}
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0),
+	m_fenceValues{}
 {
 }
 
 void D3D1211on12::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D1211on12::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
-    UINT d3d11DeviceFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
-    D2D1_FACTORY_OPTIONS d2dFactoryOptions = {};
+	UINT dxgiFactoryFlags = 0;
+	UINT d3d11DeviceFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
+	D2D1_FACTORY_OPTIONS d2dFactoryOptions = {};
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-            d3d11DeviceFlags |= D3D11_CREATE_DEVICE_DEBUG;
-            d2dFactoryOptions.debugLevel = D2D1_DEBUG_LEVEL_INFORMATION;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+			d3d11DeviceFlags |= D3D11_CREATE_DEVICE_DEBUG;
+			d2dFactoryOptions.debugLevel = D2D1_DEBUG_LEVEL_INFORMATION;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_d3d12Device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_d3d12Device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_d3d12Device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_d3d12Device)
+			));
+	}
 
 #if defined(_DEBUG)
-    // Filter a debug error coming from the 11on12 layer.
-    ComPtr<ID3D12InfoQueue> infoQueue;
-    if (SUCCEEDED(m_d3d12Device->QueryInterface(IID_PPV_ARGS(&infoQueue))))
-    {
-        // Suppress whole categories of messages.
-        //D3D12_MESSAGE_CATEGORY categories[] = {};
+	// Filter a debug error coming from the 11on12 layer.
+	ComPtr<ID3D12InfoQueue> infoQueue;
+	if (SUCCEEDED(m_d3d12Device->QueryInterface(IID_PPV_ARGS(&infoQueue))))
+	{
+		// Suppress whole categories of messages.
+		//D3D12_MESSAGE_CATEGORY categories[] = {};
 
-        // Suppress messages based on their severity level.
-        D3D12_MESSAGE_SEVERITY severities[] =
-        {
-            D3D12_MESSAGE_SEVERITY_INFO,
-        };
+		// Suppress messages based on their severity level.
+		D3D12_MESSAGE_SEVERITY severities[] =
+		{
+			D3D12_MESSAGE_SEVERITY_INFO,
+		};
 
-        // Suppress individual messages by their ID.
-        D3D12_MESSAGE_ID denyIds[] =
-        {
-            // This occurs when there are uninitialized descriptors in a descriptor table, even when a
-            // shader does not access the missing descriptors.
-            D3D12_MESSAGE_ID_INVALID_DESCRIPTOR_HANDLE,
-        };
+		// Suppress individual messages by their ID.
+		D3D12_MESSAGE_ID denyIds[] =
+		{
+			// This occurs when there are uninitialized descriptors in a descriptor table, even when a
+			// shader does not access the missing descriptors.
+			D3D12_MESSAGE_ID_INVALID_DESCRIPTOR_HANDLE,
+		};
 
-        D3D12_INFO_QUEUE_FILTER filter = {};
-        //filter.DenyList.NumCategories = _countof(categories);
-        //filter.DenyList.pCategoryList = categories;
-        filter.DenyList.NumSeverities = _countof(severities);
-        filter.DenyList.pSeverityList = severities;
-        filter.DenyList.NumIDs = _countof(denyIds);
-        filter.DenyList.pIDList = denyIds;
+		D3D12_INFO_QUEUE_FILTER filter = {};
+		//filter.DenyList.NumCategories = _countof(categories);
+		//filter.DenyList.pCategoryList = categories;
+		filter.DenyList.NumSeverities = _countof(severities);
+		filter.DenyList.pSeverityList = severities;
+		filter.DenyList.NumIDs = _countof(denyIds);
+		filter.DenyList.pIDList = denyIds;
 
-        ThrowIfFailed(infoQueue->PushStorageFilter(&filter));
-    }
+		ThrowIfFailed(infoQueue->PushStorageFilter(&filter));
+	}
 #endif
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_d3d12Device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
-    NAME_D3D12_OBJECT(m_commandQueue);
+	ThrowIfFailed(m_d3d12Device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	NAME_D3D12_OBJECT(m_commandQueue);
 
-    // Describe the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    // This sample does not support fullscreen transitions.
-    ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
+	// This sample does not support fullscreen transitions.
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create an 11 device wrapped around the 12 device and share
-    // 12's command queue.
-    ComPtr<ID3D11Device> d3d11Device;
-    ThrowIfFailed(D3D11On12CreateDevice(
-        m_d3d12Device.Get(),
-        d3d11DeviceFlags,
-        nullptr,
-        0,
-        reinterpret_cast<IUnknown**>(m_commandQueue.GetAddressOf()),
-        1,
-        0,
-        &d3d11Device,
-        &m_d3d11DeviceContext,
-        nullptr
-        ));
+	// Create an 11 device wrapped around the 12 device and share
+	// 12's command queue.
+	ComPtr<ID3D11Device> d3d11Device;
+	ThrowIfFailed(D3D11On12CreateDevice(
+		m_d3d12Device.Get(),
+		d3d11DeviceFlags,
+		nullptr,
+		0,
+		reinterpret_cast<IUnknown**>(m_commandQueue.GetAddressOf()),
+		1,
+		0,
+		&d3d11Device,
+		&m_d3d11DeviceContext,
+		nullptr
+		));
 
-    // Query the 11On12 device from the 11 device.
-    ThrowIfFailed(d3d11Device.As(&m_d3d11On12Device));
+	// Query the 11On12 device from the 11 device.
+	ThrowIfFailed(d3d11Device.As(&m_d3d11On12Device));
 
-    // Create D2D/DWrite components.
-    {
-        D2D1_DEVICE_CONTEXT_OPTIONS deviceOptions = D2D1_DEVICE_CONTEXT_OPTIONS_NONE;
-        ThrowIfFailed(D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, __uuidof(ID2D1Factory3), &d2dFactoryOptions, &m_d2dFactory));
-        ComPtr<IDXGIDevice> dxgiDevice;
-        ThrowIfFailed(m_d3d11On12Device.As(&dxgiDevice));
-        ThrowIfFailed(m_d2dFactory->CreateDevice(dxgiDevice.Get(), &m_d2dDevice));
-        ThrowIfFailed(m_d2dDevice->CreateDeviceContext(deviceOptions, &m_d2dDeviceContext));
-        ThrowIfFailed(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &m_dWriteFactory));
-    }
+	// Create D2D/DWrite components.
+	{
+		D2D1_DEVICE_CONTEXT_OPTIONS deviceOptions = D2D1_DEVICE_CONTEXT_OPTIONS_NONE;
+		ThrowIfFailed(D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, __uuidof(ID2D1Factory3), &d2dFactoryOptions, &m_d2dFactory));
+		ComPtr<IDXGIDevice> dxgiDevice;
+		ThrowIfFailed(m_d3d11On12Device.As(&dxgiDevice));
+		ThrowIfFailed(m_d2dFactory->CreateDevice(dxgiDevice.Get(), &m_d2dDevice));
+		ThrowIfFailed(m_d2dDevice->CreateDeviceContext(deviceOptions, &m_d2dDeviceContext));
+		ThrowIfFailed(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &m_dWriteFactory));
+	}
 
-    // Query the desktop's dpi settings, which will be used to create
-    // D2D's render targets.
-    float dpiX;
-    float dpiY;
-    m_d2dFactory->GetDesktopDpi(&dpiX, &dpiY);
-    D2D1_BITMAP_PROPERTIES1 bitmapProperties = D2D1::BitmapProperties1(
-        D2D1_BITMAP_OPTIONS_TARGET | D2D1_BITMAP_OPTIONS_CANNOT_DRAW,
-        D2D1::PixelFormat(DXGI_FORMAT_UNKNOWN, D2D1_ALPHA_MODE_PREMULTIPLIED),
-        dpiX,
-        dpiY
-        );
+	// Query the desktop's dpi settings, which will be used to create
+	// D2D's render targets.
+	float dpiX;
+	float dpiY;
+#pragma warning(push)
+#pragma warning(disable : 4996) // GetDesktopDpi is deprecated.
+	m_d2dFactory->GetDesktopDpi(&dpiX, &dpiY);
+#pragma warning(pop)
+	D2D1_BITMAP_PROPERTIES1 bitmapProperties = D2D1::BitmapProperties1(
+		D2D1_BITMAP_OPTIONS_TARGET | D2D1_BITMAP_OPTIONS_CANNOT_DRAW,
+		D2D1::PixelFormat(DXGI_FORMAT_UNKNOWN, D2D1_ALPHA_MODE_PREMULTIPLIED),
+		dpiX,
+		dpiY
+		);
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_d3d12Device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_d3d12Device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        m_rtvDescriptorSize = m_d3d12Device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    }
+		m_rtvDescriptorSize = m_d3d12Device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV, D2D render target, and a command allocator for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_d3d12Device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+		// Create a RTV, D2D render target, and a command allocator for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_d3d12Device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
 
-            NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
+			NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
 
-            // Create a wrapped 11On12 resource of this back buffer. Since we are 
-            // rendering all D3D12 content first and then all D2D content, we specify 
-            // the In resource state as RENDER_TARGET - because D3D12 will have last 
-            // used it in this state - and the Out resource state as PRESENT. When 
-            // ReleaseWrappedResources() is called on the 11On12 device, the resource 
-            // will be transitioned to the PRESENT state.
-            D3D11_RESOURCE_FLAGS d3d11Flags = { D3D11_BIND_RENDER_TARGET };
-            ThrowIfFailed(m_d3d11On12Device->CreateWrappedResource(
-                m_renderTargets[n].Get(),
-                &d3d11Flags,
-                D3D12_RESOURCE_STATE_RENDER_TARGET,
-                D3D12_RESOURCE_STATE_PRESENT,
-                IID_PPV_ARGS(&m_wrappedBackBuffers[n])
-                ));
+			// Create a wrapped 11On12 resource of this back buffer. Since we are 
+			// rendering all D3D12 content first and then all D2D content, we specify 
+			// the In resource state as RENDER_TARGET - because D3D12 will have last 
+			// used it in this state - and the Out resource state as PRESENT. When 
+			// ReleaseWrappedResources() is called on the 11On12 device, the resource 
+			// will be transitioned to the PRESENT state.
+			D3D11_RESOURCE_FLAGS d3d11Flags = { D3D11_BIND_RENDER_TARGET };
+			ThrowIfFailed(m_d3d11On12Device->CreateWrappedResource(
+				m_renderTargets[n].Get(),
+				&d3d11Flags,
+				D3D12_RESOURCE_STATE_RENDER_TARGET,
+				D3D12_RESOURCE_STATE_PRESENT,
+				IID_PPV_ARGS(&m_wrappedBackBuffers[n])
+				));
 
-            // Create a render target for D2D to draw directly to this back buffer.
-            ComPtr<IDXGISurface> surface;
-            ThrowIfFailed(m_wrappedBackBuffers[n].As(&surface));
-            ThrowIfFailed(m_d2dDeviceContext->CreateBitmapFromDxgiSurface(
-                surface.Get(),
-                &bitmapProperties,
-                &m_d2dRenderTargets[n]
-                ));
+			// Create a render target for D2D to draw directly to this back buffer.
+			ComPtr<IDXGISurface> surface;
+			ThrowIfFailed(m_wrappedBackBuffers[n].As(&surface));
+			ThrowIfFailed(m_d2dDeviceContext->CreateBitmapFromDxgiSurface(
+				surface.Get(),
+				&bitmapProperties,
+				&m_d2dRenderTargets[n]
+				));
 
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-            ThrowIfFailed(m_d3d12Device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
-        }
-    }
+			ThrowIfFailed(m_d3d12Device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
+		}
+	}
 }
 
 // Load the sample assets.
 void D3D1211on12::LoadAssets()
 {
-    // Create an empty root signature.
-    {
-        CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+	// Create an empty root signature.
+	{
+		CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
-        ThrowIfFailed(m_d3d12Device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-        NAME_D3D12_OBJECT(m_rootSignature);
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
+		ThrowIfFailed(m_d3d12Device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+		NAME_D3D12_OBJECT(m_rootSignature);
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Describe and create the graphics pipeline state object (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state object (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_d3d12Device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-        NAME_D3D12_OBJECT(m_pipelineState);
-    }
+		ThrowIfFailed(m_d3d12Device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+		NAME_D3D12_OBJECT(m_pipelineState);
+	}
 
-    ThrowIfFailed(m_d3d12Device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
-    NAME_D3D12_OBJECT(m_commandList);
+	ThrowIfFailed(m_d3d12Device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	NAME_D3D12_OBJECT(m_commandList);
 
-    // Create D2D/DWrite objects for rendering text.
-    {
-        ThrowIfFailed(m_d2dDeviceContext->CreateSolidColorBrush(D2D1::ColorF(D2D1::ColorF::Black), &m_textBrush));
-        ThrowIfFailed(m_dWriteFactory->CreateTextFormat(
-            L"Verdana",
-            NULL,
-            DWRITE_FONT_WEIGHT_NORMAL,
-            DWRITE_FONT_STYLE_NORMAL,
-            DWRITE_FONT_STRETCH_NORMAL,
-            50,
-            L"en-us",
-            &m_textFormat
-            ));
-        ThrowIfFailed(m_textFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER));
-        ThrowIfFailed(m_textFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER));
-    }
+	// Create D2D/DWrite objects for rendering text.
+	{
+		ThrowIfFailed(m_d2dDeviceContext->CreateSolidColorBrush(D2D1::ColorF(D2D1::ColorF::Black), &m_textBrush));
+		ThrowIfFailed(m_dWriteFactory->CreateTextFormat(
+			L"Verdana",
+			NULL,
+			DWRITE_FONT_WEIGHT_NORMAL,
+			DWRITE_FONT_STYLE_NORMAL,
+			DWRITE_FONT_STRETCH_NORMAL,
+			50,
+			L"en-us",
+			&m_textFormat
+			));
+		ThrowIfFailed(m_textFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER));
+		ThrowIfFailed(m_textFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER));
+	}
 
-    // Note: ComPtr's are CPU objects but this resource needs to stay in scope until
-    // the command list that references it has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resource is not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> vertexBufferUpload;
+	// Note: ComPtr's are CPU objects but this resource needs to stay in scope until
+	// the command list that references it has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resource is not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> vertexBufferUpload;
 
-    // Create the vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        Vertex triangleVertices[] =
-        {
-            { { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
-            { { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
-            { { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
-        };
+	// Create the vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		Vertex triangleVertices[] =
+		{
+			{ { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
+			{ { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
+			{ { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
+		};
 
-        const UINT vertexBufferSize = sizeof(triangleVertices);
+		const UINT vertexBufferSize = sizeof(triangleVertices);
 
-        ThrowIfFailed(m_d3d12Device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		ThrowIfFailed(m_d3d12Device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        ThrowIfFailed(m_d3d12Device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&vertexBufferUpload)));
+		ThrowIfFailed(m_d3d12Device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&vertexBufferUpload)));
 
-        NAME_D3D12_OBJECT(m_vertexBuffer);
+		NAME_D3D12_OBJECT(m_vertexBuffer);
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(triangleVertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(triangleVertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = vertexBufferSize;
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = vertexBufferSize;
+	}
 
-    // Close the command list and execute it to begin the vertex buffer copy into
-    // the default heap.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the vertex buffer copy into
+	// the default heap.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_d3d12Device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(m_fence.GetAddressOf())));
-        m_fenceValues[m_frameIndex]++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_d3d12Device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(m_fence.GetAddressOf())));
+		m_fenceValues[m_frameIndex]++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForGpu();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForGpu();
+	}
 }
 
 // Update frame-based values.
@@ -405,136 +408,136 @@ void D3D1211on12::OnUpdate()
 // Render the scene.
 void D3D1211on12::OnRender()
 {
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render 3D");
+	PIXBeginEvent(m_commandQueue.Get(), 0, L"Render 3D");
 
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    PIXEndEvent(m_commandQueue.Get());
+	PIXEndEvent(m_commandQueue.Get());
 
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render UI");
-    RenderUI();
-    PIXEndEvent(m_commandQueue.Get());
+	PIXBeginEvent(m_commandQueue.Get(), 0, L"Render UI");
+	RenderUI();
+	PIXEndEvent(m_commandQueue.Get());
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+	// Present the frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    MoveToNextFrame();
+	MoveToNextFrame();
 }
 
 void D3D1211on12::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForGpu();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForGpu();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D1211on12::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
-    m_commandList->DrawInstanced(3, 1, 0, 0);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+	m_commandList->DrawInstanced(3, 1, 0, 0);
 
-    // Note: do not transition the render target to present here.
-    // the transition will occur when the wrapped 11On12 render
-    // target resource is released.
+	// Note: do not transition the render target to present here.
+	// the transition will occur when the wrapped 11On12 render
+	// target resource is released.
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 // Render text over D3D12 using D2D via the 11On12 device.
 void D3D1211on12::RenderUI()
 {
-    D2D1_SIZE_F rtSize = m_d2dRenderTargets[m_frameIndex]->GetSize();
-    D2D1_RECT_F textRect = D2D1::RectF(0, 0, rtSize.width, rtSize.height);
-    static const WCHAR text[] = L"11On12";
+	D2D1_SIZE_F rtSize = m_d2dRenderTargets[m_frameIndex]->GetSize();
+	D2D1_RECT_F textRect = D2D1::RectF(0, 0, rtSize.width, rtSize.height);
+	static const WCHAR text[] = L"11On12";
 
-    // Acquire our wrapped render target resource for the current back buffer.
-    m_d3d11On12Device->AcquireWrappedResources(m_wrappedBackBuffers[m_frameIndex].GetAddressOf(), 1);
+	// Acquire our wrapped render target resource for the current back buffer.
+	m_d3d11On12Device->AcquireWrappedResources(m_wrappedBackBuffers[m_frameIndex].GetAddressOf(), 1);
 
-    // Render text directly to the back buffer.
-    m_d2dDeviceContext->SetTarget(m_d2dRenderTargets[m_frameIndex].Get());
-    m_d2dDeviceContext->BeginDraw();
-    m_d2dDeviceContext->SetTransform(D2D1::Matrix3x2F::Identity());
-    m_d2dDeviceContext->DrawText(
-        text,
-        _countof(text) - 1,
-        m_textFormat.Get(),
-        &textRect,
-        m_textBrush.Get()
-        );
-    ThrowIfFailed(m_d2dDeviceContext->EndDraw());
+	// Render text directly to the back buffer.
+	m_d2dDeviceContext->SetTarget(m_d2dRenderTargets[m_frameIndex].Get());
+	m_d2dDeviceContext->BeginDraw();
+	m_d2dDeviceContext->SetTransform(D2D1::Matrix3x2F::Identity());
+	m_d2dDeviceContext->DrawText(
+		text,
+		_countof(text) - 1,
+		m_textFormat.Get(),
+		&textRect,
+		m_textBrush.Get()
+		);
+	ThrowIfFailed(m_d2dDeviceContext->EndDraw());
 
-    // Release our wrapped render target resource. Releasing 
-    // transitions the back buffer resource to the state specified
-    // as the OutState when the wrapped resource was created.
-    m_d3d11On12Device->ReleaseWrappedResources(m_wrappedBackBuffers[m_frameIndex].GetAddressOf(), 1);
+	// Release our wrapped render target resource. Releasing 
+	// transitions the back buffer resource to the state specified
+	// as the OutState when the wrapped resource was created.
+	m_d3d11On12Device->ReleaseWrappedResources(m_wrappedBackBuffers[m_frameIndex].GetAddressOf(), 1);
 
-    // Flush to submit the 11 command list to the shared command queue.
-    m_d3d11DeviceContext->Flush();
+	// Flush to submit the 11 command list to the shared command queue.
+	m_d3d11DeviceContext->Flush();
 }
 
 // Wait for pending GPU work to complete.
 void D3D1211on12::WaitForGpu()
 {
-    // Schedule a Signal command in the queue.
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
+	// Schedule a Signal command in the queue.
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
 
-    // Wait until the fence has been processed.
-    ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-    WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	// Wait until the fence has been processed.
+	ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+	WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
 
-    // Increment the fence value for the current frame.
-    m_fenceValues[m_frameIndex]++;
+	// Increment the fence value for the current frame.
+	m_fenceValues[m_frameIndex]++;
 }
 
 // Prepare to render the next frame.
 void D3D1211on12::MoveToNextFrame()
 {
-    // Schedule a Signal command in the queue.
-    const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
+	// Schedule a Signal command in the queue.
+	const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
 
-    // Update the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Update the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-        WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+		WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	}
 
-    // Set the fence value for the next frame.
-    m_fenceValues[m_frameIndex] = currentFenceValue + 1;
+	// Set the fence value for the next frame.
+	m_fenceValues[m_frameIndex] = currentFenceValue + 1;
 }

--- a/Samples/Desktop/D3D1211On12/src/D3D1211On12.h
+++ b/Samples/Desktop/D3D1211On12/src/D3D1211On12.h
@@ -25,60 +25,60 @@ using Microsoft::WRL::ComPtr;
 class D3D1211on12 : public DXSample
 {
 public:
-    D3D1211on12(UINT width, UINT height, std::wstring name);
+	D3D1211on12(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    static const UINT FrameCount = 3;
+	static const UINT FrameCount = 3;
 
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT4 color;
-    };
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT4 color;
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D11DeviceContext> m_d3d11DeviceContext;
-    ComPtr<ID3D11On12Device> m_d3d11On12Device;
-    ComPtr<ID3D12Device> m_d3d12Device;
-    ComPtr<IDWriteFactory> m_dWriteFactory;
-    ComPtr<ID2D1Factory3> m_d2dFactory;
-    ComPtr<ID2D1Device2> m_d2dDevice;
-    ComPtr<ID2D1DeviceContext2> m_d2dDeviceContext;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D11Resource> m_wrappedBackBuffers[FrameCount];
-    ComPtr<ID2D1Bitmap1> m_d2dRenderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D11DeviceContext> m_d3d11DeviceContext;
+	ComPtr<ID3D11On12Device> m_d3d11On12Device;
+	ComPtr<ID3D12Device> m_d3d12Device;
+	ComPtr<IDWriteFactory> m_dWriteFactory;
+	ComPtr<ID2D1Factory3> m_d2dFactory;
+	ComPtr<ID2D1Device2> m_d2dDevice;
+	ComPtr<ID2D1DeviceContext2> m_d2dDeviceContext;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D11Resource> m_wrappedBackBuffers[FrameCount];
+	ComPtr<ID2D1Bitmap1> m_d2dRenderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
 
-    // App resources.
-    UINT m_rtvDescriptorSize;
-    ComPtr<ID2D1SolidColorBrush> m_textBrush;
-    ComPtr<IDWriteTextFormat> m_textFormat;
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	// App resources.
+	UINT m_rtvDescriptorSize;
+	ComPtr<ID2D1SolidColorBrush> m_textBrush;
+	ComPtr<IDWriteTextFormat> m_textFormat;
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValues[FrameCount];
+	// Synchronization objects.
+	UINT m_frameIndex;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValues[FrameCount];
 
-    void LoadPipeline();
-    void LoadAssets();
-    void PopulateCommandList();
-    void WaitForGpu();
-    void MoveToNextFrame();
-    void RenderUI();
+	void LoadPipeline();
+	void LoadAssets();
+	void PopulateCommandList();
+	void WaitForGpu();
+	void MoveToNextFrame();
+	void RenderUI();
 };

--- a/Samples/Desktop/D3D1211On12/src/DXSample.cpp
+++ b/Samples/Desktop/D3D1211On12/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,58 +34,103 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title + L": " + text;
-    SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
+	std::wstring windowText = m_title + L": " + text;
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/Desktop/D3D1211On12/src/DXSample.h
+++ b/Samples/Desktop/D3D1211On12/src/DXSample.h
@@ -17,42 +17,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/Desktop/D3D1211On12/src/Main.cpp
+++ b/Samples/Desktop/D3D1211On12/src/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D1211on12 sample(1280, 720, L"D3D12 11 on 12 Sample");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D1211on12 sample(1280, 720, L"D3D12 11 on 12 Sample");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D1211On12/src/Win32Application.cpp
+++ b/Samples/Desktop/D3D1211On12/src/Win32Application.cpp
@@ -16,104 +16,104 @@ HWND Win32Application::m_hwnd = nullptr;
 
 int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
 {
-    // Parse the command line parameters
-    int argc;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    pSample->ParseCommandLineArgs(argv, argc);
-    LocalFree(argv);
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
 
-    // Initialize the window class.
-    WNDCLASSEX windowClass = { 0 };
-    windowClass.cbSize = sizeof(WNDCLASSEX);
-    windowClass.style = CS_HREDRAW | CS_VREDRAW;
-    windowClass.lpfnWndProc = WindowProc;
-    windowClass.hInstance = hInstance;
-    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-    windowClass.lpszClassName = L"DXSampleClass";
-    RegisterClassEx(&windowClass);
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
 
-    RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
-    AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
 
-    // Create the window and store a handle to it.
-    m_hwnd = CreateWindow(
-        windowClass.lpszClassName,
-        pSample->GetTitle(),
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        windowRect.right - windowRect.left,
-        windowRect.bottom - windowRect.top,
-        nullptr,        // We have no parent window.
-        nullptr,        // We aren't using menus.
-        hInstance,
-        pSample);
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
 
-    // Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-    pSample->OnInit();
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
 
-    ShowWindow(m_hwnd, nCmdShow);
+	ShowWindow(m_hwnd, nCmdShow);
 
-    // Main sample loop.
-    MSG msg = {};
-    while (msg.message != WM_QUIT)
-    {
-        // Process any messages in the queue.
-        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
-    }
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
 
-    pSample->OnDestroy();
+	pSample->OnDestroy();
 
-    // Return this part of the WM_QUIT message to Windows.
-    return static_cast<char>(msg.wParam);
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
 }
 
 // Main message handler for the sample.
 LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
-    switch (message)
-    {
-    case WM_CREATE:
-        {
-            // Save the DXSample* passed in to CreateWindow.
-            LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
-            SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
-        }
-        return 0;
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
 
-    case WM_KEYDOWN:
-        if (pSample)
-        {
-            pSample->OnKeyDown(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_KEYUP:
-        if (pSample)
-        {
-            pSample->OnKeyUp(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_PAINT:
-        if (pSample)
-        {
-            pSample->OnUpdate();
-            pSample->OnRender();
-        }
-        return 0;
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
 
-    case WM_DESTROY:
-        PostQuitMessage(0);
-        return 0;
-    }
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
 
-    // Handle any messages the switch statement didn't.
-    return DefWindowProc(hWnd, message, wParam, lParam);
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/Desktop/D3D1211On12/src/Win32Application.h
+++ b/Samples/Desktop/D3D1211On12/src/Win32Application.h
@@ -18,12 +18,12 @@ class DXSample;
 class Win32Application
 {
 public:
-    static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
-    static HWND GetHwnd() { return m_hwnd; }
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
 
 protected:
-    static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
-    static HWND m_hwnd;
+	static HWND m_hwnd;
 };

--- a/Samples/Desktop/D3D1211On12/src/d3dx12.h
+++ b/Samples/Desktop/D3D1211On12/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D1211On12/src/shaders.hlsl
+++ b/Samples/Desktop/D3D1211On12/src/shaders.hlsl
@@ -11,21 +11,21 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VSMain(float4 position : POSITION, float4 color : COLOR)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.color = color;
+	result.position = position;
+	result.color = color;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/Desktop/D3D12Bundles/src/D3D12Bundles.cpp
+++ b/Samples/Desktop/D3D12Bundles/src/D3D12Bundles.cpp
@@ -14,634 +14,634 @@
 #include "occcity.h"
 
 D3D12Bundles::D3D12Bundles(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_frameCounter(0),
-    m_fenceValue(0),
-    m_rtvDescriptorSize(0),
-    m_currentFrameResourceIndex(0),
-    m_pCurrentFrameResource(nullptr)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_frameCounter(0),
+	m_fenceValue(0),
+	m_rtvDescriptorSize(0),
+	m_currentFrameResourceIndex(0),
+	m_pCurrentFrameResource(nullptr)
 {
 }
 
 void D3D12Bundles::OnInit()
 {
-    m_camera.Init({ 8, 8, 30 });
+	m_camera.Init({ 8, 8, 30 });
 
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12Bundles::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
-    NAME_D3D12_OBJECT(m_commandQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	NAME_D3D12_OBJECT(m_commandQueue);
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    // This sample does not support fullscreen transitions.
-    ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
+	// This sample does not support fullscreen transitions.
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a depth stencil view (DSV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
-        dsvHeapDesc.NumDescriptors = 1;
-        dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-        dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
+		// Describe and create a depth stencil view (DSV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
+		dsvHeapDesc.NumDescriptors = 1;
+		dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+		dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
 
-        // Describe and create a shader resource view (SRV) and constant 
-        // buffer view (CBV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvSrvHeapDesc = {};
-        cbvSrvHeapDesc.NumDescriptors =
-            FrameCount * CityRowCount * CityColumnCount        // FrameCount frames * CityRowCount * CityColumnCount.
-            + 1;                                            // + 1 for the SRV.
-        cbvSrvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        cbvSrvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvSrvHeapDesc, IID_PPV_ARGS(&m_cbvSrvHeap)));
-        NAME_D3D12_OBJECT(m_cbvSrvHeap);
+		// Describe and create a shader resource view (SRV) and constant 
+		// buffer view (CBV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvSrvHeapDesc = {};
+		cbvSrvHeapDesc.NumDescriptors =
+			FrameCount * CityRowCount * CityColumnCount		// FrameCount frames * CityRowCount * CityColumnCount.
+			+ 1;											// + 1 for the SRV.
+		cbvSrvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		cbvSrvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvSrvHeapDesc, IID_PPV_ARGS(&m_cbvSrvHeap)));
+		NAME_D3D12_OBJECT(m_cbvSrvHeap);
 
-        // Describe and create a sampler descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
-        samplerHeapDesc.NumDescriptors = 1;
-        samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
-        samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_samplerHeap)));
+		// Describe and create a sampler descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
+		samplerHeapDesc.NumDescriptors = 1;
+		samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
+		samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_samplerHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-        m_cbvSrvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_cbvSrvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	}
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
 }
 
 // Load the sample assets.
 void D3D12Bundles::LoadAssets()
 {
-    // Note: ComPtr's are CPU objects but these resources need to stay in scope until
-    // the command list that references them has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resources are not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> vertexBufferUploadHeap;
-    ComPtr<ID3D12Resource> indexBufferUploadHeap;
-    ComPtr<ID3D12Resource> textureUploadHeap;
+	// Note: ComPtr's are CPU objects but these resources need to stay in scope until
+	// the command list that references them has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resources are not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> vertexBufferUploadHeap;
+	ComPtr<ID3D12Resource> indexBufferUploadHeap;
+	ComPtr<ID3D12Resource> textureUploadHeap;
 
-    // Create the root signature.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signature.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[3];
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
-        ranges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[3];
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
+		ranges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
 
-        CD3DX12_ROOT_PARAMETER1 rootParameters[3];
-        rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
-        rootParameters[1].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_PIXEL);
-        rootParameters[2].InitAsDescriptorTable(1, &ranges[2], D3D12_SHADER_VISIBILITY_ALL);
+		CD3DX12_ROOT_PARAMETER1 rootParameters[3];
+		rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
+		rootParameters[1].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_PIXEL);
+		rootParameters[2].InitAsDescriptorTable(1, &ranges[2], D3D12_SHADER_VISIBILITY_ALL);
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-        NAME_D3D12_OBJECT(m_rootSignature);
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+		NAME_D3D12_OBJECT(m_rootSignature);
+	}
 
-    // Create the pipeline state, which includes loading shaders.
-    {
-        UINT8* pVertexShaderData;
-        UINT8* pPixelShaderData1;
-        UINT8* pPixelShaderData2;
-        UINT vertexShaderDataLength;
-        UINT pixelShaderDataLength1;
-        UINT pixelShaderDataLength2;
+	// Create the pipeline state, which includes loading shaders.
+	{
+		UINT8* pVertexShaderData;
+		UINT8* pPixelShaderData1;
+		UINT8* pPixelShaderData2;
+		UINT vertexShaderDataLength;
+		UINT pixelShaderDataLength1;
+		UINT pixelShaderDataLength2;
 
-        // Load pre-compiled shaders.
-        ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(L"shader_mesh_simple_vert.cso").c_str(), &pVertexShaderData, &vertexShaderDataLength));
-        ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(L"shader_mesh_simple_pixel.cso").c_str(), &pPixelShaderData1, &pixelShaderDataLength1));
-        ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(L"shader_mesh_alt_pixel.cso").c_str(), &pPixelShaderData2, &pixelShaderDataLength2));
+		// Load pre-compiled shaders.
+		ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(L"shader_mesh_simple_vert.cso").c_str(), &pVertexShaderData, &vertexShaderDataLength));
+		ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(L"shader_mesh_simple_pixel.cso").c_str(), &pPixelShaderData1, &pixelShaderDataLength1));
+		ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(L"shader_mesh_alt_pixel.cso").c_str(), &pPixelShaderData2, &pixelShaderDataLength2));
 
-        CD3DX12_RASTERIZER_DESC rasterizerStateDesc(D3D12_DEFAULT);
-        rasterizerStateDesc.CullMode = D3D12_CULL_MODE_NONE;
+		CD3DX12_RASTERIZER_DESC rasterizerStateDesc(D3D12_DEFAULT);
+		rasterizerStateDesc.CullMode = D3D12_CULL_MODE_NONE;
 
-        // Describe and create the graphics pipeline state objects (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { SampleAssets::StandardVertexDescription, SampleAssets::StandardVertexDescriptionNumElements };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(pVertexShaderData, vertexShaderDataLength);
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pPixelShaderData1, pixelShaderDataLength1);
-        psoDesc.RasterizerState = rasterizerStateDesc;
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state objects (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { SampleAssets::StandardVertexDescription, SampleAssets::StandardVertexDescriptionNumElements };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(pVertexShaderData, vertexShaderDataLength);
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pPixelShaderData1, pixelShaderDataLength1);
+		psoDesc.RasterizerState = rasterizerStateDesc;
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState1)));
-        NAME_D3D12_OBJECT(m_pipelineState1);
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState1)));
+		NAME_D3D12_OBJECT(m_pipelineState1);
 
-        // Modify the description to use an alternate pixel shader and create
-        // a second PSO.
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pPixelShaderData2, pixelShaderDataLength2);
+		// Modify the description to use an alternate pixel shader and create
+		// a second PSO.
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pPixelShaderData2, pixelShaderDataLength2);
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState2)));
-        NAME_D3D12_OBJECT(m_pipelineState2);
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState2)));
+		NAME_D3D12_OBJECT(m_pipelineState2);
 
-        delete pVertexShaderData;
-        delete pPixelShaderData1;
-        delete pPixelShaderData2;
-    }
+		delete pVertexShaderData;
+		delete pPixelShaderData1;
+		delete pPixelShaderData2;
+	}
 
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), nullptr, IID_PPV_ARGS(&m_commandList)));
-    NAME_D3D12_OBJECT(m_commandList);
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), nullptr, IID_PPV_ARGS(&m_commandList)));
+	NAME_D3D12_OBJECT(m_commandList);
 
-    // Create render target views (RTVs).
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
-    for (UINT i = 0; i < FrameCount; i++)
-    {
-        ThrowIfFailed(m_swapChain->GetBuffer(i, IID_PPV_ARGS(&m_renderTargets[i])));
-        m_device->CreateRenderTargetView(m_renderTargets[i].Get(), nullptr, rtvHandle);
-        rtvHandle.Offset(1, m_rtvDescriptorSize);
+	// Create render target views (RTVs).
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	for (UINT i = 0; i < FrameCount; i++)
+	{
+		ThrowIfFailed(m_swapChain->GetBuffer(i, IID_PPV_ARGS(&m_renderTargets[i])));
+		m_device->CreateRenderTargetView(m_renderTargets[i].Get(), nullptr, rtvHandle);
+		rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-        NAME_D3D12_OBJECT_INDEXED(m_renderTargets, i);
-    }
+		NAME_D3D12_OBJECT_INDEXED(m_renderTargets, i);
+	}
 
-    // Read in mesh data for vertex/index buffers.
-    UINT8* pMeshData;
-    UINT meshDataLength;
-    ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(SampleAssets::DataFileName).c_str(), &pMeshData, &meshDataLength));
+	// Read in mesh data for vertex/index buffers.
+	UINT8* pMeshData;
+	UINT meshDataLength;
+	ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(SampleAssets::DataFileName).c_str(), &pMeshData, &meshDataLength));
 
-    // Create the vertex buffer.
-    {
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+	// Create the vertex buffer.
+	{
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&vertexBufferUploadHeap)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&vertexBufferUploadHeap)));
 
-        NAME_D3D12_OBJECT(m_vertexBuffer);
+		NAME_D3D12_OBJECT(m_vertexBuffer);
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = pMeshData + SampleAssets::VertexDataOffset;
-        vertexData.RowPitch = SampleAssets::VertexDataSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = pMeshData + SampleAssets::VertexDataOffset;
+		vertexData.RowPitch = SampleAssets::VertexDataSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUploadHeap.Get(), 0, 0, 1, &vertexData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUploadHeap.Get(), 0, 0, 1, &vertexData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = SampleAssets::StandardVertexStride;
-        m_vertexBufferView.SizeInBytes = SampleAssets::VertexDataSize;
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = SampleAssets::StandardVertexStride;
+		m_vertexBufferView.SizeInBytes = SampleAssets::VertexDataSize;
+	}
 
-    // Create the index buffer.
-    {
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::IndexDataSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_indexBuffer)));
+	// Create the index buffer.
+	{
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::IndexDataSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_indexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::IndexDataSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&indexBufferUploadHeap)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::IndexDataSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&indexBufferUploadHeap)));
 
-        NAME_D3D12_OBJECT(m_indexBuffer);
+		NAME_D3D12_OBJECT(m_indexBuffer);
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the index buffer.
-        D3D12_SUBRESOURCE_DATA indexData = {};
-        indexData.pData = pMeshData + SampleAssets::IndexDataOffset;
-        indexData.RowPitch = SampleAssets::IndexDataSize;
-        indexData.SlicePitch = indexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the index buffer.
+		D3D12_SUBRESOURCE_DATA indexData = {};
+		indexData.pData = pMeshData + SampleAssets::IndexDataOffset;
+		indexData.RowPitch = SampleAssets::IndexDataSize;
+		indexData.SlicePitch = indexData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_indexBuffer.Get(), indexBufferUploadHeap.Get(), 0, 0, 1, &indexData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_indexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_INDEX_BUFFER));
+		UpdateSubresources<1>(m_commandList.Get(), m_indexBuffer.Get(), indexBufferUploadHeap.Get(), 0, 0, 1, &indexData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_indexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_INDEX_BUFFER));
 
-        // Describe the index buffer view.
-        m_indexBufferView.BufferLocation = m_indexBuffer->GetGPUVirtualAddress();
-        m_indexBufferView.Format = SampleAssets::StandardIndexFormat;
-        m_indexBufferView.SizeInBytes = SampleAssets::IndexDataSize;
+		// Describe the index buffer view.
+		m_indexBufferView.BufferLocation = m_indexBuffer->GetGPUVirtualAddress();
+		m_indexBufferView.Format = SampleAssets::StandardIndexFormat;
+		m_indexBufferView.SizeInBytes = SampleAssets::IndexDataSize;
 
-        m_numIndices = SampleAssets::IndexDataSize / 4;    // R32_UINT (SampleAssets::StandardIndexFormat) = 4 bytes each.
-    }
+		m_numIndices = SampleAssets::IndexDataSize / 4;	// R32_UINT (SampleAssets::StandardIndexFormat) = 4 bytes each.
+	}
 
-    // Create the texture and sampler.
-    {
-        // Describe and create a Texture2D.
-        D3D12_RESOURCE_DESC textureDesc = {};
-        textureDesc.MipLevels = SampleAssets::Textures[0].MipLevels;
-        textureDesc.Format = SampleAssets::Textures[0].Format;
-        textureDesc.Width = SampleAssets::Textures[0].Width;
-        textureDesc.Height = SampleAssets::Textures[0].Height;
-        textureDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
-        textureDesc.DepthOrArraySize = 1;
-        textureDesc.SampleDesc.Count = 1;
-        textureDesc.SampleDesc.Quality = 0;
-        textureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+	// Create the texture and sampler.
+	{
+		// Describe and create a Texture2D.
+		D3D12_RESOURCE_DESC textureDesc = {};
+		textureDesc.MipLevels = SampleAssets::Textures[0].MipLevels;
+		textureDesc.Format = SampleAssets::Textures[0].Format;
+		textureDesc.Width = SampleAssets::Textures[0].Width;
+		textureDesc.Height = SampleAssets::Textures[0].Height;
+		textureDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
+		textureDesc.DepthOrArraySize = 1;
+		textureDesc.SampleDesc.Count = 1;
+		textureDesc.SampleDesc.Quality = 0;
+		textureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &textureDesc,
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_texture)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&textureDesc,
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_texture)));
 
-        NAME_D3D12_OBJECT(m_texture);
+		NAME_D3D12_OBJECT(m_texture);
 
-        const UINT subresourceCount = textureDesc.DepthOrArraySize * textureDesc.MipLevels;
-        const UINT64 uploadBufferSize = GetRequiredIntermediateSize(m_texture.Get(), 0, subresourceCount);
+		const UINT subresourceCount = textureDesc.DepthOrArraySize * textureDesc.MipLevels;
+		const UINT64 uploadBufferSize = GetRequiredIntermediateSize(m_texture.Get(), 0, subresourceCount);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&textureUploadHeap)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&textureUploadHeap)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the Texture2D.
-        D3D12_SUBRESOURCE_DATA textureData = {};
-        textureData.pData = pMeshData + SampleAssets::Textures[0].Data[0].Offset;
-        textureData.RowPitch = SampleAssets::Textures[0].Data[0].Pitch;
-        textureData.SlicePitch = SampleAssets::Textures[0].Data[0].Size;
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the Texture2D.
+		D3D12_SUBRESOURCE_DATA textureData = {};
+		textureData.pData = pMeshData + SampleAssets::Textures[0].Data[0].Offset;
+		textureData.RowPitch = SampleAssets::Textures[0].Data[0].Pitch;
+		textureData.SlicePitch = SampleAssets::Textures[0].Data[0].Size;
 
-        UpdateSubresources(m_commandList.Get(), m_texture.Get(), textureUploadHeap.Get(), 0, 0, subresourceCount, &textureData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_texture.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
+		UpdateSubresources(m_commandList.Get(), m_texture.Get(), textureUploadHeap.Get(), 0, 0, subresourceCount, &textureData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_texture.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
 
-        // Describe and create a sampler.
-        D3D12_SAMPLER_DESC samplerDesc = {};
-        samplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-        samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.MinLOD = 0;
-        samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
-        samplerDesc.MipLODBias = 0.0f;
-        samplerDesc.MaxAnisotropy = 1;
-        samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
-        m_device->CreateSampler(&samplerDesc, m_samplerHeap->GetCPUDescriptorHandleForHeapStart());
+		// Describe and create a sampler.
+		D3D12_SAMPLER_DESC samplerDesc = {};
+		samplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.MinLOD = 0;
+		samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
+		samplerDesc.MipLODBias = 0.0f;
+		samplerDesc.MaxAnisotropy = 1;
+		samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
+		m_device->CreateSampler(&samplerDesc, m_samplerHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Describe and create a SRV for the texture.
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Format = SampleAssets::Textures->Format;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = 1;
-        m_device->CreateShaderResourceView(m_texture.Get(), &srvDesc, m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		// Describe and create a SRV for the texture.
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Format = SampleAssets::Textures->Format;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = 1;
+		m_device->CreateShaderResourceView(m_texture.Get(), &srvDesc, m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    delete pMeshData;
+	delete pMeshData;
 
-    // Create the depth stencil view.
-    {
-        D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
-        depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
-        depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
-        depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
+	// Create the depth stencil view.
+	{
+		D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
+		depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
+		depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+		depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
 
-        D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
-        depthOptimizedClearValue.Format = DXGI_FORMAT_D32_FLOAT;
-        depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
-        depthOptimizedClearValue.DepthStencil.Stencil = 0;
+		D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
+		depthOptimizedClearValue.Format = DXGI_FORMAT_D32_FLOAT;
+		depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
+		depthOptimizedClearValue.DepthStencil.Stencil = 0;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
-            D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            &depthOptimizedClearValue,
-            IID_PPV_ARGS(&m_depthStencil)
-            ));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
+			D3D12_RESOURCE_STATE_DEPTH_WRITE,
+			&depthOptimizedClearValue,
+			IID_PPV_ARGS(&m_depthStencil)
+			));
 
-        NAME_D3D12_OBJECT(m_depthStencil);
+		NAME_D3D12_OBJECT(m_depthStencil);
 
-        m_device->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		m_device->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    // Close the command list and execute it to begin the initial GPU setup.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the initial GPU setup.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_fenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValue++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_fenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValue++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
 
-        // Signal and increment the fence value.
-        const UINT64 fenceToWaitFor = m_fenceValue;
-        ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fenceToWaitFor));
-        m_fenceValue++;
+		// Signal and increment the fence value.
+		const UINT64 fenceToWaitFor = m_fenceValue;
+		ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fenceToWaitFor));
+		m_fenceValue++;
 
-        // Wait until the fence is completed.
-        ThrowIfFailed(m_fence->SetEventOnCompletion(fenceToWaitFor, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+		// Wait until the fence is completed.
+		ThrowIfFailed(m_fence->SetEventOnCompletion(fenceToWaitFor, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 
-    CreateFrameResources();
+	CreateFrameResources();
 }
 
 // Update frame-based values.
 void D3D12Bundles::OnUpdate()
 {
-    m_timer.Tick(NULL);
+	m_timer.Tick(NULL);
 
-    if (m_frameCounter == 500)
-    {
-        // Update window text with FPS value.
-        wchar_t fps[64];
-        swprintf_s(fps, L"%ufps", m_timer.GetFramesPerSecond());
-        SetCustomWindowText(fps);
-        m_frameCounter = 0;
-    }
+	if (m_frameCounter == 500)
+	{
+		// Update window text with FPS value.
+		wchar_t fps[64];
+		swprintf_s(fps, L"%ufps", m_timer.GetFramesPerSecond());
+		SetCustomWindowText(fps);
+		m_frameCounter = 0;
+	}
 
-    m_frameCounter++;
+	m_frameCounter++;
 
-    // Get current GPU progress against submitted workload. Resources still scheduled 
-    // for GPU execution cannot be modified or else undefined behavior will result.
-    const UINT64 lastCompletedFence = m_fence->GetCompletedValue();
+	// Get current GPU progress against submitted workload. Resources still scheduled 
+	// for GPU execution cannot be modified or else undefined behavior will result.
+	const UINT64 lastCompletedFence = m_fence->GetCompletedValue();
 
-    // Move to the next frame resource.
-    m_currentFrameResourceIndex = (m_currentFrameResourceIndex + 1) % FrameCount;
-    m_pCurrentFrameResource = m_frameResources[m_currentFrameResourceIndex];
+	// Move to the next frame resource.
+	m_currentFrameResourceIndex = (m_currentFrameResourceIndex + 1) % FrameCount;
+	m_pCurrentFrameResource = m_frameResources[m_currentFrameResourceIndex];
 
-    // Make sure that this frame resource isn't still in use by the GPU.
-    // If it is, wait for it to complete.
-    if (m_pCurrentFrameResource->m_fenceValue != 0 && m_pCurrentFrameResource->m_fenceValue > lastCompletedFence)
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_pCurrentFrameResource->m_fenceValue, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+	// Make sure that this frame resource isn't still in use by the GPU.
+	// If it is, wait for it to complete.
+	if (m_pCurrentFrameResource->m_fenceValue != 0 && m_pCurrentFrameResource->m_fenceValue > lastCompletedFence)
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_pCurrentFrameResource->m_fenceValue, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 
-    m_camera.Update(static_cast<float>(m_timer.GetElapsedSeconds()));
-    m_pCurrentFrameResource->UpdateConstantBuffers(m_camera.GetViewMatrix(), m_camera.GetProjectionMatrix(0.8f, m_aspectRatio));
+	m_camera.Update(static_cast<float>(m_timer.GetElapsedSeconds()));
+	m_pCurrentFrameResource->UpdateConstantBuffers(m_camera.GetViewMatrix(), m_camera.GetProjectionMatrix(0.8f, m_aspectRatio));
 }
 
 // Render the scene.
 void D3D12Bundles::OnRender()
 {
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+	PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
 
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList(m_pCurrentFrameResource);
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList(m_pCurrentFrameResource);
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    PIXEndEvent(m_commandQueue.Get());
+	PIXEndEvent(m_commandQueue.Get());
 
-    // Present and update the frame index for the next frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Present and update the frame index for the next frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Signal and increment the fence value.
-    m_pCurrentFrameResource->m_fenceValue = m_fenceValue;
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValue));
-    m_fenceValue++;
+	// Signal and increment the fence value.
+	m_pCurrentFrameResource->m_fenceValue = m_fenceValue;
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValue));
+	m_fenceValue++;
 }
 
 void D3D12Bundles::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    {
-        const UINT64 fence = m_fenceValue;
-        const UINT64 lastCompletedFence = m_fence->GetCompletedValue();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	{
+		const UINT64 fence = m_fenceValue;
+		const UINT64 lastCompletedFence = m_fence->GetCompletedValue();
 
-        // Signal and increment the fence value.
-        ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValue));
-        m_fenceValue++;
+		// Signal and increment the fence value.
+		ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValue));
+		m_fenceValue++;
 
-        // Wait until the previous frame is finished.
-        if (lastCompletedFence < fence)
-        {
-            ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
-            WaitForSingleObject(m_fenceEvent, INFINITE);
-        }
-    }
+		// Wait until the previous frame is finished.
+		if (lastCompletedFence < fence)
+		{
+			ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
+			WaitForSingleObject(m_fenceEvent, INFINITE);
+		}
+	}
 
-    for (UINT i = 0; i < m_frameResources.size(); i++)
-    {
-        delete m_frameResources.at(i);
-    }
+	for (UINT i = 0; i < m_frameResources.size(); i++)
+	{
+		delete m_frameResources.at(i);
+	}
 }
 
 void D3D12Bundles::OnKeyDown(UINT8 key)
 {
-    m_camera.OnKeyDown(key);
+	m_camera.OnKeyDown(key);
 }
 
 void D3D12Bundles::OnKeyUp(UINT8 key)
 {
-    m_camera.OnKeyUp(key);
+	m_camera.OnKeyUp(key);
 }
 
 // Create the resources that will be used every frame.
 void D3D12Bundles::CreateFrameResources()
 {
-    // Initialize each frame resource.
-    CD3DX12_CPU_DESCRIPTOR_HANDLE cbvSrvHandle(m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart(), 1, m_cbvSrvDescriptorSize);    // Move past the SRV in slot 1.
-    for (UINT i = 0; i < FrameCount; i++)
-    {
-        FrameResource* pFrameResource = new FrameResource(m_device.Get(), CityRowCount, CityColumnCount);
+	// Initialize each frame resource.
+	CD3DX12_CPU_DESCRIPTOR_HANDLE cbvSrvHandle(m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart(), 1, m_cbvSrvDescriptorSize);	// Move past the SRV in slot 1.
+	for (UINT i = 0; i < FrameCount; i++)
+	{
+		FrameResource* pFrameResource = new FrameResource(m_device.Get(), CityRowCount, CityColumnCount);
 
-        UINT64 cbOffset = 0;
-        for (UINT j = 0; j < CityRowCount; j++)
-        {
-            for (UINT k = 0; k < CityColumnCount; k++)
-            {
-                // Describe and create a constant buffer view (CBV).
-                D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
-                cbvDesc.BufferLocation = pFrameResource->m_cbvUploadHeap->GetGPUVirtualAddress() + cbOffset;
-                cbvDesc.SizeInBytes = sizeof(FrameResource::SceneConstantBuffer);
-                cbOffset += cbvDesc.SizeInBytes;
-                m_device->CreateConstantBufferView(&cbvDesc, cbvSrvHandle);
-                cbvSrvHandle.Offset(m_cbvSrvDescriptorSize);
-            }
-        }
+		UINT64 cbOffset = 0;
+		for (UINT j = 0; j < CityRowCount; j++)
+		{
+			for (UINT k = 0; k < CityColumnCount; k++)
+			{
+				// Describe and create a constant buffer view (CBV).
+				D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
+				cbvDesc.BufferLocation = pFrameResource->m_cbvUploadHeap->GetGPUVirtualAddress() + cbOffset;
+				cbvDesc.SizeInBytes = sizeof(FrameResource::SceneConstantBuffer);
+				cbOffset += cbvDesc.SizeInBytes;
+				m_device->CreateConstantBufferView(&cbvDesc, cbvSrvHandle);
+				cbvSrvHandle.Offset(m_cbvSrvDescriptorSize);
+			}
+		}
 
-        pFrameResource->InitBundle(m_device.Get(), m_pipelineState1.Get(), m_pipelineState2.Get(), i, m_numIndices, &m_indexBufferView,
-            &m_vertexBufferView, m_cbvSrvHeap.Get(), m_cbvSrvDescriptorSize, m_samplerHeap.Get(), m_rootSignature.Get());
+		pFrameResource->InitBundle(m_device.Get(), m_pipelineState1.Get(), m_pipelineState2.Get(), i, m_numIndices, &m_indexBufferView,
+			&m_vertexBufferView, m_cbvSrvHeap.Get(), m_cbvSrvDescriptorSize, m_samplerHeap.Get(), m_rootSignature.Get());
 
-        m_frameResources.push_back(pFrameResource);
-    }
+		m_frameResources.push_back(pFrameResource);
+	}
 }
 
 void D3D12Bundles::PopulateCommandList(FrameResource* pFrameResource)
 {
-    // Command list allocators can only be reset when the associated
-    // command lists have finished execution on the GPU; apps should use
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_pCurrentFrameResource->m_commandAllocator->Reset());
+	// Command list allocators can only be reset when the associated
+	// command lists have finished execution on the GPU; apps should use
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_pCurrentFrameResource->m_commandAllocator->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command
-    // list, that command list can then be reset at any time and must be before
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_pCurrentFrameResource->m_commandAllocator.Get(), m_pipelineState1.Get()));
+	// However, when ExecuteCommandList() is called on a particular command
+	// list, that command list can then be reset at any time and must be before
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_pCurrentFrameResource->m_commandAllocator.Get(), m_pipelineState1.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvHeap.Get(), m_samplerHeap.Get() };
-    m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvHeap.Get(), m_samplerHeap.Get() };
+	m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    m_commandList->ClearDepthStencilView(m_dsvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	m_commandList->ClearDepthStencilView(m_dsvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
 
-    if (UseBundles)
-    {
-        // Execute the prebuilt bundle.
-        m_commandList->ExecuteBundle(pFrameResource->m_bundle.Get());
-    }
-    else
-    {
-        // Populate a new command list.
-        pFrameResource->PopulateCommandList(m_commandList.Get(), m_pipelineState1.Get(), m_pipelineState2.Get(), m_currentFrameResourceIndex, m_numIndices, &m_indexBufferView,
-            &m_vertexBufferView, m_cbvSrvHeap.Get(), m_cbvSrvDescriptorSize, m_samplerHeap.Get(), m_rootSignature.Get());
-    }
+	if (UseBundles)
+	{
+		// Execute the prebuilt bundle.
+		m_commandList->ExecuteBundle(pFrameResource->m_bundle.Get());
+	}
+	else
+	{
+		// Populate a new command list.
+		pFrameResource->PopulateCommandList(m_commandList.Get(), m_pipelineState1.Get(), m_pipelineState2.Get(), m_currentFrameResourceIndex, m_numIndices, &m_indexBufferView,
+			&m_vertexBufferView, m_cbvSrvHeap.Get(), m_cbvSrvDescriptorSize, m_samplerHeap.Get(), m_rootSignature.Get());
+	}
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }

--- a/Samples/Desktop/D3D12Bundles/src/D3D12Bundles.h
+++ b/Samples/Desktop/D3D12Bundles/src/D3D12Bundles.h
@@ -28,65 +28,65 @@ using Microsoft::WRL::ComPtr;
 class D3D12Bundles : public DXSample
 {
 public:
-    D3D12Bundles(UINT width, UINT height, std::wstring name);
+	D3D12Bundles(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
-    virtual void OnKeyDown(UINT8 key);
-    virtual void OnKeyUp(UINT8 key);
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
+	virtual void OnKeyDown(UINT8 key);
+	virtual void OnKeyUp(UINT8 key);
 
 private:
-    static const UINT FrameCount = 3;
-    static const UINT CityRowCount = 10;
-    static const UINT CityColumnCount = 3;
-    static const bool UseBundles = true;
+	static const UINT FrameCount = 3;
+	static const UINT CityRowCount = 10;
+	static const UINT CityColumnCount = 3;
+	static const bool UseBundles = true;
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12Resource> m_depthStencil;
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature >m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_cbvSrvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_samplerHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState1;
-    ComPtr<ID3D12PipelineState> m_pipelineState2;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12Resource> m_depthStencil;
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature >m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_cbvSrvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_samplerHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState1;
+	ComPtr<ID3D12PipelineState> m_pipelineState2;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
 
-    // App resources.
-    UINT m_numIndices;
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    ComPtr<ID3D12Resource> m_indexBuffer;
-    ComPtr<ID3D12Resource> m_texture;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
-    D3D12_INDEX_BUFFER_VIEW m_indexBufferView;
-    StepTimer m_timer;
-    UINT m_cbvSrvDescriptorSize;
-    UINT m_rtvDescriptorSize;
-    SimpleCamera m_camera;
+	// App resources.
+	UINT m_numIndices;
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	ComPtr<ID3D12Resource> m_indexBuffer;
+	ComPtr<ID3D12Resource> m_texture;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	D3D12_INDEX_BUFFER_VIEW m_indexBufferView;
+	StepTimer m_timer;
+	UINT m_cbvSrvDescriptorSize;
+	UINT m_rtvDescriptorSize;
+	SimpleCamera m_camera;
 
-    // Frame resources.
-    std::vector<FrameResource*> m_frameResources;
-    FrameResource* m_pCurrentFrameResource;
-    UINT m_currentFrameResourceIndex;
+	// Frame resources.
+	std::vector<FrameResource*> m_frameResources;
+	FrameResource* m_pCurrentFrameResource;
+	UINT m_currentFrameResourceIndex;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    UINT m_frameCounter;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValue;
+	// Synchronization objects.
+	UINT m_frameIndex;
+	UINT m_frameCounter;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValue;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void CreateFrameResources();
-    void PopulateCommandList(FrameResource* pFrameResource);
+	void LoadPipeline();
+	void LoadAssets();
+	void CreateFrameResources();
+	void PopulateCommandList(FrameResource* pFrameResource);
 };

--- a/Samples/Desktop/D3D12Bundles/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12Bundles/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,58 +34,103 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title + L": " + text;
-    SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
+	std::wstring windowText = m_title + L": " + text;
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/Desktop/D3D12Bundles/src/DXSample.h
+++ b/Samples/Desktop/D3D12Bundles/src/DXSample.h
@@ -17,42 +17,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/Desktop/D3D12Bundles/src/FrameResource.cpp
+++ b/Samples/Desktop/D3D12Bundles/src/FrameResource.cpp
@@ -13,134 +13,134 @@
 #include "FrameResource.h"
 
 FrameResource::FrameResource(ID3D12Device* pDevice, UINT cityRowCount, UINT cityColumnCount) : 
-    m_fenceValue(0),
-    m_cityRowCount(cityRowCount),
-    m_cityColumnCount(cityColumnCount)
+	m_fenceValue(0),
+	m_cityRowCount(cityRowCount),
+	m_cityColumnCount(cityColumnCount)
 {
-    m_modelMatrices.resize(m_cityRowCount * m_cityColumnCount);
+	m_modelMatrices.resize(m_cityRowCount * m_cityColumnCount);
 
-    // The command allocator is used by the main sample class when 
-    // resetting the command list in the main update loop. Each frame 
-    // resource needs a command allocator because command allocators 
-    // cannot be reused until the GPU is done executing the commands 
-    // associated with it.
-    ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
-    ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_BUNDLE, IID_PPV_ARGS(&m_bundleAllocator)));
+	// The command allocator is used by the main sample class when 
+	// resetting the command list in the main update loop. Each frame 
+	// resource needs a command allocator because command allocators 
+	// cannot be reused until the GPU is done executing the commands 
+	// associated with it.
+	ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_BUNDLE, IID_PPV_ARGS(&m_bundleAllocator)));
 
-    // Create an upload heap for the constant buffers.
-    ThrowIfFailed(pDevice->CreateCommittedResource(
-        &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-        D3D12_HEAP_FLAG_NONE,
-        &CD3DX12_RESOURCE_DESC::Buffer(sizeof(SceneConstantBuffer) * m_cityRowCount * m_cityColumnCount),
-        D3D12_RESOURCE_STATE_GENERIC_READ,
-        nullptr,
-        IID_PPV_ARGS(&m_cbvUploadHeap)));
+	// Create an upload heap for the constant buffers.
+	ThrowIfFailed(pDevice->CreateCommittedResource(
+		&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+		D3D12_HEAP_FLAG_NONE,
+		&CD3DX12_RESOURCE_DESC::Buffer(sizeof(SceneConstantBuffer) * m_cityRowCount * m_cityColumnCount),
+		D3D12_RESOURCE_STATE_GENERIC_READ,
+		nullptr,
+		IID_PPV_ARGS(&m_cbvUploadHeap)));
 
-    // Map the constant buffers. Note that unlike D3D11, the resource 
-    // does not need to be unmapped for use by the GPU. In this sample, 
-    // the resource stays 'permenantly' mapped to avoid overhead with 
-    // mapping/unmapping each frame.
-    CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-    ThrowIfFailed(m_cbvUploadHeap->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBuffers)));
+	// Map the constant buffers. Note that unlike D3D11, the resource 
+	// does not need to be unmapped for use by the GPU. In this sample, 
+	// the resource stays 'permenantly' mapped to avoid overhead with 
+	// mapping/unmapping each frame.
+	CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+	ThrowIfFailed(m_cbvUploadHeap->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBuffers)));
 
-    // Update all of the model matrices once; our cities don't move so 
-    // we don't need to do this ever again.
-    SetCityPositions(8.0f, -8.0f);
+	// Update all of the model matrices once; our cities don't move so 
+	// we don't need to do this ever again.
+	SetCityPositions(8.0f, -8.0f);
 }
 
 FrameResource::~FrameResource()
 {
-    m_cbvUploadHeap->Unmap(0, nullptr);
-    m_pConstantBuffers = nullptr;
+	m_cbvUploadHeap->Unmap(0, nullptr);
+	m_pConstantBuffers = nullptr;
 }
 
 void FrameResource::InitBundle(ID3D12Device* pDevice, ID3D12PipelineState* pPso1, ID3D12PipelineState* pPso2,
-    UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
-    ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature)
+	UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
+	ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature)
 {
-    ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_BUNDLE, m_bundleAllocator.Get(), pPso1, IID_PPV_ARGS(&m_bundle)));
-    NAME_D3D12_OBJECT(m_bundle);
+	ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_BUNDLE, m_bundleAllocator.Get(), pPso1, IID_PPV_ARGS(&m_bundle)));
+	NAME_D3D12_OBJECT(m_bundle);
 
-    PopulateCommandList(m_bundle.Get(), pPso1, pPso2, frameResourceIndex, numIndices, pIndexBufferViewDesc,
-        pVertexBufferViewDesc, pCbvSrvDescriptorHeap, cbvSrvDescriptorSize, pSamplerDescriptorHeap, pRootSignature);
+	PopulateCommandList(m_bundle.Get(), pPso1, pPso2, frameResourceIndex, numIndices, pIndexBufferViewDesc,
+		pVertexBufferViewDesc, pCbvSrvDescriptorHeap, cbvSrvDescriptorSize, pSamplerDescriptorHeap, pRootSignature);
 
-    ThrowIfFailed(m_bundle->Close());
+	ThrowIfFailed(m_bundle->Close());
 }
 
 void FrameResource::SetCityPositions(FLOAT intervalX, FLOAT intervalZ)
 {
-    for (UINT i = 0; i < m_cityRowCount; i++)
-    {
-        FLOAT cityOffsetZ = i * intervalZ;
-        for (UINT j = 0; j < m_cityColumnCount; j++)
-        {
-            FLOAT cityOffsetX = j * intervalX;
+	for (UINT i = 0; i < m_cityRowCount; i++)
+	{
+		FLOAT cityOffsetZ = i * intervalZ;
+		for (UINT j = 0; j < m_cityColumnCount; j++)
+		{
+			FLOAT cityOffsetX = j * intervalX;
 
-            // The y position is based off of the city's row and column 
-            // position to prevent z-fighting.
-            XMStoreFloat4x4(&m_modelMatrices[i * m_cityColumnCount + j], XMMatrixTranslation(cityOffsetX, 0.02f * (i * m_cityColumnCount + j), cityOffsetZ));
-        }
-    }
+			// The y position is based off of the city's row and column 
+			// position to prevent z-fighting.
+			XMStoreFloat4x4(&m_modelMatrices[i * m_cityColumnCount + j], XMMatrixTranslation(cityOffsetX, 0.02f * (i * m_cityColumnCount + j), cityOffsetZ));
+		}
+	}
 }
 
 void FrameResource::PopulateCommandList(ID3D12GraphicsCommandList* pCommandList, ID3D12PipelineState* pPso1, ID3D12PipelineState* pPso2,
-    UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
-    ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature)
+	UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
+	ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature)
 {
-    // If the root signature matches the root signature of the caller, then
-    // bindings are inherited, otherwise the bind space is reset.
-    pCommandList->SetGraphicsRootSignature(pRootSignature);
+	// If the root signature matches the root signature of the caller, then
+	// bindings are inherited, otherwise the bind space is reset.
+	pCommandList->SetGraphicsRootSignature(pRootSignature);
 
-    ID3D12DescriptorHeap* ppHeaps[] = { pCbvSrvDescriptorHeap, pSamplerDescriptorHeap };
-    pCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
-    pCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    pCommandList->IASetIndexBuffer(pIndexBufferViewDesc);
-    pCommandList->IASetVertexBuffers(0, 1, pVertexBufferViewDesc);
-    pCommandList->SetGraphicsRootDescriptorTable(0, pCbvSrvDescriptorHeap->GetGPUDescriptorHandleForHeapStart());
-    pCommandList->SetGraphicsRootDescriptorTable(1, pSamplerDescriptorHeap->GetGPUDescriptorHandleForHeapStart());
+	ID3D12DescriptorHeap* ppHeaps[] = { pCbvSrvDescriptorHeap, pSamplerDescriptorHeap };
+	pCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	pCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	pCommandList->IASetIndexBuffer(pIndexBufferViewDesc);
+	pCommandList->IASetVertexBuffers(0, 1, pVertexBufferViewDesc);
+	pCommandList->SetGraphicsRootDescriptorTable(0, pCbvSrvDescriptorHeap->GetGPUDescriptorHandleForHeapStart());
+	pCommandList->SetGraphicsRootDescriptorTable(1, pSamplerDescriptorHeap->GetGPUDescriptorHandleForHeapStart());
 
-    // Calculate the descriptor offset due to multiple frame resources.
-    // 1 SRV + how many CBVs we have currently.
-    UINT frameResourceDescriptorOffset = 1 + (frameResourceIndex * m_cityRowCount * m_cityColumnCount);
-    CD3DX12_GPU_DESCRIPTOR_HANDLE cbvSrvHandle(pCbvSrvDescriptorHeap->GetGPUDescriptorHandleForHeapStart(), frameResourceDescriptorOffset, cbvSrvDescriptorSize);
+	// Calculate the descriptor offset due to multiple frame resources.
+	// 1 SRV + how many CBVs we have currently.
+	UINT frameResourceDescriptorOffset = 1 + (frameResourceIndex * m_cityRowCount * m_cityColumnCount);
+	CD3DX12_GPU_DESCRIPTOR_HANDLE cbvSrvHandle(pCbvSrvDescriptorHeap->GetGPUDescriptorHandleForHeapStart(), frameResourceDescriptorOffset, cbvSrvDescriptorSize);
 
-    PIXBeginEvent(pCommandList, 0, L"Draw cities");
-    BOOL usePso1 = TRUE;
-    for (UINT i = 0; i < m_cityRowCount; i++)
-    {
-        for (UINT j = 0; j < m_cityColumnCount; j++)
-        {
-            // Alternate which PSO to use; the pixel shader is different on 
-            // each just as a PSO setting demonstration.
-            pCommandList->SetPipelineState(usePso1 ? pPso1 : pPso2);
-            usePso1 = !usePso1;
+	PIXBeginEvent(pCommandList, 0, L"Draw cities");
+	BOOL usePso1 = TRUE;
+	for (UINT i = 0; i < m_cityRowCount; i++)
+	{
+		for (UINT j = 0; j < m_cityColumnCount; j++)
+		{
+			// Alternate which PSO to use; the pixel shader is different on 
+			// each just as a PSO setting demonstration.
+			pCommandList->SetPipelineState(usePso1 ? pPso1 : pPso2);
+			usePso1 = !usePso1;
 
-            // Set this city's CBV table and move to the next descriptor.
-            pCommandList->SetGraphicsRootDescriptorTable(2, cbvSrvHandle);
-            cbvSrvHandle.Offset(cbvSrvDescriptorSize);
+			// Set this city's CBV table and move to the next descriptor.
+			pCommandList->SetGraphicsRootDescriptorTable(2, cbvSrvHandle);
+			cbvSrvHandle.Offset(cbvSrvDescriptorSize);
 
-            pCommandList->DrawIndexedInstanced(numIndices, 1, 0, 0, 0);
-        }
-    }
-    PIXEndEvent(pCommandList);
+			pCommandList->DrawIndexedInstanced(numIndices, 1, 0, 0, 0);
+		}
+	}
+	PIXEndEvent(pCommandList);
 }
 
 void XM_CALLCONV FrameResource::UpdateConstantBuffers(FXMMATRIX view, CXMMATRIX projection)
 {
-    XMMATRIX model;
-    XMFLOAT4X4 mvp;
+	XMMATRIX model;
+	XMFLOAT4X4 mvp;
 
-    for (UINT i = 0; i < m_cityRowCount; i++)
-    {
-        for (UINT j = 0; j < m_cityColumnCount; j++)
-        {
-            model = XMLoadFloat4x4(&m_modelMatrices[i * m_cityColumnCount + j]);
+	for (UINT i = 0; i < m_cityRowCount; i++)
+	{
+		for (UINT j = 0; j < m_cityColumnCount; j++)
+		{
+			model = XMLoadFloat4x4(&m_modelMatrices[i * m_cityColumnCount + j]);
 
-            // Compute the model-view-projection matrix.
-            XMStoreFloat4x4(&mvp, XMMatrixTranspose(model * view * projection));
+			// Compute the model-view-projection matrix.
+			XMStoreFloat4x4(&mvp, XMMatrixTranspose(model * view * projection));
 
-            // Copy this matrix into the appropriate location in the upload heap subresource.
-            memcpy(&m_pConstantBuffers[i * m_cityColumnCount + j], &mvp, sizeof(mvp));
-        }
-    }
+			// Copy this matrix into the appropriate location in the upload heap subresource.
+			memcpy(&m_pConstantBuffers[i * m_cityColumnCount + j], &mvp, sizeof(mvp));
+		}
+	}
 }

--- a/Samples/Desktop/D3D12Bundles/src/FrameResource.h
+++ b/Samples/Desktop/D3D12Bundles/src/FrameResource.h
@@ -19,36 +19,36 @@ using Microsoft::WRL::ComPtr;
 class FrameResource
 {
 private:
-    void SetCityPositions(FLOAT intervalX, FLOAT intervalZ);
+	void SetCityPositions(FLOAT intervalX, FLOAT intervalZ);
 
 public:
-    struct SceneConstantBuffer
-    {
-        XMFLOAT4X4 mvp;        // Model-view-projection (MVP) matrix.
-        FLOAT padding[48];
-    };
+	struct SceneConstantBuffer
+	{
+		XMFLOAT4X4 mvp;		// Model-view-projection (MVP) matrix.
+		FLOAT padding[48];
+	};
 
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandAllocator> m_bundleAllocator;
-    ComPtr<ID3D12GraphicsCommandList> m_bundle;
-    ComPtr<ID3D12Resource> m_cbvUploadHeap;
-    SceneConstantBuffer* m_pConstantBuffers;
-    UINT64 m_fenceValue;
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandAllocator> m_bundleAllocator;
+	ComPtr<ID3D12GraphicsCommandList> m_bundle;
+	ComPtr<ID3D12Resource> m_cbvUploadHeap;
+	SceneConstantBuffer* m_pConstantBuffers;
+	UINT64 m_fenceValue;
 
-    std::vector<XMFLOAT4X4> m_modelMatrices;
-    UINT m_cityRowCount;
-    UINT m_cityColumnCount;
+	std::vector<XMFLOAT4X4> m_modelMatrices;
+	UINT m_cityRowCount;
+	UINT m_cityColumnCount;
 
-    FrameResource(ID3D12Device* pDevice, UINT cityRowCount, UINT cityColumnCount);
-    ~FrameResource();
+	FrameResource(ID3D12Device* pDevice, UINT cityRowCount, UINT cityColumnCount);
+	~FrameResource();
 
-    void InitBundle(ID3D12Device* pDevice, ID3D12PipelineState* pPso1, ID3D12PipelineState* pPso2,
-        UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
-        ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature);
+	void InitBundle(ID3D12Device* pDevice, ID3D12PipelineState* pPso1, ID3D12PipelineState* pPso2,
+		UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
+		ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature);
 
-    void PopulateCommandList(ID3D12GraphicsCommandList* pCommandList, ID3D12PipelineState* pPso1, ID3D12PipelineState* pPso2,
-        UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
-        ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature);
+	void PopulateCommandList(ID3D12GraphicsCommandList* pCommandList, ID3D12PipelineState* pPso1, ID3D12PipelineState* pPso2,
+		UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
+		ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature);
 
-    void XM_CALLCONV UpdateConstantBuffers(FXMMATRIX view, CXMMATRIX projection);
+	void XM_CALLCONV UpdateConstantBuffers(FXMMATRIX view, CXMMATRIX projection);
 };

--- a/Samples/Desktop/D3D12Bundles/src/Main.cpp
+++ b/Samples/Desktop/D3D12Bundles/src/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12Bundles sample(1280, 720, L"D3D12 Bundles Sample");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12Bundles sample(1280, 720, L"D3D12 Bundles Sample");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12Bundles/src/SimpleCamera.cpp
+++ b/Samples/Desktop/D3D12Bundles/src/SimpleCamera.cpp
@@ -13,163 +13,163 @@
 #include "SimpleCamera.h"
 
 SimpleCamera::SimpleCamera():
-    m_initialPosition(0, 0, 0),
-    m_position(m_initialPosition),
-    m_yaw(XM_PI),
-    m_pitch(0.0f),
-    m_lookDirection(0, 0, -1),
-    m_upDirection(0, 1, 0),
-    m_moveSpeed(20.0f),
-    m_turnSpeed(XM_PIDIV2),
-    m_keysPressed{}
+	m_initialPosition(0, 0, 0),
+	m_position(m_initialPosition),
+	m_yaw(XM_PI),
+	m_pitch(0.0f),
+	m_lookDirection(0, 0, -1),
+	m_upDirection(0, 1, 0),
+	m_moveSpeed(20.0f),
+	m_turnSpeed(XM_PIDIV2),
+	m_keysPressed{}
 {
 }
 
 void SimpleCamera::Init(XMFLOAT3 position)
 {
-    m_initialPosition = position;
-    Reset();
+	m_initialPosition = position;
+	Reset();
 }
 
 void SimpleCamera::SetMoveSpeed(float unitsPerSecond)
 {
-    m_moveSpeed = unitsPerSecond;
+	m_moveSpeed = unitsPerSecond;
 }
 
 void SimpleCamera::SetTurnSpeed(float radiansPerSecond)
 {
-    m_turnSpeed = radiansPerSecond;
+	m_turnSpeed = radiansPerSecond;
 }
 
 void SimpleCamera::Reset()
 {
-    m_position = m_initialPosition;
-    m_yaw = XM_PI;
-    m_pitch = 0.0f;
-    m_lookDirection = { 0, 0, -1 };
+	m_position = m_initialPosition;
+	m_yaw = XM_PI;
+	m_pitch = 0.0f;
+	m_lookDirection = { 0, 0, -1 };
 }
 
 void SimpleCamera::Update(float elapsedSeconds)
 {
-    // Calculate the move vector in camera space.
-    XMFLOAT3 move(0, 0, 0);
+	// Calculate the move vector in camera space.
+	XMFLOAT3 move(0, 0, 0);
 
-    if (m_keysPressed.a)
-        move.x -= 1.0f;
-    if (m_keysPressed.d)
-        move.x += 1.0f;
-    if (m_keysPressed.w)
-        move.z -= 1.0f;
-    if (m_keysPressed.s)
-        move.z += 1.0f;
+	if (m_keysPressed.a)
+		move.x -= 1.0f;
+	if (m_keysPressed.d)
+		move.x += 1.0f;
+	if (m_keysPressed.w)
+		move.z -= 1.0f;
+	if (m_keysPressed.s)
+		move.z += 1.0f;
 
-    if (fabs(move.x) > 0.1f && fabs(move.z) > 0.1f)
-    {
-        XMVECTOR vector = XMVector3Normalize(XMLoadFloat3(&move));
-        move.x = XMVectorGetX(vector);
-        move.z = XMVectorGetZ(vector);
-    }
+	if (fabs(move.x) > 0.1f && fabs(move.z) > 0.1f)
+	{
+		XMVECTOR vector = XMVector3Normalize(XMLoadFloat3(&move));
+		move.x = XMVectorGetX(vector);
+		move.z = XMVectorGetZ(vector);
+	}
 
-    float moveInterval = m_moveSpeed * elapsedSeconds;
-    float rotateInterval = m_turnSpeed * elapsedSeconds;
+	float moveInterval = m_moveSpeed * elapsedSeconds;
+	float rotateInterval = m_turnSpeed * elapsedSeconds;
 
-    if (m_keysPressed.left)
-        m_yaw += rotateInterval;
-    if (m_keysPressed.right)
-        m_yaw -= rotateInterval;
-    if (m_keysPressed.up)
-        m_pitch += rotateInterval;
-    if (m_keysPressed.down)
-        m_pitch -= rotateInterval;
+	if (m_keysPressed.left)
+		m_yaw += rotateInterval;
+	if (m_keysPressed.right)
+		m_yaw -= rotateInterval;
+	if (m_keysPressed.up)
+		m_pitch += rotateInterval;
+	if (m_keysPressed.down)
+		m_pitch -= rotateInterval;
 
-    // Prevent looking too far up or down.
-    m_pitch = min(m_pitch, XM_PIDIV4);
-    m_pitch = max(-XM_PIDIV4, m_pitch);
+	// Prevent looking too far up or down.
+	m_pitch = min(m_pitch, XM_PIDIV4);
+	m_pitch = max(-XM_PIDIV4, m_pitch);
 
-    // Move the camera in model space.
-    float x = move.x * -cosf(m_yaw) - move.z * sinf(m_yaw);
-    float z = move.x * sinf(m_yaw) - move.z * cosf(m_yaw);
-    m_position.x += x * moveInterval;
-    m_position.z += z * moveInterval;
+	// Move the camera in model space.
+	float x = move.x * -cosf(m_yaw) - move.z * sinf(m_yaw);
+	float z = move.x * sinf(m_yaw) - move.z * cosf(m_yaw);
+	m_position.x += x * moveInterval;
+	m_position.z += z * moveInterval;
 
-    // Determine the look direction.
-    float r = cosf(m_pitch);
-    m_lookDirection.x = r * sinf(m_yaw);
-    m_lookDirection.y = sinf(m_pitch);
-    m_lookDirection.z = r * cosf(m_yaw);
+	// Determine the look direction.
+	float r = cosf(m_pitch);
+	m_lookDirection.x = r * sinf(m_yaw);
+	m_lookDirection.y = sinf(m_pitch);
+	m_lookDirection.z = r * cosf(m_yaw);
 }
 
 XMMATRIX SimpleCamera::GetViewMatrix()
 {
-    return XMMatrixLookToRH(XMLoadFloat3(&m_position), XMLoadFloat3(&m_lookDirection), XMLoadFloat3(&m_upDirection));
+	return XMMatrixLookToRH(XMLoadFloat3(&m_position), XMLoadFloat3(&m_lookDirection), XMLoadFloat3(&m_upDirection));
 }
 
 XMMATRIX SimpleCamera::GetProjectionMatrix(float fov, float aspectRatio, float nearPlane, float farPlane)
 {
-    return XMMatrixPerspectiveFovRH(fov, aspectRatio, nearPlane, farPlane);
+	return XMMatrixPerspectiveFovRH(fov, aspectRatio, nearPlane, farPlane);
 }
 
 void SimpleCamera::OnKeyDown(WPARAM key)
 {
-    switch (key)
-    {
-    case 'W':
-        m_keysPressed.w = true;
-        break;
-    case 'A':
-        m_keysPressed.a = true;
-        break;
-    case 'S':
-        m_keysPressed.s = true;
-        break;
-    case 'D':
-        m_keysPressed.d = true;
-        break;
-    case VK_LEFT:
-        m_keysPressed.left = true;
-        break;
-    case VK_RIGHT:
-        m_keysPressed.right = true;
-        break;
-    case VK_UP:
-        m_keysPressed.up = true;
-        break;
-    case VK_DOWN:
-        m_keysPressed.down = true;
-        break;
-    case VK_ESCAPE:
-        Reset();
-        break;
-    }
+	switch (key)
+	{
+	case 'W':
+		m_keysPressed.w = true;
+		break;
+	case 'A':
+		m_keysPressed.a = true;
+		break;
+	case 'S':
+		m_keysPressed.s = true;
+		break;
+	case 'D':
+		m_keysPressed.d = true;
+		break;
+	case VK_LEFT:
+		m_keysPressed.left = true;
+		break;
+	case VK_RIGHT:
+		m_keysPressed.right = true;
+		break;
+	case VK_UP:
+		m_keysPressed.up = true;
+		break;
+	case VK_DOWN:
+		m_keysPressed.down = true;
+		break;
+	case VK_ESCAPE:
+		Reset();
+		break;
+	}
 }
 
 void SimpleCamera::OnKeyUp(WPARAM key)
 {
-    switch (key)
-    {
-    case 'W':
-        m_keysPressed.w = false;
-        break;
-    case 'A':
-        m_keysPressed.a = false;
-        break;
-    case 'S':
-        m_keysPressed.s = false;
-        break;
-    case 'D':
-        m_keysPressed.d = false;
-        break;
-    case VK_LEFT:
-        m_keysPressed.left = false;
-        break;
-    case VK_RIGHT:
-        m_keysPressed.right = false;
-        break;
-    case VK_UP:
-        m_keysPressed.up = false;
-        break;
-    case VK_DOWN:
-        m_keysPressed.down = false;
-        break;
-    }
+	switch (key)
+	{
+	case 'W':
+		m_keysPressed.w = false;
+		break;
+	case 'A':
+		m_keysPressed.a = false;
+		break;
+	case 'S':
+		m_keysPressed.s = false;
+		break;
+	case 'D':
+		m_keysPressed.d = false;
+		break;
+	case VK_LEFT:
+		m_keysPressed.left = false;
+		break;
+	case VK_RIGHT:
+		m_keysPressed.right = false;
+		break;
+	case VK_UP:
+		m_keysPressed.up = false;
+		break;
+	case VK_DOWN:
+		m_keysPressed.down = false;
+		break;
+	}
 }

--- a/Samples/Desktop/D3D12Bundles/src/SimpleCamera.h
+++ b/Samples/Desktop/D3D12Bundles/src/SimpleCamera.h
@@ -16,42 +16,42 @@ using namespace DirectX;
 class SimpleCamera
 {
 public:
-    SimpleCamera();
+	SimpleCamera();
 
-    void Init(XMFLOAT3 position);
-    void Update(float elapsedSeconds);
-    XMMATRIX GetViewMatrix();
-    XMMATRIX GetProjectionMatrix(float fov, float aspectRatio, float nearPlane = 1.0f, float farPlane = 1000.0f);
-    void SetMoveSpeed(float unitsPerSecond);
-    void SetTurnSpeed(float radiansPerSecond);
+	void Init(XMFLOAT3 position);
+	void Update(float elapsedSeconds);
+	XMMATRIX GetViewMatrix();
+	XMMATRIX GetProjectionMatrix(float fov, float aspectRatio, float nearPlane = 1.0f, float farPlane = 1000.0f);
+	void SetMoveSpeed(float unitsPerSecond);
+	void SetTurnSpeed(float radiansPerSecond);
 
-    void OnKeyDown(WPARAM key);
-    void OnKeyUp(WPARAM key);
+	void OnKeyDown(WPARAM key);
+	void OnKeyUp(WPARAM key);
 
 private:
-    void Reset();
+	void Reset();
 
-    struct KeysPressed
-    {
-        bool w;
-        bool a;
-        bool s;
-        bool d;
+	struct KeysPressed
+	{
+		bool w;
+		bool a;
+		bool s;
+		bool d;
 
-        bool left;
-        bool right;
-        bool up;
-        bool down;
-    };
+		bool left;
+		bool right;
+		bool up;
+		bool down;
+	};
 
-    XMFLOAT3 m_initialPosition;
-    XMFLOAT3 m_position;
-    float m_yaw;                // Relative to the +z axis.
-    float m_pitch;                // Relative to the xz plane.
-    XMFLOAT3 m_lookDirection;
-    XMFLOAT3 m_upDirection;
-    float m_moveSpeed;            // Speed at which the camera moves, in units per second.
-    float m_turnSpeed;            // Speed at which the camera turns, in radians per second.
+	XMFLOAT3 m_initialPosition;
+	XMFLOAT3 m_position;
+	float m_yaw;				// Relative to the +z axis.
+	float m_pitch;				// Relative to the xz plane.
+	XMFLOAT3 m_lookDirection;
+	XMFLOAT3 m_upDirection;
+	float m_moveSpeed;			// Speed at which the camera moves, in units per second.
+	float m_turnSpeed;			// Speed at which the camera turns, in radians per second.
 
-    KeysPressed m_keysPressed;
+	KeysPressed m_keysPressed;
 };

--- a/Samples/Desktop/D3D12Bundles/src/Win32Application.cpp
+++ b/Samples/Desktop/D3D12Bundles/src/Win32Application.cpp
@@ -16,104 +16,104 @@ HWND Win32Application::m_hwnd = nullptr;
 
 int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
 {
-    // Parse the command line parameters
-    int argc;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    pSample->ParseCommandLineArgs(argv, argc);
-    LocalFree(argv);
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
 
-    // Initialize the window class.
-    WNDCLASSEX windowClass = { 0 };
-    windowClass.cbSize = sizeof(WNDCLASSEX);
-    windowClass.style = CS_HREDRAW | CS_VREDRAW;
-    windowClass.lpfnWndProc = WindowProc;
-    windowClass.hInstance = hInstance;
-    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-    windowClass.lpszClassName = L"DXSampleClass";
-    RegisterClassEx(&windowClass);
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
 
-    RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
-    AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
 
-    // Create the window and store a handle to it.
-    m_hwnd = CreateWindow(
-        windowClass.lpszClassName,
-        pSample->GetTitle(),
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        windowRect.right - windowRect.left,
-        windowRect.bottom - windowRect.top,
-        nullptr,        // We have no parent window.
-        nullptr,        // We aren't using menus.
-        hInstance,
-        pSample);
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
 
-    // Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-    pSample->OnInit();
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
 
-    ShowWindow(m_hwnd, nCmdShow);
+	ShowWindow(m_hwnd, nCmdShow);
 
-    // Main sample loop.
-    MSG msg = {};
-    while (msg.message != WM_QUIT)
-    {
-        // Process any messages in the queue.
-        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
-    }
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
 
-    pSample->OnDestroy();
+	pSample->OnDestroy();
 
-    // Return this part of the WM_QUIT message to Windows.
-    return static_cast<char>(msg.wParam);
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
 }
 
 // Main message handler for the sample.
 LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
-    switch (message)
-    {
-    case WM_CREATE:
-        {
-            // Save the DXSample* passed in to CreateWindow.
-            LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
-            SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
-        }
-        return 0;
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
 
-    case WM_KEYDOWN:
-        if (pSample)
-        {
-            pSample->OnKeyDown(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_KEYUP:
-        if (pSample)
-        {
-            pSample->OnKeyUp(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_PAINT:
-        if (pSample)
-        {
-            pSample->OnUpdate();
-            pSample->OnRender();
-        }
-        return 0;
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
 
-    case WM_DESTROY:
-        PostQuitMessage(0);
-        return 0;
-    }
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
 
-    // Handle any messages the switch statement didn't.
-    return DefWindowProc(hWnd, message, wParam, lParam);
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/Desktop/D3D12Bundles/src/Win32Application.h
+++ b/Samples/Desktop/D3D12Bundles/src/Win32Application.h
@@ -18,12 +18,12 @@ class DXSample;
 class Win32Application
 {
 public:
-    static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
-    static HWND GetHwnd() { return m_hwnd; }
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
 
 protected:
-    static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
-    static HWND m_hwnd;
+	static HWND m_hwnd;
 };

--- a/Samples/Desktop/D3D12Bundles/src/d3dx12.h
+++ b/Samples/Desktop/D3D12Bundles/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12Bundles/src/occcity.h
+++ b/Samples/Desktop/D3D12Bundles/src/occcity.h
@@ -13,57 +13,57 @@
 
 namespace SampleAssets
 {
-    LPCWSTR DataFileName = L"occcity.bin";
+	LPCWSTR DataFileName = L"occcity.bin";
 
-    const D3D12_INPUT_ELEMENT_DESC StandardVertexDescription[] =
-    {
-        { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,  D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "NORMAL",   0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,    0, 24, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "TANGENT",  0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 32, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-    };
-    UINT StandardVertexDescriptionNumElements = _countof(StandardVertexDescription);
+	const D3D12_INPUT_ELEMENT_DESC StandardVertexDescription[] =
+	{
+		{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,  D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		{ "NORMAL",   0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,    0, 24, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		{ "TANGENT",  0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 32, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+	};
+	UINT StandardVertexDescriptionNumElements = _countof(StandardVertexDescription);
 
-    const UINT StandardVertexStride = 44;
+	const UINT StandardVertexStride = 44;
 
-    const DXGI_FORMAT StandardIndexFormat = DXGI_FORMAT_R32_UINT;
+	const DXGI_FORMAT StandardIndexFormat = DXGI_FORMAT_R32_UINT;
 
-    struct TextureResource
-    {
-        UINT Width;
-        UINT Height;
-        UINT16 MipLevels;
-        DXGI_FORMAT Format;
-        struct DataProperties
-        {
-            UINT Offset;
-            UINT Size;
-            UINT Pitch;
-        } Data[D3D12_REQ_MIP_LEVELS];
-    };
+	struct TextureResource
+	{
+		UINT Width;
+		UINT Height;
+		UINT16 MipLevels;
+		DXGI_FORMAT Format;
+		struct DataProperties
+		{
+			UINT Offset;
+			UINT Size;
+			UINT Pitch;
+		} Data[D3D12_REQ_MIP_LEVELS];
+	};
 
-    struct DrawParameters
-    {
-        INT DiffuseTextureIndex;
-        INT NormalTextureIndex;
-        INT SpecularTextureIndex;
-        UINT IndexStart;
-        UINT IndexCount;
-        UINT VertexBase;
-    };
+	struct DrawParameters
+	{
+		INT DiffuseTextureIndex;
+		INT NormalTextureIndex;
+		INT SpecularTextureIndex;
+		UINT IndexStart;
+		UINT IndexCount;
+		UINT VertexBase;
+	};
 
-    const UINT VertexDataOffset = 524288;
-    const UINT VertexDataSize = 820248;
-    const UINT IndexDataOffset = 1344536;
-    const UINT IndexDataSize = 74568;
+	const UINT VertexDataOffset = 524288;
+	const UINT VertexDataSize = 820248;
+	const UINT IndexDataOffset = 1344536;
+	const UINT IndexDataSize = 74568;
 
-    TextureResource Textures[] =
-    {
-        { 1024, 1024, 1, DXGI_FORMAT_BC1_UNORM, { { 0, 524288, 2048 }, } }, // city.dds
-    };
+	TextureResource Textures[] =
+	{
+		{ 1024, 1024, 1, DXGI_FORMAT_BC1_UNORM, { { 0, 524288, 2048 }, } }, // city.dds
+	};
 
-    DrawParameters Draws[] =
-    {
-        { 0, -1, -1, 0, 18642, 0 },
-    };
+	DrawParameters Draws[] =
+	{
+		{ 0, -1, -1, 0, 18642, 0 },
+	};
 }

--- a/Samples/Desktop/D3D12Bundles/src/shader_mesh_alt_pixel.hlsl
+++ b/Samples/Desktop/D3D12Bundles/src/shader_mesh_alt_pixel.hlsl
@@ -11,19 +11,19 @@
 
 struct PSInput
 {
-    float4 position    : SV_POSITION;
-    float2 uv        : TEXCOORD0;
+	float4 position	: SV_POSITION;
+	float2 uv		: TEXCOORD0;
 };
 
-Texture2D        g_txDiffuse : register(t0);
-SamplerState    g_sampler : register(s0);
+Texture2D		g_txDiffuse : register(t0);
+SamplerState	g_sampler : register(s0);
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    float3 color = g_txDiffuse.Sample(g_sampler, input.uv).rgb;
+	float3 color = g_txDiffuse.Sample(g_sampler, input.uv).rgb;
 
-    // Reduce R and B contributions to the output color.
-    float3 filter = float3(0.25f, 1.0f, 0.25f);
+	// Reduce R and B contributions to the output color.
+	float3 filter = float3(0.25f, 1.0f, 0.25f);
 
-    return float4(color.xyz * filter, 1.0f);
+	return float4(color.xyz * filter, 1.0f);
 }

--- a/Samples/Desktop/D3D12Bundles/src/shader_mesh_simple_pixel.hlsl
+++ b/Samples/Desktop/D3D12Bundles/src/shader_mesh_simple_pixel.hlsl
@@ -11,14 +11,14 @@
 
 struct PSInput
 {
-    float4 position    : SV_POSITION;
-    float2 uv        : TEXCOORD0;
+	float4 position	: SV_POSITION;
+	float2 uv		: TEXCOORD0;
 };
 
-Texture2D        g_txDiffuse : register(t0);
-SamplerState    g_sampler : register(s0);
+Texture2D		g_txDiffuse : register(t0);
+SamplerState	g_sampler : register(s0);
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return g_txDiffuse.Sample(g_sampler, input.uv);
+	return g_txDiffuse.Sample(g_sampler, input.uv);
 }

--- a/Samples/Desktop/D3D12Bundles/src/shader_mesh_simple_vert.hlsl
+++ b/Samples/Desktop/D3D12Bundles/src/shader_mesh_simple_vert.hlsl
@@ -11,29 +11,29 @@
 
 struct VSInput
 {
-    float3 position    : POSITION;
-    float3 normal    : NORMAL;
-    float2 uv        : TEXCOORD0;
-    float3 tangent    : TANGENT;
+	float3 position	: POSITION;
+	float3 normal	: NORMAL;
+	float2 uv		: TEXCOORD0;
+	float3 tangent	: TANGENT;
 };
 
 struct PSInput
 {
-    float4 position    : SV_POSITION;
-    float2 uv        : TEXCOORD0;
+	float4 position	: SV_POSITION;
+	float2 uv		: TEXCOORD0;
 };
 
 cbuffer cb0 : register(b0)
 {
-    float4x4 g_mWorldViewProj;
+	float4x4 g_mWorldViewProj;
 };
 
 PSInput VSMain(VSInput input)
 {
-    PSInput result;
-    
-    result.position = mul(float4(input.position, 1.0f), g_mWorldViewProj);
-    result.uv = input.uv;
-    
-    return result;
+	PSInput result;
+	
+	result.position = mul(float4(input.position, 1.0f), g_mWorldViewProj);
+	result.uv = input.uv;
+	
+	return result;
 }

--- a/Samples/Desktop/D3D12DepthBoundsTest/src/D3D12DepthBoundsTest.cpp
+++ b/Samples/Desktop/D3D12DepthBoundsTest/src/D3D12DepthBoundsTest.cpp
@@ -13,171 +13,171 @@
 #include "D3D12DepthBoundsTest.h"
 
 D3D12DepthBoundsTest::D3D12DepthBoundsTest(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_frameNumber(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_frameNumber(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0)
 {
 }
 
 void D3D12DepthBoundsTest::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12DepthBoundsTest::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-        ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+		));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-        ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+		));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
+	ComPtr<IDXGISwapChain1> swapChain;
 
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-    ));
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+	));
 
-    // This sample does not support fullscreen transitions.
-    ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
+	// This sample does not support fullscreen transitions.
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a depth stencil view (DSV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
-        dsvHeapDesc.NumDescriptors = 1;
-        dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-        dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
+		// Describe and create a depth stencil view (DSV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
+		dsvHeapDesc.NumDescriptors = 1;
+		dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+		dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
-        }
-    }
+		// Create a RTV for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
+		}
+	}
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
 }
 
 // Load the sample assets.
 void D3D12DepthBoundsTest::LoadAssets()
 {
-    // Create an empty root signature.
-    {
-        CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+	// Create an empty root signature.
+	{
+		CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
         // To bring up depth bounds feature, DX12 introduces a new concept to create pipeline state, called PSO stream. 
         // It is required to use PSO stream to enable depth bounds test.
@@ -251,208 +251,208 @@ void D3D12DepthBoundsTest::LoadAssets()
 
         const D3D12_PIPELINE_STATE_STREAM_DESC depthOnlyPSOStreamDesc = { sizeof(depthOnlyPSOStream), &depthOnlyPSOStream };
         ThrowIfFailed(m_device->CreatePipelineState(&depthOnlyPSOStreamDesc, IID_PPV_ARGS(&m_depthOnlyPipelineState)));
-    }
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
 
-    // Command lists are created in the recording state, but there is nothing
-    // to record yet. The main loop expects it to be closed, so close it now.
-    ThrowIfFailed(m_commandList->Close());
+	// Command lists are created in the recording state, but there is nothing
+	// to record yet. The main loop expects it to be closed, so close it now.
+	ThrowIfFailed(m_commandList->Close());
 
-    // Create the vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        Vertex triangleVertices[] =
-        {
-            { { 0.00f,  0.25f * m_aspectRatio, 0.1f },    // Top
-            { 1.0f,   0.0f,  0.0f,  1.0f } },        // Red
-            { { 0.25f, -0.25f * m_aspectRatio, 0.9f },    // Right
-            { 0.0f,   1.0f,  0.0f,  1.0f } },        // Green
-            { { -0.25f, -0.25f * m_aspectRatio, 0.5f },    // Left
-            { 0.0f,   0.0f,  1.0f,  1.0f } }         // Blue
-        };
+	// Create the vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		Vertex triangleVertices[] =
+		{
+			{ { 0.00f,  0.25f * m_aspectRatio, 0.1f },	// Top
+			{ 1.0f,   0.0f,  0.0f,  1.0f } },		// Red
+			{ { 0.25f, -0.25f * m_aspectRatio, 0.9f },	// Right
+			{ 0.0f,   1.0f,  0.0f,  1.0f } },		// Green
+			{ { -0.25f, -0.25f * m_aspectRatio, 0.5f },	// Left
+			{ 0.0f,   0.0f,  1.0f,  1.0f } } 		// Blue
+		};
 
-        const UINT vertexBufferSize = sizeof(triangleVertices);
+		const UINT vertexBufferSize = sizeof(triangleVertices);
 
-        // Note: using upload heaps to transfer static data like vert buffers is not 
-        // recommended. Every time the GPU needs it, the upload heap will be marshalled 
-        // over. Please read up on Default Heap usage. An upload heap is used here for 
-        // code simplicity and because there are very few verts to actually transfer.
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		// Note: using upload heaps to transfer static data like vert buffers is not 
+		// recommended. Every time the GPU needs it, the upload heap will be marshalled 
+		// over. Please read up on Default Heap usage. An upload heap is used here for 
+		// code simplicity and because there are very few verts to actually transfer.
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        // Copy the triangle data to the vertex buffer.
-        UINT8* pVertexDataBegin;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
-        memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
-        m_vertexBuffer->Unmap(0, nullptr);
+		// Copy the triangle data to the vertex buffer.
+		UINT8* pVertexDataBegin;
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
+		memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
+		m_vertexBuffer->Unmap(0, nullptr);
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = vertexBufferSize;
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = vertexBufferSize;
+	}
 
-    // Create the depth stencil view.
-    {
-        D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
-        depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
-        depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
-        depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
+	// Create the depth stencil view.
+	{
+		D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
+		depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
+		depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+		depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
 
-        D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
-        depthOptimizedClearValue.Format = DXGI_FORMAT_D32_FLOAT;
-        depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
-        depthOptimizedClearValue.DepthStencil.Stencil = 0;
+		D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
+		depthOptimizedClearValue.Format = DXGI_FORMAT_D32_FLOAT;
+		depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
+		depthOptimizedClearValue.DepthStencil.Stencil = 0;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
-            D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            &depthOptimizedClearValue,
-            IID_PPV_ARGS(&m_depthStencil)
-        ));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
+			D3D12_RESOURCE_STATE_DEPTH_WRITE,
+			&depthOptimizedClearValue,
+			IID_PPV_ARGS(&m_depthStencil)
+		));
 
-        NAME_D3D12_OBJECT(m_depthStencil);
+		NAME_D3D12_OBJECT(m_depthStencil);
 
-        m_device->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		m_device->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValue = 1;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValue = 1;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForPreviousFrame();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForPreviousFrame();
+	}
 }
 
 // Update frame-based values.
 void D3D12DepthBoundsTest::OnUpdate()
 {
-    m_frameNumber++;
+	m_frameNumber++;
 }
 
 // Render the scene.
 void D3D12DepthBoundsTest::OnRender()
 {
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+	// Present the frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    WaitForPreviousFrame();
+	WaitForPreviousFrame();
 }
 
 void D3D12DepthBoundsTest::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForPreviousFrame();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForPreviousFrame();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12DepthBoundsTest::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocator->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocator->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_depthOnlyPipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_depthOnlyPipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
 
-    // Record commands.
-    const float clearColor[] = { 0.392f, 0.584f, 0.929f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    m_commandList->ClearDepthStencilView(m_dsvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+	// Record commands.
+	const float clearColor[] = { 0.392f, 0.584f, 0.929f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	m_commandList->ClearDepthStencilView(m_dsvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
 
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
 
     // Render only the depth stencil view of the triangle to prime the depth value of the triangle
-    m_commandList->DrawInstanced(3, 1, 0, 0);
+	m_commandList->DrawInstanced(3, 1, 0, 0);
 
     // Move depth bounds so we can see they move. Depth bound test will test against DEST depth
-    // that we primed previously
-    const FLOAT f = 0.125f + sinf((m_frameNumber & 0x7F) / 127.f) * 0.125f;      // [0.. 0.25]
-    if (DepthBoundsTestSupported)
-    {
-        m_commandList->OMSetDepthBounds(0.0f + f, 1.0f - f);
-    }
+	// that we primed previously
+	const FLOAT f = 0.125f + sinf((m_frameNumber & 0x7F) / 127.f) * 0.125f;      // [0.. 0.25]
+	if (DepthBoundsTestSupported)
+	{
+		m_commandList->OMSetDepthBounds(0.0f + f, 1.0f - f);
+	}
 
-    // Render the triangle with depth bounds
-    m_commandList->SetPipelineState(m_pipelineState.Get());
-    m_commandList->DrawInstanced(3, 1, 0, 0);
+	// Render the triangle with depth bounds
+	m_commandList->SetPipelineState(m_pipelineState.Get());
+	m_commandList->DrawInstanced(3, 1, 0, 0);
 
-    // Disable depth bounds on Direct3D 12 by resetting back to the default range
-    if (DepthBoundsTestSupported)
-    {
-        m_commandList->OMSetDepthBounds(0.0f, 1.0f);
-    }
+	// Disable depth bounds on Direct3D 12 by resetting back to the default range
+	if (DepthBoundsTestSupported)
+	{
+		m_commandList->OMSetDepthBounds(0.0f, 1.0f);
+	}
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 void D3D12DepthBoundsTest::WaitForPreviousFrame()
 {
-    // WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
-    // This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
-    // sample illustrates how to use fences for efficient resource usage and to
-    // maximize GPU utilization.
+	// WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
+	// This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
+	// sample illustrates how to use fences for efficient resource usage and to
+	// maximize GPU utilization.
 
-    // Signal and increment the fence value.
-    const UINT64 fence = m_fenceValue;
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
-    m_fenceValue++;
+	// Signal and increment the fence value.
+	const UINT64 fence = m_fenceValue;
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
+	m_fenceValue++;
 
-    // Wait until the previous frame is finished.
-    if (m_fence->GetCompletedValue() < fence)
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+	// Wait until the previous frame is finished.
+	if (m_fence->GetCompletedValue() < fence)
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 }

--- a/Samples/Desktop/D3D12DepthBoundsTest/src/D3D12DepthBoundsTest.h
+++ b/Samples/Desktop/D3D12DepthBoundsTest/src/D3D12DepthBoundsTest.h
@@ -25,53 +25,53 @@ using Microsoft::WRL::ComPtr;
 class D3D12DepthBoundsTest : public DXSample
 {
 public:
-    D3D12DepthBoundsTest(UINT width, UINT height, std::wstring name);
+	D3D12DepthBoundsTest(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    static const UINT FrameCount = 2;
+	static const UINT FrameCount = 2;
 
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT4 color;
-    };
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT4 color;
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device2> m_device;
-    ComPtr<ID3D12Resource> m_depthStencil;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12PipelineState> m_depthOnlyPipelineState;
-    ComPtr<ID3D12GraphicsCommandList1> m_commandList;
-    UINT m_rtvDescriptorSize;
-    bool DepthBoundsTestSupported;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device2> m_device;
+	ComPtr<ID3D12Resource> m_depthStencil;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12PipelineState> m_depthOnlyPipelineState;
+	ComPtr<ID3D12GraphicsCommandList1> m_commandList;
+	UINT m_rtvDescriptorSize;
+	bool DepthBoundsTestSupported;
 
-    // App resources.
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	// App resources.
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    UINT m_frameNumber;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValue;
+	// Synchronization objects.
+	UINT m_frameIndex;
+	UINT m_frameNumber;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValue;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void PopulateCommandList();
-    void WaitForPreviousFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	void PopulateCommandList();
+	void WaitForPreviousFrame();
 };

--- a/Samples/Desktop/D3D12DepthBoundsTest/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12DepthBoundsTest/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,58 +34,103 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title + L": " + text;
-    SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
+	std::wstring windowText = m_title + L": " + text;
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/Desktop/D3D12DepthBoundsTest/src/DXSample.h
+++ b/Samples/Desktop/D3D12DepthBoundsTest/src/DXSample.h
@@ -17,42 +17,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/Desktop/D3D12DepthBoundsTest/src/Main.cpp
+++ b/Samples/Desktop/D3D12DepthBoundsTest/src/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12DepthBoundsTest sample(1280, 720, L"D3D12 Depth Bounds Test Sample");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12DepthBoundsTest sample(1280, 720, L"D3D12 Depth Bounds Test Sample");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12DepthBoundsTest/src/Win32Application.cpp
+++ b/Samples/Desktop/D3D12DepthBoundsTest/src/Win32Application.cpp
@@ -16,104 +16,104 @@ HWND Win32Application::m_hwnd = nullptr;
 
 int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
 {
-    // Parse the command line parameters
-    int argc;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    pSample->ParseCommandLineArgs(argv, argc);
-    LocalFree(argv);
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
 
-    // Initialize the window class.
-    WNDCLASSEX windowClass = { 0 };
-    windowClass.cbSize = sizeof(WNDCLASSEX);
-    windowClass.style = CS_HREDRAW | CS_VREDRAW;
-    windowClass.lpfnWndProc = WindowProc;
-    windowClass.hInstance = hInstance;
-    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-    windowClass.lpszClassName = L"DXSampleClass";
-    RegisterClassEx(&windowClass);
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
 
-    RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
-    AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
 
-    // Create the window and store a handle to it.
-    m_hwnd = CreateWindow(
-        windowClass.lpszClassName,
-        pSample->GetTitle(),
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        windowRect.right - windowRect.left,
-        windowRect.bottom - windowRect.top,
-        nullptr,        // We have no parent window.
-        nullptr,        // We aren't using menus.
-        hInstance,
-        pSample);
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
 
-    // Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-    pSample->OnInit();
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
 
-    ShowWindow(m_hwnd, nCmdShow);
+	ShowWindow(m_hwnd, nCmdShow);
 
-    // Main sample loop.
-    MSG msg = {};
-    while (msg.message != WM_QUIT)
-    {
-        // Process any messages in the queue.
-        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
-    }
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
 
-    pSample->OnDestroy();
+	pSample->OnDestroy();
 
-    // Return this part of the WM_QUIT message to Windows.
-    return static_cast<char>(msg.wParam);
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
 }
 
 // Main message handler for the sample.
 LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
-    switch (message)
-    {
-    case WM_CREATE:
-        {
-            // Save the DXSample* passed in to CreateWindow.
-            LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
-            SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
-        }
-        return 0;
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
 
-    case WM_KEYDOWN:
-        if (pSample)
-        {
-            pSample->OnKeyDown(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_KEYUP:
-        if (pSample)
-        {
-            pSample->OnKeyUp(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_PAINT:
-        if (pSample)
-        {
-            pSample->OnUpdate();
-            pSample->OnRender();
-        }
-        return 0;
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
 
-    case WM_DESTROY:
-        PostQuitMessage(0);
-        return 0;
-    }
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
 
-    // Handle any messages the switch statement didn't.
-    return DefWindowProc(hWnd, message, wParam, lParam);
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/Desktop/D3D12DepthBoundsTest/src/Win32Application.h
+++ b/Samples/Desktop/D3D12DepthBoundsTest/src/Win32Application.h
@@ -18,12 +18,12 @@ class DXSample;
 class Win32Application
 {
 public:
-    static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
-    static HWND GetHwnd() { return m_hwnd; }
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
 
 protected:
-    static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
-    static HWND m_hwnd;
+	static HWND m_hwnd;
 };

--- a/Samples/Desktop/D3D12DepthBoundsTest/src/d3dx12.h
+++ b/Samples/Desktop/D3D12DepthBoundsTest/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12DepthBoundsTest/src/shaders.hlsl
+++ b/Samples/Desktop/D3D12DepthBoundsTest/src/shaders.hlsl
@@ -11,21 +11,21 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VSMain(float4 position : POSITION, float4 color : COLOR)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.color = color;
+	result.position = position;
+	result.color = color;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/Desktop/D3D12DynamicIndexing/src/D3D12DynamicIndexing.cpp
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/D3D12DynamicIndexing.cpp
@@ -16,730 +16,730 @@
 const float D3D12DynamicIndexing::CitySpacingInterval = 16.0f;
 
 D3D12DynamicIndexing::D3D12DynamicIndexing(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_frameCounter(0),
-    m_fenceValue(0),
-    m_rtvDescriptorSize(0),
-    m_cbvSrvDescriptorSize(0),
-    m_currentFrameResourceIndex(0),
-    m_pCurrentFrameResource(nullptr)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_frameCounter(0),
+	m_fenceValue(0),
+	m_rtvDescriptorSize(0),
+	m_cbvSrvDescriptorSize(0),
+	m_currentFrameResourceIndex(0),
+	m_pCurrentFrameResource(nullptr)
 {
 }
 
 void D3D12DynamicIndexing::OnInit()
 {
-    m_camera.Init({ (CityColumnCount / 2.0f) * CitySpacingInterval - (CitySpacingInterval / 2.0f), 15, 50 });
-    m_camera.SetMoveSpeed(CitySpacingInterval * 2.0f);
+	m_camera.Init({ (CityColumnCount / 2.0f) * CitySpacingInterval - (CitySpacingInterval / 2.0f), 15, 50 });
+	m_camera.SetMoveSpeed(CitySpacingInterval * 2.0f);
 
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12DynamicIndexing::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
-    NAME_D3D12_OBJECT(m_commandQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	NAME_D3D12_OBJECT(m_commandQueue);
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    // This sample does not support fullscreen transitions.
-    ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
+	// This sample does not support fullscreen transitions.
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a depth stencil view (DSV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
-        dsvHeapDesc.NumDescriptors = 1;
-        dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-        dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
+		// Describe and create a depth stencil view (DSV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
+		dsvHeapDesc.NumDescriptors = 1;
+		dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+		dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
 
-        // Describe and create a shader resource view (SRV) and constant 
-        // buffer view (CBV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvSrvHeapDesc = {};
-        cbvSrvHeapDesc.NumDescriptors =
-            FrameCount * CityRowCount * CityColumnCount +    // FrameCount frames * CityRowCount * CityColumnCount.
-            CityMaterialCount + 1;                            // CityMaterialCount + 1 for the SRVs.
-        cbvSrvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        cbvSrvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvSrvHeapDesc, IID_PPV_ARGS(&m_cbvSrvHeap)));
-        NAME_D3D12_OBJECT(m_cbvSrvHeap);
+		// Describe and create a shader resource view (SRV) and constant 
+		// buffer view (CBV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvSrvHeapDesc = {};
+		cbvSrvHeapDesc.NumDescriptors =
+			FrameCount * CityRowCount * CityColumnCount +	// FrameCount frames * CityRowCount * CityColumnCount.
+			CityMaterialCount + 1;							// CityMaterialCount + 1 for the SRVs.
+		cbvSrvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		cbvSrvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvSrvHeapDesc, IID_PPV_ARGS(&m_cbvSrvHeap)));
+		NAME_D3D12_OBJECT(m_cbvSrvHeap);
 
-        // Describe and create a sampler descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
-        samplerHeapDesc.NumDescriptors = 1;
-        samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
-        samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_samplerHeap)));
+		// Describe and create a sampler descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
+		samplerHeapDesc.NumDescriptors = 1;
+		samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
+		samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_samplerHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-        m_cbvSrvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_cbvSrvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	}
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
 }
 
 // Load the sample assets.
 void D3D12DynamicIndexing::LoadAssets()
 {
-    // Note: ComPtr's are CPU objects but these resources need to stay in scope until
-    // the command list that references them has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resources are not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> vertexBufferUploadHeap;
-    ComPtr<ID3D12Resource> indexBufferUploadHeap;
-    ComPtr<ID3D12Resource> textureUploadHeap;
-    ComPtr<ID3D12Resource> materialsUploadHeap;
+	// Note: ComPtr's are CPU objects but these resources need to stay in scope until
+	// the command list that references them has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resources are not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> vertexBufferUploadHeap;
+	ComPtr<ID3D12Resource> indexBufferUploadHeap;
+	ComPtr<ID3D12Resource> textureUploadHeap;
+	ComPtr<ID3D12Resource> materialsUploadHeap;
 
-    // Create the root signature.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signature.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[3];
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1 + CityMaterialCount, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);    // Diffuse texture + array of materials.
-        ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
-        ranges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[3];
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1 + CityMaterialCount, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);	// Diffuse texture + array of materials.
+		ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
+		ranges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
 
-        CD3DX12_ROOT_PARAMETER1 rootParameters[4];
-        rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
-        rootParameters[1].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_PIXEL);
-        rootParameters[2].InitAsDescriptorTable(1, &ranges[2], D3D12_SHADER_VISIBILITY_VERTEX);
-        rootParameters[3].InitAsConstants(1, 0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
+		CD3DX12_ROOT_PARAMETER1 rootParameters[4];
+		rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
+		rootParameters[1].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_PIXEL);
+		rootParameters[2].InitAsDescriptorTable(1, &ranges[2], D3D12_SHADER_VISIBILITY_VERTEX);
+		rootParameters[3].InitAsConstants(1, 0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-        NAME_D3D12_OBJECT(m_rootSignature);
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+		NAME_D3D12_OBJECT(m_rootSignature);
+	}
 
-    // Create the pipeline state, which includes loading shaders.
-    {
-        UINT8* pVertexShaderData;
-        UINT8* pPixelShaderData;
-        UINT vertexShaderDataLength;
-        UINT pixelShaderDataLength;
+	// Create the pipeline state, which includes loading shaders.
+	{
+		UINT8* pVertexShaderData;
+		UINT8* pPixelShaderData;
+		UINT vertexShaderDataLength;
+		UINT pixelShaderDataLength;
 
-        ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(L"shader_mesh_simple_vert.cso").c_str(), &pVertexShaderData, &vertexShaderDataLength));
-        ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(L"shader_mesh_dynamic_indexing_pixel.cso").c_str(), &pPixelShaderData, &pixelShaderDataLength));
+		ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(L"shader_mesh_simple_vert.cso").c_str(), &pVertexShaderData, &vertexShaderDataLength));
+		ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(L"shader_mesh_dynamic_indexing_pixel.cso").c_str(), &pPixelShaderData, &pixelShaderDataLength));
 
-        CD3DX12_RASTERIZER_DESC rasterizerStateDesc(D3D12_DEFAULT);
-        rasterizerStateDesc.CullMode = D3D12_CULL_MODE_NONE;
+		CD3DX12_RASTERIZER_DESC rasterizerStateDesc(D3D12_DEFAULT);
+		rasterizerStateDesc.CullMode = D3D12_CULL_MODE_NONE;
 
-        // Describe and create the graphics pipeline state object (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { SampleAssets::StandardVertexDescription, SampleAssets::StandardVertexDescriptionNumElements };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(pVertexShaderData, vertexShaderDataLength);
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pPixelShaderData, pixelShaderDataLength);
-        psoDesc.RasterizerState = rasterizerStateDesc;
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state object (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { SampleAssets::StandardVertexDescription, SampleAssets::StandardVertexDescriptionNumElements };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(pVertexShaderData, vertexShaderDataLength);
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pPixelShaderData, pixelShaderDataLength);
+		psoDesc.RasterizerState = rasterizerStateDesc;
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-        NAME_D3D12_OBJECT(m_pipelineState);
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+		NAME_D3D12_OBJECT(m_pipelineState);
 
-        delete pVertexShaderData;
-        delete pPixelShaderData;
-    }
+		delete pVertexShaderData;
+		delete pPixelShaderData;
+	}
 
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), nullptr, IID_PPV_ARGS(&m_commandList)));
-    NAME_D3D12_OBJECT(m_commandList);
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), nullptr, IID_PPV_ARGS(&m_commandList)));
+	NAME_D3D12_OBJECT(m_commandList);
 
-    // Create render target views (RTVs).
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
-    for (UINT i = 0; i < FrameCount; i++)
-    {
-        ThrowIfFailed(m_swapChain->GetBuffer(i, IID_PPV_ARGS(&m_renderTargets[i])));
-        m_device->CreateRenderTargetView(m_renderTargets[i].Get(), nullptr, rtvHandle);
-        rtvHandle.Offset(1, m_rtvDescriptorSize);
+	// Create render target views (RTVs).
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	for (UINT i = 0; i < FrameCount; i++)
+	{
+		ThrowIfFailed(m_swapChain->GetBuffer(i, IID_PPV_ARGS(&m_renderTargets[i])));
+		m_device->CreateRenderTargetView(m_renderTargets[i].Get(), nullptr, rtvHandle);
+		rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-        NAME_D3D12_OBJECT_INDEXED(m_renderTargets, i);
-    }
+		NAME_D3D12_OBJECT_INDEXED(m_renderTargets, i);
+	}
 
-    // Read in mesh data for vertex/index buffers.
-    UINT8* pMeshData;
-    UINT meshDataLength;
-    ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(SampleAssets::DataFileName).c_str(), &pMeshData, &meshDataLength));
+	// Read in mesh data for vertex/index buffers.
+	UINT8* pMeshData;
+	UINT meshDataLength;
+	ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(SampleAssets::DataFileName).c_str(), &pMeshData, &meshDataLength));
 
-    // Create the vertex buffer.
-    {
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+	// Create the vertex buffer.
+	{
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&vertexBufferUploadHeap)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&vertexBufferUploadHeap)));
 
-        NAME_D3D12_OBJECT(m_vertexBuffer);
+		NAME_D3D12_OBJECT(m_vertexBuffer);
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = pMeshData + SampleAssets::VertexDataOffset;
-        vertexData.RowPitch = SampleAssets::VertexDataSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = pMeshData + SampleAssets::VertexDataOffset;
+		vertexData.RowPitch = SampleAssets::VertexDataSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUploadHeap.Get(), 0, 0, 1, &vertexData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUploadHeap.Get(), 0, 0, 1, &vertexData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = SampleAssets::StandardVertexStride;
-        m_vertexBufferView.SizeInBytes = SampleAssets::VertexDataSize;
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = SampleAssets::StandardVertexStride;
+		m_vertexBufferView.SizeInBytes = SampleAssets::VertexDataSize;
+	}
 
-    // Create the index buffer.
-    {
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::IndexDataSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_indexBuffer)));
+	// Create the index buffer.
+	{
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::IndexDataSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_indexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::IndexDataSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&indexBufferUploadHeap)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::IndexDataSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&indexBufferUploadHeap)));
 
-        NAME_D3D12_OBJECT(m_indexBuffer);
+		NAME_D3D12_OBJECT(m_indexBuffer);
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the index buffer.
-        D3D12_SUBRESOURCE_DATA indexData = {};
-        indexData.pData = pMeshData + SampleAssets::IndexDataOffset;
-        indexData.RowPitch = SampleAssets::IndexDataSize;
-        indexData.SlicePitch = indexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the index buffer.
+		D3D12_SUBRESOURCE_DATA indexData = {};
+		indexData.pData = pMeshData + SampleAssets::IndexDataOffset;
+		indexData.RowPitch = SampleAssets::IndexDataSize;
+		indexData.SlicePitch = indexData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_indexBuffer.Get(), indexBufferUploadHeap.Get(), 0, 0, 1, &indexData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_indexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_INDEX_BUFFER));
+		UpdateSubresources<1>(m_commandList.Get(), m_indexBuffer.Get(), indexBufferUploadHeap.Get(), 0, 0, 1, &indexData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_indexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_INDEX_BUFFER));
 
-        // Describe the index buffer view.
-        m_indexBufferView.BufferLocation = m_indexBuffer->GetGPUVirtualAddress();
-        m_indexBufferView.Format = SampleAssets::StandardIndexFormat;
-        m_indexBufferView.SizeInBytes = SampleAssets::IndexDataSize;
+		// Describe the index buffer view.
+		m_indexBufferView.BufferLocation = m_indexBuffer->GetGPUVirtualAddress();
+		m_indexBufferView.Format = SampleAssets::StandardIndexFormat;
+		m_indexBufferView.SizeInBytes = SampleAssets::IndexDataSize;
 
-        m_numIndices = SampleAssets::IndexDataSize / 4;    // R32_UINT (SampleAssets::StandardIndexFormat) = 4 bytes each.
-    }
+		m_numIndices = SampleAssets::IndexDataSize / 4;	// R32_UINT (SampleAssets::StandardIndexFormat) = 4 bytes each.
+	}
 
-    // Create the textures and sampler.
-    {
-        // Procedurally generate an array of textures to use as city materials.
-        {
-            // All of these materials use the same texture desc.
-            D3D12_RESOURCE_DESC textureDesc = {};
-            textureDesc.MipLevels = 1;
-            textureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-            textureDesc.Width = CityMaterialTextureWidth;
-            textureDesc.Height = CityMaterialTextureHeight;
-            textureDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
-            textureDesc.DepthOrArraySize = 1;
-            textureDesc.SampleDesc.Count = 1;
-            textureDesc.SampleDesc.Quality = 0;
-            textureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+	// Create the textures and sampler.
+	{
+		// Procedurally generate an array of textures to use as city materials.
+		{
+			// All of these materials use the same texture desc.
+			D3D12_RESOURCE_DESC textureDesc = {};
+			textureDesc.MipLevels = 1;
+			textureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+			textureDesc.Width = CityMaterialTextureWidth;
+			textureDesc.Height = CityMaterialTextureHeight;
+			textureDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
+			textureDesc.DepthOrArraySize = 1;
+			textureDesc.SampleDesc.Count = 1;
+			textureDesc.SampleDesc.Quality = 0;
+			textureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
 
-            // The textures evenly span the color rainbow so that each city gets
-            // a different material.
-            float materialGradStep = (1.0f / static_cast<float>(CityMaterialCount));
+			// The textures evenly span the color rainbow so that each city gets
+			// a different material.
+			float materialGradStep = (1.0f / static_cast<float>(CityMaterialCount));
 
-            // Generate texture data.
-            std::vector<std::vector<unsigned char>> cityTextureData;
-            cityTextureData.resize(CityMaterialCount);
-            for (UINT i = 0; i < CityMaterialCount; ++i)
-            {
-                ThrowIfFailed(m_device->CreateCommittedResource(
-                    &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-                    D3D12_HEAP_FLAG_NONE,
-                    &textureDesc,
-                    D3D12_RESOURCE_STATE_COPY_DEST,
-                    nullptr,
-                    IID_PPV_ARGS(&m_cityMaterialTextures[i])));
+			// Generate texture data.
+			std::vector<std::vector<unsigned char>> cityTextureData;
+			cityTextureData.resize(CityMaterialCount);
+			for (UINT i = 0; i < CityMaterialCount; ++i)
+			{
+				ThrowIfFailed(m_device->CreateCommittedResource(
+					&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+					D3D12_HEAP_FLAG_NONE,
+					&textureDesc,
+					D3D12_RESOURCE_STATE_COPY_DEST,
+					nullptr,
+					IID_PPV_ARGS(&m_cityMaterialTextures[i])));
 
-                NAME_D3D12_OBJECT_INDEXED(m_cityMaterialTextures, i);
+				NAME_D3D12_OBJECT_INDEXED(m_cityMaterialTextures, i);
 
-                // Fill the texture.
-                float t = i * materialGradStep;
-                cityTextureData[i].resize(CityMaterialTextureWidth * CityMaterialTextureHeight * CityMaterialTextureChannelCount);
-                for (int x = 0; x < CityMaterialTextureWidth; ++x)
-                {
-                    for (int y = 0; y < CityMaterialTextureHeight; ++y)
-                    {
-                        // Compute the appropriate index into the buffer based on the x/y coordinates.
-                        int pixelIndex = (y * CityMaterialTextureChannelCount * CityMaterialTextureWidth) + (x * CityMaterialTextureChannelCount);
+				// Fill the texture.
+				float t = i * materialGradStep;
+				cityTextureData[i].resize(CityMaterialTextureWidth * CityMaterialTextureHeight * CityMaterialTextureChannelCount);
+				for (int x = 0; x < CityMaterialTextureWidth; ++x)
+				{
+					for (int y = 0; y < CityMaterialTextureHeight; ++y)
+					{
+						// Compute the appropriate index into the buffer based on the x/y coordinates.
+						int pixelIndex = (y * CityMaterialTextureChannelCount * CityMaterialTextureWidth) + (x * CityMaterialTextureChannelCount);
 
-                        // Determine this row's position along the rainbow gradient.
-                        float tPrime = t + ((static_cast<float>(y) / static_cast<float>(CityMaterialTextureHeight)) * materialGradStep);
+						// Determine this row's position along the rainbow gradient.
+						float tPrime = t + ((static_cast<float>(y) / static_cast<float>(CityMaterialTextureHeight)) * materialGradStep);
 
-                        // Compute the RGB value for this position along the rainbow
-                        // and pack the pixel value.
-                        XMVECTOR hsl = XMVectorSet(tPrime, 0.5f, 0.5f, 1.0f);
-                        XMVECTOR rgb = XMColorHSLToRGB(hsl);
-                        cityTextureData[i][pixelIndex + 0] = static_cast<unsigned char>((255 * XMVectorGetX(rgb)));
-                        cityTextureData[i][pixelIndex + 1] = static_cast<unsigned char>((255 * XMVectorGetY(rgb)));
-                        cityTextureData[i][pixelIndex + 2] = static_cast<unsigned char>((255 * XMVectorGetZ(rgb)));
-                        cityTextureData[i][pixelIndex + 3] = 255;
-                    }
-                }
-            }
+						// Compute the RGB value for this position along the rainbow
+						// and pack the pixel value.
+						XMVECTOR hsl = XMVectorSet(tPrime, 0.5f, 0.5f, 1.0f);
+						XMVECTOR rgb = XMColorHSLToRGB(hsl);
+						cityTextureData[i][pixelIndex + 0] = static_cast<unsigned char>((255 * XMVectorGetX(rgb)));
+						cityTextureData[i][pixelIndex + 1] = static_cast<unsigned char>((255 * XMVectorGetY(rgb)));
+						cityTextureData[i][pixelIndex + 2] = static_cast<unsigned char>((255 * XMVectorGetZ(rgb)));
+						cityTextureData[i][pixelIndex + 3] = 255;
+					}
+				}
+			}
 
-            // Upload texture data to the default heap resources.
-            {
-                const UINT subresourceCount = textureDesc.DepthOrArraySize * textureDesc.MipLevels;
-                const UINT64 uploadBufferStep = GetRequiredIntermediateSize(m_cityMaterialTextures[0].Get(), 0, subresourceCount); // All of our textures are the same size in this case.
-                const UINT64 uploadBufferSize = uploadBufferStep * CityMaterialCount;
-                ThrowIfFailed(m_device->CreateCommittedResource(
-                    &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-                    D3D12_HEAP_FLAG_NONE,
-                    &CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
-                    D3D12_RESOURCE_STATE_GENERIC_READ,
-                    nullptr,
-                    IID_PPV_ARGS(&materialsUploadHeap)));
+			// Upload texture data to the default heap resources.
+			{
+				const UINT subresourceCount = textureDesc.DepthOrArraySize * textureDesc.MipLevels;
+				const UINT64 uploadBufferStep = GetRequiredIntermediateSize(m_cityMaterialTextures[0].Get(), 0, subresourceCount); // All of our textures are the same size in this case.
+				const UINT64 uploadBufferSize = uploadBufferStep * CityMaterialCount;
+				ThrowIfFailed(m_device->CreateCommittedResource(
+					&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+					D3D12_HEAP_FLAG_NONE,
+					&CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
+					D3D12_RESOURCE_STATE_GENERIC_READ,
+					nullptr,
+					IID_PPV_ARGS(&materialsUploadHeap)));
 
-                for (int i = 0; i < CityMaterialCount; ++i)
-                {
-                    // Copy data to the intermediate upload heap and then schedule 
-                    // a copy from the upload heap to the appropriate texture.
-                    D3D12_SUBRESOURCE_DATA textureData = {};
-                    textureData.pData = &cityTextureData[i][0];
-                    textureData.RowPitch = static_cast<LONG_PTR>((CityMaterialTextureChannelCount * textureDesc.Width));
-                    textureData.SlicePitch = textureData.RowPitch * textureDesc.Height;
+				for (int i = 0; i < CityMaterialCount; ++i)
+				{
+					// Copy data to the intermediate upload heap and then schedule 
+					// a copy from the upload heap to the appropriate texture.
+					D3D12_SUBRESOURCE_DATA textureData = {};
+					textureData.pData = &cityTextureData[i][0];
+					textureData.RowPitch = static_cast<LONG_PTR>((CityMaterialTextureChannelCount * textureDesc.Width));
+					textureData.SlicePitch = textureData.RowPitch * textureDesc.Height;
 
-                    UpdateSubresources(m_commandList.Get(), m_cityMaterialTextures[i].Get(), materialsUploadHeap.Get(), i * uploadBufferStep, 0, subresourceCount, &textureData);
-                    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_cityMaterialTextures[i].Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
-                }
-            }
-        }
+					UpdateSubresources(m_commandList.Get(), m_cityMaterialTextures[i].Get(), materialsUploadHeap.Get(), i * uploadBufferStep, 0, subresourceCount, &textureData);
+					m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_cityMaterialTextures[i].Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
+				}
+			}
+		}
 
-        // Load the occcity diffuse texture with baked-in ambient lighting.
-        // This texture will be blended with a texture from the materials
-        // array in the pixel shader.
-        {
-            D3D12_RESOURCE_DESC textureDesc = {};
-            textureDesc.MipLevels = SampleAssets::Textures[0].MipLevels;
-            textureDesc.Format = SampleAssets::Textures[0].Format;
-            textureDesc.Width = SampleAssets::Textures[0].Width;
-            textureDesc.Height = SampleAssets::Textures[0].Height;
-            textureDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
-            textureDesc.DepthOrArraySize = 1;
-            textureDesc.SampleDesc.Count = 1;
-            textureDesc.SampleDesc.Quality = 0;
-            textureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+		// Load the occcity diffuse texture with baked-in ambient lighting.
+		// This texture will be blended with a texture from the materials
+		// array in the pixel shader.
+		{
+			D3D12_RESOURCE_DESC textureDesc = {};
+			textureDesc.MipLevels = SampleAssets::Textures[0].MipLevels;
+			textureDesc.Format = SampleAssets::Textures[0].Format;
+			textureDesc.Width = SampleAssets::Textures[0].Width;
+			textureDesc.Height = SampleAssets::Textures[0].Height;
+			textureDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
+			textureDesc.DepthOrArraySize = 1;
+			textureDesc.SampleDesc.Count = 1;
+			textureDesc.SampleDesc.Quality = 0;
+			textureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
 
-            ThrowIfFailed(m_device->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-                D3D12_HEAP_FLAG_NONE,
-                &textureDesc,
-                D3D12_RESOURCE_STATE_COPY_DEST,
-                nullptr,
-                IID_PPV_ARGS(&m_cityDiffuseTexture)));
+			ThrowIfFailed(m_device->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+				D3D12_HEAP_FLAG_NONE,
+				&textureDesc,
+				D3D12_RESOURCE_STATE_COPY_DEST,
+				nullptr,
+				IID_PPV_ARGS(&m_cityDiffuseTexture)));
 
-            const UINT subresourceCount = textureDesc.DepthOrArraySize * textureDesc.MipLevels;
-            const UINT64 uploadBufferSize = GetRequiredIntermediateSize(m_cityDiffuseTexture.Get(), 0, subresourceCount);
-            ThrowIfFailed(m_device->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-                D3D12_HEAP_FLAG_NONE,
-                &CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
-                D3D12_RESOURCE_STATE_GENERIC_READ,
-                nullptr,
-                IID_PPV_ARGS(&textureUploadHeap)));
+			const UINT subresourceCount = textureDesc.DepthOrArraySize * textureDesc.MipLevels;
+			const UINT64 uploadBufferSize = GetRequiredIntermediateSize(m_cityDiffuseTexture.Get(), 0, subresourceCount);
+			ThrowIfFailed(m_device->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+				D3D12_HEAP_FLAG_NONE,
+				&CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
+				D3D12_RESOURCE_STATE_GENERIC_READ,
+				nullptr,
+				IID_PPV_ARGS(&textureUploadHeap)));
 
-            NAME_D3D12_OBJECT(m_cityDiffuseTexture);
+			NAME_D3D12_OBJECT(m_cityDiffuseTexture);
 
-            // Copy data to the intermediate upload heap and then schedule 
-            // a copy from the upload heap to the diffuse texture.
-            D3D12_SUBRESOURCE_DATA textureData = {};
-            textureData.pData = pMeshData + SampleAssets::Textures[0].Data[0].Offset;
-            textureData.RowPitch = SampleAssets::Textures[0].Data[0].Pitch;
-            textureData.SlicePitch = SampleAssets::Textures[0].Data[0].Size;
+			// Copy data to the intermediate upload heap and then schedule 
+			// a copy from the upload heap to the diffuse texture.
+			D3D12_SUBRESOURCE_DATA textureData = {};
+			textureData.pData = pMeshData + SampleAssets::Textures[0].Data[0].Offset;
+			textureData.RowPitch = SampleAssets::Textures[0].Data[0].Pitch;
+			textureData.SlicePitch = SampleAssets::Textures[0].Data[0].Size;
 
-            UpdateSubresources(m_commandList.Get(), m_cityDiffuseTexture.Get(), textureUploadHeap.Get(), 0, 0, subresourceCount, &textureData);
-            m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_cityDiffuseTexture.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
-        }
+			UpdateSubresources(m_commandList.Get(), m_cityDiffuseTexture.Get(), textureUploadHeap.Get(), 0, 0, subresourceCount, &textureData);
+			m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_cityDiffuseTexture.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
+		}
 
-        // Describe and create a sampler.
-        D3D12_SAMPLER_DESC samplerDesc = {};
-        samplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-        samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.MinLOD = 0;
-        samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
-        samplerDesc.MipLODBias = 0.0f;
-        samplerDesc.MaxAnisotropy = 1;
-        samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
-        m_device->CreateSampler(&samplerDesc, m_samplerHeap->GetCPUDescriptorHandleForHeapStart());
+		// Describe and create a sampler.
+		D3D12_SAMPLER_DESC samplerDesc = {};
+		samplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.MinLOD = 0;
+		samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
+		samplerDesc.MipLODBias = 0.0f;
+		samplerDesc.MaxAnisotropy = 1;
+		samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
+		m_device->CreateSampler(&samplerDesc, m_samplerHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create SRV for the city's diffuse texture.
-        CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart(), 0, m_cbvSrvDescriptorSize);
-        D3D12_SHADER_RESOURCE_VIEW_DESC diffuseSrvDesc = {};
-        diffuseSrvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        diffuseSrvDesc.Format = SampleAssets::Textures->Format;
-        diffuseSrvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        diffuseSrvDesc.Texture2D.MipLevels = 1;
-        m_device->CreateShaderResourceView(m_cityDiffuseTexture.Get(), &diffuseSrvDesc, srvHandle);
-        srvHandle.Offset(m_cbvSrvDescriptorSize);
+		// Create SRV for the city's diffuse texture.
+		CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart(), 0, m_cbvSrvDescriptorSize);
+		D3D12_SHADER_RESOURCE_VIEW_DESC diffuseSrvDesc = {};
+		diffuseSrvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		diffuseSrvDesc.Format = SampleAssets::Textures->Format;
+		diffuseSrvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		diffuseSrvDesc.Texture2D.MipLevels = 1;
+		m_device->CreateShaderResourceView(m_cityDiffuseTexture.Get(), &diffuseSrvDesc, srvHandle);
+		srvHandle.Offset(m_cbvSrvDescriptorSize);
 
-        // Create SRVs for each city material.
-        for (int i = 0; i < CityMaterialCount; ++i)
-        {
-            D3D12_SHADER_RESOURCE_VIEW_DESC materialSrvDesc = {};
-            materialSrvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-            materialSrvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-            materialSrvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-            materialSrvDesc.Texture2D.MipLevels = 1;
-            m_device->CreateShaderResourceView(m_cityMaterialTextures[i].Get(), &materialSrvDesc, srvHandle);
+		// Create SRVs for each city material.
+		for (int i = 0; i < CityMaterialCount; ++i)
+		{
+			D3D12_SHADER_RESOURCE_VIEW_DESC materialSrvDesc = {};
+			materialSrvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+			materialSrvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+			materialSrvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+			materialSrvDesc.Texture2D.MipLevels = 1;
+			m_device->CreateShaderResourceView(m_cityMaterialTextures[i].Get(), &materialSrvDesc, srvHandle);
 
-            srvHandle.Offset(m_cbvSrvDescriptorSize);
-        }
-    }
+			srvHandle.Offset(m_cbvSrvDescriptorSize);
+		}
+	}
 
-    delete pMeshData;
+	delete pMeshData;
 
-    // Create the depth stencil view.
-    {
-        D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
-        depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
-        depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
-        depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
+	// Create the depth stencil view.
+	{
+		D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
+		depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
+		depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+		depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
 
-        D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
-        depthOptimizedClearValue.Format = DXGI_FORMAT_D32_FLOAT;
-        depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
-        depthOptimizedClearValue.DepthStencil.Stencil = 0;
+		D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
+		depthOptimizedClearValue.Format = DXGI_FORMAT_D32_FLOAT;
+		depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
+		depthOptimizedClearValue.DepthStencil.Stencil = 0;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
-            D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            &depthOptimizedClearValue,
-            IID_PPV_ARGS(&m_depthStencil)
-            ));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
+			D3D12_RESOURCE_STATE_DEPTH_WRITE,
+			&depthOptimizedClearValue,
+			IID_PPV_ARGS(&m_depthStencil)
+			));
 
-        NAME_D3D12_OBJECT(m_depthStencil);
+		NAME_D3D12_OBJECT(m_depthStencil);
 
-        m_device->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		m_device->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    // Close the command list and execute it to begin the initial GPU setup.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the initial GPU setup.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_fenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValue++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_fenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValue++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
 
-        // Signal and increment the fence value.
-        const UINT64 fenceToWaitFor = m_fenceValue;
-        ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fenceToWaitFor));
-        m_fenceValue++;
+		// Signal and increment the fence value.
+		const UINT64 fenceToWaitFor = m_fenceValue;
+		ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fenceToWaitFor));
+		m_fenceValue++;
 
-        // Wait until the fence is completed.
-        ThrowIfFailed(m_fence->SetEventOnCompletion(fenceToWaitFor, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+		// Wait until the fence is completed.
+		ThrowIfFailed(m_fence->SetEventOnCompletion(fenceToWaitFor, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 
-    CreateFrameResources();
+	CreateFrameResources();
 }
 
 // Update frame-based values.
 void D3D12DynamicIndexing::OnUpdate()
 {
-    m_timer.Tick(NULL);
+	m_timer.Tick(NULL);
 
-    if (m_frameCounter == 500)
-    {
-        // Update window text with FPS value.
-        wchar_t fps[64];
-        swprintf_s(fps, L"%ufps", m_timer.GetFramesPerSecond());
-        SetCustomWindowText(fps);
-        m_frameCounter = 0;
-    }
+	if (m_frameCounter == 500)
+	{
+		// Update window text with FPS value.
+		wchar_t fps[64];
+		swprintf_s(fps, L"%ufps", m_timer.GetFramesPerSecond());
+		SetCustomWindowText(fps);
+		m_frameCounter = 0;
+	}
 
-    m_frameCounter++;
+	m_frameCounter++;
 
-    // Get current GPU progress against submitted workload. Resources still scheduled 
-    // for GPU execution cannot be modified or else undefined behavior will result.
-    const UINT64 lastCompletedFence = m_fence->GetCompletedValue();
+	// Get current GPU progress against submitted workload. Resources still scheduled 
+	// for GPU execution cannot be modified or else undefined behavior will result.
+	const UINT64 lastCompletedFence = m_fence->GetCompletedValue();
 
-    // Move to the next frame resource.
-    m_currentFrameResourceIndex = (m_currentFrameResourceIndex + 1) % FrameCount;
-    m_pCurrentFrameResource = m_frameResources[m_currentFrameResourceIndex];
+	// Move to the next frame resource.
+	m_currentFrameResourceIndex = (m_currentFrameResourceIndex + 1) % FrameCount;
+	m_pCurrentFrameResource = m_frameResources[m_currentFrameResourceIndex];
 
-    // Make sure that this frame resource isn't still in use by the GPU.
-    // If it is, wait for it to complete.
-    if (m_pCurrentFrameResource->m_fenceValue != 0 && m_pCurrentFrameResource->m_fenceValue > lastCompletedFence)
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_pCurrentFrameResource->m_fenceValue, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+	// Make sure that this frame resource isn't still in use by the GPU.
+	// If it is, wait for it to complete.
+	if (m_pCurrentFrameResource->m_fenceValue != 0 && m_pCurrentFrameResource->m_fenceValue > lastCompletedFence)
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_pCurrentFrameResource->m_fenceValue, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 
-    m_camera.Update(static_cast<float>(m_timer.GetElapsedSeconds()));
-    m_pCurrentFrameResource->UpdateConstantBuffers(m_camera.GetViewMatrix(), m_camera.GetProjectionMatrix(0.8f, m_aspectRatio));
+	m_camera.Update(static_cast<float>(m_timer.GetElapsedSeconds()));
+	m_pCurrentFrameResource->UpdateConstantBuffers(m_camera.GetViewMatrix(), m_camera.GetProjectionMatrix(0.8f, m_aspectRatio));
 }
 
 // Render the scene.
 void D3D12DynamicIndexing::OnRender()
 {
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+	PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
 
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList(m_pCurrentFrameResource);
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList(m_pCurrentFrameResource);
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    PIXEndEvent(m_commandQueue.Get());
+	PIXEndEvent(m_commandQueue.Get());
 
-    // Present and update the frame index for the next frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Present and update the frame index for the next frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Signal and increment the fence value.
-    m_pCurrentFrameResource->m_fenceValue = m_fenceValue;
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValue));
-    m_fenceValue++;
+	// Signal and increment the fence value.
+	m_pCurrentFrameResource->m_fenceValue = m_fenceValue;
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValue));
+	m_fenceValue++;
 }
 
 void D3D12DynamicIndexing::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    {
-        const UINT64 fence = m_fenceValue;
-        const UINT64 lastCompletedFence = m_fence->GetCompletedValue();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	{
+		const UINT64 fence = m_fenceValue;
+		const UINT64 lastCompletedFence = m_fence->GetCompletedValue();
 
-        // Signal and increment the fence value.
-        ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValue));
-        m_fenceValue++;
+		// Signal and increment the fence value.
+		ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValue));
+		m_fenceValue++;
 
-        // Wait until the previous frame is finished.
-        if (lastCompletedFence < fence)
-        {
-            ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
-            WaitForSingleObject(m_fenceEvent, INFINITE);
-        }
-    }
+		// Wait until the previous frame is finished.
+		if (lastCompletedFence < fence)
+		{
+			ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
+			WaitForSingleObject(m_fenceEvent, INFINITE);
+		}
+	}
 
-    for (UINT i = 0; i < m_frameResources.size(); i++)
-    {
-        delete m_frameResources.at(i);
-    }
+	for (UINT i = 0; i < m_frameResources.size(); i++)
+	{
+		delete m_frameResources.at(i);
+	}
 }
 
 void D3D12DynamicIndexing::OnKeyDown(UINT8 key)
 {
-    m_camera.OnKeyDown(key);
+	m_camera.OnKeyDown(key);
 }
 
 void D3D12DynamicIndexing::OnKeyUp(UINT8 key)
 {
-    m_camera.OnKeyUp(key);
+	m_camera.OnKeyUp(key);
 }
 
 // Create the resources that will be used every frame.
 void D3D12DynamicIndexing::CreateFrameResources()
 {
-    // Initialize each frame resource.
-    CD3DX12_CPU_DESCRIPTOR_HANDLE cbvSrvHandle(m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart(), CityMaterialCount + 1, m_cbvSrvDescriptorSize);    // Move past the SRVs.
-    for (UINT i = 0; i < FrameCount; i++)
-    {
-        FrameResource* pFrameResource = new FrameResource(m_device.Get(), CityRowCount, CityColumnCount, CityMaterialCount, CitySpacingInterval);
+	// Initialize each frame resource.
+	CD3DX12_CPU_DESCRIPTOR_HANDLE cbvSrvHandle(m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart(), CityMaterialCount + 1, m_cbvSrvDescriptorSize);	// Move past the SRVs.
+	for (UINT i = 0; i < FrameCount; i++)
+	{
+		FrameResource* pFrameResource = new FrameResource(m_device.Get(), CityRowCount, CityColumnCount, CityMaterialCount, CitySpacingInterval);
 
-        UINT64 cbOffset = 0;
-        for (UINT j = 0; j < CityRowCount; j++)
-        {
-            for (UINT k = 0; k < CityColumnCount; k++)
-            {
-                // Describe and create a constant buffer view (CBV).
-                D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
-                cbvDesc.BufferLocation = pFrameResource->m_cbvUploadHeap->GetGPUVirtualAddress() + cbOffset;
-                cbvDesc.SizeInBytes = sizeof(FrameResource::SceneConstantBuffer);
-                cbOffset += cbvDesc.SizeInBytes;
-                m_device->CreateConstantBufferView(&cbvDesc, cbvSrvHandle);
-                cbvSrvHandle.Offset(m_cbvSrvDescriptorSize);
-            }
-        }
+		UINT64 cbOffset = 0;
+		for (UINT j = 0; j < CityRowCount; j++)
+		{
+			for (UINT k = 0; k < CityColumnCount; k++)
+			{
+				// Describe and create a constant buffer view (CBV).
+				D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
+				cbvDesc.BufferLocation = pFrameResource->m_cbvUploadHeap->GetGPUVirtualAddress() + cbOffset;
+				cbvDesc.SizeInBytes = sizeof(FrameResource::SceneConstantBuffer);
+				cbOffset += cbvDesc.SizeInBytes;
+				m_device->CreateConstantBufferView(&cbvDesc, cbvSrvHandle);
+				cbvSrvHandle.Offset(m_cbvSrvDescriptorSize);
+			}
+		}
 
-        pFrameResource->InitBundle(m_device.Get(), m_pipelineState.Get(), i, m_numIndices, &m_indexBufferView,
-            &m_vertexBufferView, m_cbvSrvHeap.Get(), m_cbvSrvDescriptorSize, m_samplerHeap.Get(), m_rootSignature.Get());
+		pFrameResource->InitBundle(m_device.Get(), m_pipelineState.Get(), i, m_numIndices, &m_indexBufferView,
+			&m_vertexBufferView, m_cbvSrvHeap.Get(), m_cbvSrvDescriptorSize, m_samplerHeap.Get(), m_rootSignature.Get());
 
-        m_frameResources.push_back(pFrameResource);
-    }
+		m_frameResources.push_back(pFrameResource);
+	}
 }
 
 void D3D12DynamicIndexing::PopulateCommandList(FrameResource* pFrameResource)
 {
-    // Command list allocators can only be reset when the associated
-    // command lists have finished execution on the GPU; apps should use
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_pCurrentFrameResource->m_commandAllocator->Reset());
+	// Command list allocators can only be reset when the associated
+	// command lists have finished execution on the GPU; apps should use
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_pCurrentFrameResource->m_commandAllocator->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command
-    // list, that command list can then be reset at any time and must be before
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_pCurrentFrameResource->m_commandAllocator.Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command
+	// list, that command list can then be reset at any time and must be before
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_pCurrentFrameResource->m_commandAllocator.Get(), m_pipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvHeap.Get(), m_samplerHeap.Get() };
-    m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvHeap.Get(), m_samplerHeap.Get() };
+	m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    m_commandList->ClearDepthStencilView(m_dsvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	m_commandList->ClearDepthStencilView(m_dsvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
 
-    if (UseBundles)
-    {
-        // Execute the prebuilt bundle.
-        m_commandList->ExecuteBundle(pFrameResource->m_bundle.Get());
-    }
-    else
-    {
-        // Populate a new command list.
-        pFrameResource->PopulateCommandList(m_commandList.Get(), m_pipelineState.Get(), m_currentFrameResourceIndex, m_numIndices, &m_indexBufferView,
-            &m_vertexBufferView, m_cbvSrvHeap.Get(), m_cbvSrvDescriptorSize, m_samplerHeap.Get(), m_rootSignature.Get());
-    }
+	if (UseBundles)
+	{
+		// Execute the prebuilt bundle.
+		m_commandList->ExecuteBundle(pFrameResource->m_bundle.Get());
+	}
+	else
+	{
+		// Populate a new command list.
+		pFrameResource->PopulateCommandList(m_commandList.Get(), m_pipelineState.Get(), m_currentFrameResourceIndex, m_numIndices, &m_indexBufferView,
+			&m_vertexBufferView, m_cbvSrvHeap.Get(), m_cbvSrvDescriptorSize, m_samplerHeap.Get(), m_rootSignature.Get());
+	}
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }

--- a/Samples/Desktop/D3D12DynamicIndexing/src/D3D12DynamicIndexing.h
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/D3D12DynamicIndexing.h
@@ -28,70 +28,70 @@ using Microsoft::WRL::ComPtr;
 class D3D12DynamicIndexing : public DXSample
 {
 public:
-    D3D12DynamicIndexing(UINT width, UINT height, std::wstring name);
+	D3D12DynamicIndexing(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
-    virtual void OnKeyDown(UINT8 key);
-    virtual void OnKeyUp(UINT8 key);
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
+	virtual void OnKeyDown(UINT8 key);
+	virtual void OnKeyUp(UINT8 key);
 
 private:
-    static const UINT FrameCount = 3;
-    static const UINT CityRowCount = 15;
-    static const UINT CityColumnCount = 8;
-    static const UINT CityMaterialCount = CityRowCount * CityColumnCount;
-    static const UINT CityMaterialTextureWidth = 64;
-    static const UINT CityMaterialTextureHeight = 64;
-    static const UINT CityMaterialTextureChannelCount = 4;
-    static const bool UseBundles = true;
-    static const float CitySpacingInterval;
+	static const UINT FrameCount = 3;
+	static const UINT CityRowCount = 15;
+	static const UINT CityColumnCount = 8;
+	static const UINT CityMaterialCount = CityRowCount * CityColumnCount;
+	static const UINT CityMaterialTextureWidth = 64;
+	static const UINT CityMaterialTextureHeight = 64;
+	static const UINT CityMaterialTextureChannelCount = 4;
+	static const bool UseBundles = true;
+	static const float CitySpacingInterval;
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12Resource> m_depthStencil;
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_cbvSrvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_samplerHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12Resource> m_depthStencil;
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_cbvSrvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_samplerHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
 
-    // App resources.
-    UINT m_numIndices;
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    ComPtr<ID3D12Resource> m_indexBuffer;
-    ComPtr<ID3D12Resource> m_cityDiffuseTexture;
-    ComPtr<ID3D12Resource> m_cityMaterialTextures[CityMaterialCount];
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
-    D3D12_INDEX_BUFFER_VIEW m_indexBufferView;
-    StepTimer m_timer;
-    UINT m_cbvSrvDescriptorSize;
-    UINT m_rtvDescriptorSize;
-    SimpleCamera m_camera;
+	// App resources.
+	UINT m_numIndices;
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	ComPtr<ID3D12Resource> m_indexBuffer;
+	ComPtr<ID3D12Resource> m_cityDiffuseTexture;
+	ComPtr<ID3D12Resource> m_cityMaterialTextures[CityMaterialCount];
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	D3D12_INDEX_BUFFER_VIEW m_indexBufferView;
+	StepTimer m_timer;
+	UINT m_cbvSrvDescriptorSize;
+	UINT m_rtvDescriptorSize;
+	SimpleCamera m_camera;
 
-    // Frame resources.
-    std::vector<FrameResource*> m_frameResources;
-    FrameResource* m_pCurrentFrameResource;
-    UINT m_currentFrameResourceIndex;
+	// Frame resources.
+	std::vector<FrameResource*> m_frameResources;
+	FrameResource* m_pCurrentFrameResource;
+	UINT m_currentFrameResourceIndex;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    UINT m_frameCounter;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValue;
+	// Synchronization objects.
+	UINT m_frameIndex;
+	UINT m_frameCounter;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValue;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void CreateFrameResources();
-    void PopulateCommandList(FrameResource* pFrameResource);
+	void LoadPipeline();
+	void LoadAssets();
+	void CreateFrameResources();
+	void PopulateCommandList(FrameResource* pFrameResource);
 };

--- a/Samples/Desktop/D3D12DynamicIndexing/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,58 +34,103 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title + L": " + text;
-    SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
+	std::wstring windowText = m_title + L": " + text;
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/Desktop/D3D12DynamicIndexing/src/DXSample.h
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/DXSample.h
@@ -17,42 +17,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/Desktop/D3D12DynamicIndexing/src/FrameResource.cpp
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/FrameResource.cpp
@@ -13,134 +13,134 @@
 #include "FrameResource.h"
 
 FrameResource::FrameResource(ID3D12Device* pDevice, UINT cityRowCount, UINT cityColumnCount, UINT cityMaterialCount, float citySpacingInterval) :
-    m_fenceValue(0),
-    m_cityRowCount(cityRowCount),
-    m_cityColumnCount(cityColumnCount),
-    m_cityMaterialCount(cityMaterialCount)
+	m_fenceValue(0),
+	m_cityRowCount(cityRowCount),
+	m_cityColumnCount(cityColumnCount),
+	m_cityMaterialCount(cityMaterialCount)
 {
-    m_modelMatrices.resize(m_cityRowCount * m_cityColumnCount);
+	m_modelMatrices.resize(m_cityRowCount * m_cityColumnCount);
 
-    // The command allocator is used by the main sample class when 
-    // resetting the command list in the main update loop. Each frame 
-    // resource needs a command allocator because command allocators 
-    // cannot be reused until the GPU is done executing the commands 
-    // associated with it.
-    ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
-    ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_BUNDLE, IID_PPV_ARGS(&m_bundleAllocator)));
+	// The command allocator is used by the main sample class when 
+	// resetting the command list in the main update loop. Each frame 
+	// resource needs a command allocator because command allocators 
+	// cannot be reused until the GPU is done executing the commands 
+	// associated with it.
+	ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_BUNDLE, IID_PPV_ARGS(&m_bundleAllocator)));
 
-    // Create an upload heap for the constant buffers.
-    ThrowIfFailed(pDevice->CreateCommittedResource(
-        &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-        D3D12_HEAP_FLAG_NONE,
-        &CD3DX12_RESOURCE_DESC::Buffer(sizeof(SceneConstantBuffer) * m_cityRowCount * m_cityColumnCount),
-        D3D12_RESOURCE_STATE_GENERIC_READ,
-        nullptr,
-        IID_PPV_ARGS(&m_cbvUploadHeap)));
+	// Create an upload heap for the constant buffers.
+	ThrowIfFailed(pDevice->CreateCommittedResource(
+		&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+		D3D12_HEAP_FLAG_NONE,
+		&CD3DX12_RESOURCE_DESC::Buffer(sizeof(SceneConstantBuffer) * m_cityRowCount * m_cityColumnCount),
+		D3D12_RESOURCE_STATE_GENERIC_READ,
+		nullptr,
+		IID_PPV_ARGS(&m_cbvUploadHeap)));
 
-    // Map the constant buffers. Note that unlike D3D11, the resource 
-    // does not need to be unmapped for use by the GPU. In this sample, 
-    // the resource stays 'permenantly' mapped to avoid overhead with 
-    // mapping/unmapping each frame.
-    CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-    ThrowIfFailed(m_cbvUploadHeap->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBuffers)));
+	// Map the constant buffers. Note that unlike D3D11, the resource 
+	// does not need to be unmapped for use by the GPU. In this sample, 
+	// the resource stays 'permenantly' mapped to avoid overhead with 
+	// mapping/unmapping each frame.
+	CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+	ThrowIfFailed(m_cbvUploadHeap->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBuffers)));
 
-    // Update all of the model matrices once; our cities don't move so 
-    // we don't need to do this ever again.
-    SetCityPositions(citySpacingInterval, -citySpacingInterval);
+	// Update all of the model matrices once; our cities don't move so 
+	// we don't need to do this ever again.
+	SetCityPositions(citySpacingInterval, -citySpacingInterval);
 }
 
 FrameResource::~FrameResource()
 {
-    m_cbvUploadHeap->Unmap(0, nullptr);
-    m_pConstantBuffers = nullptr;
+	m_cbvUploadHeap->Unmap(0, nullptr);
+	m_pConstantBuffers = nullptr;
 }
 
 void FrameResource::InitBundle(ID3D12Device* pDevice, ID3D12PipelineState* pPso,
-    UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
-    ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature)
+	UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
+	ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature)
 {
-    ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_BUNDLE, m_bundleAllocator.Get(), pPso, IID_PPV_ARGS(&m_bundle)));
-    NAME_D3D12_OBJECT(m_bundle);
+	ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_BUNDLE, m_bundleAllocator.Get(), pPso, IID_PPV_ARGS(&m_bundle)));
+	NAME_D3D12_OBJECT(m_bundle);
 
-    PopulateCommandList(m_bundle.Get(), pPso, frameResourceIndex, numIndices, pIndexBufferViewDesc,
-        pVertexBufferViewDesc, pCbvSrvDescriptorHeap, cbvSrvDescriptorSize, pSamplerDescriptorHeap, pRootSignature);
+	PopulateCommandList(m_bundle.Get(), pPso, frameResourceIndex, numIndices, pIndexBufferViewDesc,
+		pVertexBufferViewDesc, pCbvSrvDescriptorHeap, cbvSrvDescriptorSize, pSamplerDescriptorHeap, pRootSignature);
 
-    ThrowIfFailed(m_bundle->Close());
+	ThrowIfFailed(m_bundle->Close());
 }
 
 void FrameResource::SetCityPositions(FLOAT intervalX, FLOAT intervalZ)
 {
-    for (UINT i = 0; i < m_cityRowCount; i++)
-    {
-        FLOAT cityOffsetZ = i * intervalZ;
-        for (UINT j = 0; j < m_cityColumnCount; j++)
-        {
-            FLOAT cityOffsetX = j * intervalX;
+	for (UINT i = 0; i < m_cityRowCount; i++)
+	{
+		FLOAT cityOffsetZ = i * intervalZ;
+		for (UINT j = 0; j < m_cityColumnCount; j++)
+		{
+			FLOAT cityOffsetX = j * intervalX;
 
-            // The y position is based off of the city's row and column 
-            // position to prevent z-fighting.
-            XMStoreFloat4x4(&m_modelMatrices[i * m_cityColumnCount + j], XMMatrixTranslation(cityOffsetX, 0.02f * (i * m_cityColumnCount + j), cityOffsetZ));
-        }
-    }
+			// The y position is based off of the city's row and column 
+			// position to prevent z-fighting.
+			XMStoreFloat4x4(&m_modelMatrices[i * m_cityColumnCount + j], XMMatrixTranslation(cityOffsetX, 0.02f * (i * m_cityColumnCount + j), cityOffsetZ));
+		}
+	}
 }
 
 void FrameResource::PopulateCommandList(ID3D12GraphicsCommandList* pCommandList, ID3D12PipelineState* pPso,
-    UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
-    ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature)
+	UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
+	ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature)
 {
-    // If the root signature matches the root signature of the caller, then
-    // bindings are inherited, otherwise the bind space is reset.
-    pCommandList->SetGraphicsRootSignature(pRootSignature);
+	// If the root signature matches the root signature of the caller, then
+	// bindings are inherited, otherwise the bind space is reset.
+	pCommandList->SetGraphicsRootSignature(pRootSignature);
 
-    ID3D12DescriptorHeap* ppHeaps[] = { pCbvSrvDescriptorHeap, pSamplerDescriptorHeap };
-    pCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
-    pCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    pCommandList->IASetIndexBuffer(pIndexBufferViewDesc);
-    pCommandList->IASetVertexBuffers(0, 1, pVertexBufferViewDesc);
-    pCommandList->SetGraphicsRootDescriptorTable(0, pCbvSrvDescriptorHeap->GetGPUDescriptorHandleForHeapStart());
-    pCommandList->SetGraphicsRootDescriptorTable(1, pSamplerDescriptorHeap->GetGPUDescriptorHandleForHeapStart());
+	ID3D12DescriptorHeap* ppHeaps[] = { pCbvSrvDescriptorHeap, pSamplerDescriptorHeap };
+	pCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	pCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	pCommandList->IASetIndexBuffer(pIndexBufferViewDesc);
+	pCommandList->IASetVertexBuffers(0, 1, pVertexBufferViewDesc);
+	pCommandList->SetGraphicsRootDescriptorTable(0, pCbvSrvDescriptorHeap->GetGPUDescriptorHandleForHeapStart());
+	pCommandList->SetGraphicsRootDescriptorTable(1, pSamplerDescriptorHeap->GetGPUDescriptorHandleForHeapStart());
 
-    // Calculate the descriptor offset due to multiple frame resources.
-    // (m_cityMaterialCount + 1) SRVs + how many CBVs we have currently.
-    UINT frameResourceDescriptorOffset = (m_cityMaterialCount + 1) + (frameResourceIndex * m_cityRowCount * m_cityColumnCount);
-    CD3DX12_GPU_DESCRIPTOR_HANDLE cbvSrvHandle(pCbvSrvDescriptorHeap->GetGPUDescriptorHandleForHeapStart(), frameResourceDescriptorOffset, cbvSrvDescriptorSize);
+	// Calculate the descriptor offset due to multiple frame resources.
+	// (m_cityMaterialCount + 1) SRVs + how many CBVs we have currently.
+	UINT frameResourceDescriptorOffset = (m_cityMaterialCount + 1) + (frameResourceIndex * m_cityRowCount * m_cityColumnCount);
+	CD3DX12_GPU_DESCRIPTOR_HANDLE cbvSrvHandle(pCbvSrvDescriptorHeap->GetGPUDescriptorHandleForHeapStart(), frameResourceDescriptorOffset, cbvSrvDescriptorSize);
 
-    PIXBeginEvent(pCommandList, 0, L"Draw cities");
-    for (UINT i = 0; i < m_cityRowCount; i++)
-    {
-        for (UINT j = 0; j < m_cityColumnCount; j++)
-        {
-            pCommandList->SetPipelineState(pPso);
+	PIXBeginEvent(pCommandList, 0, L"Draw cities");
+	for (UINT i = 0; i < m_cityRowCount; i++)
+	{
+		for (UINT j = 0; j < m_cityColumnCount; j++)
+		{
+			pCommandList->SetPipelineState(pPso);
 
-            // Set the city's root constant for dynamically indexing into the material array.
-            pCommandList->SetGraphicsRoot32BitConstant(3, (i * m_cityColumnCount) + j, 0);
+			// Set the city's root constant for dynamically indexing into the material array.
+			pCommandList->SetGraphicsRoot32BitConstant(3, (i * m_cityColumnCount) + j, 0);
 
-            // Set this city's CBV table and move to the next descriptor.
-            pCommandList->SetGraphicsRootDescriptorTable(2, cbvSrvHandle);
-            cbvSrvHandle.Offset(cbvSrvDescriptorSize);
+			// Set this city's CBV table and move to the next descriptor.
+			pCommandList->SetGraphicsRootDescriptorTable(2, cbvSrvHandle);
+			cbvSrvHandle.Offset(cbvSrvDescriptorSize);
 
-            pCommandList->DrawIndexedInstanced(numIndices, 1, 0, 0, 0);
-        }
-    }
-    PIXEndEvent(pCommandList);
+			pCommandList->DrawIndexedInstanced(numIndices, 1, 0, 0, 0);
+		}
+	}
+	PIXEndEvent(pCommandList);
 }
 
 void XM_CALLCONV FrameResource::UpdateConstantBuffers(FXMMATRIX view, CXMMATRIX projection)
 {
-    XMMATRIX model;
-    XMFLOAT4X4 mvp;
+	XMMATRIX model;
+	XMFLOAT4X4 mvp;
 
-    for (UINT i = 0; i < m_cityRowCount; i++)
-    {
-        for (UINT j = 0; j < m_cityColumnCount; j++)
-        {
-            model = XMLoadFloat4x4(&m_modelMatrices[i * m_cityColumnCount + j]);
+	for (UINT i = 0; i < m_cityRowCount; i++)
+	{
+		for (UINT j = 0; j < m_cityColumnCount; j++)
+		{
+			model = XMLoadFloat4x4(&m_modelMatrices[i * m_cityColumnCount + j]);
 
-            // Compute the model-view-projection matrix.
-            XMStoreFloat4x4(&mvp, XMMatrixTranspose(model * view * projection));
+			// Compute the model-view-projection matrix.
+			XMStoreFloat4x4(&mvp, XMMatrixTranspose(model * view * projection));
 
-            // Copy this matrix into the appropriate location in the upload heap subresource.
-            memcpy(&m_pConstantBuffers[i * m_cityColumnCount + j], &mvp, sizeof(mvp));
-        }
-    }
+			// Copy this matrix into the appropriate location in the upload heap subresource.
+			memcpy(&m_pConstantBuffers[i * m_cityColumnCount + j], &mvp, sizeof(mvp));
+		}
+	}
 }

--- a/Samples/Desktop/D3D12DynamicIndexing/src/FrameResource.h
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/FrameResource.h
@@ -19,37 +19,37 @@ using Microsoft::WRL::ComPtr;
 class FrameResource
 {
 private:
-    void SetCityPositions(FLOAT intervalX, FLOAT intervalZ);
+	void SetCityPositions(FLOAT intervalX, FLOAT intervalZ);
 
 public:
-    struct SceneConstantBuffer
-    {
-        XMFLOAT4X4 mvp;        // Model-view-projection (MVP) matrix.
-        FLOAT padding[48];
-    };
+	struct SceneConstantBuffer
+	{
+		XMFLOAT4X4 mvp;		// Model-view-projection (MVP) matrix.
+		FLOAT padding[48];
+	};
 
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandAllocator> m_bundleAllocator;
-    ComPtr<ID3D12GraphicsCommandList> m_bundle;
-    ComPtr<ID3D12Resource> m_cbvUploadHeap;
-    SceneConstantBuffer* m_pConstantBuffers;
-    UINT64 m_fenceValue;
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandAllocator> m_bundleAllocator;
+	ComPtr<ID3D12GraphicsCommandList> m_bundle;
+	ComPtr<ID3D12Resource> m_cbvUploadHeap;
+	SceneConstantBuffer* m_pConstantBuffers;
+	UINT64 m_fenceValue;
 
-    std::vector<XMFLOAT4X4> m_modelMatrices;
-    UINT m_cityRowCount;
-    UINT m_cityColumnCount;
-    UINT m_cityMaterialCount;
+	std::vector<XMFLOAT4X4> m_modelMatrices;
+	UINT m_cityRowCount;
+	UINT m_cityColumnCount;
+	UINT m_cityMaterialCount;
 
-    FrameResource(ID3D12Device* pDevice, UINT cityRowCount, UINT cityColumnCount, UINT cityMaterialCount, float citySpacingInterval);
-    ~FrameResource();
+	FrameResource(ID3D12Device* pDevice, UINT cityRowCount, UINT cityColumnCount, UINT cityMaterialCount, float citySpacingInterval);
+	~FrameResource();
 
-    void InitBundle(ID3D12Device* pDevice, ID3D12PipelineState* pPso,
-        UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
-        ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature);
+	void InitBundle(ID3D12Device* pDevice, ID3D12PipelineState* pPso,
+		UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
+		ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature);
 
-    void PopulateCommandList(ID3D12GraphicsCommandList* pCommandList, ID3D12PipelineState* pPso,
-        UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
-        ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature);
+	void PopulateCommandList(ID3D12GraphicsCommandList* pCommandList, ID3D12PipelineState* pPso,
+		UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
+		ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature);
 
-    void XM_CALLCONV UpdateConstantBuffers(FXMMATRIX view, CXMMATRIX projection);
+	void XM_CALLCONV UpdateConstantBuffers(FXMMATRIX view, CXMMATRIX projection);
 };

--- a/Samples/Desktop/D3D12DynamicIndexing/src/Main.cpp
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12DynamicIndexing sample(1280, 720, L"D3D12 Dynamic Indexing Sample");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12DynamicIndexing sample(1280, 720, L"D3D12 Dynamic Indexing Sample");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12DynamicIndexing/src/SimpleCamera.cpp
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/SimpleCamera.cpp
@@ -13,163 +13,163 @@
 #include "SimpleCamera.h"
 
 SimpleCamera::SimpleCamera():
-    m_initialPosition(0, 0, 0),
-    m_position(m_initialPosition),
-    m_yaw(XM_PI),
-    m_pitch(0.0f),
-    m_lookDirection(0, 0, -1),
-    m_upDirection(0, 1, 0),
-    m_moveSpeed(20.0f),
-    m_turnSpeed(XM_PIDIV2),
-    m_keysPressed{}
+	m_initialPosition(0, 0, 0),
+	m_position(m_initialPosition),
+	m_yaw(XM_PI),
+	m_pitch(0.0f),
+	m_lookDirection(0, 0, -1),
+	m_upDirection(0, 1, 0),
+	m_moveSpeed(20.0f),
+	m_turnSpeed(XM_PIDIV2),
+	m_keysPressed{}
 {
 }
 
 void SimpleCamera::Init(XMFLOAT3 position)
 {
-    m_initialPosition = position;
-    Reset();
+	m_initialPosition = position;
+	Reset();
 }
 
 void SimpleCamera::SetMoveSpeed(float unitsPerSecond)
 {
-    m_moveSpeed = unitsPerSecond;
+	m_moveSpeed = unitsPerSecond;
 }
 
 void SimpleCamera::SetTurnSpeed(float radiansPerSecond)
 {
-    m_turnSpeed = radiansPerSecond;
+	m_turnSpeed = radiansPerSecond;
 }
 
 void SimpleCamera::Reset()
 {
-    m_position = m_initialPosition;
-    m_yaw = XM_PI;
-    m_pitch = 0.0f;
-    m_lookDirection = { 0, 0, -1 };
+	m_position = m_initialPosition;
+	m_yaw = XM_PI;
+	m_pitch = 0.0f;
+	m_lookDirection = { 0, 0, -1 };
 }
 
 void SimpleCamera::Update(float elapsedSeconds)
 {
-    // Calculate the move vector in camera space.
-    XMFLOAT3 move(0, 0, 0);
+	// Calculate the move vector in camera space.
+	XMFLOAT3 move(0, 0, 0);
 
-    if (m_keysPressed.a)
-        move.x -= 1.0f;
-    if (m_keysPressed.d)
-        move.x += 1.0f;
-    if (m_keysPressed.w)
-        move.z -= 1.0f;
-    if (m_keysPressed.s)
-        move.z += 1.0f;
+	if (m_keysPressed.a)
+		move.x -= 1.0f;
+	if (m_keysPressed.d)
+		move.x += 1.0f;
+	if (m_keysPressed.w)
+		move.z -= 1.0f;
+	if (m_keysPressed.s)
+		move.z += 1.0f;
 
-    if (fabs(move.x) > 0.1f && fabs(move.z) > 0.1f)
-    {
-        XMVECTOR vector = XMVector3Normalize(XMLoadFloat3(&move));
-        move.x = XMVectorGetX(vector);
-        move.z = XMVectorGetZ(vector);
-    }
+	if (fabs(move.x) > 0.1f && fabs(move.z) > 0.1f)
+	{
+		XMVECTOR vector = XMVector3Normalize(XMLoadFloat3(&move));
+		move.x = XMVectorGetX(vector);
+		move.z = XMVectorGetZ(vector);
+	}
 
-    float moveInterval = m_moveSpeed * elapsedSeconds;
-    float rotateInterval = m_turnSpeed * elapsedSeconds;
+	float moveInterval = m_moveSpeed * elapsedSeconds;
+	float rotateInterval = m_turnSpeed * elapsedSeconds;
 
-    if (m_keysPressed.left)
-        m_yaw += rotateInterval;
-    if (m_keysPressed.right)
-        m_yaw -= rotateInterval;
-    if (m_keysPressed.up)
-        m_pitch += rotateInterval;
-    if (m_keysPressed.down)
-        m_pitch -= rotateInterval;
+	if (m_keysPressed.left)
+		m_yaw += rotateInterval;
+	if (m_keysPressed.right)
+		m_yaw -= rotateInterval;
+	if (m_keysPressed.up)
+		m_pitch += rotateInterval;
+	if (m_keysPressed.down)
+		m_pitch -= rotateInterval;
 
-    // Prevent looking too far up or down.
-    m_pitch = min(m_pitch, XM_PIDIV4);
-    m_pitch = max(-XM_PIDIV4, m_pitch);
+	// Prevent looking too far up or down.
+	m_pitch = min(m_pitch, XM_PIDIV4);
+	m_pitch = max(-XM_PIDIV4, m_pitch);
 
-    // Move the camera in model space.
-    float x = move.x * -cosf(m_yaw) - move.z * sinf(m_yaw);
-    float z = move.x * sinf(m_yaw) - move.z * cosf(m_yaw);
-    m_position.x += x * moveInterval;
-    m_position.z += z * moveInterval;
+	// Move the camera in model space.
+	float x = move.x * -cosf(m_yaw) - move.z * sinf(m_yaw);
+	float z = move.x * sinf(m_yaw) - move.z * cosf(m_yaw);
+	m_position.x += x * moveInterval;
+	m_position.z += z * moveInterval;
 
-    // Determine the look direction.
-    float r = cosf(m_pitch);
-    m_lookDirection.x = r * sinf(m_yaw);
-    m_lookDirection.y = sinf(m_pitch);
-    m_lookDirection.z = r * cosf(m_yaw);
+	// Determine the look direction.
+	float r = cosf(m_pitch);
+	m_lookDirection.x = r * sinf(m_yaw);
+	m_lookDirection.y = sinf(m_pitch);
+	m_lookDirection.z = r * cosf(m_yaw);
 }
 
 XMMATRIX SimpleCamera::GetViewMatrix()
 {
-    return XMMatrixLookToRH(XMLoadFloat3(&m_position), XMLoadFloat3(&m_lookDirection), XMLoadFloat3(&m_upDirection));
+	return XMMatrixLookToRH(XMLoadFloat3(&m_position), XMLoadFloat3(&m_lookDirection), XMLoadFloat3(&m_upDirection));
 }
 
 XMMATRIX SimpleCamera::GetProjectionMatrix(float fov, float aspectRatio, float nearPlane, float farPlane)
 {
-    return XMMatrixPerspectiveFovRH(fov, aspectRatio, nearPlane, farPlane);
+	return XMMatrixPerspectiveFovRH(fov, aspectRatio, nearPlane, farPlane);
 }
 
 void SimpleCamera::OnKeyDown(WPARAM key)
 {
-    switch (key)
-    {
-    case 'W':
-        m_keysPressed.w = true;
-        break;
-    case 'A':
-        m_keysPressed.a = true;
-        break;
-    case 'S':
-        m_keysPressed.s = true;
-        break;
-    case 'D':
-        m_keysPressed.d = true;
-        break;
-    case VK_LEFT:
-        m_keysPressed.left = true;
-        break;
-    case VK_RIGHT:
-        m_keysPressed.right = true;
-        break;
-    case VK_UP:
-        m_keysPressed.up = true;
-        break;
-    case VK_DOWN:
-        m_keysPressed.down = true;
-        break;
-    case VK_ESCAPE:
-        Reset();
-        break;
-    }
+	switch (key)
+	{
+	case 'W':
+		m_keysPressed.w = true;
+		break;
+	case 'A':
+		m_keysPressed.a = true;
+		break;
+	case 'S':
+		m_keysPressed.s = true;
+		break;
+	case 'D':
+		m_keysPressed.d = true;
+		break;
+	case VK_LEFT:
+		m_keysPressed.left = true;
+		break;
+	case VK_RIGHT:
+		m_keysPressed.right = true;
+		break;
+	case VK_UP:
+		m_keysPressed.up = true;
+		break;
+	case VK_DOWN:
+		m_keysPressed.down = true;
+		break;
+	case VK_ESCAPE:
+		Reset();
+		break;
+	}
 }
 
 void SimpleCamera::OnKeyUp(WPARAM key)
 {
-    switch (key)
-    {
-    case 'W':
-        m_keysPressed.w = false;
-        break;
-    case 'A':
-        m_keysPressed.a = false;
-        break;
-    case 'S':
-        m_keysPressed.s = false;
-        break;
-    case 'D':
-        m_keysPressed.d = false;
-        break;
-    case VK_LEFT:
-        m_keysPressed.left = false;
-        break;
-    case VK_RIGHT:
-        m_keysPressed.right = false;
-        break;
-    case VK_UP:
-        m_keysPressed.up = false;
-        break;
-    case VK_DOWN:
-        m_keysPressed.down = false;
-        break;
-    }
+	switch (key)
+	{
+	case 'W':
+		m_keysPressed.w = false;
+		break;
+	case 'A':
+		m_keysPressed.a = false;
+		break;
+	case 'S':
+		m_keysPressed.s = false;
+		break;
+	case 'D':
+		m_keysPressed.d = false;
+		break;
+	case VK_LEFT:
+		m_keysPressed.left = false;
+		break;
+	case VK_RIGHT:
+		m_keysPressed.right = false;
+		break;
+	case VK_UP:
+		m_keysPressed.up = false;
+		break;
+	case VK_DOWN:
+		m_keysPressed.down = false;
+		break;
+	}
 }

--- a/Samples/Desktop/D3D12DynamicIndexing/src/SimpleCamera.h
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/SimpleCamera.h
@@ -16,42 +16,42 @@ using namespace DirectX;
 class SimpleCamera
 {
 public:
-    SimpleCamera();
+	SimpleCamera();
 
-    void Init(XMFLOAT3 position);
-    void Update(float elapsedSeconds);
-    XMMATRIX GetViewMatrix();
-    XMMATRIX GetProjectionMatrix(float fov, float aspectRatio, float nearPlane = 1.0f, float farPlane = 1000.0f);
-    void SetMoveSpeed(float unitsPerSecond);
-    void SetTurnSpeed(float radiansPerSecond);
+	void Init(XMFLOAT3 position);
+	void Update(float elapsedSeconds);
+	XMMATRIX GetViewMatrix();
+	XMMATRIX GetProjectionMatrix(float fov, float aspectRatio, float nearPlane = 1.0f, float farPlane = 1000.0f);
+	void SetMoveSpeed(float unitsPerSecond);
+	void SetTurnSpeed(float radiansPerSecond);
 
-    void OnKeyDown(WPARAM key);
-    void OnKeyUp(WPARAM key);
+	void OnKeyDown(WPARAM key);
+	void OnKeyUp(WPARAM key);
 
 private:
-    void Reset();
+	void Reset();
 
-    struct KeysPressed
-    {
-        bool w;
-        bool a;
-        bool s;
-        bool d;
+	struct KeysPressed
+	{
+		bool w;
+		bool a;
+		bool s;
+		bool d;
 
-        bool left;
-        bool right;
-        bool up;
-        bool down;
-    };
+		bool left;
+		bool right;
+		bool up;
+		bool down;
+	};
 
-    XMFLOAT3 m_initialPosition;
-    XMFLOAT3 m_position;
-    float m_yaw;                // Relative to the +z axis.
-    float m_pitch;                // Relative to the xz plane.
-    XMFLOAT3 m_lookDirection;
-    XMFLOAT3 m_upDirection;
-    float m_moveSpeed;            // Speed at which the camera moves, in units per second.
-    float m_turnSpeed;            // Speed at which the camera turns, in radians per second.
+	XMFLOAT3 m_initialPosition;
+	XMFLOAT3 m_position;
+	float m_yaw;				// Relative to the +z axis.
+	float m_pitch;				// Relative to the xz plane.
+	XMFLOAT3 m_lookDirection;
+	XMFLOAT3 m_upDirection;
+	float m_moveSpeed;			// Speed at which the camera moves, in units per second.
+	float m_turnSpeed;			// Speed at which the camera turns, in radians per second.
 
-    KeysPressed m_keysPressed;
+	KeysPressed m_keysPressed;
 };

--- a/Samples/Desktop/D3D12DynamicIndexing/src/Win32Application.cpp
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/Win32Application.cpp
@@ -16,104 +16,104 @@ HWND Win32Application::m_hwnd = nullptr;
 
 int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
 {
-    // Parse the command line parameters
-    int argc;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    pSample->ParseCommandLineArgs(argv, argc);
-    LocalFree(argv);
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
 
-    // Initialize the window class.
-    WNDCLASSEX windowClass = { 0 };
-    windowClass.cbSize = sizeof(WNDCLASSEX);
-    windowClass.style = CS_HREDRAW | CS_VREDRAW;
-    windowClass.lpfnWndProc = WindowProc;
-    windowClass.hInstance = hInstance;
-    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-    windowClass.lpszClassName = L"DXSampleClass";
-    RegisterClassEx(&windowClass);
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
 
-    RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
-    AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
 
-    // Create the window and store a handle to it.
-    m_hwnd = CreateWindow(
-        windowClass.lpszClassName,
-        pSample->GetTitle(),
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        windowRect.right - windowRect.left,
-        windowRect.bottom - windowRect.top,
-        nullptr,        // We have no parent window.
-        nullptr,        // We aren't using menus.
-        hInstance,
-        pSample);
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
 
-    // Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-    pSample->OnInit();
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
 
-    ShowWindow(m_hwnd, nCmdShow);
+	ShowWindow(m_hwnd, nCmdShow);
 
-    // Main sample loop.
-    MSG msg = {};
-    while (msg.message != WM_QUIT)
-    {
-        // Process any messages in the queue.
-        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
-    }
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
 
-    pSample->OnDestroy();
+	pSample->OnDestroy();
 
-    // Return this part of the WM_QUIT message to Windows.
-    return static_cast<char>(msg.wParam);
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
 }
 
 // Main message handler for the sample.
 LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
-    switch (message)
-    {
-    case WM_CREATE:
-        {
-            // Save the DXSample* passed in to CreateWindow.
-            LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
-            SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
-        }
-        return 0;
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
 
-    case WM_KEYDOWN:
-        if (pSample)
-        {
-            pSample->OnKeyDown(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_KEYUP:
-        if (pSample)
-        {
-            pSample->OnKeyUp(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_PAINT:
-        if (pSample)
-        {
-            pSample->OnUpdate();
-            pSample->OnRender();
-        }
-        return 0;
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
 
-    case WM_DESTROY:
-        PostQuitMessage(0);
-        return 0;
-    }
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
 
-    // Handle any messages the switch statement didn't.
-    return DefWindowProc(hWnd, message, wParam, lParam);
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/Desktop/D3D12DynamicIndexing/src/Win32Application.h
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/Win32Application.h
@@ -18,12 +18,12 @@ class DXSample;
 class Win32Application
 {
 public:
-    static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
-    static HWND GetHwnd() { return m_hwnd; }
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
 
 protected:
-    static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
-    static HWND m_hwnd;
+	static HWND m_hwnd;
 };

--- a/Samples/Desktop/D3D12DynamicIndexing/src/d3dx12.h
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12DynamicIndexing/src/occcity.h
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/occcity.h
@@ -13,57 +13,57 @@
 
 namespace SampleAssets
 {
-    LPCWSTR DataFileName = L"occcity.bin";
+	LPCWSTR DataFileName = L"occcity.bin";
 
-    const D3D12_INPUT_ELEMENT_DESC StandardVertexDescription[] =
-    {
-        { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,  D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "NORMAL",   0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,    0, 24, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "TANGENT",  0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 32, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-    };
-    UINT StandardVertexDescriptionNumElements = _countof(StandardVertexDescription);
+	const D3D12_INPUT_ELEMENT_DESC StandardVertexDescription[] =
+	{
+		{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,  D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		{ "NORMAL",   0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,    0, 24, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		{ "TANGENT",  0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 32, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+	};
+	UINT StandardVertexDescriptionNumElements = _countof(StandardVertexDescription);
 
-    const UINT StandardVertexStride = 44;
+	const UINT StandardVertexStride = 44;
 
-    const DXGI_FORMAT StandardIndexFormat = DXGI_FORMAT_R32_UINT;
+	const DXGI_FORMAT StandardIndexFormat = DXGI_FORMAT_R32_UINT;
 
-    struct TextureResource
-    {
-        UINT Width;
-        UINT Height;
-        UINT16 MipLevels;
-        DXGI_FORMAT Format;
-        struct DataProperties
-        {
-            UINT Offset;
-            UINT Size;
-            UINT Pitch;
-        } Data[D3D12_REQ_MIP_LEVELS];
-    };
+	struct TextureResource
+	{
+		UINT Width;
+		UINT Height;
+		UINT16 MipLevels;
+		DXGI_FORMAT Format;
+		struct DataProperties
+		{
+			UINT Offset;
+			UINT Size;
+			UINT Pitch;
+		} Data[D3D12_REQ_MIP_LEVELS];
+	};
 
-    struct DrawParameters
-    {
-        INT DiffuseTextureIndex;
-        INT NormalTextureIndex;
-        INT SpecularTextureIndex;
-        UINT IndexStart;
-        UINT IndexCount;
-        UINT VertexBase;
-    };
+	struct DrawParameters
+	{
+		INT DiffuseTextureIndex;
+		INT NormalTextureIndex;
+		INT SpecularTextureIndex;
+		UINT IndexStart;
+		UINT IndexCount;
+		UINT VertexBase;
+	};
 
-    const UINT VertexDataOffset = 524288;
-    const UINT VertexDataSize = 820248;
-    const UINT IndexDataOffset = 1344536;
-    const UINT IndexDataSize = 74568;
+	const UINT VertexDataOffset = 524288;
+	const UINT VertexDataSize = 820248;
+	const UINT IndexDataOffset = 1344536;
+	const UINT IndexDataSize = 74568;
 
-    TextureResource Textures[] =
-    {
-        { 1024, 1024, 1, DXGI_FORMAT_BC1_UNORM, { { 0, 524288, 2048 }, } }, // city.dds
-    };
+	TextureResource Textures[] =
+	{
+		{ 1024, 1024, 1, DXGI_FORMAT_BC1_UNORM, { { 0, 524288, 2048 }, } }, // city.dds
+	};
 
-    DrawParameters Draws[] =
-    {
-        { 0, -1, -1, 0, 18642, 0 },
-    };
+	DrawParameters Draws[] =
+	{
+		{ 0, -1, -1, 0, 18642, 0 },
+	};
 }

--- a/Samples/Desktop/D3D12DynamicIndexing/src/shader_mesh_dynamic_indexing_pixel.hlsl
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/shader_mesh_dynamic_indexing_pixel.hlsl
@@ -11,23 +11,23 @@
 
 struct PSInput
 {
-    float4 position    : SV_POSITION;
-    float2 uv        : TEXCOORD0;
+	float4 position	: SV_POSITION;
+	float2 uv		: TEXCOORD0;
 };
 
 struct MaterialConstants
 {
-    uint matIndex;    // Dynamically set index for looking up from g_txMats[].
+	uint matIndex;	// Dynamically set index for looking up from g_txMats[].
 };
 
 ConstantBuffer<MaterialConstants> materialConstants : register(b0, space0);
-Texture2D        g_txDiffuse    : register(t0);
-Texture2D        g_txMats[]    : register(t1);
-SamplerState    g_sampler    : register(s0);
+Texture2D		g_txDiffuse	: register(t0);
+Texture2D		g_txMats[]	: register(t1);
+SamplerState	g_sampler	: register(s0);
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    float3 diffuse = g_txDiffuse.Sample(g_sampler, input.uv).rgb;
-    float3 mat = g_txMats[materialConstants.matIndex].Sample(g_sampler, input.uv).rgb;
-    return float4(diffuse * mat, 1.0f);
+	float3 diffuse = g_txDiffuse.Sample(g_sampler, input.uv).rgb;
+	float3 mat = g_txMats[materialConstants.matIndex].Sample(g_sampler, input.uv).rgb;
+	return float4(diffuse * mat, 1.0f);
 }

--- a/Samples/Desktop/D3D12DynamicIndexing/src/shader_mesh_simple_vert.hlsl
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/shader_mesh_simple_vert.hlsl
@@ -11,29 +11,29 @@
 
 struct VSInput
 {
-    float3 position    : POSITION;
-    float3 normal    : NORMAL;
-    float2 uv        : TEXCOORD0;
-    float3 tangent    : TANGENT;
+	float3 position	: POSITION;
+	float3 normal	: NORMAL;
+	float2 uv		: TEXCOORD0;
+	float3 tangent	: TANGENT;
 };
 
 struct PSInput
 {
-    float4 position    : SV_POSITION;
-    float2 uv        : TEXCOORD0;
+	float4 position	: SV_POSITION;
+	float2 uv		: TEXCOORD0;
 };
 
 cbuffer cb0 : register(b0)
 {
-    float4x4 g_mWorldViewProj;
+	float4x4 g_mWorldViewProj;
 };
 
 PSInput VSMain(VSInput input)
 {
-    PSInput result;
-    
-    result.position = mul(float4(input.position, 1.0f), g_mWorldViewProj);
-    result.uv = input.uv;
-    
-    return result;
+	PSInput result;
+	
+	result.position = mul(float4(input.position, 1.0f), g_mWorldViewProj);
+	result.uv = input.uv;
+	
+	return result;
 }

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.cpp
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.cpp
@@ -19,801 +19,845 @@ const float D3D12ExecuteIndirect::TriangleDepth = 1.0f;
 const float D3D12ExecuteIndirect::CullingCutoff = 0.5f;
 
 D3D12ExecuteIndirect::D3D12ExecuteIndirect(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_cullingScissorRect(),
-    m_rtvDescriptorSize(0),
-    m_cbvSrvUavDescriptorSize(0),
-    m_csRootConstants(),
-    m_enableCulling(true),
-    m_fenceValues{}
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_cullingScissorRect(),
+	m_rtvDescriptorSize(0),
+	m_cbvSrvUavDescriptorSize(0),
+	m_csRootConstants(),
+	m_enableCulling(true),
+	m_fenceValues{}
 {
-    m_constantBufferData.resize(TriangleCount);
+	m_constantBufferData.resize(TriangleCount);
 
-    m_csRootConstants.xOffset = TriangleHalfWidth;
-    m_csRootConstants.zOffset = TriangleDepth;
-    m_csRootConstants.cullOffset = CullingCutoff;
-    m_csRootConstants.commandCount = TriangleCount;
+	m_csRootConstants.xOffset = TriangleHalfWidth;
+	m_csRootConstants.zOffset = TriangleDepth;
+	m_csRootConstants.cullOffset = CullingCutoff;
+	m_csRootConstants.commandCount = TriangleCount;
 
-    float center = width / 2.0f;
-    m_cullingScissorRect.left = static_cast<LONG>(center - (center * CullingCutoff));
-    m_cullingScissorRect.right = static_cast<LONG>(center + (center * CullingCutoff));
-    m_cullingScissorRect.bottom = static_cast<LONG>(height);
+	float center = width / 2.0f;
+	m_cullingScissorRect.left = static_cast<LONG>(center - (center * CullingCutoff));
+	m_cullingScissorRect.right = static_cast<LONG>(center + (center * CullingCutoff));
+	m_cullingScissorRect.bottom = static_cast<LONG>(height);
+
+#if !defined(_XBOX_ONE)
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
+#endif
 }
 
 void D3D12ExecuteIndirect::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12ExecuteIndirect::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter, true);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queues.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queues.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
-    NAME_D3D12_OBJECT(m_commandQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	NAME_D3D12_OBJECT(m_commandQueue);
 
-    D3D12_COMMAND_QUEUE_DESC computeQueueDesc = {};
-    computeQueueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    computeQueueDesc.Type = D3D12_COMMAND_LIST_TYPE_COMPUTE;
+	D3D12_COMMAND_QUEUE_DESC computeQueueDesc = {};
+	computeQueueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	computeQueueDesc.Type = D3D12_COMMAND_LIST_TYPE_COMPUTE;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&computeQueueDesc, IID_PPV_ARGS(&m_computeCommandQueue)));
-    NAME_D3D12_OBJECT(m_computeCommandQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&computeQueueDesc, IID_PPV_ARGS(&m_computeCommandQueue)));
+	NAME_D3D12_OBJECT(m_computeCommandQueue);
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    // This sample does not support fullscreen transitions.
-    ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
+	// This sample does not support fullscreen transitions.
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a depth stencil view (DSV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
-        dsvHeapDesc.NumDescriptors = 1;
-        dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-        dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
+		// Describe and create a depth stencil view (DSV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
+		dsvHeapDesc.NumDescriptors = 1;
+		dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+		dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
 
-        // Describe and create a constant buffer view (CBV), Shader resource
-        // view (SRV), and unordered access view (UAV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvSrvUavHeapDesc = {};
-        cbvSrvUavHeapDesc.NumDescriptors = CbvSrvUavDescriptorCountPerFrame * FrameCount;
-        cbvSrvUavHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        cbvSrvUavHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvSrvUavHeapDesc, IID_PPV_ARGS(&m_cbvSrvUavHeap)));
-        NAME_D3D12_OBJECT(m_cbvSrvUavHeap);
+		// Describe and create a constant buffer view (CBV), Shader resource
+		// view (SRV), and unordered access view (UAV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvSrvUavHeapDesc = {};
+		cbvSrvUavHeapDesc.NumDescriptors = CbvSrvUavDescriptorCountPerFrame * FrameCount;
+		cbvSrvUavHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		cbvSrvUavHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvSrvUavHeapDesc, IID_PPV_ARGS(&m_cbvSrvUavHeap)));
+		NAME_D3D12_OBJECT(m_cbvSrvUavHeap);
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-        m_cbvSrvUavDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_cbvSrvUavDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV and command allocators for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
+		// Create a RTV and command allocators for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-            NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
+			NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
 
-            ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
-            ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_COMPUTE, IID_PPV_ARGS(&m_computeCommandAllocators[n])));
-        }
-    }
+			ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
+			ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_COMPUTE, IID_PPV_ARGS(&m_computeCommandAllocators[n])));
+		}
+	}
 }
 
 // Load the sample assets.
 void D3D12ExecuteIndirect::LoadAssets()
 {
-    // Create the root signatures.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signatures.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        CD3DX12_ROOT_PARAMETER1 rootParameters[GraphicsRootParametersCount];
-        rootParameters[Cbv].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_VERTEX);
+		CD3DX12_ROOT_PARAMETER1 rootParameters[GraphicsRootParametersCount];
+		rootParameters[Cbv].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_VERTEX);
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-        NAME_D3D12_OBJECT(m_rootSignature);
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+		NAME_D3D12_OBJECT(m_rootSignature);
 
-        // Create compute signature.
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[2];
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_VOLATILE);
+		// Create compute signature.
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[2];
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_VOLATILE);
 
-        CD3DX12_ROOT_PARAMETER1 computeRootParameters[ComputeRootParametersCount];
-        computeRootParameters[SrvUavTable].InitAsDescriptorTable(2, ranges);
-        computeRootParameters[RootConstants].InitAsConstants(4, 0);
+		CD3DX12_ROOT_PARAMETER1 computeRootParameters[ComputeRootParametersCount];
+		computeRootParameters[SrvUavTable].InitAsDescriptorTable(2, ranges);
+		computeRootParameters[RootConstants].InitAsConstants(4, 0);
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC computeRootSignatureDesc;
-        computeRootSignatureDesc.Init_1_1(_countof(computeRootParameters), computeRootParameters);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC computeRootSignatureDesc;
+		computeRootSignatureDesc.Init_1_1(_countof(computeRootParameters), computeRootParameters);
 
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&computeRootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_computeRootSignature)));
-        NAME_D3D12_OBJECT(m_computeRootSignature);
-    }
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&computeRootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_computeRootSignature)));
+		NAME_D3D12_OBJECT(m_computeRootSignature);
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
-        ComPtr<ID3DBlob> computeShader;
-        ComPtr<ID3DBlob> error;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
+		ComPtr<ID3DBlob> computeShader;
+		ComPtr<ID3DBlob> error;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, &error));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, &error));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"compute.hlsl").c_str(), nullptr, nullptr, "CSMain", "cs_5_0", compileFlags, 0, &computeShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"compute.hlsl").c_str(), nullptr, nullptr, "CSMain", "cs_5_0", compileFlags, 0, &computeShader, &error));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        // Describe and create the graphics pipeline state objects (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state objects (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-        NAME_D3D12_OBJECT(m_pipelineState);
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+		NAME_D3D12_OBJECT(m_pipelineState);
 
-        // Describe and create the compute pipeline state object (PSO).
-        D3D12_COMPUTE_PIPELINE_STATE_DESC computePsoDesc = {};
-        computePsoDesc.pRootSignature = m_computeRootSignature.Get();
-        computePsoDesc.CS = CD3DX12_SHADER_BYTECODE(computeShader.Get());
+		// Describe and create the compute pipeline state object (PSO).
+		D3D12_COMPUTE_PIPELINE_STATE_DESC computePsoDesc = {};
+		computePsoDesc.pRootSignature = m_computeRootSignature.Get();
+		computePsoDesc.CS = CD3DX12_SHADER_BYTECODE(computeShader.Get());
 
-        ThrowIfFailed(m_device->CreateComputePipelineState(&computePsoDesc, IID_PPV_ARGS(&m_computeState)));
-        NAME_D3D12_OBJECT(m_computeState);
-    }
+		ThrowIfFailed(m_device->CreateComputePipelineState(&computePsoDesc, IID_PPV_ARGS(&m_computeState)));
+		NAME_D3D12_OBJECT(m_computeState);
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_COMPUTE, m_computeCommandAllocators[m_frameIndex].Get(), m_computeState.Get(), IID_PPV_ARGS(&m_computeCommandList)));
-    ThrowIfFailed(m_computeCommandList->Close());
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_COMPUTE, m_computeCommandAllocators[m_frameIndex].Get(), m_computeState.Get(), IID_PPV_ARGS(&m_computeCommandList)));
+	ThrowIfFailed(m_computeCommandList->Close());
 
-    NAME_D3D12_OBJECT(m_commandList);
-    NAME_D3D12_OBJECT(m_computeCommandList);
+	NAME_D3D12_OBJECT(m_commandList);
+	NAME_D3D12_OBJECT(m_computeCommandList);
 
-    // Note: ComPtr's are CPU objects but these resources need to stay in scope until
-    // the command list that references them has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resources are not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> vertexBufferUpload;
-    ComPtr<ID3D12Resource> commandBufferUpload;
+	// Note: ComPtr's are CPU objects but these resources need to stay in scope until
+	// the command list that references them has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resources are not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> vertexBufferUpload;
+	ComPtr<ID3D12Resource> commandBufferUpload;
 
-    // Create the vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        Vertex triangleVertices[] =
-        {
-            { { 0.0f, TriangleHalfWidth, TriangleDepth } },
-            { { TriangleHalfWidth, -TriangleHalfWidth, TriangleDepth } },
-            { { -TriangleHalfWidth, -TriangleHalfWidth, TriangleDepth } }
-        };
+	// Create the vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		Vertex triangleVertices[] =
+		{
+			{ { 0.0f, TriangleHalfWidth, TriangleDepth } },
+			{ { TriangleHalfWidth, -TriangleHalfWidth, TriangleDepth } },
+			{ { -TriangleHalfWidth, -TriangleHalfWidth, TriangleDepth } }
+		};
 
-        const UINT vertexBufferSize = sizeof(triangleVertices);
+		const UINT vertexBufferSize = sizeof(triangleVertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&vertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&vertexBufferUpload)));
 
-        NAME_D3D12_OBJECT(m_vertexBuffer);
+		NAME_D3D12_OBJECT(m_vertexBuffer);
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(triangleVertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(triangleVertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = sizeof(triangleVertices);
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = sizeof(triangleVertices);
+	}
 
-    // Create the depth stencil view.
-    {
-        D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
-        depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
-        depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
-        depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
+	// Create the depth stencil view.
+	{
+		D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
+		depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
+		depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+		depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
 
-        D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
-        depthOptimizedClearValue.Format = DXGI_FORMAT_D32_FLOAT;
-        depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
-        depthOptimizedClearValue.DepthStencil.Stencil = 0;
+		D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
+		depthOptimizedClearValue.Format = DXGI_FORMAT_D32_FLOAT;
+		depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
+		depthOptimizedClearValue.DepthStencil.Stencil = 0;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
-            D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            &depthOptimizedClearValue,
-            IID_PPV_ARGS(&m_depthStencil)
-            ));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
+			D3D12_RESOURCE_STATE_DEPTH_WRITE,
+			&depthOptimizedClearValue,
+			IID_PPV_ARGS(&m_depthStencil)
+			));
 
-        NAME_D3D12_OBJECT(m_depthStencil);
+		NAME_D3D12_OBJECT(m_depthStencil);
 
-        m_device->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		m_device->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    // Create the constant buffers.
-    {
-        const UINT constantBufferDataSize = TriangleResourceCount * sizeof(SceneConstantBuffer);
+	// Create the constant buffers.
+	{
+		const UINT constantBufferDataSize = TriangleResourceCount * sizeof(SceneConstantBuffer);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(constantBufferDataSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_constantBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(constantBufferDataSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_constantBuffer)));
 
-        NAME_D3D12_OBJECT(m_constantBuffer);
+		NAME_D3D12_OBJECT(m_constantBuffer);
 
-        // Initialize the constant buffers for each of the triangles.
-        for (UINT n = 0; n < TriangleCount; n++)
-        {
-            m_constantBufferData[n].velocity = XMFLOAT4(GetRandomFloat(0.01f, 0.02f), 0.0f, 0.0f, 0.0f);
-            m_constantBufferData[n].offset = XMFLOAT4(GetRandomFloat(-5.0f, -1.5f), GetRandomFloat(-1.0f, 1.0f), GetRandomFloat(0.0f, 2.0f), 0.0f);
-            m_constantBufferData[n].color = XMFLOAT4(GetRandomFloat(0.5f, 1.0f), GetRandomFloat(0.5f, 1.0f), GetRandomFloat(0.5f, 1.0f), 1.0f);
-            XMStoreFloat4x4(&m_constantBufferData[n].projection, XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f)));
-        }
+		// Initialize the constant buffers for each of the triangles.
+		for (UINT n = 0; n < TriangleCount; n++)
+		{
+			m_constantBufferData[n].velocity = XMFLOAT4(GetRandomFloat(0.01f, 0.02f), 0.0f, 0.0f, 0.0f);
+			m_constantBufferData[n].offset = XMFLOAT4(GetRandomFloat(-5.0f, -1.5f), GetRandomFloat(-1.0f, 1.0f), GetRandomFloat(0.0f, 2.0f), 0.0f);
+			m_constantBufferData[n].color = XMFLOAT4(GetRandomFloat(0.5f, 1.0f), GetRandomFloat(0.5f, 1.0f), GetRandomFloat(0.5f, 1.0f), 1.0f);
+			XMStoreFloat4x4(&m_constantBufferData[n].projection, XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f)));
+		}
 
-        // Map and initialize the constant buffer. We don't unmap this until the
-        // app closes. Keeping things mapped for the lifetime of the resource is okay.
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbvDataBegin)));
-        memcpy(m_pCbvDataBegin, &m_constantBufferData[0], TriangleCount * sizeof(SceneConstantBuffer));
+		// Map and initialize the constant buffer. We don't unmap this until the
+		// app closes. Keeping things mapped for the lifetime of the resource is okay.
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbvDataBegin)));
+		memcpy(m_pCbvDataBegin, &m_constantBufferData[0], TriangleCount * sizeof(SceneConstantBuffer));
 
-        // Create shader resource views (SRV) of the constant buffers for the
-        // compute shader to read from.
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Format = DXGI_FORMAT_UNKNOWN;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Buffer.NumElements = TriangleCount;
-        srvDesc.Buffer.StructureByteStride = sizeof(SceneConstantBuffer);
-        srvDesc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_NONE;
+		// Create shader resource views (SRV) of the constant buffers for the
+		// compute shader to read from.
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Format = DXGI_FORMAT_UNKNOWN;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Buffer.NumElements = TriangleCount;
+		srvDesc.Buffer.StructureByteStride = sizeof(SceneConstantBuffer);
+		srvDesc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_NONE;
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE cbvSrvHandle(m_cbvSrvUavHeap->GetCPUDescriptorHandleForHeapStart(), CbvSrvOffset, m_cbvSrvUavDescriptorSize);
-        for (UINT frame = 0; frame < FrameCount; frame++)
-        {
-            srvDesc.Buffer.FirstElement = frame * TriangleCount;
-            m_device->CreateShaderResourceView(m_constantBuffer.Get(), &srvDesc, cbvSrvHandle);
-            cbvSrvHandle.Offset(CbvSrvUavDescriptorCountPerFrame, m_cbvSrvUavDescriptorSize);
-        }
-    }
+		CD3DX12_CPU_DESCRIPTOR_HANDLE cbvSrvHandle(m_cbvSrvUavHeap->GetCPUDescriptorHandleForHeapStart(), CbvSrvOffset, m_cbvSrvUavDescriptorSize);
+		for (UINT frame = 0; frame < FrameCount; frame++)
+		{
+			srvDesc.Buffer.FirstElement = frame * TriangleCount;
+			m_device->CreateShaderResourceView(m_constantBuffer.Get(), &srvDesc, cbvSrvHandle);
+			cbvSrvHandle.Offset(CbvSrvUavDescriptorCountPerFrame, m_cbvSrvUavDescriptorSize);
+		}
+	}
 
-    // Create the command signature used for indirect drawing.
-    {
-        // Each command consists of a CBV update and a DrawInstanced call.
-        D3D12_INDIRECT_ARGUMENT_DESC argumentDescs[2] = {};
-        argumentDescs[0].Type = D3D12_INDIRECT_ARGUMENT_TYPE_CONSTANT_BUFFER_VIEW;
-        argumentDescs[0].ConstantBufferView.RootParameterIndex = Cbv;
-        argumentDescs[1].Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW;
+	// Create the command signature used for indirect drawing.
+	{
+		// Each command consists of a CBV update and a DrawInstanced call.
+		D3D12_INDIRECT_ARGUMENT_DESC argumentDescs[2] = {};
+		argumentDescs[0].Type = D3D12_INDIRECT_ARGUMENT_TYPE_CONSTANT_BUFFER_VIEW;
+		argumentDescs[0].ConstantBufferView.RootParameterIndex = Cbv;
+		argumentDescs[1].Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW;
 
-        D3D12_COMMAND_SIGNATURE_DESC commandSignatureDesc = {};
-        commandSignatureDesc.pArgumentDescs = argumentDescs;
-        commandSignatureDesc.NumArgumentDescs = _countof(argumentDescs);
-        commandSignatureDesc.ByteStride = sizeof(IndirectCommand);
+		D3D12_COMMAND_SIGNATURE_DESC commandSignatureDesc = {};
+		commandSignatureDesc.pArgumentDescs = argumentDescs;
+		commandSignatureDesc.NumArgumentDescs = _countof(argumentDescs);
+		commandSignatureDesc.ByteStride = sizeof(IndirectCommand);
 
-        ThrowIfFailed(m_device->CreateCommandSignature(&commandSignatureDesc, m_rootSignature.Get(), IID_PPV_ARGS(&m_commandSignature)));
-        NAME_D3D12_OBJECT(m_commandSignature);
-    }
+		ThrowIfFailed(m_device->CreateCommandSignature(&commandSignatureDesc, m_rootSignature.Get(), IID_PPV_ARGS(&m_commandSignature)));
+		NAME_D3D12_OBJECT(m_commandSignature);
+	}
 
-    // Create the command buffers and UAVs to store the results of the compute work.
-    {
-        std::vector<IndirectCommand> commands;
-        commands.resize(TriangleResourceCount);
-        const UINT commandBufferSize = CommandSizePerFrame * FrameCount;
+	// Create the command buffers and UAVs to store the results of the compute work.
+	{
+		std::vector<IndirectCommand> commands;
+		commands.resize(TriangleResourceCount);
+		const UINT commandBufferSize = CommandSizePerFrame * FrameCount;
 
-        D3D12_RESOURCE_DESC commandBufferDesc = CD3DX12_RESOURCE_DESC::Buffer(commandBufferSize);
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &commandBufferDesc,
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_commandBuffer)));
+		D3D12_RESOURCE_DESC commandBufferDesc = CD3DX12_RESOURCE_DESC::Buffer(commandBufferSize);
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&commandBufferDesc,
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_commandBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(commandBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&commandBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(commandBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&commandBufferUpload)));
 
-        NAME_D3D12_OBJECT(m_commandBuffer);
+		NAME_D3D12_OBJECT(m_commandBuffer);
 
-        D3D12_GPU_VIRTUAL_ADDRESS gpuAddress = m_constantBuffer->GetGPUVirtualAddress();
-        UINT commandIndex = 0;
+		D3D12_GPU_VIRTUAL_ADDRESS gpuAddress = m_constantBuffer->GetGPUVirtualAddress();
+		UINT commandIndex = 0;
 
-        for (UINT frame = 0; frame < FrameCount; frame++)
-        {
-            for (UINT n = 0; n < TriangleCount; n++)
-            {
-                commands[commandIndex].cbv = gpuAddress;
-                commands[commandIndex].drawArguments.VertexCountPerInstance = 3;
-                commands[commandIndex].drawArguments.InstanceCount = 1;
-                commands[commandIndex].drawArguments.StartVertexLocation = 0;
-                commands[commandIndex].drawArguments.StartInstanceLocation = 0;
+		for (UINT frame = 0; frame < FrameCount; frame++)
+		{
+			for (UINT n = 0; n < TriangleCount; n++)
+			{
+				commands[commandIndex].cbv = gpuAddress;
+				commands[commandIndex].drawArguments.VertexCountPerInstance = 3;
+				commands[commandIndex].drawArguments.InstanceCount = 1;
+				commands[commandIndex].drawArguments.StartVertexLocation = 0;
+				commands[commandIndex].drawArguments.StartInstanceLocation = 0;
 
-                commandIndex++;
-                gpuAddress += sizeof(SceneConstantBuffer);
-            }
-        }
+				commandIndex++;
+				gpuAddress += sizeof(SceneConstantBuffer);
+			}
+		}
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the command buffer.
-        D3D12_SUBRESOURCE_DATA commandData = {};
-        commandData.pData = reinterpret_cast<UINT8*>(&commands[0]);
-        commandData.RowPitch = commandBufferSize;
-        commandData.SlicePitch = commandData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the command buffer.
+		D3D12_SUBRESOURCE_DATA commandData = {};
+		commandData.pData = reinterpret_cast<UINT8*>(&commands[0]);
+		commandData.RowPitch = commandBufferSize;
+		commandData.SlicePitch = commandData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_commandBuffer.Get(), commandBufferUpload.Get(), 0, 0, 1, &commandData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_commandBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE));
+		UpdateSubresources<1>(m_commandList.Get(), m_commandBuffer.Get(), commandBufferUpload.Get(), 0, 0, 1, &commandData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_commandBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE));
 
-        // Create SRVs for the command buffers.
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Format = DXGI_FORMAT_UNKNOWN;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Buffer.NumElements = TriangleCount;
-        srvDesc.Buffer.StructureByteStride = sizeof(IndirectCommand);
-        srvDesc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_NONE;
+		// Create SRVs for the command buffers.
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Format = DXGI_FORMAT_UNKNOWN;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Buffer.NumElements = TriangleCount;
+		srvDesc.Buffer.StructureByteStride = sizeof(IndirectCommand);
+		srvDesc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_NONE;
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE commandsHandle(m_cbvSrvUavHeap->GetCPUDescriptorHandleForHeapStart(), CommandsOffset, m_cbvSrvUavDescriptorSize);
-        for (UINT frame = 0; frame < FrameCount; frame++)
-        {
-            srvDesc.Buffer.FirstElement = frame * TriangleCount;
-            m_device->CreateShaderResourceView(m_commandBuffer.Get(), &srvDesc, commandsHandle);
-            commandsHandle.Offset(CbvSrvUavDescriptorCountPerFrame, m_cbvSrvUavDescriptorSize);
-        }
+		CD3DX12_CPU_DESCRIPTOR_HANDLE commandsHandle(m_cbvSrvUavHeap->GetCPUDescriptorHandleForHeapStart(), CommandsOffset, m_cbvSrvUavDescriptorSize);
+		for (UINT frame = 0; frame < FrameCount; frame++)
+		{
+			srvDesc.Buffer.FirstElement = frame * TriangleCount;
+			m_device->CreateShaderResourceView(m_commandBuffer.Get(), &srvDesc, commandsHandle);
+			commandsHandle.Offset(CbvSrvUavDescriptorCountPerFrame, m_cbvSrvUavDescriptorSize);
+		}
 
-        // Create the unordered access views (UAVs) that store the results of the compute work.
-        CD3DX12_CPU_DESCRIPTOR_HANDLE processedCommandsHandle(m_cbvSrvUavHeap->GetCPUDescriptorHandleForHeapStart(), ProcessedCommandsOffset, m_cbvSrvUavDescriptorSize);
-        for (UINT frame = 0; frame < FrameCount; frame++)
-        {
-            // Allocate a buffer large enough to hold all of the indirect commands
-            // for a single frame as well as a UAV counter.
-            commandBufferDesc = CD3DX12_RESOURCE_DESC::Buffer(CommandBufferCounterOffset + sizeof(UINT), D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
-            ThrowIfFailed(m_device->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-                D3D12_HEAP_FLAG_NONE,
-                &commandBufferDesc,
-                D3D12_RESOURCE_STATE_COPY_DEST,
-                nullptr,
-                IID_PPV_ARGS(&m_processedCommandBuffers[frame])));
+		// Create the unordered access views (UAVs) that store the results of the compute work.
+		CD3DX12_CPU_DESCRIPTOR_HANDLE processedCommandsHandle(m_cbvSrvUavHeap->GetCPUDescriptorHandleForHeapStart(), ProcessedCommandsOffset, m_cbvSrvUavDescriptorSize);
+		for (UINT frame = 0; frame < FrameCount; frame++)
+		{
+			// Allocate a buffer large enough to hold all of the indirect commands
+			// for a single frame as well as a UAV counter.
+			commandBufferDesc = CD3DX12_RESOURCE_DESC::Buffer(CommandBufferCounterOffset + sizeof(UINT), D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+			ThrowIfFailed(m_device->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+				D3D12_HEAP_FLAG_NONE,
+				&commandBufferDesc,
+				D3D12_RESOURCE_STATE_COPY_DEST,
+				nullptr,
+				IID_PPV_ARGS(&m_processedCommandBuffers[frame])));
 
-            NAME_D3D12_OBJECT_INDEXED(m_processedCommandBuffers, frame);
+			NAME_D3D12_OBJECT_INDEXED(m_processedCommandBuffers, frame);
 
-            D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
-            uavDesc.Format = DXGI_FORMAT_UNKNOWN;
-            uavDesc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
-            uavDesc.Buffer.FirstElement = 0;
-            uavDesc.Buffer.NumElements = TriangleCount;
-            uavDesc.Buffer.StructureByteStride = sizeof(IndirectCommand);
-            uavDesc.Buffer.CounterOffsetInBytes = CommandBufferCounterOffset;
-            uavDesc.Buffer.Flags = D3D12_BUFFER_UAV_FLAG_NONE;
+			D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
+			uavDesc.Format = DXGI_FORMAT_UNKNOWN;
+			uavDesc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
+			uavDesc.Buffer.FirstElement = 0;
+			uavDesc.Buffer.NumElements = TriangleCount;
+			uavDesc.Buffer.StructureByteStride = sizeof(IndirectCommand);
+			uavDesc.Buffer.CounterOffsetInBytes = CommandBufferCounterOffset;
+			uavDesc.Buffer.Flags = D3D12_BUFFER_UAV_FLAG_NONE;
 
-            m_device->CreateUnorderedAccessView(
-                m_processedCommandBuffers[frame].Get(),
-                m_processedCommandBuffers[frame].Get(),
-                &uavDesc,
-                processedCommandsHandle);
+			m_device->CreateUnorderedAccessView(
+				m_processedCommandBuffers[frame].Get(),
+				m_processedCommandBuffers[frame].Get(),
+				&uavDesc,
+				processedCommandsHandle);
 
-            processedCommandsHandle.Offset(CbvSrvUavDescriptorCountPerFrame, m_cbvSrvUavDescriptorSize);
-        }
+			processedCommandsHandle.Offset(CbvSrvUavDescriptorCountPerFrame, m_cbvSrvUavDescriptorSize);
+		}
 
-        // Allocate a buffer that can be used to reset the UAV counters and initialize
-        // it to 0.
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(sizeof(UINT)),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_processedCommandBufferCounterReset)));
+		// Allocate a buffer that can be used to reset the UAV counters and initialize
+		// it to 0.
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(sizeof(UINT)),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_processedCommandBufferCounterReset)));
 
-        UINT8* pMappedCounterReset = nullptr;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_processedCommandBufferCounterReset->Map(0, &readRange, reinterpret_cast<void**>(&pMappedCounterReset)));
-        ZeroMemory(pMappedCounterReset, sizeof(UINT));
-        m_processedCommandBufferCounterReset->Unmap(0, nullptr);
-    }
+		UINT8* pMappedCounterReset = nullptr;
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_processedCommandBufferCounterReset->Map(0, &readRange, reinterpret_cast<void**>(&pMappedCounterReset)));
+		ZeroMemory(pMappedCounterReset, sizeof(UINT));
+		m_processedCommandBufferCounterReset->Unmap(0, nullptr);
+	}
 
-    // Close the command list and execute it to begin the vertex buffer copy into
-    // the default heap.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the vertex buffer copy into
+	// the default heap.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_computeFence)));
-        m_fenceValues[m_frameIndex]++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_computeFence)));
+		m_fenceValues[m_frameIndex]++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForGpu();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForGpu();
+	}
 }
 
 // Get a random float value between min and max.
 float D3D12ExecuteIndirect::GetRandomFloat(float min, float max)
 {
-    float scale = static_cast<float>(rand()) / RAND_MAX;
-    float range = max - min;
-    return scale * range + min;
+	float scale = static_cast<float>(rand()) / RAND_MAX;
+	float range = max - min;
+	return scale * range + min;
 }
 
 // Update frame-based values.
 void D3D12ExecuteIndirect::OnUpdate()
 {
-    for (UINT n = 0; n < TriangleCount; n++)
-    {
-        const float offsetBounds = 2.5f;
+	for (UINT n = 0; n < TriangleCount; n++)
+	{
+		const float offsetBounds = 2.5f;
 
-        // Animate the triangles.
-        m_constantBufferData[n].offset.x += m_constantBufferData[n].velocity.x;
-        if (m_constantBufferData[n].offset.x > offsetBounds)
-        {
-            m_constantBufferData[n].velocity.x = GetRandomFloat(0.01f, 0.02f);
-            m_constantBufferData[n].offset.x = -offsetBounds;
-        }
-    }
+		// Animate the triangles.
+		m_constantBufferData[n].offset.x += m_constantBufferData[n].velocity.x;
+		if (m_constantBufferData[n].offset.x > offsetBounds)
+		{
+			m_constantBufferData[n].velocity.x = GetRandomFloat(0.01f, 0.02f);
+			m_constantBufferData[n].offset.x = -offsetBounds;
+		}
+	}
 
-    UINT8* destination = m_pCbvDataBegin + (TriangleCount * m_frameIndex * sizeof(SceneConstantBuffer));
-    memcpy(destination, &m_constantBufferData[0], TriangleCount * sizeof(SceneConstantBuffer));
+	UINT8* destination = m_pCbvDataBegin + (TriangleCount * m_frameIndex * sizeof(SceneConstantBuffer));
+	memcpy(destination, &m_constantBufferData[0], TriangleCount * sizeof(SceneConstantBuffer));
 }
 
 // Render the scene.
 void D3D12ExecuteIndirect::OnRender()
 {
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandLists();
-
-    // Execute the compute work.
-    if (m_enableCulling)
+    try
     {
-        PIXBeginEvent(m_commandQueue.Get(), 0, L"Cull invisible triangles");
+        // Record all the commands we need to render the scene into the command list.
+        PopulateCommandLists();
 
-        ID3D12CommandList* ppCommandLists[] = { m_computeCommandList.Get() };
-        m_computeCommandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+        // Execute the compute work.
+        if (m_enableCulling)
+        {
+            PIXBeginEvent(m_commandQueue.Get(), 0, L"Cull invisible triangles");
+
+            ID3D12CommandList* ppCommandLists[] = { m_computeCommandList.Get() };
+            m_computeCommandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+
+            PIXEndEvent(m_commandQueue.Get());
+
+            m_computeCommandQueue->Signal(m_computeFence.Get(), m_fenceValues[m_frameIndex]);
+
+            // Execute the rendering work only when the compute work is complete.
+            m_commandQueue->Wait(m_computeFence.Get(), m_fenceValues[m_frameIndex]);
+        }
+
+        PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+
+        // Execute the rendering work.
+        ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+        m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
         PIXEndEvent(m_commandQueue.Get());
 
-        m_computeCommandQueue->Signal(m_computeFence.Get(), m_fenceValues[m_frameIndex]);
+        // Present the frame.
+        ThrowIfFailed(m_swapChain->Present(1, 0));
 
-        // Execute the rendering work only when the compute work is complete.
-        m_commandQueue->Wait(m_computeFence.Get(), m_fenceValues[m_frameIndex]);
+        MoveToNextFrame();
     }
+    catch (HrException& e)
+    {
+        if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
+        {
+            RestoreD3DResources();
+        }
+        else
+        {
+            throw;
+        }
+    }
+}
 
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+// Release sample's D3D objects.
+void D3D12ExecuteIndirect::ReleaseD3DResources()
+{
+    m_fence.Reset();
+    ResetComPtrArray(&m_renderTargets);
+    m_commandQueue.Reset();
+    m_swapChain.Reset();
+    m_device.Reset();
+}
 
-    // Execute the rendering work.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
-
-    PIXEndEvent(m_commandQueue.Get());
-
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
-
-    MoveToNextFrame();
+// Tears down D3D resources and reinitializes them.
+void D3D12ExecuteIndirect::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
+    {
+        WaitForGpu();
+    }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
 }
 
 void D3D12ExecuteIndirect::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForGpu();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForGpu();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12ExecuteIndirect::OnKeyDown(UINT8 key)
 {
-    if (key == VK_SPACE)
-    {
-        m_enableCulling = !m_enableCulling;
-    }
+	if (key == VK_SPACE)
+	{
+		m_enableCulling = !m_enableCulling;
+	}
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12ExecuteIndirect::PopulateCommandLists()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_computeCommandAllocators[m_frameIndex]->Reset());
-    ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_computeCommandAllocators[m_frameIndex]->Reset());
+	ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_computeCommandList->Reset(m_computeCommandAllocators[m_frameIndex].Get(), m_computeState.Get()));
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_computeCommandList->Reset(m_computeCommandAllocators[m_frameIndex].Get(), m_computeState.Get()));
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
 
-    // Record the compute commands that will cull triangles and prevent them from being processed by the vertex shader.
-    if (m_enableCulling)
-    {
-        UINT frameDescriptorOffset = m_frameIndex * CbvSrvUavDescriptorCountPerFrame;
-        D3D12_GPU_DESCRIPTOR_HANDLE cbvSrvUavHandle = m_cbvSrvUavHeap->GetGPUDescriptorHandleForHeapStart();
+	// Record the compute commands that will cull triangles and prevent them from being processed by the vertex shader.
+	if (m_enableCulling)
+	{
+		UINT frameDescriptorOffset = m_frameIndex * CbvSrvUavDescriptorCountPerFrame;
+		D3D12_GPU_DESCRIPTOR_HANDLE cbvSrvUavHandle = m_cbvSrvUavHeap->GetGPUDescriptorHandleForHeapStart();
 
-        m_computeCommandList->SetComputeRootSignature(m_computeRootSignature.Get());
+		m_computeCommandList->SetComputeRootSignature(m_computeRootSignature.Get());
 
-        ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvUavHeap.Get() };
-        m_computeCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+		ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvUavHeap.Get() };
+		m_computeCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-        m_computeCommandList->SetComputeRootDescriptorTable(
-            SrvUavTable,
-            CD3DX12_GPU_DESCRIPTOR_HANDLE(cbvSrvUavHandle, CbvSrvOffset + frameDescriptorOffset, m_cbvSrvUavDescriptorSize));
+		m_computeCommandList->SetComputeRootDescriptorTable(
+			SrvUavTable,
+			CD3DX12_GPU_DESCRIPTOR_HANDLE(cbvSrvUavHandle, CbvSrvOffset + frameDescriptorOffset, m_cbvSrvUavDescriptorSize));
 
-        m_computeCommandList->SetComputeRoot32BitConstants(RootConstants, 4, reinterpret_cast<void*>(&m_csRootConstants), 0);
+		m_computeCommandList->SetComputeRoot32BitConstants(RootConstants, 4, reinterpret_cast<void*>(&m_csRootConstants), 0);
 
-        // Reset the UAV counter for this frame.
-        m_computeCommandList->CopyBufferRegion(m_processedCommandBuffers[m_frameIndex].Get(), CommandBufferCounterOffset, m_processedCommandBufferCounterReset.Get(), 0, sizeof(UINT));
+		// Reset the UAV counter for this frame.
+		m_computeCommandList->CopyBufferRegion(m_processedCommandBuffers[m_frameIndex].Get(), CommandBufferCounterOffset, m_processedCommandBufferCounterReset.Get(), 0, sizeof(UINT));
 
-        D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(m_processedCommandBuffers[m_frameIndex].Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
-        m_computeCommandList->ResourceBarrier(1, &barrier);
+		D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(m_processedCommandBuffers[m_frameIndex].Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+		m_computeCommandList->ResourceBarrier(1, &barrier);
 
-        m_computeCommandList->Dispatch(static_cast<UINT>(ceil(TriangleCount / float(ComputeThreadBlockSize))), 1, 1);
-    }
+		m_computeCommandList->Dispatch(static_cast<UINT>(ceil(TriangleCount / float(ComputeThreadBlockSize))), 1, 1);
+	}
 
-    ThrowIfFailed(m_computeCommandList->Close());
+	ThrowIfFailed(m_computeCommandList->Close());
 
-    // Record the rendering commands.
-    {
-        // Set necessary state.
-        m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Record the rendering commands.
+	{
+		// Set necessary state.
+		m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-        ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvUavHeap.Get() };
-        m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+		ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvUavHeap.Get() };
+		m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-        m_commandList->RSSetViewports(1, &m_viewport);
-        m_commandList->RSSetScissorRects(1, m_enableCulling ? &m_cullingScissorRect : &m_scissorRect);
+		m_commandList->RSSetViewports(1, &m_viewport);
+		m_commandList->RSSetScissorRects(1, m_enableCulling ? &m_cullingScissorRect : &m_scissorRect);
 
-        // Indicate that the command buffer will be used for indirect drawing
-        // and that the back buffer will be used as a render target.
-        D3D12_RESOURCE_BARRIER barriers[2] = {
-            CD3DX12_RESOURCE_BARRIER::Transition(
-                m_enableCulling ? m_processedCommandBuffers[m_frameIndex].Get() : m_commandBuffer.Get(),
-                m_enableCulling ? D3D12_RESOURCE_STATE_UNORDERED_ACCESS : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT),
-            CD3DX12_RESOURCE_BARRIER::Transition(
-                m_renderTargets[m_frameIndex].Get(),
-                D3D12_RESOURCE_STATE_PRESENT,
-                D3D12_RESOURCE_STATE_RENDER_TARGET)
-        };
+		// Indicate that the command buffer will be used for indirect drawing
+		// and that the back buffer will be used as a render target.
+		D3D12_RESOURCE_BARRIER barriers[2] = {
+			CD3DX12_RESOURCE_BARRIER::Transition(
+				m_enableCulling ? m_processedCommandBuffers[m_frameIndex].Get() : m_commandBuffer.Get(),
+				m_enableCulling ? D3D12_RESOURCE_STATE_UNORDERED_ACCESS : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+				D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT),
+			CD3DX12_RESOURCE_BARRIER::Transition(
+				m_renderTargets[m_frameIndex].Get(),
+				D3D12_RESOURCE_STATE_PRESENT,
+				D3D12_RESOURCE_STATE_RENDER_TARGET)
+		};
 
-        m_commandList->ResourceBarrier(_countof(barriers), barriers);
+		m_commandList->ResourceBarrier(_countof(barriers), barriers);
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-        CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-        m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+		m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
 
-        // Record commands.
-        const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-        m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-        m_commandList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+		// Record commands.
+		const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+		m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+		m_commandList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
 
-        m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-        m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+		m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+		m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
 
-        if (m_enableCulling)
-        {
-            PIXBeginEvent(m_commandList.Get(), 0, L"Draw visible triangles");
+		if (m_enableCulling)
+		{
+			PIXBeginEvent(m_commandList.Get(), 0, L"Draw visible triangles");
 
-            // Draw the triangles that have not been culled.
-            m_commandList->ExecuteIndirect(
-                m_commandSignature.Get(),
-                TriangleCount,
-                m_processedCommandBuffers[m_frameIndex].Get(),
-                0,
-                m_processedCommandBuffers[m_frameIndex].Get(),
-                CommandBufferCounterOffset);
-        }
-        else
-        {
-            PIXBeginEvent(m_commandList.Get(), 0, L"Draw all triangles");
+			// Draw the triangles that have not been culled.
+			m_commandList->ExecuteIndirect(
+				m_commandSignature.Get(),
+				TriangleCount,
+				m_processedCommandBuffers[m_frameIndex].Get(),
+				0,
+				m_processedCommandBuffers[m_frameIndex].Get(),
+				CommandBufferCounterOffset);
+		}
+		else
+		{
+			PIXBeginEvent(m_commandList.Get(), 0, L"Draw all triangles");
 
-            // Draw all of the triangles.
-            m_commandList->ExecuteIndirect(
-                m_commandSignature.Get(),
-                TriangleCount,
-                m_commandBuffer.Get(),
-                CommandSizePerFrame * m_frameIndex,
-                nullptr,
-                0);
-        }
-        PIXEndEvent(m_commandList.Get());
+			// Draw all of the triangles.
+			m_commandList->ExecuteIndirect(
+				m_commandSignature.Get(),
+				TriangleCount,
+				m_commandBuffer.Get(),
+				CommandSizePerFrame * m_frameIndex,
+				nullptr,
+				0);
+		}
+		PIXEndEvent(m_commandList.Get());
 
-        // Indicate that the command buffer may be used by the compute shader
-        // and that the back buffer will now be used to present.
-        barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT;
-        barriers[0].Transition.StateAfter = m_enableCulling ? D3D12_RESOURCE_STATE_COPY_DEST : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
-        barriers[1].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-        barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
+		// Indicate that the command buffer may be used by the compute shader
+		// and that the back buffer will now be used to present.
+		barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT;
+		barriers[0].Transition.StateAfter = m_enableCulling ? D3D12_RESOURCE_STATE_COPY_DEST : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+		barriers[1].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+		barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
 
-        m_commandList->ResourceBarrier(_countof(barriers), barriers);
+		m_commandList->ResourceBarrier(_countof(barriers), barriers);
 
-        ThrowIfFailed(m_commandList->Close());
-    }
+		ThrowIfFailed(m_commandList->Close());
+	}
 }
 
 // Wait for pending GPU work to complete.
 void D3D12ExecuteIndirect::WaitForGpu()
 {
-    // Schedule a Signal command in the queue.
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
+	// Schedule a Signal command in the queue.
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
 
-    // Wait until the fence has been processed.
-    ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-    WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	// Wait until the fence has been processed.
+	ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+	WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
 
-    // Increment the fence value for the current frame.
-    m_fenceValues[m_frameIndex]++;
+	// Increment the fence value for the current frame.
+	m_fenceValues[m_frameIndex]++;
 }
 
 // Prepare to render the next frame.
 void D3D12ExecuteIndirect::MoveToNextFrame()
 {
-    // Schedule a Signal command in the queue.
-    const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
+	// Schedule a Signal command in the queue.
+	const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
 
-    // Update the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Update the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-        WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+		WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	}
 
-    // Set the fence value for the next frame.
-    m_fenceValues[m_frameIndex] = currentFenceValue + 1;
+	// Set the fence value for the next frame.
+	m_fenceValues[m_frameIndex] = currentFenceValue + 1;
 }

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.h
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.h
@@ -25,145 +25,147 @@ using Microsoft::WRL::ComPtr;
 class D3D12ExecuteIndirect : public DXSample
 {
 public:
-    D3D12ExecuteIndirect(UINT width, UINT height, std::wstring name);
+	D3D12ExecuteIndirect(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
-    virtual void OnKeyDown(UINT8 key);
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
+	virtual void OnKeyDown(UINT8 key);
 
 private:
-    static const UINT FrameCount = 3;
-    static const UINT TriangleCount = 1024;
-    static const UINT TriangleResourceCount = TriangleCount * FrameCount;
-    static const UINT CommandSizePerFrame;                // The size of the indirect commands to draw all of the triangles in a single frame.
-    static const UINT CommandBufferCounterOffset;        // The offset of the UAV counter in the processed command buffer.
-    static const UINT ComputeThreadBlockSize = 128;        // Should match the value in compute.hlsl.
-    static const float TriangleHalfWidth;                // The x and y offsets used by the triangle vertices.
-    static const float TriangleDepth;                    // The z offset used by the triangle vertices.
-    static const float CullingCutoff;                    // The +/- x offset of the clipping planes in homogenous space [-1,1].
+	static const UINT FrameCount = 3;
+	static const UINT TriangleCount = 1024;
+	static const UINT TriangleResourceCount = TriangleCount * FrameCount;
+	static const UINT CommandSizePerFrame;				// The size of the indirect commands to draw all of the triangles in a single frame.
+	static const UINT CommandBufferCounterOffset;		// The offset of the UAV counter in the processed command buffer.
+	static const UINT ComputeThreadBlockSize = 128;		// Should match the value in compute.hlsl.
+	static const float TriangleHalfWidth;				// The x and y offsets used by the triangle vertices.
+	static const float TriangleDepth;					// The z offset used by the triangle vertices.
+	static const float CullingCutoff;					// The +/- x offset of the clipping planes in homogenous space [-1,1].
 
-    // Vertex definition.
-    struct Vertex
-    {
-        XMFLOAT3 position;
-    };
+	// Vertex definition.
+	struct Vertex
+	{
+		XMFLOAT3 position;
+	};
 
-    // Constant buffer definition.
-    struct SceneConstantBuffer
-    {
-        XMFLOAT4 velocity;
-        XMFLOAT4 offset;
-        XMFLOAT4 color;
-        XMFLOAT4X4 projection;
+	// Constant buffer definition.
+	struct SceneConstantBuffer
+	{
+		XMFLOAT4 velocity;
+		XMFLOAT4 offset;
+		XMFLOAT4 color;
+		XMFLOAT4X4 projection;
 
-        // Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
-        // to be array-indexed.
-        float padding[36];
-    };
+		// Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
+		// to be array-indexed.
+		float padding[36];
+	};
 
-    // Root constants for the compute shader.
-    struct CSRootConstants
-    {
-        float xOffset;
-        float zOffset;
-        float cullOffset;
-        float commandCount;
-    };
+	// Root constants for the compute shader.
+	struct CSRootConstants
+	{
+		float xOffset;
+		float zOffset;
+		float cullOffset;
+		float commandCount;
+	};
 
-    // Data structure to match the command signature used for ExecuteIndirect.
-    struct IndirectCommand
-    {
-        D3D12_GPU_VIRTUAL_ADDRESS cbv;
-        D3D12_DRAW_ARGUMENTS drawArguments;
-    };
+	// Data structure to match the command signature used for ExecuteIndirect.
+	struct IndirectCommand
+	{
+		D3D12_GPU_VIRTUAL_ADDRESS cbv;
+		D3D12_DRAW_ARGUMENTS drawArguments;
+	};
 
-    // Graphics root signature parameter offsets.
-    enum GraphicsRootParameters
-    {
-        Cbv,
-        GraphicsRootParametersCount
-    };
+	// Graphics root signature parameter offsets.
+	enum GraphicsRootParameters
+	{
+		Cbv,
+		GraphicsRootParametersCount
+	};
 
-    // Compute root signature parameter offsets.
-    enum ComputeRootParameters
-    {
-        SrvUavTable,
-        RootConstants,            // Root constants that give the shader information about the triangle vertices and culling planes.
-        ComputeRootParametersCount
-    };
+	// Compute root signature parameter offsets.
+	enum ComputeRootParameters
+	{
+		SrvUavTable,
+		RootConstants,			// Root constants that give the shader information about the triangle vertices and culling planes.
+		ComputeRootParametersCount
+	};
 
-    // CBV/SRV/UAV desciptor heap offsets.
-    enum HeapOffsets
-    {
-        CbvSrvOffset = 0,                                                    // SRV that points to the constant buffers used by the rendering thread.
-        CommandsOffset = CbvSrvOffset + 1,                                    // SRV that points to all of the indirect commands.
-        ProcessedCommandsOffset = CommandsOffset + 1,                        // UAV that records the commands we actually want to execute.
-        CbvSrvUavDescriptorCountPerFrame = ProcessedCommandsOffset + 1        // 2 SRVs + 1 UAV for the compute shader.
-    };
+	// CBV/SRV/UAV desciptor heap offsets.
+	enum HeapOffsets
+	{
+		CbvSrvOffset = 0,													// SRV that points to the constant buffers used by the rendering thread.
+		CommandsOffset = CbvSrvOffset + 1,									// SRV that points to all of the indirect commands.
+		ProcessedCommandsOffset = CommandsOffset + 1,						// UAV that records the commands we actually want to execute.
+		CbvSrvUavDescriptorCountPerFrame = ProcessedCommandsOffset + 1		// 2 SRVs + 1 UAV for the compute shader.
+	};
 
-    // Each triangle gets its own constant buffer per frame.
-    std::vector<SceneConstantBuffer> m_constantBufferData;
-    UINT8* m_pCbvDataBegin;
+	// Each triangle gets its own constant buffer per frame.
+	std::vector<SceneConstantBuffer> m_constantBufferData;
+	UINT8* m_pCbvDataBegin;
 
-    CSRootConstants m_csRootConstants;    // Constants for the compute shader.
-    bool m_enableCulling;                // Toggle whether the compute shader pre-processes the indirect commands.
+	CSRootConstants m_csRootConstants;	// Constants for the compute shader.
+	bool m_enableCulling;				// Toggle whether the compute shader pre-processes the indirect commands.
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    D3D12_RECT m_cullingScissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_computeCommandAllocators[FrameCount];
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12CommandQueue> m_computeCommandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12RootSignature> m_computeRootSignature;
-    ComPtr<ID3D12CommandSignature> m_commandSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_cbvSrvUavHeap;
-    UINT m_rtvDescriptorSize;
-    UINT m_cbvSrvUavDescriptorSize;
-    UINT m_frameIndex;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	D3D12_RECT m_cullingScissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_computeCommandAllocators[FrameCount];
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12CommandQueue> m_computeCommandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12RootSignature> m_computeRootSignature;
+	ComPtr<ID3D12CommandSignature> m_commandSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_cbvSrvUavHeap;
+	UINT m_rtvDescriptorSize;
+	UINT m_cbvSrvUavDescriptorSize;
+	UINT m_frameIndex;
 
-    // Synchronization objects.
-    ComPtr<ID3D12Fence> m_fence;
-    ComPtr<ID3D12Fence> m_computeFence;
-    UINT64 m_fenceValues[FrameCount];
-    HANDLE m_fenceEvent;
+	// Synchronization objects.
+	ComPtr<ID3D12Fence> m_fence;
+	ComPtr<ID3D12Fence> m_computeFence;
+	UINT64 m_fenceValues[FrameCount];
+	HANDLE m_fenceEvent;
 
-    // Asset objects.
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12PipelineState> m_computeState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    ComPtr<ID3D12GraphicsCommandList> m_computeCommandList;
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    ComPtr<ID3D12Resource> m_constantBuffer;
-    ComPtr<ID3D12Resource> m_depthStencil;
-    ComPtr<ID3D12Resource> m_commandBuffer;
-    ComPtr<ID3D12Resource> m_processedCommandBuffers[FrameCount];
-    ComPtr<ID3D12Resource> m_processedCommandBufferCounterReset;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	// Asset objects.
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12PipelineState> m_computeState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	ComPtr<ID3D12GraphicsCommandList> m_computeCommandList;
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	ComPtr<ID3D12Resource> m_constantBuffer;
+	ComPtr<ID3D12Resource> m_depthStencil;
+	ComPtr<ID3D12Resource> m_commandBuffer;
+	ComPtr<ID3D12Resource> m_processedCommandBuffers[FrameCount];
+	ComPtr<ID3D12Resource> m_processedCommandBufferCounterReset;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
 
-    void LoadPipeline();
-    void LoadAssets();
-    float GetRandomFloat(float min, float max);
-    void PopulateCommandLists();
-    void WaitForGpu();
-    void MoveToNextFrame();
+	void LoadPipeline();
+	void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
+	float GetRandomFloat(float min, float max);
+	void PopulateCommandLists();
+	void WaitForGpu();
+	void MoveToNextFrame();
 
-    // We pack the UAV counter into the same buffer as the commands rather than create
-    // a separate 64K resource/heap for it. The counter must be aligned on 4K boundaries,
-    // so we pad the command buffer (if necessary) such that the counter will be placed
-    // at a valid location in the buffer.
-    static inline UINT AlignForUavCounter(UINT bufferSize)
-    {
-        const UINT alignment = D3D12_UAV_COUNTER_PLACEMENT_ALIGNMENT;
-        return (bufferSize + (alignment - 1)) & ~(alignment - 1);
-    }
+	// We pack the UAV counter into the same buffer as the commands rather than create
+	// a separate 64K resource/heap for it. The counter must be aligned on 4K boundaries,
+	// so we pad the command buffer (if necessary) such that the counter will be placed
+	// at a valid location in the buffer.
+	static inline UINT AlignForUavCounter(UINT bufferSize)
+	{
+		const UINT alignment = D3D12_UAV_COUNTER_PLACEMENT_ALIGNMENT;
+		return (bufferSize + (alignment - 1)) & ~(alignment - 1);
+	}
 };

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,58 +34,103 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title + L": " + text;
-    SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
+	std::wstring windowText = m_title + L": " + text;
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/DXSample.h
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/DXSample.h
@@ -17,42 +17,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/Main.cpp
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12ExecuteIndirect sample(1280, 720, L"D3D12 Execute Indirect sample - Press the SPACE bar to toggle GPU primitive culling");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12ExecuteIndirect sample(1280, 720, L"D3D12 Execute Indirect sample - Press the SPACE bar to toggle GPU primitive culling");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/Win32Application.cpp
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/Win32Application.cpp
@@ -16,104 +16,104 @@ HWND Win32Application::m_hwnd = nullptr;
 
 int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
 {
-    // Parse the command line parameters
-    int argc;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    pSample->ParseCommandLineArgs(argv, argc);
-    LocalFree(argv);
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
 
-    // Initialize the window class.
-    WNDCLASSEX windowClass = { 0 };
-    windowClass.cbSize = sizeof(WNDCLASSEX);
-    windowClass.style = CS_HREDRAW | CS_VREDRAW;
-    windowClass.lpfnWndProc = WindowProc;
-    windowClass.hInstance = hInstance;
-    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-    windowClass.lpszClassName = L"DXSampleClass";
-    RegisterClassEx(&windowClass);
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
 
-    RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
-    AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
 
-    // Create the window and store a handle to it.
-    m_hwnd = CreateWindow(
-        windowClass.lpszClassName,
-        pSample->GetTitle(),
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        windowRect.right - windowRect.left,
-        windowRect.bottom - windowRect.top,
-        nullptr,        // We have no parent window.
-        nullptr,        // We aren't using menus.
-        hInstance,
-        pSample);
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
 
-    // Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-    pSample->OnInit();
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
 
-    ShowWindow(m_hwnd, nCmdShow);
+	ShowWindow(m_hwnd, nCmdShow);
 
-    // Main sample loop.
-    MSG msg = {};
-    while (msg.message != WM_QUIT)
-    {
-        // Process any messages in the queue.
-        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
-    }
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
 
-    pSample->OnDestroy();
+	pSample->OnDestroy();
 
-    // Return this part of the WM_QUIT message to Windows.
-    return static_cast<char>(msg.wParam);
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
 }
 
 // Main message handler for the sample.
 LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
-    switch (message)
-    {
-    case WM_CREATE:
-        {
-            // Save the DXSample* passed in to CreateWindow.
-            LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
-            SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
-        }
-        return 0;
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
 
-    case WM_KEYDOWN:
-        if (pSample)
-        {
-            pSample->OnKeyDown(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_KEYUP:
-        if (pSample)
-        {
-            pSample->OnKeyUp(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_PAINT:
-        if (pSample)
-        {
-            pSample->OnUpdate();
-            pSample->OnRender();
-        }
-        return 0;
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
 
-    case WM_DESTROY:
-        PostQuitMessage(0);
-        return 0;
-    }
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
 
-    // Handle any messages the switch statement didn't.
-    return DefWindowProc(hWnd, message, wParam, lParam);
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/Win32Application.h
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/Win32Application.h
@@ -18,12 +18,12 @@ class DXSample;
 class Win32Application
 {
 public:
-    static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
-    static HWND GetHwnd() { return m_hwnd; }
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
 
 protected:
-    static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
-    static HWND m_hwnd;
+	static HWND m_hwnd;
 };

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/compute.hlsl
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/compute.hlsl
@@ -13,54 +13,54 @@
 
 struct SceneConstantBuffer
 {
-    float4 velocity;
-    float4 offset;
-    float4 color;
-    float4x4 projection;
-    float4 padding[9];
+	float4 velocity;
+	float4 offset;
+	float4 color;
+	float4x4 projection;
+	float4 padding[9];
 };
 
 struct IndirectCommand
 {
-    uint2 cbvAddress;
-    uint4 drawArguments;
+	uint2 cbvAddress;
+	uint4 drawArguments;
 };
 
 cbuffer RootConstants : register(b0)
 {
-    float xOffset;        // Half the width of the triangles.
-    float zOffset;        // The z offset for the triangle vertices.
-    float cullOffset;    // The culling plane offset in homogenous space.
-    float commandCount;    // The number of commands to be processed.
+	float xOffset;		// Half the width of the triangles.
+	float zOffset;		// The z offset for the triangle vertices.
+	float cullOffset;	// The culling plane offset in homogenous space.
+	float commandCount;	// The number of commands to be processed.
 };
 
-StructuredBuffer<SceneConstantBuffer> cbv                : register(t0);    // SRV: Wrapped constant buffers
-StructuredBuffer<IndirectCommand> inputCommands            : register(t1);    // SRV: Indirect commands
-AppendStructuredBuffer<IndirectCommand> outputCommands    : register(u0);    // UAV: Processed indirect commands
+StructuredBuffer<SceneConstantBuffer> cbv				: register(t0);	// SRV: Wrapped constant buffers
+StructuredBuffer<IndirectCommand> inputCommands			: register(t1);	// SRV: Indirect commands
+AppendStructuredBuffer<IndirectCommand> outputCommands	: register(u0);	// UAV: Processed indirect commands
 
 [numthreads(threadBlockSize, 1, 1)]
 void CSMain(uint3 groupId : SV_GroupID, uint groupIndex : SV_GroupIndex)
 {
-    // Each thread of the CS operates on one of the indirect commands.
-    uint index = (groupId.x * threadBlockSize) + groupIndex;
+	// Each thread of the CS operates on one of the indirect commands.
+	uint index = (groupId.x * threadBlockSize) + groupIndex;
 
-    // Don't attempt to access commands that don't exist if more threads are allocated
-    // than commands.
-    if (index < commandCount)
-    {
-        // Project the left and right bounds of the triangle into homogenous space.
-        float4 left = float4(-xOffset, 0.0f, zOffset, 1.0f) + cbv[index].offset;
-        left = mul(left, cbv[index].projection);
-        left /= left.w;
+	// Don't attempt to access commands that don't exist if more threads are allocated
+	// than commands.
+	if (index < commandCount)
+	{
+		// Project the left and right bounds of the triangle into homogenous space.
+		float4 left = float4(-xOffset, 0.0f, zOffset, 1.0f) + cbv[index].offset;
+		left = mul(left, cbv[index].projection);
+		left /= left.w;
 
-        float4 right = float4(xOffset, 0.0f, zOffset, 1.0f) + cbv[index].offset;
-        right = mul(right, cbv[index].projection);
-        right /= right.w;
+		float4 right = float4(xOffset, 0.0f, zOffset, 1.0f) + cbv[index].offset;
+		right = mul(right, cbv[index].projection);
+		right /= right.w;
 
-        // Only draw triangles that are within the culling space.
-        if (-cullOffset < right.x && left.x < cullOffset)
-        {
-            outputCommands.Append(inputCommands[index]);
-        }
-    }
+		// Only draw triangles that are within the culling space.
+		if (-cullOffset < right.x && left.x < cullOffset)
+		{
+			outputCommands.Append(inputCommands[index]);
+		}
+	}
 }

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/d3dx12.h
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/shaders.hlsl
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/shaders.hlsl
@@ -11,31 +11,31 @@
 
 cbuffer SceneConstantBuffer : register(b0)
 {
-    float4 velocity;
-    float4 offset;
-    float4 color;
-    float4x4 projection;
+	float4 velocity;
+	float4 offset;
+	float4 color;
+	float4x4 projection;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VSMain(float4 position : POSITION)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = mul(position + offset, projection);
+	result.position = mul(position + offset, projection);
 
-    float intensity = saturate((4.0f - result.position.z) / 2.0f);
-    result.color = float4(color.xyz * intensity, 1.0f);
+	float intensity = saturate((4.0f - result.position.z) / 2.0f);
+	result.color = float4(color.xyz * intensity, 1.0f);
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/stdafx.h
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include "d3dx12.h"

--- a/Samples/Desktop/D3D12Fullscreen/src/D3D12Fullscreen.cpp
+++ b/Samples/Desktop/D3D12Fullscreen/src/D3D12Fullscreen.cpp
@@ -19,897 +19,938 @@ const float D3D12Fullscreen::ClearColor[4] = { 0.0f, 0.2f, 0.4f, 1.0f };
 
 const D3D12Fullscreen::Resolution D3D12Fullscreen::m_resolutionOptions[] =
 {
-    { 800u, 600u },
-    { 1200u, 900u },
-    { 1280u, 720u },
-    { 1920u, 1080u },
-    { 1920u, 1200u },
-    { 2560u, 1440u },
-    { 3440u, 1440u },
-    { 3840u, 2160u }
+	{ 800u, 600u },
+	{ 1200u, 900u },
+	{ 1280u, 720u },
+	{ 1920u, 1080u },
+	{ 1920u, 1200u },
+	{ 2560u, 1440u },
+	{ 3440u, 1440u },
+	{ 3840u, 2160u }
 };
 const UINT D3D12Fullscreen::m_resolutionOptionsCount = _countof(m_resolutionOptions);
 UINT D3D12Fullscreen::m_resolutionIndex = 2;
 
 D3D12Fullscreen::D3D12Fullscreen(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_pCbvDataBegin(nullptr),
-    m_sceneViewport(0.0f, 0.0f, 0.0f, 0.0f),
-    m_sceneScissorRect(0, 0, 0, 0),
-    m_postViewport(0.0f, 0.0f, 0.0f, 0.0f),
-    m_postScissorRect(0, 0, 0, 0),
-    m_rtvDescriptorSize(0),
-    m_cbvSrvDescriptorSize(0),
-    m_windowVisible(true),
-    m_windowedMode(true),
-    m_sceneConstantBufferData{},
-    m_fenceValues{}
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_pCbvDataBegin(nullptr),
+	m_sceneViewport(0.0f, 0.0f, 0.0f, 0.0f),
+	m_sceneScissorRect(0, 0, 0, 0),
+	m_postViewport(0.0f, 0.0f, 0.0f, 0.0f),
+	m_postScissorRect(0, 0, 0, 0),
+	m_rtvDescriptorSize(0),
+	m_cbvSrvDescriptorSize(0),
+	m_windowVisible(true),
+	m_windowedMode(true),
+	m_sceneConstantBufferData{},
+	m_fenceValues{}
 {
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
 }
 
 void D3D12Fullscreen::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12Fullscreen::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter, true);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
-    NAME_D3D12_OBJECT(m_commandQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	NAME_D3D12_OBJECT(m_commandQueue);
 
-    // Describe and create the swap chain.
-    // The resolution of the swap chain buffers will match the resolution of the window, enabling the
-    // app to enter iFlip when in fullscreen mode. We will also keep a separate buffer that is not part
-    // of the swap chain as an intermediate render target, whose resolution will control the rendering
-    // resolution of the scene.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	// The resolution of the swap chain buffers will match the resolution of the window, enabling the
+	// app to enter iFlip when in fullscreen mode. We will also keep a separate buffer that is not part
+	// of the swap chain as an intermediate render target, whose resolution will control the rendering
+	// resolution of the scene.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    // It is recommended to always use the tearing flag when it is available.
-    swapChainDesc.Flags = m_tearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
+	// It is recommended to always use the tearing flag when it is available.
+	swapChainDesc.Flags = m_tearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    if (m_tearingSupport)
-    {
-        // When tearing support is enabled we will handle ALT+Enter key presses in the
-        // window message loop rather than let DXGI handle it by calling SetFullscreenState.
-        factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER);
-    }
+	if (m_tearingSupport)
+	{
+		// When tearing support is enabled we will handle ALT+Enter key presses in the
+		// window message loop rather than let DXGI handle it by calling SetFullscreenState.
+		factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER);
+	}
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount + 1; // + 1 for the intermediate render target.
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount + 1; // + 1 for the intermediate render target.
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
 
-        // Describe and create a constant buffer view (CBV) and shader resource view (SRV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvSrvHeapDesc = {};
-        cbvSrvHeapDesc.NumDescriptors = FrameCount + 1; // One CBV per frame and one SRV for the intermediate render target.
-        cbvSrvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        cbvSrvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvSrvHeapDesc, IID_PPV_ARGS(&m_cbvSrvHeap)));
+		// Describe and create a constant buffer view (CBV) and shader resource view (SRV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvSrvHeapDesc = {};
+		cbvSrvHeapDesc.NumDescriptors = FrameCount + 1; // One CBV per frame and one SRV for the intermediate render target.
+		cbvSrvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		cbvSrvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvSrvHeapDesc, IID_PPV_ARGS(&m_cbvSrvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-        m_cbvSrvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_cbvSrvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	}
 
-    // Create command allocators for each frame.
-    for (UINT n = 0; n < FrameCount; n++)
-    {
-        ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[n])));
-        ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_postCommandAllocators[n])));
-    }
+	// Create command allocators for each frame.
+	for (UINT n = 0; n < FrameCount; n++)
+	{
+		ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[n])));
+		ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_postCommandAllocators[n])));
+	}
 }
 
 // Load the sample assets.
 void D3D12Fullscreen::LoadAssets()
 {
-    D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-    // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-    featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+	// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+	featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-    if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-    {
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-    }
+	if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+	{
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+	}
 
-    // Create a root signature consisting of a descriptor table with a single CBV.
-    {
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
-        CD3DX12_ROOT_PARAMETER1 rootParameters[1];
+	// Create a root signature consisting of a descriptor table with a single CBV.
+	{
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
+		CD3DX12_ROOT_PARAMETER1 rootParameters[1];
 
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_VERTEX);
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_VERTEX);
 
-        // Allow input layout and deny uneccessary access to certain pipeline stages.
-        D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
-            D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_PIXEL_SHADER_ROOT_ACCESS;
+		// Allow input layout and deny uneccessary access to certain pipeline stages.
+		D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
+			D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_PIXEL_SHADER_ROOT_ACCESS;
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, rootSignatureFlags);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, rootSignatureFlags);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_sceneRootSignature)));
-        NAME_D3D12_OBJECT(m_sceneRootSignature);
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_sceneRootSignature)));
+		NAME_D3D12_OBJECT(m_sceneRootSignature);
+	}
 
-    // Create a root signature consisting of a descriptor table with a SRV and a sampler.
-    {
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
-        CD3DX12_ROOT_PARAMETER1 rootParameters[1];
+	// Create a root signature consisting of a descriptor table with a SRV and a sampler.
+	{
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
+		CD3DX12_ROOT_PARAMETER1 rootParameters[1];
 
-        // We don't modify the SRV in the post-processing command list after
-        // SetGraphicsRootDescriptorTable is executed on the GPU so we can use the default
-        // range behavior: D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
-        rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
+		// We don't modify the SRV in the post-processing command list after
+		// SetGraphicsRootDescriptorTable is executed on the GPU so we can use the default
+		// range behavior: D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
+		rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
 
-        // Allow input layout and pixel shader access and deny uneccessary access to certain pipeline stages.
-        D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
-            D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS;
+		// Allow input layout and pixel shader access and deny uneccessary access to certain pipeline stages.
+		D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
+			D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS;
 
-        // Create a sampler.
-        D3D12_STATIC_SAMPLER_DESC sampler = {};
-        sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-        sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.MipLODBias = 0;
-        sampler.MaxAnisotropy = 0;
-        sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
-        sampler.BorderColor = D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
-        sampler.MinLOD = 0.0f;
-        sampler.MaxLOD = D3D12_FLOAT32_MAX;
-        sampler.ShaderRegister = 0;
-        sampler.RegisterSpace = 0;
-        sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+		// Create a sampler.
+		D3D12_STATIC_SAMPLER_DESC sampler = {};
+		sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.MipLODBias = 0;
+		sampler.MaxAnisotropy = 0;
+		sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
+		sampler.BorderColor = D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
+		sampler.MinLOD = 0.0f;
+		sampler.MaxLOD = D3D12_FLOAT32_MAX;
+		sampler.ShaderRegister = 0;
+		sampler.RegisterSpace = 0;
+		sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &sampler, rootSignatureFlags);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &sampler, rootSignatureFlags);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_postRootSignature)));
-        NAME_D3D12_OBJECT(m_postRootSignature);
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_postRootSignature)));
+		NAME_D3D12_OBJECT(m_postRootSignature);
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> sceneVertexShader;
-        ComPtr<ID3DBlob> scenePixelShader;
-        ComPtr<ID3DBlob> postVertexShader;
-        ComPtr<ID3DBlob> postPixelShader;
-        ComPtr<ID3DBlob> error;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> sceneVertexShader;
+		ComPtr<ID3DBlob> scenePixelShader;
+		ComPtr<ID3DBlob> postVertexShader;
+		ComPtr<ID3DBlob> postPixelShader;
+		ComPtr<ID3DBlob> error;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"sceneShaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &sceneVertexShader, &error));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"sceneShaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &scenePixelShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"sceneShaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &sceneVertexShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"sceneShaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &scenePixelShader, &error));
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"postShaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &postVertexShader, &error));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"postShaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &postPixelShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"postShaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &postVertexShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"postShaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &postPixelShader, &error));
 
-        // Define the vertex input layouts.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
-        D3D12_INPUT_ELEMENT_DESC scaleInputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layouts.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
+		D3D12_INPUT_ELEMENT_DESC scaleInputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Describe and create the graphics pipeline state objects (PSOs).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_sceneRootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(sceneVertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(scenePixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state objects (PSOs).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_sceneRootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(sceneVertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(scenePixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_scenePipelineState)));
-        NAME_D3D12_OBJECT(m_scenePipelineState);
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_scenePipelineState)));
+		NAME_D3D12_OBJECT(m_scenePipelineState);
 
-        psoDesc.InputLayout = { scaleInputElementDescs, _countof(scaleInputElementDescs) };
-        psoDesc.pRootSignature = m_postRootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(postVertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(postPixelShader.Get());
+		psoDesc.InputLayout = { scaleInputElementDescs, _countof(scaleInputElementDescs) };
+		psoDesc.pRootSignature = m_postRootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(postVertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(postPixelShader.Get());
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_postPipelineState)));
-        NAME_D3D12_OBJECT(m_postPipelineState);
-    }
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_postPipelineState)));
+		NAME_D3D12_OBJECT(m_postPipelineState);
+	}
 
-    // Single-use command allocator and command list for creating resources.
-    ComPtr<ID3D12CommandAllocator> commandAllocator;
-    ComPtr<ID3D12GraphicsCommandList> commandList;
+	// Single-use command allocator and command list for creating resources.
+	ComPtr<ID3D12CommandAllocator> commandAllocator;
+	ComPtr<ID3D12GraphicsCommandList> commandList;
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator)));
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
 
-    // Create the command lists.
-    {
-        ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_sceneCommandAllocators[m_frameIndex].Get(), m_scenePipelineState.Get(), IID_PPV_ARGS(&m_sceneCommandList)));
-        NAME_D3D12_OBJECT(m_sceneCommandList);
+	// Create the command lists.
+	{
+		ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_sceneCommandAllocators[m_frameIndex].Get(), m_scenePipelineState.Get(), IID_PPV_ARGS(&m_sceneCommandList)));
+		NAME_D3D12_OBJECT(m_sceneCommandList);
 
-        ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_postCommandAllocators[m_frameIndex].Get(), m_postPipelineState.Get(), IID_PPV_ARGS(&m_postCommandList)));
-        NAME_D3D12_OBJECT(m_postCommandList);
+		ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_postCommandAllocators[m_frameIndex].Get(), m_postPipelineState.Get(), IID_PPV_ARGS(&m_postCommandList)));
+		NAME_D3D12_OBJECT(m_postCommandList);
 
-        // Close the command lists.
-        ThrowIfFailed(m_sceneCommandList->Close());
-        ThrowIfFailed(m_postCommandList->Close());
-    }
+		// Close the command lists.
+		ThrowIfFailed(m_sceneCommandList->Close());
+		ThrowIfFailed(m_postCommandList->Close());
+	}
 
-    LoadSizeDependentResources();
-    LoadSceneResolutionDependentResources();
+	LoadSizeDependentResources();
+	LoadSceneResolutionDependentResources();
 
-    // Create/update the vertex buffer.
-    ComPtr<ID3D12Resource> sceneVertexBufferUpload;
-    {
-        // Define the geometry for a thin quad that will animate across the screen.
-        const float x = QuadWidth / 2.0f;
-        const float y = QuadHeight / 2.0f;
-        SceneVertex quadVertices[] =
-        {
-            { { -x, -y, 1.0f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
-            { { -x, y, 1.0f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
-            { { x, -y, 1.0f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
-            { { x, y, 1.0f }, { 1.0f, 1.0f, 1.0f, 1.0f } }
-        };
+	// Create/update the vertex buffer.
+	ComPtr<ID3D12Resource> sceneVertexBufferUpload;
+	{
+		// Define the geometry for a thin quad that will animate across the screen.
+		const float x = QuadWidth / 2.0f;
+		const float y = QuadHeight / 2.0f;
+		SceneVertex quadVertices[] =
+		{
+			{ { -x, -y, 1.0f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
+			{ { -x, y, 1.0f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
+			{ { x, -y, 1.0f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
+			{ { x, y, 1.0f }, { 1.0f, 1.0f, 1.0f, 1.0f } }
+		};
 
-        const UINT vertexBufferSize = sizeof(quadVertices);
+		const UINT vertexBufferSize = sizeof(quadVertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_sceneVertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_sceneVertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&sceneVertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&sceneVertexBufferUpload)));
 
-        NAME_D3D12_OBJECT(m_sceneVertexBuffer);
+		NAME_D3D12_OBJECT(m_sceneVertexBuffer);
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the vertex buffer.
-        UINT8* pVertexDataBegin;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(sceneVertexBufferUpload->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
-        memcpy(pVertexDataBegin, quadVertices, sizeof(quadVertices));
-        sceneVertexBufferUpload->Unmap(0, nullptr);
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the vertex buffer.
+		UINT8* pVertexDataBegin;
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(sceneVertexBufferUpload->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
+		memcpy(pVertexDataBegin, quadVertices, sizeof(quadVertices));
+		sceneVertexBufferUpload->Unmap(0, nullptr);
 
-        commandList->CopyBufferRegion(m_sceneVertexBuffer.Get(), 0, sceneVertexBufferUpload.Get(), 0, vertexBufferSize);
-        commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_sceneVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		commandList->CopyBufferRegion(m_sceneVertexBuffer.Get(), 0, sceneVertexBufferUpload.Get(), 0, vertexBufferSize);
+		commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_sceneVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer views.
-        m_sceneVertexBufferView.BufferLocation = m_sceneVertexBuffer->GetGPUVirtualAddress();
-        m_sceneVertexBufferView.StrideInBytes = sizeof(SceneVertex);
-        m_sceneVertexBufferView.SizeInBytes = vertexBufferSize;
-    }
+		// Initialize the vertex buffer views.
+		m_sceneVertexBufferView.BufferLocation = m_sceneVertexBuffer->GetGPUVirtualAddress();
+		m_sceneVertexBufferView.StrideInBytes = sizeof(SceneVertex);
+		m_sceneVertexBufferView.SizeInBytes = vertexBufferSize;
+	}
 
-    // Create/update the fullscreen quad vertex buffer.
-    ComPtr<ID3D12Resource> postVertexBufferUpload;
-    {
-        // Define the geometry for a fullscreen quad.
-        PostVertex quadVertices[] =
-        {
-            { { -1.0f, -1.0f, 0.0f, 1.0f }, { 0.0f, 0.0f } },    // Bottom left.
-            { { -1.0f, 1.0f, 0.0f, 1.0f }, { 0.0f, 1.0f } },    // Top left.
-            { { 1.0f, -1.0f, 0.0f, 1.0f }, { 1.0f, 0.0f } },    // Bottom right.
-            { { 1.0f, 1.0f, 0.0f, 1.0f }, { 1.0f, 1.0f } }        // Top right.
-        };
+	// Create/update the fullscreen quad vertex buffer.
+	ComPtr<ID3D12Resource> postVertexBufferUpload;
+	{
+		// Define the geometry for a fullscreen quad.
+		PostVertex quadVertices[] =
+		{
+			{ { -1.0f, -1.0f, 0.0f, 1.0f }, { 0.0f, 0.0f } },	// Bottom left.
+			{ { -1.0f, 1.0f, 0.0f, 1.0f }, { 0.0f, 1.0f } },	// Top left.
+			{ { 1.0f, -1.0f, 0.0f, 1.0f }, { 1.0f, 0.0f } },	// Bottom right.
+			{ { 1.0f, 1.0f, 0.0f, 1.0f }, { 1.0f, 1.0f } }		// Top right.
+		};
 
-        const UINT vertexBufferSize = sizeof(quadVertices);
+		const UINT vertexBufferSize = sizeof(quadVertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_postVertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_postVertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&postVertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&postVertexBufferUpload)));
 
-        NAME_D3D12_OBJECT(m_postVertexBuffer);
+		NAME_D3D12_OBJECT(m_postVertexBuffer);
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the vertex buffer.
-        UINT8* pVertexDataBegin;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(postVertexBufferUpload->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
-        memcpy(pVertexDataBegin, quadVertices, sizeof(quadVertices));
-        postVertexBufferUpload->Unmap(0, nullptr);
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the vertex buffer.
+		UINT8* pVertexDataBegin;
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(postVertexBufferUpload->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
+		memcpy(pVertexDataBegin, quadVertices, sizeof(quadVertices));
+		postVertexBufferUpload->Unmap(0, nullptr);
 
-        commandList->CopyBufferRegion(m_postVertexBuffer.Get(), 0, postVertexBufferUpload.Get(), 0, vertexBufferSize);
-        commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_postVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		commandList->CopyBufferRegion(m_postVertexBuffer.Get(), 0, postVertexBufferUpload.Get(), 0, vertexBufferSize);
+		commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_postVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer views.
-        m_postVertexBufferView.BufferLocation = m_postVertexBuffer->GetGPUVirtualAddress();
-        m_postVertexBufferView.StrideInBytes = sizeof(PostVertex);
-        m_postVertexBufferView.SizeInBytes = vertexBufferSize;
-    }
+		// Initialize the vertex buffer views.
+		m_postVertexBufferView.BufferLocation = m_postVertexBuffer->GetGPUVirtualAddress();
+		m_postVertexBufferView.StrideInBytes = sizeof(PostVertex);
+		m_postVertexBufferView.SizeInBytes = vertexBufferSize;
+	}
 
-    // Create the constant buffer.
-    {
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(sizeof(SceneConstantBuffer) * FrameCount),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_sceneConstantBuffer)));
+	// Create the constant buffer.
+	{
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(sizeof(SceneConstantBuffer) * FrameCount),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_sceneConstantBuffer)));
 
-        NAME_D3D12_OBJECT(m_sceneConstantBuffer);
+		NAME_D3D12_OBJECT(m_sceneConstantBuffer);
 
-        // Describe and create constant buffer views.
-        D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
-        cbvDesc.BufferLocation = m_sceneConstantBuffer->GetGPUVirtualAddress();
-        cbvDesc.SizeInBytes = sizeof(SceneConstantBuffer);
+		// Describe and create constant buffer views.
+		D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
+		cbvDesc.BufferLocation = m_sceneConstantBuffer->GetGPUVirtualAddress();
+		cbvDesc.SizeInBytes = sizeof(SceneConstantBuffer);
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart(), 1, m_cbvSrvDescriptorSize);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart(), 1, m_cbvSrvDescriptorSize);
 
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            m_device->CreateConstantBufferView(&cbvDesc, cpuHandle);
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			m_device->CreateConstantBufferView(&cbvDesc, cpuHandle);
 
-            cbvDesc.BufferLocation += sizeof(SceneConstantBuffer);
-            cpuHandle.Offset(m_cbvSrvDescriptorSize);
-        }
+			cbvDesc.BufferLocation += sizeof(SceneConstantBuffer);
+			cpuHandle.Offset(m_cbvSrvDescriptorSize);
+		}
 
-        // Map and initialize the constant buffer. We don't unmap this until the
-        // app closes. Keeping things mapped for the lifetime of the resource is okay.
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_sceneConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbvDataBegin)));
-        memcpy(m_pCbvDataBegin, &m_sceneConstantBufferData, sizeof(m_sceneConstantBufferData));
-    }
+		// Map and initialize the constant buffer. We don't unmap this until the
+		// app closes. Keeping things mapped for the lifetime of the resource is okay.
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_sceneConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbvDataBegin)));
+		memcpy(m_pCbvDataBegin, &m_sceneConstantBufferData, sizeof(m_sceneConstantBufferData));
+	}
 
-    // Close the resource creation command list and execute it to begin the vertex buffer copy into
-    // the default heap.
-    ThrowIfFailed(commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the resource creation command list and execute it to begin the vertex buffer copy into
+	// the default heap.
+	ThrowIfFailed(commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValues[m_frameIndex]++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValues[m_frameIndex]++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute before continuing.
-        WaitForGpu();
-    }
+		// Wait for the command list to execute before continuing.
+		WaitForGpu();
+	}
 }
 
 void D3D12Fullscreen::LoadSizeDependentResources()
 {
-    UpdatePostViewAndScissor();
+	UpdatePostViewAndScissor();
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
+		// Create a RTV for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-            NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
-        }
-    }
+			NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
+		}
+	}
 
-    // Update resolutions shown in app title.
-    UpdateTitle();
+	// Update resolutions shown in app title.
+	UpdateTitle();
 
-    // This is where you would create/resize intermediate render targets, depth stencils, or other resources
-    // dependent on the window size.
+	// This is where you would create/resize intermediate render targets, depth stencils, or other resources
+	// dependent on the window size.
 }
 
 // Update frame-based values.
 void D3D12Fullscreen::OnUpdate()
 {
-    const float translationSpeed = 0.0001f;
-    const float offsetBounds = 1.0f;
+	const float translationSpeed = 0.0001f;
+	const float offsetBounds = 1.0f;
 
-    m_sceneConstantBufferData.offset.x += translationSpeed;
-    if (m_sceneConstantBufferData.offset.x > offsetBounds)
-    {
-        m_sceneConstantBufferData.offset.x = -offsetBounds;
-    }
+	m_sceneConstantBufferData.offset.x += translationSpeed;
+	if (m_sceneConstantBufferData.offset.x > offsetBounds)
+	{
+		m_sceneConstantBufferData.offset.x = -offsetBounds;
+	}
 
-    XMMATRIX transform = XMMatrixMultiply(
-        XMMatrixOrthographicLH(static_cast<float>(m_resolutionOptions[m_resolutionIndex].Width), static_cast<float>(m_resolutionOptions[m_resolutionIndex].Height), 0.0f, 100.0f),
-        XMMatrixTranslation(m_sceneConstantBufferData.offset.x, 0.0f, 0.0f));
+	XMMATRIX transform = XMMatrixMultiply(
+		XMMatrixOrthographicLH(static_cast<float>(m_resolutionOptions[m_resolutionIndex].Width), static_cast<float>(m_resolutionOptions[m_resolutionIndex].Height), 0.0f, 100.0f),
+		XMMatrixTranslation(m_sceneConstantBufferData.offset.x, 0.0f, 0.0f));
 
-    XMStoreFloat4x4(&m_sceneConstantBufferData.transform, XMMatrixTranspose(transform));
+	XMStoreFloat4x4(&m_sceneConstantBufferData.transform, XMMatrixTranspose(transform));
 
-    UINT offset = m_frameIndex * sizeof(SceneConstantBuffer);
-    memcpy(m_pCbvDataBegin + offset, &m_sceneConstantBufferData, sizeof(m_sceneConstantBufferData));
+	UINT offset = m_frameIndex * sizeof(SceneConstantBuffer);
+	memcpy(m_pCbvDataBegin + offset, &m_sceneConstantBufferData, sizeof(m_sceneConstantBufferData));
 }
 
 // Render the scene.
 void D3D12Fullscreen::OnRender()
 {
-    if (m_windowVisible)
+	if (m_windowVisible)
+	{
+        try
+        {
+            PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+
+            // Record all the commands we need to render the scene into the command lists.
+            PopulateCommandLists();
+
+            // Execute the command lists.
+            ID3D12CommandList* ppCommandLists[] = { m_sceneCommandList.Get(), m_postCommandList.Get() };
+            m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+
+            PIXEndEvent(m_commandQueue.Get());
+
+            // When using sync interval 0, it is recommended to always pass the tearing
+            // flag when it is supported, even when presenting in windowed mode.
+            // However, this flag cannot be used if the app is in fullscreen mode as a
+            // result of calling SetFullscreenState.
+            UINT presentFlags = (m_tearingSupport && m_windowedMode) ? DXGI_PRESENT_ALLOW_TEARING : 0;
+
+            // Present the frame.
+            ThrowIfFailed(m_swapChain->Present(0, presentFlags));
+
+            MoveToNextFrame();
+        }
+        catch (HrException& e)
+        {
+            if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
+            {
+                RestoreD3DResources();
+            }
+            else
+            {
+                throw;
+            }
+        }
+	}
+}
+
+// Release sample's D3D objects.
+void D3D12Fullscreen::ReleaseD3DResources()
+{
+    m_fence.Reset();
+    ResetComPtrArray(&m_renderTargets);
+    m_commandQueue.Reset();
+    m_swapChain.Reset();
+    m_device.Reset();
+}
+
+// Tears down D3D resources and reinitializes them.
+void D3D12Fullscreen::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
     {
-        PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
-
-        // Record all the commands we need to render the scene into the command lists.
-        PopulateCommandLists();
-
-        // Execute the command lists.
-        ID3D12CommandList* ppCommandLists[] = { m_sceneCommandList.Get(), m_postCommandList.Get() };
-        m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
-
-        PIXEndEvent(m_commandQueue.Get());
-
-        // When using sync interval 0, it is recommended to always pass the tearing
-        // flag when it is supported, even when presenting in windowed mode.
-        // However, this flag cannot be used if the app is in fullscreen mode as a
-        // result of calling SetFullscreenState.
-        UINT presentFlags = (m_tearingSupport && m_windowedMode) ? DXGI_PRESENT_ALLOW_TEARING : 0;
-
-        // Present the frame.
-        ThrowIfFailed(m_swapChain->Present(0, presentFlags));
-
-        MoveToNextFrame();
+        WaitForGpu();
     }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
 }
 
 void D3D12Fullscreen::OnSizeChanged(UINT width, UINT height, bool minimized)
 {
-    // Determine if the swap buffers and other resources need to be resized or not.
-    if ((width != m_width || height != m_height) && !minimized)
-    {
-        // Flush all current GPU commands.
-        WaitForGpu();
+	// Determine if the swap buffers and other resources need to be resized or not.
+	if ((width != m_width || height != m_height) && !minimized)
+	{
+		// Flush all current GPU commands.
+		WaitForGpu();
 
-        // Release the resources holding references to the swap chain (requirement of
-        // IDXGISwapChain::ResizeBuffers) and reset the frame fence values to the
-        // current fence value.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            m_renderTargets[n].Reset();
-            m_fenceValues[n] = m_fenceValues[m_frameIndex];
-        }
+		// Release the resources holding references to the swap chain (requirement of
+		// IDXGISwapChain::ResizeBuffers) and reset the frame fence values to the
+		// current fence value.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			m_renderTargets[n].Reset();
+			m_fenceValues[n] = m_fenceValues[m_frameIndex];
+		}
 
-        // Resize the swap chain to the desired dimensions.
-        DXGI_SWAP_CHAIN_DESC desc = {};
-        m_swapChain->GetDesc(&desc);
-        ThrowIfFailed(m_swapChain->ResizeBuffers(FrameCount, width, height, desc.BufferDesc.Format, desc.Flags));
+		// Resize the swap chain to the desired dimensions.
+		DXGI_SWAP_CHAIN_DESC desc = {};
+		m_swapChain->GetDesc(&desc);
+		ThrowIfFailed(m_swapChain->ResizeBuffers(FrameCount, width, height, desc.BufferDesc.Format, desc.Flags));
 
-        BOOL fullscreenState;
-        ThrowIfFailed(m_swapChain->GetFullscreenState(&fullscreenState, nullptr));
-        m_windowedMode = !fullscreenState;
+		BOOL fullscreenState;
+		ThrowIfFailed(m_swapChain->GetFullscreenState(&fullscreenState, nullptr));
+		m_windowedMode = !fullscreenState;
 
-        // Reset the frame index to the current back buffer index.
-        m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+		// Reset the frame index to the current back buffer index.
+		m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-        // Update the width, height, and aspect ratio member variables.
-        UpdateForSizeChange(width, height);
+		// Update the width, height, and aspect ratio member variables.
+		UpdateForSizeChange(width, height);
 
-        LoadSizeDependentResources();
-    }
+		LoadSizeDependentResources();
+	}
 
-    m_windowVisible = !minimized;
+	m_windowVisible = !minimized;
 }
 
 void D3D12Fullscreen::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForGpu();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForGpu();
 
-    if (!m_tearingSupport)
-    {
-        // Fullscreen state should always be false before exiting the app.
-        ThrowIfFailed(m_swapChain->SetFullscreenState(FALSE, nullptr));
-    }
+	if (!m_tearingSupport)
+	{
+		// Fullscreen state should always be false before exiting the app.
+		ThrowIfFailed(m_swapChain->SetFullscreenState(FALSE, nullptr));
+	}
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12Fullscreen::OnKeyDown(UINT8 key)
 {
-    switch (key)
-    {
-    // Instrument the Space Bar to toggle between fullscreen states.
-    // The window message loop callback will receive a WM_SIZE message once the
-    // window is in the fullscreen state. At that point, the IDXGISwapChain should
-    // be resized to match the new window size.
-    //
-    // NOTE: ALT+Enter will perform a similar operation; the code below is not
-    // required to enable that key combination.
-    case VK_SPACE:
-    {
-        if (m_tearingSupport)
-        {
-            Win32Application::ToggleFullscreenWindow();
-        }
-        else
-        {
-            BOOL fullscreenState;
-            ThrowIfFailed(m_swapChain->GetFullscreenState(&fullscreenState, nullptr));
-            if (FAILED(m_swapChain->SetFullscreenState(!fullscreenState, nullptr)))
-            {
-                // Transitions to fullscreen mode can fail when running apps over
-                // terminal services or for some other unexpected reason.  Consider
-                // notifying the user in some way when this happens.
-                OutputDebugString(L"Fullscreen transition failed");
-                assert(false);
-            }
-        }
-        break;
-    }
+	switch (key)
+	{
+	// Instrument the Space Bar to toggle between fullscreen states.
+	// The window message loop callback will receive a WM_SIZE message once the
+	// window is in the fullscreen state. At that point, the IDXGISwapChain should
+	// be resized to match the new window size.
+	//
+	// NOTE: ALT+Enter will perform a similar operation; the code below is not
+	// required to enable that key combination.
+	case VK_SPACE:
+	{
+		if (m_tearingSupport)
+		{
+			Win32Application::ToggleFullscreenWindow();
+		}
+		else
+		{
+			BOOL fullscreenState;
+			ThrowIfFailed(m_swapChain->GetFullscreenState(&fullscreenState, nullptr));
+			if (FAILED(m_swapChain->SetFullscreenState(!fullscreenState, nullptr)))
+			{
+				// Transitions to fullscreen mode can fail when running apps over
+				// terminal services or for some other unexpected reason.  Consider
+				// notifying the user in some way when this happens.
+				OutputDebugString(L"Fullscreen transition failed");
+				assert(false);
+			}
+		}
+		break;
+	}
 
-    // Instrument the Right Arrow key to change the scene rendering resolution 
-    // to the next resolution option. 
-    case VK_RIGHT:
-    {
-        m_resolutionIndex = (m_resolutionIndex + 1) % m_resolutionOptionsCount;
+	// Instrument the Right Arrow key to change the scene rendering resolution 
+	// to the next resolution option. 
+	case VK_RIGHT:
+	{
+		m_resolutionIndex = (m_resolutionIndex + 1) % m_resolutionOptionsCount;
 
-        // Wait for the GPU to finish with the resources we're about to free.
-        WaitForGpu();
+		// Wait for the GPU to finish with the resources we're about to free.
+		WaitForGpu();
 
-        // Update resources dependent on the scene rendering resolution.
-        LoadSceneResolutionDependentResources();
-    }
-    break;
+		// Update resources dependent on the scene rendering resolution.
+		LoadSceneResolutionDependentResources();
+	}
+	break;
 
-    // Instrument the Left Arrow key to change the scene rendering resolution 
-    // to the previous resolution option.
-    case VK_LEFT:
-    {
-        if (m_resolutionIndex == 0)
-        {
-            m_resolutionIndex = m_resolutionOptionsCount - 1;
-        }
-        else
-        {
-            m_resolutionIndex--;
-        }
+	// Instrument the Left Arrow key to change the scene rendering resolution 
+	// to the previous resolution option.
+	case VK_LEFT:
+	{
+		if (m_resolutionIndex == 0)
+		{
+			m_resolutionIndex = m_resolutionOptionsCount - 1;
+		}
+		else
+		{
+			m_resolutionIndex--;
+		}
 
-        // Wait for the GPU to finish with the resources we're about to free.
-        WaitForGpu();
+		// Wait for the GPU to finish with the resources we're about to free.
+		WaitForGpu();
 
-        // Update resources dependent on the scene rendering resolution.
-        LoadSceneResolutionDependentResources();
-    }
-    break;
-    }
+		// Update resources dependent on the scene rendering resolution.
+		LoadSceneResolutionDependentResources();
+	}
+	break;
+	}
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12Fullscreen::PopulateCommandLists()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_sceneCommandAllocators[m_frameIndex]->Reset());
-    ThrowIfFailed(m_postCommandAllocators[m_frameIndex]->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_sceneCommandAllocators[m_frameIndex]->Reset());
+	ThrowIfFailed(m_postCommandAllocators[m_frameIndex]->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_sceneCommandList->Reset(m_sceneCommandAllocators[m_frameIndex].Get(), m_scenePipelineState.Get()));
-    ThrowIfFailed(m_postCommandList->Reset(m_postCommandAllocators[m_frameIndex].Get(), m_postPipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_sceneCommandList->Reset(m_sceneCommandAllocators[m_frameIndex].Get(), m_scenePipelineState.Get()));
+	ThrowIfFailed(m_postCommandList->Reset(m_postCommandAllocators[m_frameIndex].Get(), m_postPipelineState.Get()));
 
-    // Populate m_sceneCommandList to render scene to intermediate render target.
-    {
-        // Set necessary state.
-        m_sceneCommandList->SetGraphicsRootSignature(m_sceneRootSignature.Get());
+	// Populate m_sceneCommandList to render scene to intermediate render target.
+	{
+		// Set necessary state.
+		m_sceneCommandList->SetGraphicsRootSignature(m_sceneRootSignature.Get());
 
-        ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvHeap.Get() };
-        m_sceneCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+		ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvHeap.Get() };
+		m_sceneCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-        CD3DX12_GPU_DESCRIPTOR_HANDLE cbvHandle(m_cbvSrvHeap->GetGPUDescriptorHandleForHeapStart(), m_frameIndex + 1, m_cbvSrvDescriptorSize);
-        m_sceneCommandList->SetGraphicsRootDescriptorTable(0, cbvHandle);
-        m_sceneCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-        m_sceneCommandList->RSSetViewports(1, &m_sceneViewport);
-        m_sceneCommandList->RSSetScissorRects(1, &m_sceneScissorRect);
+		CD3DX12_GPU_DESCRIPTOR_HANDLE cbvHandle(m_cbvSrvHeap->GetGPUDescriptorHandleForHeapStart(), m_frameIndex + 1, m_cbvSrvDescriptorSize);
+		m_sceneCommandList->SetGraphicsRootDescriptorTable(0, cbvHandle);
+		m_sceneCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+		m_sceneCommandList->RSSetViewports(1, &m_sceneViewport);
+		m_sceneCommandList->RSSetScissorRects(1, &m_sceneScissorRect);
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSize);
-        m_sceneCommandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSize);
+		m_sceneCommandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-        // Record commands.
-        m_sceneCommandList->ClearRenderTargetView(rtvHandle, ClearColor, 0, nullptr);
-        m_sceneCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-        m_sceneCommandList->IASetVertexBuffers(0, 1, &m_sceneVertexBufferView);
+		// Record commands.
+		m_sceneCommandList->ClearRenderTargetView(rtvHandle, ClearColor, 0, nullptr);
+		m_sceneCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+		m_sceneCommandList->IASetVertexBuffers(0, 1, &m_sceneVertexBufferView);
 
-        PIXBeginEvent(m_sceneCommandList.Get(), 0, L"Draw a thin rectangle");
-        m_sceneCommandList->DrawInstanced(4, 1, 0, 0);
-        PIXEndEvent(m_sceneCommandList.Get());
-    }
+		PIXBeginEvent(m_sceneCommandList.Get(), 0, L"Draw a thin rectangle");
+		m_sceneCommandList->DrawInstanced(4, 1, 0, 0);
+		PIXEndEvent(m_sceneCommandList.Get());
+	}
 
-    ThrowIfFailed(m_sceneCommandList->Close());
+	ThrowIfFailed(m_sceneCommandList->Close());
 
-    // Populate m_postCommandList to scale intermediate render target to screen.
-    {
-        // Set necessary state.
-        m_postCommandList->SetGraphicsRootSignature(m_postRootSignature.Get());
+	// Populate m_postCommandList to scale intermediate render target to screen.
+	{
+		// Set necessary state.
+		m_postCommandList->SetGraphicsRootSignature(m_postRootSignature.Get());
 
-        ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvHeap.Get() };
-        m_postCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+		ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvHeap.Get() };
+		m_postCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-        // Indicate that the back buffer will be used as a render target and the
-        // intermediate render target will be used as a SRV.
-        D3D12_RESOURCE_BARRIER barriers[] = {
-            CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET),
-            CD3DX12_RESOURCE_BARRIER::Transition(m_intermediateRenderTarget.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE)
-        };
+		// Indicate that the back buffer will be used as a render target and the
+		// intermediate render target will be used as a SRV.
+		D3D12_RESOURCE_BARRIER barriers[] = {
+			CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET),
+			CD3DX12_RESOURCE_BARRIER::Transition(m_intermediateRenderTarget.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE)
+		};
 
-        m_postCommandList->ResourceBarrier(_countof(barriers), barriers);
+		m_postCommandList->ResourceBarrier(_countof(barriers), barriers);
 
-        m_postCommandList->SetGraphicsRootDescriptorTable(0, m_cbvSrvHeap->GetGPUDescriptorHandleForHeapStart());
-        m_postCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-        m_postCommandList->RSSetViewports(1, &m_postViewport);
-        m_postCommandList->RSSetScissorRects(1, &m_postScissorRect);
+		m_postCommandList->SetGraphicsRootDescriptorTable(0, m_cbvSrvHeap->GetGPUDescriptorHandleForHeapStart());
+		m_postCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+		m_postCommandList->RSSetViewports(1, &m_postViewport);
+		m_postCommandList->RSSetScissorRects(1, &m_postScissorRect);
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-        m_postCommandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+		m_postCommandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-        // Record commands.
-        m_postCommandList->ClearRenderTargetView(rtvHandle, LetterboxColor, 0, nullptr);
-        m_postCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-        m_postCommandList->IASetVertexBuffers(0, 1, &m_postVertexBufferView);
+		// Record commands.
+		m_postCommandList->ClearRenderTargetView(rtvHandle, LetterboxColor, 0, nullptr);
+		m_postCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+		m_postCommandList->IASetVertexBuffers(0, 1, &m_postVertexBufferView);
 
-        PIXBeginEvent(m_postCommandList.Get(), 0, L"Draw texture to screen.");
-        m_postCommandList->DrawInstanced(4, 1, 0, 0);
-        PIXEndEvent(m_postCommandList.Get());
+		PIXBeginEvent(m_postCommandList.Get(), 0, L"Draw texture to screen.");
+		m_postCommandList->DrawInstanced(4, 1, 0, 0);
+		PIXEndEvent(m_postCommandList.Get());
 
-        // Revert resource states back to original values.
-        barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-        barriers[0].Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
-        barriers[1].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-        barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+		// Revert resource states back to original values.
+		barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+		barriers[0].Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
+		barriers[1].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+		barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
 
-        m_postCommandList->ResourceBarrier(_countof(barriers), barriers);
-    }
+		m_postCommandList->ResourceBarrier(_countof(barriers), barriers);
+	}
 
-    ThrowIfFailed(m_postCommandList->Close());
+	ThrowIfFailed(m_postCommandList->Close());
 }
 
 // Wait for pending GPU work to complete.
 void D3D12Fullscreen::WaitForGpu()
 {
-    // Schedule a Signal command in the queue.
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
+	// Schedule a Signal command in the queue.
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
 
-    // Wait until the fence has been processed.
-    ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-    WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	// Wait until the fence has been processed.
+	ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+	WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
 
-    // Increment the fence value for the current frame.
-    m_fenceValues[m_frameIndex]++;
+	// Increment the fence value for the current frame.
+	m_fenceValues[m_frameIndex]++;
 }
 
 // Prepare to render the next frame.
 void D3D12Fullscreen::MoveToNextFrame()
 {
-    // Schedule a Signal command in the queue.
-    const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
+	// Schedule a Signal command in the queue.
+	const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
 
-    // Update the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Update the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-        WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+		WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	}
 
-    // Set the fence value for the next frame.
-    m_fenceValues[m_frameIndex] = currentFenceValue + 1;
+	// Set the fence value for the next frame.
+	m_fenceValues[m_frameIndex] = currentFenceValue + 1;
 }
 
 // Set up the screen viewport and scissor rect to match the current window size and scene rendering resolution.
 void D3D12Fullscreen::UpdatePostViewAndScissor()
 {
-    float viewWidthRatio = static_cast<float>(m_resolutionOptions[m_resolutionIndex].Width) / m_width;
-    float viewHeightRatio = static_cast<float>(m_resolutionOptions[m_resolutionIndex].Height) / m_height;
+	float viewWidthRatio = static_cast<float>(m_resolutionOptions[m_resolutionIndex].Width) / m_width;
+	float viewHeightRatio = static_cast<float>(m_resolutionOptions[m_resolutionIndex].Height) / m_height;
 
-    float x = 1.0f;
-    float y = 1.0f;
+	float x = 1.0f;
+	float y = 1.0f;
 
-    if (viewWidthRatio < viewHeightRatio)
-    {
-        // The scaled image's height will fit to the viewport's height and 
-        // its width will be smaller than the viewport's width.
-        x = viewWidthRatio / viewHeightRatio;
-    }
-    else
-    {
-        // The scaled image's width will fit to the viewport's width and 
-        // its height may be smaller than the viewport's height.
-        y = viewHeightRatio / viewWidthRatio;
-    }
+	if (viewWidthRatio < viewHeightRatio)
+	{
+		// The scaled image's height will fit to the viewport's height and 
+		// its width will be smaller than the viewport's width.
+		x = viewWidthRatio / viewHeightRatio;
+	}
+	else
+	{
+		// The scaled image's width will fit to the viewport's width and 
+		// its height may be smaller than the viewport's height.
+		y = viewHeightRatio / viewWidthRatio;
+	}
 
-    m_postViewport.TopLeftX = m_width * (1.0f - x) / 2.0f;
-    m_postViewport.TopLeftY = m_height * (1.0f - y) / 2.0f;
-    m_postViewport.Width = x * m_width;
-    m_postViewport.Height = y * m_height;
+	m_postViewport.TopLeftX = m_width * (1.0f - x) / 2.0f;
+	m_postViewport.TopLeftY = m_height * (1.0f - y) / 2.0f;
+	m_postViewport.Width = x * m_width;
+	m_postViewport.Height = y * m_height;
 
-    m_postScissorRect.left = static_cast<LONG>(m_postViewport.TopLeftX);
-    m_postScissorRect.right = static_cast<LONG>(m_postViewport.TopLeftX + m_postViewport.Width);
-    m_postScissorRect.top = static_cast<LONG>(m_postViewport.TopLeftY);
-    m_postScissorRect.bottom = static_cast<LONG>(m_postViewport.TopLeftY + m_postViewport.Height);
+	m_postScissorRect.left = static_cast<LONG>(m_postViewport.TopLeftX);
+	m_postScissorRect.right = static_cast<LONG>(m_postViewport.TopLeftX + m_postViewport.Width);
+	m_postScissorRect.top = static_cast<LONG>(m_postViewport.TopLeftY);
+	m_postScissorRect.bottom = static_cast<LONG>(m_postViewport.TopLeftY + m_postViewport.Height);
 }
 
 // Set up appropriate views for the intermediate render target.
 void D3D12Fullscreen::LoadSceneResolutionDependentResources()
 {
-    // Update resolutions shown in app title.
-    UpdateTitle();
+	// Update resolutions shown in app title.
+	UpdateTitle();
 
-    // Set up the scene viewport and scissor rect to match the current scene rendering resolution.
-    {
-        m_sceneViewport.Width = static_cast<float>(m_resolutionOptions[m_resolutionIndex].Width);
-        m_sceneViewport.Height = static_cast<float>(m_resolutionOptions[m_resolutionIndex].Height);
+	// Set up the scene viewport and scissor rect to match the current scene rendering resolution.
+	{
+		m_sceneViewport.Width = static_cast<float>(m_resolutionOptions[m_resolutionIndex].Width);
+		m_sceneViewport.Height = static_cast<float>(m_resolutionOptions[m_resolutionIndex].Height);
 
-        m_sceneScissorRect.right = static_cast<LONG>(m_resolutionOptions[m_resolutionIndex].Width);
-        m_sceneScissorRect.bottom = static_cast<LONG>(m_resolutionOptions[m_resolutionIndex].Height);
-    }
+		m_sceneScissorRect.right = static_cast<LONG>(m_resolutionOptions[m_resolutionIndex].Width);
+		m_sceneScissorRect.bottom = static_cast<LONG>(m_resolutionOptions[m_resolutionIndex].Height);
+	}
 
-    // Update post-process viewport and scissor rectangle.
-    UpdatePostViewAndScissor();
+	// Update post-process viewport and scissor rectangle.
+	UpdatePostViewAndScissor();
 
-    // Create RTV for the intermediate render target.
-    {
-        D3D12_RESOURCE_DESC swapChainDesc = m_renderTargets[m_frameIndex]->GetDesc();
-        const CD3DX12_CLEAR_VALUE clearValue(swapChainDesc.Format, ClearColor);
-        const CD3DX12_RESOURCE_DESC renderTargetDesc = CD3DX12_RESOURCE_DESC::Tex2D(
-            swapChainDesc.Format,
-            m_resolutionOptions[m_resolutionIndex].Width,
-            m_resolutionOptions[m_resolutionIndex].Height,
-            1u, 1u,
-            swapChainDesc.SampleDesc.Count,
-            swapChainDesc.SampleDesc.Quality,
-            D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET,
-            D3D12_TEXTURE_LAYOUT_UNKNOWN, 0u);
+	// Create RTV for the intermediate render target.
+	{
+		D3D12_RESOURCE_DESC swapChainDesc = m_renderTargets[m_frameIndex]->GetDesc();
+		const CD3DX12_CLEAR_VALUE clearValue(swapChainDesc.Format, ClearColor);
+		const CD3DX12_RESOURCE_DESC renderTargetDesc = CD3DX12_RESOURCE_DESC::Tex2D(
+			swapChainDesc.Format,
+			m_resolutionOptions[m_resolutionIndex].Width,
+			m_resolutionOptions[m_resolutionIndex].Height,
+			1u, 1u,
+			swapChainDesc.SampleDesc.Count,
+			swapChainDesc.SampleDesc.Quality,
+			D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET,
+			D3D12_TEXTURE_LAYOUT_UNKNOWN, 0u);
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSize);
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &renderTargetDesc,
-            D3D12_RESOURCE_STATE_RENDER_TARGET,
-            &clearValue,
-            IID_PPV_ARGS(&m_intermediateRenderTarget)));
-        m_device->CreateRenderTargetView(m_intermediateRenderTarget.Get(), nullptr, rtvHandle);
-        NAME_D3D12_OBJECT(m_intermediateRenderTarget);
-    }
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSize);
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&renderTargetDesc,
+			D3D12_RESOURCE_STATE_RENDER_TARGET,
+			&clearValue,
+			IID_PPV_ARGS(&m_intermediateRenderTarget)));
+		m_device->CreateRenderTargetView(m_intermediateRenderTarget.Get(), nullptr, rtvHandle);
+		NAME_D3D12_OBJECT(m_intermediateRenderTarget);
+	}
 
-    // Create SRV for the intermediate render target.
-    m_device->CreateShaderResourceView(m_intermediateRenderTarget.Get(), nullptr, m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create SRV for the intermediate render target.
+	m_device->CreateShaderResourceView(m_intermediateRenderTarget.Get(), nullptr, m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart());
 }
 
 void D3D12Fullscreen::UpdateTitle() 
 {
-    // Update resolutions shown in app title.
-    wchar_t updatedTitle[256];
-    swprintf_s(updatedTitle, L"( %u x %u ) scaled to ( %u x %u )", m_resolutionOptions[m_resolutionIndex].Width, m_resolutionOptions[m_resolutionIndex].Height, m_width, m_height);
-    SetCustomWindowText(updatedTitle);
+	// Update resolutions shown in app title.
+	wchar_t updatedTitle[256];
+	swprintf_s(updatedTitle, L"( %u x %u ) scaled to ( %u x %u )", m_resolutionOptions[m_resolutionIndex].Width, m_resolutionOptions[m_resolutionIndex].Height, m_width, m_height);
+	SetCustomWindowText(updatedTitle);
 }
 
 void D3D12Fullscreen::OnWindowMoved(int, int)

--- a/Samples/Desktop/D3D12Fullscreen/src/D3D12Fullscreen.h
+++ b/Samples/Desktop/D3D12Fullscreen/src/D3D12Fullscreen.h
@@ -26,104 +26,106 @@ using Microsoft::WRL::ComPtr;
 class D3D12Fullscreen : public DXSample
 {
 public:
-    D3D12Fullscreen(UINT width, UINT height, std::wstring name);
+	D3D12Fullscreen(UINT width, UINT height, std::wstring name);
 
 protected:
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
     virtual void OnWindowMoved(int, int);
-    virtual void OnDestroy();
-    virtual void OnKeyDown(UINT8 key);
+	virtual void OnDestroy();
+	virtual void OnKeyDown(UINT8 key);
     virtual IDXGISwapChain* GetSwapchain() { return m_swapChain.Get(); }
 
 private:
-    static const UINT FrameCount = 2;
-    static const float QuadWidth;
-    static const float QuadHeight;
-    static const float LetterboxColor[4];
-    static const float ClearColor[4];
+	static const UINT FrameCount = 2;
+	static const float QuadWidth;
+	static const float QuadHeight;
+	static const float LetterboxColor[4];
+	static const float ClearColor[4];
 
-    struct SceneVertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT4 color;
-    };
+	struct SceneVertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT4 color;
+	};
 
-    struct PostVertex
-    {
-        XMFLOAT4 position;
-        XMFLOAT2 uv;
-    };
+	struct PostVertex
+	{
+		XMFLOAT4 position;
+		XMFLOAT2 uv;
+	};
 
-    struct SceneConstantBuffer
-    {
-        XMFLOAT4X4 transform;
-        XMFLOAT4 offset;
-        UINT padding[44];
-    }; 
-    
-    struct Resolution
-    {
-        UINT Width;
-        UINT Height;
-    };
+	struct SceneConstantBuffer
+	{
+		XMFLOAT4X4 transform;
+		XMFLOAT4 offset;
+		UINT padding[44];
+	}; 
+	
+	struct Resolution
+	{
+		UINT Width;
+		UINT Height;
+	};
 
-    static const Resolution m_resolutionOptions[];
-    static const UINT m_resolutionOptionsCount;
-    static UINT m_resolutionIndex; // Index of the current scene rendering resolution from m_resolutionOptions.
+	static const Resolution m_resolutionOptions[];
+	static const UINT m_resolutionOptionsCount;
+	static UINT m_resolutionIndex; // Index of the current scene rendering resolution from m_resolutionOptions.
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_sceneViewport;
-    CD3DX12_VIEWPORT m_postViewport;
-    CD3DX12_RECT m_sceneScissorRect;
-    CD3DX12_RECT m_postScissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12Resource> m_intermediateRenderTarget;
-    ComPtr<ID3D12CommandAllocator> m_sceneCommandAllocators[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_postCommandAllocators[FrameCount];
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_sceneRootSignature;
-    ComPtr<ID3D12RootSignature> m_postRootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_cbvSrvHeap;
-    ComPtr<ID3D12PipelineState> m_scenePipelineState;
-    ComPtr<ID3D12PipelineState> m_postPipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_sceneCommandList;
-    ComPtr<ID3D12GraphicsCommandList> m_postCommandList;
-    UINT m_rtvDescriptorSize;
-    UINT m_cbvSrvDescriptorSize;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_sceneViewport;
+	CD3DX12_VIEWPORT m_postViewport;
+	CD3DX12_RECT m_sceneScissorRect;
+	CD3DX12_RECT m_postScissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12Resource> m_intermediateRenderTarget;
+	ComPtr<ID3D12CommandAllocator> m_sceneCommandAllocators[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_postCommandAllocators[FrameCount];
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_sceneRootSignature;
+	ComPtr<ID3D12RootSignature> m_postRootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_cbvSrvHeap;
+	ComPtr<ID3D12PipelineState> m_scenePipelineState;
+	ComPtr<ID3D12PipelineState> m_postPipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_sceneCommandList;
+	ComPtr<ID3D12GraphicsCommandList> m_postCommandList;
+	UINT m_rtvDescriptorSize;
+	UINT m_cbvSrvDescriptorSize;
 
-    // App resources.
-    ComPtr<ID3D12Resource> m_sceneVertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_sceneVertexBufferView;
-    ComPtr<ID3D12Resource> m_postVertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_postVertexBufferView;
-    ComPtr<ID3D12Resource> m_sceneConstantBuffer;
-    SceneConstantBuffer m_sceneConstantBufferData;
-    UINT8* m_pCbvDataBegin;
+	// App resources.
+	ComPtr<ID3D12Resource> m_sceneVertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_sceneVertexBufferView;
+	ComPtr<ID3D12Resource> m_postVertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_postVertexBufferView;
+	ComPtr<ID3D12Resource> m_sceneConstantBuffer;
+	SceneConstantBuffer m_sceneConstantBufferData;
+	UINT8* m_pCbvDataBegin;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValues[FrameCount];
+	// Synchronization objects.
+	UINT m_frameIndex;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValues[FrameCount];
 
-    // Track the state of the window.
-    // If it's minimized the app may decide not to render frames.
-    bool m_windowVisible;
-    bool m_windowedMode;
+	// Track the state of the window.
+	// If it's minimized the app may decide not to render frames.
+	bool m_windowVisible;
+	bool m_windowedMode;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void LoadSizeDependentResources();
-    void LoadSceneResolutionDependentResources();
-    void PopulateCommandLists();
-    void WaitForGpu();
-    void MoveToNextFrame();
-    void UpdatePostViewAndScissor();
-    void UpdateTitle();
+	void LoadPipeline();
+	void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
+	void LoadSizeDependentResources();
+	void LoadSceneResolutionDependentResources();
+	void PopulateCommandLists();
+	void WaitForGpu();
+	void MoveToNextFrame();
+	void UpdatePostViewAndScissor();
+	void UpdateTitle();
 };

--- a/Samples/Desktop/D3D12Fullscreen/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12Fullscreen/src/DXSample.cpp
@@ -52,33 +52,78 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
+
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+            }
+#if !defined(_XBOX_ONE)
+        }
+#endif
 
     *ppAdapter = adapter.Detach();
-}
+    }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)

--- a/Samples/Desktop/D3D12Fullscreen/src/DXSample.h
+++ b/Samples/Desktop/D3D12Fullscreen/src/DXSample.h
@@ -49,7 +49,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/Desktop/D3D12Fullscreen/src/Main.cpp
+++ b/Samples/Desktop/D3D12Fullscreen/src/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12Fullscreen sample(1280, 720, L"D3D12 Fullscreen sample - Press the SPACE bar or ALT+Enter to toggle fullscreen mode and use the left and right arrow keys to change the rendering resolution");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12Fullscreen sample(1280, 720, L"D3D12 Fullscreen sample - Press the SPACE bar or ALT+Enter to toggle fullscreen mode and use the left and right arrow keys to change the rendering resolution");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12Fullscreen/src/d3dx12.h
+++ b/Samples/Desktop/D3D12Fullscreen/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12Fullscreen/src/postShaders.hlsl
+++ b/Samples/Desktop/D3D12Fullscreen/src/postShaders.hlsl
@@ -14,22 +14,22 @@ SamplerState g_sampler : register(s0);
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 // A pass-through function for the texture coordinate data.
 PSInput VSMain(float4 position : POSITION, float2 uv : TEXCOORD)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.uv = uv;
+	result.position = position;
+	result.uv = uv;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return g_texture.Sample(g_sampler, input.uv);
+	return g_texture.Sample(g_sampler, input.uv);
 }

--- a/Samples/Desktop/D3D12Fullscreen/src/sceneShaders.hlsl
+++ b/Samples/Desktop/D3D12Fullscreen/src/sceneShaders.hlsl
@@ -11,27 +11,27 @@
 
 cbuffer SceneConstantBuffer : register(b0)
 {
-    float4x4 transform;
-    float4 offset;
+	float4x4 transform;
+	float4 offset;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VSMain(float4 position : POSITION, float4 color : COLOR)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = mul(position, transform);
-    result.color = color;
+	result.position = mul(position, transform);
+	result.color = color;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/Desktop/D3D12HDR/src/D3D12HDR.cpp
+++ b/Samples/Desktop/D3D12HDR/src/D3D12HDR.cpp
@@ -52,98 +52,98 @@ D3D12HDR::D3D12HDR(UINT width, UINT height, std::wstring name) :
     m_windowVisible(true),
     m_windowedMode(true)
 {
-    // Alias the root constants so that we can easily set them as either floats or UINTs.
-    m_rootConstantsF = reinterpret_cast<float*>(m_rootConstants);
+	// Alias the root constants so that we can easily set them as either floats or UINTs.
+	m_rootConstantsF = reinterpret_cast<float*>(m_rootConstants);
 }
 
 void D3D12HDR::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12HDR::LoadPipeline()
 {
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            m_dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			m_dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ThrowIfFailed(CreateDXGIFactory2(m_dxgiFactoryFlags, IID_PPV_ARGS(&m_dxgiFactory)));
+	ThrowIfFailed(CreateDXGIFactory2(m_dxgiFactoryFlags, IID_PPV_ARGS(&m_dxgiFactory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(m_dxgiFactory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(m_dxgiFactory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(m_dxgiFactory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(m_dxgiFactory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
-    NAME_D3D12_OBJECT(m_commandQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	NAME_D3D12_OBJECT(m_commandQueue);
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = m_swapChainFormats[m_currentSwapChainBitDepth];
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = m_swapChainFormats[m_currentSwapChainBitDepth];
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    // It is recommended to always use the tearing flag when it is available.
-    swapChainDesc.Flags = m_tearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
+	// It is recommended to always use the tearing flag when it is available.
+	swapChainDesc.Flags = m_tearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(m_dxgiFactory->CreateSwapChainForHwnd(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(m_dxgiFactory->CreateSwapChainForHwnd(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    if (m_tearingSupport)
-    {
-        // When tearing support is enabled we will handle ALT+Enter key presses in the
-        // window message loop rather than let DXGI handle it by calling SetFullscreenState.
-        m_dxgiFactory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER);
-    }
+	if (m_tearingSupport)
+	{
+		// When tearing support is enabled we will handle ALT+Enter key presses in the
+		// window message loop rather than let DXGI handle it by calling SetFullscreenState.
+		m_dxgiFactory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER);
+	}
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
+	ThrowIfFailed(swapChain.As(&m_swapChain));
     
     // Check display HDR support and initialize ST.2084 support to match the display's support.
     CheckDisplayHDRSupport();
@@ -151,425 +151,425 @@ void D3D12HDR::LoadPipeline()
     EnsureSwapChainColorSpace(m_currentSwapChainBitDepth, m_enableST2084);
     SetHDRMetaData(HDRMetaDataPool[m_hdrMetaDataPoolIdx][0], HDRMetaDataPool[m_hdrMetaDataPoolIdx][1], HDRMetaDataPool[m_hdrMetaDataPoolIdx][2], HDRMetaDataPool[m_hdrMetaDataPoolIdx][3]);
 
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount + 2;    // A descriptor for each frame + 2 intermediate render targets.
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount + 2;	// A descriptor for each frame + 2 intermediate render targets.
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a shader resource view (SRV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
-        srvHeapDesc.NumDescriptors = 2;                    // A descriptor for each of the 2 intermediate render targets.
-        srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
+		// Describe and create a shader resource view (SRV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
+		srvHeapDesc.NumDescriptors = 2;					// A descriptor for each of the 2 intermediate render targets.
+		srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-        m_srvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_srvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	}
 
-    // Create a command allocator for each frame.
-    for (UINT n = 0; n < FrameCount; n++)
-    {
-        ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
-    }
+	// Create a command allocator for each frame.
+	for (UINT n = 0; n < FrameCount; n++)
+	{
+		ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
+	}
 }
 
 // Load the sample assets.
 void D3D12HDR::LoadAssets()
 {
-    // Create a root signature containing root constants for brightness information
-    // and the desired output curve as well as a SRV descriptor table pointing to the
-    // intermediate render targets.
-    {
-        CD3DX12_DESCRIPTOR_RANGE ranges[1];
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 0);
+	// Create a root signature containing root constants for brightness information
+	// and the desired output curve as well as a SRV descriptor table pointing to the
+	// intermediate render targets.
+	{
+		CD3DX12_DESCRIPTOR_RANGE ranges[1];
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 0);
 
-        CD3DX12_ROOT_PARAMETER rootParameters[2];
-        rootParameters[0].InitAsConstants(4, 0);
-        rootParameters[1].InitAsDescriptorTable(1, &ranges[0]);
+		CD3DX12_ROOT_PARAMETER rootParameters[2];
+		rootParameters[0].InitAsConstants(4, 0);
+		rootParameters[1].InitAsDescriptorTable(1, &ranges[0]);
 
-        D3D12_STATIC_SAMPLER_DESC sampler = {};
-        sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
-        sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
-        sampler.MaxLOD = D3D12_FLOAT32_MAX;
-        sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+		D3D12_STATIC_SAMPLER_DESC sampler = {};
+		sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
+		sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
+		sampler.MaxLOD = D3D12_FLOAT32_MAX;
+		sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
 
-        // Allow input layout and deny uneccessary access to certain pipeline stages.
-        D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
-            D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS;
+		// Allow input layout and deny uneccessary access to certain pipeline stages.
+		D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
+			D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS;
 
-        CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init(_countof(rootParameters), rootParameters, 1, &sampler, rootSignatureFlags);
+		CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init(_countof(rootParameters), rootParameters, 1, &sampler, rootSignatureFlags);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+	}
 
-    // Create the pipeline state objects for the different views and render target formats
-    // as well as the intermediate blend step.
-    {
-        // Create the pipeline state for the scene geometry.
+	// Create the pipeline state objects for the different views and render target formats
+	// as well as the intermediate blend step.
+	{
+		// Create the pipeline state for the scene geometry.
 
-        D3D12_INPUT_ELEMENT_DESC gradientElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "COLOR", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+		D3D12_INPUT_ELEMENT_DESC gradientElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "COLOR", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        // Describe and create the graphics pipeline state objects (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { gradientElementDescs, _countof(gradientElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_gradientVS, sizeof(g_gradientVS));
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_gradientPS, sizeof(g_gradientPS));
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = m_intermediateRenderTargetFormat;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state objects (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { gradientElementDescs, _countof(gradientElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_gradientVS, sizeof(g_gradientVS));
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_gradientPS, sizeof(g_gradientPS));
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = m_intermediateRenderTargetFormat;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStates[GradientPSO])));
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStates[GradientPSO])));
 
-        // Create pipeline state for the color space triangles.
+		// Create pipeline state for the color space triangles.
 
-        D3D12_INPUT_ELEMENT_DESC colorElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+		D3D12_INPUT_ELEMENT_DESC colorElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        psoDesc.InputLayout = { colorElementDescs, _countof(colorElementDescs) };
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_paletteVS, sizeof(g_paletteVS));
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_palettePS, sizeof(g_palettePS));
-        psoDesc.RTVFormats[0] = m_intermediateRenderTargetFormat;
+		psoDesc.InputLayout = { colorElementDescs, _countof(colorElementDescs) };
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_paletteVS, sizeof(g_paletteVS));
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_palettePS, sizeof(g_palettePS));
+		psoDesc.RTVFormats[0] = m_intermediateRenderTargetFormat;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStates[PalettePSO])));
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStates[PalettePSO])));
 
-        // Create pipeline states for the final blend step.
-        // There will be one for each swap chain format the sample supports.
+		// Create pipeline states for the final blend step.
+		// There will be one for each swap chain format the sample supports.
 
-        D3D12_INPUT_ELEMENT_DESC quadElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+		D3D12_INPUT_ELEMENT_DESC quadElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        psoDesc.InputLayout = { quadElementDescs, _countof(quadElementDescs) };
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_presentVS, sizeof(g_presentVS));
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_presentPS, sizeof(g_presentPS));
-        psoDesc.RTVFormats[0] = m_swapChainFormats[_8];
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStates[Present8bitPSO])));
+		psoDesc.InputLayout = { quadElementDescs, _countof(quadElementDescs) };
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_presentVS, sizeof(g_presentVS));
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_presentPS, sizeof(g_presentPS));
+		psoDesc.RTVFormats[0] = m_swapChainFormats[_8];
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStates[Present8bitPSO])));
 
-        psoDesc.RTVFormats[0] = m_swapChainFormats[_10];
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStates[Present10bitPSO])));
+		psoDesc.RTVFormats[0] = m_swapChainFormats[_10];
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStates[Present10bitPSO])));
 
-        psoDesc.RTVFormats[0] = m_swapChainFormats[_16];
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStates[Present16bitPSO])));
-    }
+		psoDesc.RTVFormats[0] = m_swapChainFormats[_16];
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStates[Present16bitPSO])));
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), nullptr, IID_PPV_ARGS(&m_commandList)));
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), nullptr, IID_PPV_ARGS(&m_commandList)));
 
-    // Create the vertex buffer.
-    {
-        // Create geometry for the different sections of the render target.
-        GradientVertex gradientVertices[] =
-        {
-            // Upper strip. SDR Gradient from [0,1].
+	// Create the vertex buffer.
+	{
+		// Create geometry for the different sections of the render target.
+		GradientVertex gradientVertices[] =
+		{
+			// Upper strip. SDR Gradient from [0,1].
 
-            { { -1.0f, 0.45f, 0.0f }, { 0.0f, 0.0f, 0.0f } },
-            { { -1.0f, 0.55f, 0.0f }, { 0.0f, 0.0f, 0.0f } },
-            { { 0.0f, 0.45f, 0.0f }, { 1.0f, 1.0f, 1.0f } },
-            { { 0.0f, 0.55f, 0.0f }, { 1.0f, 1.0f, 1.0f } },
+			{ { -1.0f, 0.45f, 0.0f }, { 0.0f, 0.0f, 0.0f } },
+			{ { -1.0f, 0.55f, 0.0f }, { 0.0f, 0.0f, 0.0f } },
+			{ { 0.0f, 0.45f, 0.0f }, { 1.0f, 1.0f, 1.0f } },
+			{ { 0.0f, 0.55f, 0.0f }, { 1.0f, 1.0f, 1.0f } },
 
-            // Lower strip. HDR Gradient from [0,9]. Perceptually, 9.0 is about 3 times as bright as 1.0. (See gradientPS.hlsl.)
+			// Lower strip. HDR Gradient from [0,9]. Perceptually, 9.0 is about 3 times as bright as 1.0. (See gradientPS.hlsl.)
 
-            { { -1.0f, -0.55f, 0.0f }, { 0.0f, 0.0f, 0.0f } },
-            { { -1.0f, -0.45f, 0.0f }, { 0.0f, 0.0f, 0.0f } },
-            { { 0.0f, -0.55f, 0.0f }, { 3.0f, 3.0f, 3.0f } },
-            { { 0.0f, -0.45f, 0.0f }, { 3.0f, 3.0f, 3.0f } },
-        };
+			{ { -1.0f, -0.55f, 0.0f }, { 0.0f, 0.0f, 0.0f } },
+			{ { -1.0f, -0.45f, 0.0f }, { 0.0f, 0.0f, 0.0f } },
+			{ { 0.0f, -0.55f, 0.0f }, { 3.0f, 3.0f, 3.0f } },
+			{ { 0.0f, -0.45f, 0.0f }, { 3.0f, 3.0f, 3.0f } },
+		};
 
-        // The vertices for the color space triangles are dependent on the size of the
-        // render target and will not be loaded at this time. We'll leave a gap in the
-        // buffer that will be filled in later.
-        const UINT triangleVerticesSize = sizeof(TrianglesVertex) * TrianglesVertexCount;
-        m_updateVertexBuffer = true;
+		// The vertices for the color space triangles are dependent on the size of the
+		// render target and will not be loaded at this time. We'll leave a gap in the
+		// buffer that will be filled in later.
+		const UINT triangleVerticesSize = sizeof(TrianglesVertex) * TrianglesVertexCount;
+		m_updateVertexBuffer = true;
 
-        PresentVertex presentVertices[] =
-        {
-            // 1 triangle that fills the entire render target.
+		PresentVertex presentVertices[] =
+		{
+			// 1 triangle that fills the entire render target.
 
-            { { -1.0f, -3.0f, 0.0f }, { 0.0f, 2.0f } },    // Bottom left
-            { { -1.0f, 1.0f, 0.0f }, { 0.0f, 0.0f } },    // Top left
-            { { 3.0f, 1.0f, 0.0f }, { 2.0f, 0.0f } },    // Top right
-        };
+			{ { -1.0f, -3.0f, 0.0f }, { 0.0f, 2.0f } },	// Bottom left
+			{ { -1.0f, 1.0f, 0.0f }, { 0.0f, 0.0f } },	// Top left
+			{ { 3.0f, 1.0f, 0.0f }, { 2.0f, 0.0f } },	// Top right
+		};
 
-        const UINT vertexBufferSize = sizeof(gradientVertices) + triangleVerticesSize + sizeof(presentVertices);
+		const UINT vertexBufferSize = sizeof(gradientVertices) + triangleVerticesSize + sizeof(presentVertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap. It will be uploaded to the
-        // DEFAULT buffer when the color space triangle vertices are updated.
-        UINT8* mappedUploadHeap = nullptr;
-        ThrowIfFailed(m_vertexBufferUpload->Map(0, &CD3DX12_RANGE(0, 0), reinterpret_cast<void**>(&mappedUploadHeap)));
+		// Copy data to the intermediate upload heap. It will be uploaded to the
+		// DEFAULT buffer when the color space triangle vertices are updated.
+		UINT8* mappedUploadHeap = nullptr;
+		ThrowIfFailed(m_vertexBufferUpload->Map(0, &CD3DX12_RANGE(0, 0), reinterpret_cast<void**>(&mappedUploadHeap)));
 
-        memcpy(mappedUploadHeap, gradientVertices, sizeof(gradientVertices));
-        mappedUploadHeap += sizeof(gradientVertices) + triangleVerticesSize;
-        memcpy(mappedUploadHeap, presentVertices, sizeof(presentVertices));
+		memcpy(mappedUploadHeap, gradientVertices, sizeof(gradientVertices));
+		mappedUploadHeap += sizeof(gradientVertices) + triangleVerticesSize;
+		memcpy(mappedUploadHeap, presentVertices, sizeof(presentVertices));
 
-        m_vertexBufferUpload->Unmap(0, &CD3DX12_RANGE(0, 0));
+		m_vertexBufferUpload->Unmap(0, &CD3DX12_RANGE(0, 0));
 
-        // Initialize the vertex buffer views.
-        m_gradientVertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_gradientVertexBufferView.StrideInBytes = sizeof(GradientVertex);
-        m_gradientVertexBufferView.SizeInBytes = sizeof(gradientVertices);
+		// Initialize the vertex buffer views.
+		m_gradientVertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_gradientVertexBufferView.StrideInBytes = sizeof(GradientVertex);
+		m_gradientVertexBufferView.SizeInBytes = sizeof(gradientVertices);
 
-        m_trianglesVertexBufferView.BufferLocation = m_gradientVertexBufferView.BufferLocation + m_gradientVertexBufferView.SizeInBytes;
-        m_trianglesVertexBufferView.StrideInBytes = sizeof(TrianglesVertex);
-        m_trianglesVertexBufferView.SizeInBytes = triangleVerticesSize;
+		m_trianglesVertexBufferView.BufferLocation = m_gradientVertexBufferView.BufferLocation + m_gradientVertexBufferView.SizeInBytes;
+		m_trianglesVertexBufferView.StrideInBytes = sizeof(TrianglesVertex);
+		m_trianglesVertexBufferView.SizeInBytes = triangleVerticesSize;
 
-        m_presentVertexBufferView.BufferLocation = m_trianglesVertexBufferView.BufferLocation + m_trianglesVertexBufferView.SizeInBytes;
-        m_presentVertexBufferView.StrideInBytes = sizeof(PresentVertex);
-        m_presentVertexBufferView.SizeInBytes = sizeof(presentVertices);
-    }
+		m_presentVertexBufferView.BufferLocation = m_trianglesVertexBufferView.BufferLocation + m_trianglesVertexBufferView.SizeInBytes;
+		m_presentVertexBufferView.StrideInBytes = sizeof(PresentVertex);
+		m_presentVertexBufferView.SizeInBytes = sizeof(presentVertices);
+	}
 
-    LoadSizeDependentResources();
+	LoadSizeDependentResources();
 
-    // Close the command list and execute it to begin the vertex buffer copy into
-    // the default heap.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the vertex buffer copy into
+	// the default heap.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValues[m_frameIndex]++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValues[m_frameIndex]++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForGpu();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForGpu();
+	}
 }
 
 // Load resources that are dependent on the size of the main window.
 void D3D12HDR::LoadSizeDependentResources()
 {
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
+		// Create a RTV for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-            NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
-        }
+			NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
+		}
 
-        // Create the intermediate render target and an RTV for it.
-        D3D12_RESOURCE_DESC renderTargetDesc = m_renderTargets[0]->GetDesc();
-        renderTargetDesc.Format = m_intermediateRenderTargetFormat;
+		// Create the intermediate render target and an RTV for it.
+		D3D12_RESOURCE_DESC renderTargetDesc = m_renderTargets[0]->GetDesc();
+		renderTargetDesc.Format = m_intermediateRenderTargetFormat;
 
-        D3D12_CLEAR_VALUE clearValue = {};
-        clearValue.Format = m_intermediateRenderTargetFormat;
+		D3D12_CLEAR_VALUE clearValue = {};
+		clearValue.Format = m_intermediateRenderTargetFormat;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &renderTargetDesc,
-            D3D12_RESOURCE_STATE_RENDER_TARGET,
-            &clearValue,
-            IID_PPV_ARGS(&m_intermediateRenderTarget)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&renderTargetDesc,
+			D3D12_RESOURCE_STATE_RENDER_TARGET,
+			&clearValue,
+			IID_PPV_ARGS(&m_intermediateRenderTarget)));
 
-        NAME_D3D12_OBJECT(m_intermediateRenderTarget);
+		NAME_D3D12_OBJECT(m_intermediateRenderTarget);
 
-        m_device->CreateRenderTargetView(m_intermediateRenderTarget.Get(), nullptr, rtvHandle);
-        rtvHandle.Offset(1, m_rtvDescriptorSize);
+		m_device->CreateRenderTargetView(m_intermediateRenderTarget.Get(), nullptr, rtvHandle);
+		rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_srvHeap->GetCPUDescriptorHandleForHeapStart());
-        m_device->CreateShaderResourceView(m_intermediateRenderTarget.Get(), nullptr, srvHandle);
-        srvHandle.Offset(1, m_srvDescriptorSize);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_srvHeap->GetCPUDescriptorHandleForHeapStart());
+		m_device->CreateShaderResourceView(m_intermediateRenderTarget.Get(), nullptr, srvHandle);
+		srvHandle.Offset(1, m_srvDescriptorSize);
 
-        // Create the UI render target and an RTV for it.
-        renderTargetDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        clearValue.Format = renderTargetDesc.Format;
+		// Create the UI render target and an RTV for it.
+		renderTargetDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+		clearValue.Format = renderTargetDesc.Format;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &renderTargetDesc,
-            D3D12_RESOURCE_STATE_RENDER_TARGET,
-            &clearValue,
-            IID_PPV_ARGS(&m_UIRenderTarget)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&renderTargetDesc,
+			D3D12_RESOURCE_STATE_RENDER_TARGET,
+			&clearValue,
+			IID_PPV_ARGS(&m_UIRenderTarget)));
 
-        NAME_D3D12_OBJECT(m_UIRenderTarget);
+		NAME_D3D12_OBJECT(m_UIRenderTarget);
 
-        m_device->CreateRenderTargetView(m_UIRenderTarget.Get(), nullptr, rtvHandle);
-        m_device->CreateShaderResourceView(m_UIRenderTarget.Get(), nullptr, srvHandle);
-    }
+		m_device->CreateRenderTargetView(m_UIRenderTarget.Get(), nullptr, rtvHandle);
+		m_device->CreateShaderResourceView(m_UIRenderTarget.Get(), nullptr, srvHandle);
+	}
 
-    m_viewport.Width = static_cast<float>(m_width);
-    m_viewport.Height = static_cast<float>(m_height);
+	m_viewport.Width = static_cast<float>(m_width);
+	m_viewport.Height = static_cast<float>(m_height);
 
     m_scissorRect.left = 0;
     m_scissorRect.top = 0;
-    m_scissorRect.right = static_cast<LONG>(m_width);
-    m_scissorRect.bottom = static_cast<LONG>(m_height);
+	m_scissorRect.right = static_cast<LONG>(m_width);
+	m_scissorRect.bottom = static_cast<LONG>(m_height);
 
-    // Update the color space triangle vertices when the command list is back in
-    // the recording state.
-    m_updateVertexBuffer = true;
+	// Update the color space triangle vertices when the command list is back in
+	// the recording state.
+	m_updateVertexBuffer = true;
 
-    if (m_enableUI)
-    {
-        if (!m_uiLayer)
-        {
-            m_uiLayer = std::make_shared<UILayer>(this);
-        }
-        else
-        {
-            m_uiLayer->Resize();
-        }
-    }
+	if (m_enableUI)
+	{
+		if (!m_uiLayer)
+		{
+			m_uiLayer = std::make_shared<UILayer>(this);
+		}
+		else
+		{
+			m_uiLayer->Resize();
+		}
+	}
 }
 
 // Transform the triangle coordinates so that they remain centered and at the right scale.
 // (mapping a [0,0,1,1] square into a [0,0,1,1] rectangle)
 inline XMFLOAT3 D3D12HDR::TransformVertex(XMFLOAT2 point, XMFLOAT2 offset)
 {
-    auto scale = XMFLOAT2(min(1.0f, 1.0f / m_aspectRatio), min(1.0f, m_aspectRatio));
-    auto margin = XMFLOAT2(0.5f * (1.0f - scale.x), 0.5f * (1.0f - scale.y));
-    auto v = XMVectorMultiplyAdd(
-        XMLoadFloat2(&point),
-        XMLoadFloat2(&scale),
-        XMVectorAdd(XMLoadFloat2(&margin), XMLoadFloat2(&offset)));
+	auto scale = XMFLOAT2(min(1.0f, 1.0f / m_aspectRatio), min(1.0f, m_aspectRatio));
+	auto margin = XMFLOAT2(0.5f * (1.0f - scale.x), 0.5f * (1.0f - scale.y));
+	auto v = XMVectorMultiplyAdd(
+		XMLoadFloat2(&point),
+		XMLoadFloat2(&scale),
+		XMVectorAdd(XMLoadFloat2(&margin), XMLoadFloat2(&offset)));
 
-    XMFLOAT3 result;
-    XMStoreFloat3(&result, v);
-    return result;
+	XMFLOAT3 result;
+	XMStoreFloat3(&result, v);
+	return result;
 }
 
 // Recalculate vertex positions for the color space triangles and then update the vertex buffer.
 // The scene's command list must be in the recording state when this method is called.
 void D3D12HDR::UpdateVertexBuffer()
 {
-    const XMFLOAT2 primaries709[] =
-    {
-        { 0.64f, 0.33f },
-        { 0.30f, 0.60f },
-        { 0.15f, 0.06f },
-        { 0.3127f, 0.3290f }
-    };
-    const XMFLOAT2 primaries2020[] =
-    {
-        { 0.708f, 0.292f },
-        { 0.170f, 0.797f },
-        { 0.131f, 0.046f },
-        { 0.3127f, 0.3290f }
-    };
-    const XMFLOAT2 offset1 = { 0.2f, 0.0f };
-    const XMFLOAT2 offset2 = { 0.2f, -1.0f };
-    const XMFLOAT3 triangle709[] =
-    {
-        TransformVertex(primaries709[0], offset1),    // R
-        TransformVertex(primaries709[1], offset1),    // G
-        TransformVertex(primaries709[2], offset1),    // B
-        TransformVertex(primaries709[3], offset1)    // White
-    };
-    const XMFLOAT3 triangle2020[] =
-    {
-        TransformVertex(primaries2020[0], offset2),    // R
-        TransformVertex(primaries2020[1], offset2),    // G
-        TransformVertex(primaries2020[2], offset2),    // B
-        TransformVertex(primaries2020[3], offset2)    // White
-    };
+	const XMFLOAT2 primaries709[] =
+	{
+		{ 0.64f, 0.33f },
+		{ 0.30f, 0.60f },
+		{ 0.15f, 0.06f },
+		{ 0.3127f, 0.3290f }
+	};
+	const XMFLOAT2 primaries2020[] =
+	{
+		{ 0.708f, 0.292f },
+		{ 0.170f, 0.797f },
+		{ 0.131f, 0.046f },
+		{ 0.3127f, 0.3290f }
+	};
+	const XMFLOAT2 offset1 = { 0.2f, 0.0f };
+	const XMFLOAT2 offset2 = { 0.2f, -1.0f };
+	const XMFLOAT3 triangle709[] =
+	{
+		TransformVertex(primaries709[0], offset1),	// R
+		TransformVertex(primaries709[1], offset1),	// G
+		TransformVertex(primaries709[2], offset1),	// B
+		TransformVertex(primaries709[3], offset1)	// White
+	};
+	const XMFLOAT3 triangle2020[] =
+	{
+		TransformVertex(primaries2020[0], offset2),	// R
+		TransformVertex(primaries2020[1], offset2),	// G
+		TransformVertex(primaries2020[2], offset2),	// B
+		TransformVertex(primaries2020[3], offset2)	// White
+	};
 
-    TrianglesVertex triangleVertices[] =
-    {
-        // Upper triangles.  Rec 709 primaries.
+	TrianglesVertex triangleVertices[] =
+	{
+		// Upper triangles.  Rec 709 primaries.
 
-        { triangle709[2], primaries709[2] },
-        { triangle709[1], primaries709[1] },
-        { triangle709[3], primaries709[3] },
+		{ triangle709[2], primaries709[2] },
+		{ triangle709[1], primaries709[1] },
+		{ triangle709[3], primaries709[3] },
 
-        { triangle709[1], primaries709[1] },
-        { triangle709[0], primaries709[0] },
-        { triangle709[3], primaries709[3] },
+		{ triangle709[1], primaries709[1] },
+		{ triangle709[0], primaries709[0] },
+		{ triangle709[3], primaries709[3] },
 
-        { triangle709[0], primaries709[0] },
-        { triangle709[2], primaries709[2] },
-        { triangle709[3], primaries709[3] },
+		{ triangle709[0], primaries709[0] },
+		{ triangle709[2], primaries709[2] },
+		{ triangle709[3], primaries709[3] },
 
-        // Lower triangles. Rec 2020 primaries.
+		// Lower triangles. Rec 2020 primaries.
 
-        { triangle2020[2], primaries2020[2] },
-        { triangle2020[1], primaries2020[1] },
-        { triangle2020[3], primaries2020[3] },
+		{ triangle2020[2], primaries2020[2] },
+		{ triangle2020[1], primaries2020[1] },
+		{ triangle2020[3], primaries2020[3] },
 
-        { triangle2020[1], primaries2020[1] },
-        { triangle2020[0], primaries2020[0] },
-        { triangle2020[3], primaries2020[3] },
+		{ triangle2020[1], primaries2020[1] },
+		{ triangle2020[0], primaries2020[0] },
+		{ triangle2020[3], primaries2020[3] },
 
-        { triangle2020[0], primaries2020[0] },
-        { triangle2020[2], primaries2020[2] },
-        { triangle2020[3], primaries2020[3] },
-    };
+		{ triangle2020[0], primaries2020[0] },
+		{ triangle2020[2], primaries2020[2] },
+		{ triangle2020[3], primaries2020[3] },
+	};
 
-    // Copy data to the intermediate upload heap and then schedule a copy
-    // from the upload heap to the vertex buffer.
-    UINT8* mappedUploadHeap = nullptr;
-    ThrowIfFailed(m_vertexBufferUpload->Map(0, &CD3DX12_RANGE(0, 0), reinterpret_cast<void**>(&mappedUploadHeap)));
+	// Copy data to the intermediate upload heap and then schedule a copy
+	// from the upload heap to the vertex buffer.
+	UINT8* mappedUploadHeap = nullptr;
+	ThrowIfFailed(m_vertexBufferUpload->Map(0, &CD3DX12_RANGE(0, 0), reinterpret_cast<void**>(&mappedUploadHeap)));
 
-    mappedUploadHeap += m_gradientVertexBufferView.SizeInBytes;
-    memcpy(mappedUploadHeap, triangleVertices, sizeof(triangleVertices));
+	mappedUploadHeap += m_gradientVertexBufferView.SizeInBytes;
+	memcpy(mappedUploadHeap, triangleVertices, sizeof(triangleVertices));
 
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER, D3D12_RESOURCE_STATE_COPY_DEST));
-    m_commandList->CopyBufferRegion(m_vertexBuffer.Get(), 0, m_vertexBufferUpload.Get(), 0, m_vertexBuffer->GetDesc().Width);
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER, D3D12_RESOURCE_STATE_COPY_DEST));
+	m_commandList->CopyBufferRegion(m_vertexBuffer.Get(), 0, m_vertexBufferUpload.Get(), 0, m_vertexBuffer->GetDesc().Width);
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 }
 
 // Update frame-based values.
@@ -584,152 +584,152 @@ void D3D12HDR::OnUpdate()
 // Render the scene.
 void D3D12HDR::OnRender()
 {
-    if (m_windowVisible)
-    {
-        if (m_enableUI)
-        {
-            PIXBeginEvent(m_commandQueue.Get(), 0, L"Render UI");
-            m_uiLayer->Render();
-            PIXEndEvent(m_commandQueue.Get());
-        }
+	if (m_windowVisible)
+	{
+		if (m_enableUI)
+		{
+			PIXBeginEvent(m_commandQueue.Get(), 0, L"Render UI");
+			m_uiLayer->Render();
+			PIXEndEvent(m_commandQueue.Get());
+		}
 
-        PIXBeginEvent(m_commandQueue.Get(), 0, L"Render Scene");
-        RenderScene();
-        PIXEndEvent(m_commandQueue.Get());
+		PIXBeginEvent(m_commandQueue.Get(), 0, L"Render Scene");
+		RenderScene();
+		PIXEndEvent(m_commandQueue.Get());
 
-        // Present the frame.
-        ThrowIfFailed(m_swapChain->Present(1, 0));
+		// Present the frame.
+		ThrowIfFailed(m_swapChain->Present(1, 0));
 
-        MoveToNextFrame();
-    }
+		MoveToNextFrame();
+	}
 }
 
 // Fill the command list with all the render commands and dependent state and
 // submit it to the command queue.
 void D3D12HDR::RenderScene()
 {
-    // Command list allocators can only be reset when the associated
-    // command lists have finished execution on the GPU; apps should use
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
+	// Command list allocators can only be reset when the associated
+	// command lists have finished execution on the GPU; apps should use
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command
-    // list, that command list can then be reset at any time and must be before
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineStates[GradientPSO].Get()));
+	// However, when ExecuteCommandList() is called on a particular command
+	// list, that command list can then be reset at any time and must be before
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineStates[GradientPSO].Get()));
 
-    if (m_updateVertexBuffer)
-    {
-        UpdateVertexBuffer();
-        m_updateVertexBuffer = false;
-    }
+	if (m_updateVertexBuffer)
+	{
+		UpdateVertexBuffer();
+		m_updateVertexBuffer = false;
+	}
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
-    m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
+	m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Bind the root constants and the SRV table to the pipeline.
-    m_rootConstantsF[ReferenceWhiteNits] = m_referenceWhiteNits;
+	// Bind the root constants and the SRV table to the pipeline.
+	m_rootConstantsF[ReferenceWhiteNits] = m_referenceWhiteNits;
 
-    m_commandList->SetGraphicsRoot32BitConstants(0, RootConstantsCount, m_rootConstants, 0);
-    m_commandList->SetGraphicsRootDescriptorTable(1, m_srvHeap->GetGPUDescriptorHandleForHeapStart());
+	m_commandList->SetGraphicsRoot32BitConstants(0, RootConstantsCount, m_rootConstants, 0);
+	m_commandList->SetGraphicsRootDescriptorTable(1, m_srvHeap->GetGPUDescriptorHandleForHeapStart());
 
-    // Draw the scene into the intermediate render target.
-    {
-        PIXBeginEvent(m_commandList.Get(), 0, L"Draw scene content");
+	// Draw the scene into the intermediate render target.
+	{
+		PIXBeginEvent(m_commandList.Get(), 0, L"Draw scene content");
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE intermediateRtv(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSize);
-        m_commandList->OMSetRenderTargets(1, &intermediateRtv, FALSE, nullptr);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE intermediateRtv(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSize);
+		m_commandList->OMSetRenderTargets(1, &intermediateRtv, FALSE, nullptr);
 
-        const float clearColor[] = { 0.0f, 0.0f, 0.0f, 0.0f };
-        m_commandList->ClearRenderTargetView(intermediateRtv, clearColor, 0, nullptr);
+		const float clearColor[] = { 0.0f, 0.0f, 0.0f, 0.0f };
+		m_commandList->ClearRenderTargetView(intermediateRtv, clearColor, 0, nullptr);
 
-        m_commandList->IASetVertexBuffers(0, 1, &m_gradientVertexBufferView);
-        PIXBeginEvent(m_commandList.Get(), 0, L"Standard Gradient");
-        m_commandList->DrawInstanced(4, 1, 0, 0);
-        PIXEndEvent(m_commandList.Get());
+		m_commandList->IASetVertexBuffers(0, 1, &m_gradientVertexBufferView);
+		PIXBeginEvent(m_commandList.Get(), 0, L"Standard Gradient");
+		m_commandList->DrawInstanced(4, 1, 0, 0);
+		PIXEndEvent(m_commandList.Get());
 
-        PIXBeginEvent(m_commandList.Get(), 0, L"Bright Gradient");
-        m_commandList->DrawInstanced(4, 1, 4, 0);
-        PIXEndEvent(m_commandList.Get());
+		PIXBeginEvent(m_commandList.Get(), 0, L"Bright Gradient");
+		m_commandList->DrawInstanced(4, 1, 4, 0);
+		PIXEndEvent(m_commandList.Get());
 
-        m_commandList->SetPipelineState(m_pipelineStates[PalettePSO].Get());
-        m_commandList->IASetVertexBuffers(0, 1, &m_trianglesVertexBufferView);
-        m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+		m_commandList->SetPipelineState(m_pipelineStates[PalettePSO].Get());
+		m_commandList->IASetVertexBuffers(0, 1, &m_trianglesVertexBufferView);
+		m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 
-        PIXBeginEvent(m_commandList.Get(), 0, L"Rec709 Triangles");
-        m_commandList->DrawInstanced(3, 1, 0, 0);
-        m_commandList->DrawInstanced(3, 1, 3, 0);
-        m_commandList->DrawInstanced(3, 1, 6, 0);
-        PIXEndEvent(m_commandList.Get());
+		PIXBeginEvent(m_commandList.Get(), 0, L"Rec709 Triangles");
+		m_commandList->DrawInstanced(3, 1, 0, 0);
+		m_commandList->DrawInstanced(3, 1, 3, 0);
+		m_commandList->DrawInstanced(3, 1, 6, 0);
+		PIXEndEvent(m_commandList.Get());
 
-        m_commandList->SetPipelineState(m_pipelineStates[PalettePSO].Get());
-        PIXBeginEvent(m_commandList.Get(), 0, L"Rec2020 Triangles");
-        m_commandList->DrawInstanced(3, 1, 9, 0);
-        m_commandList->DrawInstanced(3, 1, 12, 0);
-        m_commandList->DrawInstanced(3, 1, 15, 0);
-        PIXEndEvent(m_commandList.Get());
+		m_commandList->SetPipelineState(m_pipelineStates[PalettePSO].Get());
+		PIXBeginEvent(m_commandList.Get(), 0, L"Rec2020 Triangles");
+		m_commandList->DrawInstanced(3, 1, 9, 0);
+		m_commandList->DrawInstanced(3, 1, 12, 0);
+		m_commandList->DrawInstanced(3, 1, 15, 0);
+		PIXEndEvent(m_commandList.Get());
 
-        PIXEndEvent(m_commandList.Get());
+		PIXEndEvent(m_commandList.Get());
 
-        if (!m_enableUI)
-        {
-            intermediateRtv.Offset(1, m_rtvDescriptorSize);
-            m_commandList->OMSetRenderTargets(1, &intermediateRtv, FALSE, nullptr);
-            m_commandList->ClearRenderTargetView(intermediateRtv, clearColor, 0, nullptr);
-        }
-    }
+		if (!m_enableUI)
+		{
+			intermediateRtv.Offset(1, m_rtvDescriptorSize);
+			m_commandList->OMSetRenderTargets(1, &intermediateRtv, FALSE, nullptr);
+			m_commandList->ClearRenderTargetView(intermediateRtv, clearColor, 0, nullptr);
+		}
+	}
 
-    // Indicate that the intermediates will be used as SRVs in the pixel shader
-    // and the back buffer will be used as a render target.
-    D3D12_RESOURCE_BARRIER barriers[] = {
-        CD3DX12_RESOURCE_BARRIER::Transition(m_intermediateRenderTarget.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE),
-        CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET),
-        CD3DX12_RESOURCE_BARRIER::Transition(m_UIRenderTarget.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE),
-    };
+	// Indicate that the intermediates will be used as SRVs in the pixel shader
+	// and the back buffer will be used as a render target.
+	D3D12_RESOURCE_BARRIER barriers[] = {
+		CD3DX12_RESOURCE_BARRIER::Transition(m_intermediateRenderTarget.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE),
+		CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET),
+		CD3DX12_RESOURCE_BARRIER::Transition(m_UIRenderTarget.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE),
+	};
 
-    // Process the intermediate and draw into the swap chain render target.
-    {
-        PIXBeginEvent(m_commandList.Get(), 0, L"Apply HDR");
+	// Process the intermediate and draw into the swap chain render target.
+	{
+		PIXBeginEvent(m_commandList.Get(), 0, L"Apply HDR");
 
-        // If the UI is enabled, the 11on12 layer will do the state transition for us.
-        UINT barrierCount = m_enableUI ? 2 : _countof(barriers);
-        m_commandList->ResourceBarrier(barrierCount, barriers);
-        m_commandList->SetPipelineState(m_pipelineStates[Present8bitPSO + m_currentSwapChainBitDepth].Get());
+		// If the UI is enabled, the 11on12 layer will do the state transition for us.
+		UINT barrierCount = m_enableUI ? 2 : _countof(barriers);
+		m_commandList->ResourceBarrier(barrierCount, barriers);
+		m_commandList->SetPipelineState(m_pipelineStates[Present8bitPSO + m_currentSwapChainBitDepth].Get());
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-        m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+		m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-        m_commandList->ClearRenderTargetView(rtvHandle, ClearColor, 0, nullptr);
+		m_commandList->ClearRenderTargetView(rtvHandle, ClearColor, 0, nullptr);
 
-        m_commandList->IASetVertexBuffers(0, 1, &m_presentVertexBufferView);
-        m_commandList->DrawInstanced(3, 1, 0, 0);
+		m_commandList->IASetVertexBuffers(0, 1, &m_presentVertexBufferView);
+		m_commandList->DrawInstanced(3, 1, 0, 0);
 
-        PIXEndEvent(m_commandList.Get());
-    }
+		PIXEndEvent(m_commandList.Get());
+	}
 
-    // Indicate that the intermediates will be used as render targets and the swap chain
-    // back buffer will be used for presentation.
-    barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-    barriers[0].Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barriers[1].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
-    barriers[2].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-    barriers[2].Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	// Indicate that the intermediates will be used as render targets and the swap chain
+	// back buffer will be used for presentation.
+	barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	barriers[0].Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barriers[1].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
+	barriers[2].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	barriers[2].Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
 
-    m_commandList->ResourceBarrier(_countof(barriers), barriers);
+	m_commandList->ResourceBarrier(_countof(barriers), barriers);
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 }
 
 
@@ -763,52 +763,52 @@ void D3D12HDR::OnSizeChanged(UINT width, UINT height, bool minimized)
 
 void D3D12HDR::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForGpu();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForGpu();
 
-    if (!m_tearingSupport)
-    {
-        // Fullscreen state should always be false before exiting the app.
-        ThrowIfFailed(m_swapChain->SetFullscreenState(FALSE, nullptr));
-    }
-    CloseHandle(m_fenceEvent);
+	if (!m_tearingSupport)
+	{
+		// Fullscreen state should always be false before exiting the app.
+		ThrowIfFailed(m_swapChain->SetFullscreenState(FALSE, nullptr));
+	}
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12HDR::OnKeyDown(UINT8 key)
 {
-    switch (key)
-    {
-        // Instrument the Space Bar to toggle between fullscreen states.
-        // The window message loop callback will receive a WM_SIZE message once the
-        // window is in the fullscreen state. At that point, the IDXGISwapChain should
-        // be resized to match the new window size.
-        //
-        // NOTE: ALT+Enter will perform a similar operation; the code below is not
-        // required to enable that key combination.
-        case VK_SPACE:
-        {
-            if (m_tearingSupport)
-            {
-                Win32Application::ToggleFullscreenWindow();
-            }
-            else
-            {
-                BOOL fullscreenState;
-                ThrowIfFailed(m_swapChain->GetFullscreenState(&fullscreenState, nullptr));
-                if (FAILED(m_swapChain->SetFullscreenState(!fullscreenState, nullptr)))
-                {
-                    // Transitions to fullscreen mode can fail when running apps over
-                    // terminal services or for some other unexpected reason.  Consider
-                    // notifying the user in some way when this happens.
-                    OutputDebugString(L"Fullscreen transition failed");
-                    assert(false);
-                }
-            }
-            break;
-        }
+	switch (key)
+	{
+	    // Instrument the Space Bar to toggle between fullscreen states.
+	    // The window message loop callback will receive a WM_SIZE message once the
+	    // window is in the fullscreen state. At that point, the IDXGISwapChain should
+	    // be resized to match the new window size.
+	    //
+	    // NOTE: ALT+Enter will perform a similar operation; the code below is not
+	    // required to enable that key combination.
+	    case VK_SPACE:
+	    {
+		    if (m_tearingSupport)
+		    {
+			    Win32Application::ToggleFullscreenWindow();
+		    }
+		    else
+		    {
+			    BOOL fullscreenState;
+			    ThrowIfFailed(m_swapChain->GetFullscreenState(&fullscreenState, nullptr));
+			    if (FAILED(m_swapChain->SetFullscreenState(!fullscreenState, nullptr)))
+			    {
+				    // Transitions to fullscreen mode can fail when running apps over
+				    // terminal services or for some other unexpected reason.  Consider
+				    // notifying the user in some way when this happens.
+				    OutputDebugString(L"Fullscreen transition failed");
+				    assert(false);
+			    }
+		    }
+		    break;
+	    }
 
-        case VK_PRIOR:    // Page Up
+	    case VK_PRIOR:	// Page Up
         {
             m_currentSwapChainBitDepth = static_cast<SwapChainBitDepth>((m_currentSwapChainBitDepth - 1 + SwapChainBitDepthCount) % SwapChainBitDepthCount);
             DXGI_FORMAT newFormat = m_swapChainFormats[m_currentSwapChainBitDepth];
@@ -817,7 +817,7 @@ void D3D12HDR::OnKeyDown(UINT8 key)
             break;
         }
 
-        case VK_NEXT:    // Page Down
+	    case VK_NEXT:	// Page Down
         {
             m_currentSwapChainBitDepth = static_cast<SwapChainBitDepth>((m_currentSwapChainBitDepth + 1) % SwapChainBitDepthCount);
             DXGI_FORMAT newFormat = m_swapChainFormats[m_currentSwapChainBitDepth];
@@ -826,7 +826,7 @@ void D3D12HDR::OnKeyDown(UINT8 key)
             break;
         }
 
-        case 'H':
+	    case 'H':
         {
             m_enableST2084 = !m_enableST2084;
             if (m_currentSwapChainBitDepth == _10)
@@ -838,7 +838,7 @@ void D3D12HDR::OnKeyDown(UINT8 key)
             break;
         }
 
-        case 'U':
+	    case 'U':
         {
             m_enableUI = !m_enableUI;
             if (m_enableUI)
@@ -860,42 +860,42 @@ void D3D12HDR::OnKeyDown(UINT8 key)
             SetHDRMetaData(HDRMetaDataPool[m_hdrMetaDataPoolIdx][0], HDRMetaDataPool[m_hdrMetaDataPoolIdx][1], HDRMetaDataPool[m_hdrMetaDataPoolIdx][2], HDRMetaDataPool[m_hdrMetaDataPoolIdx][3]);
             break;
         }
-    }
+	}
 }
 
 // Wait for pending GPU work to complete.
 void D3D12HDR::WaitForGpu()
 {
-    // Schedule a Signal command in the queue.
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
+	// Schedule a Signal command in the queue.
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
 
-    // Wait until the fence has been processed.
-    ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-    WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	// Wait until the fence has been processed.
+	ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+	WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
 
-    // Increment the fence value for the current frame.
-    m_fenceValues[m_frameIndex]++;
+	// Increment the fence value for the current frame.
+	m_fenceValues[m_frameIndex]++;
 }
 
 // Prepare to render the next frame.
 void D3D12HDR::MoveToNextFrame()
 {
-    // Schedule a Signal command in the queue.
-    const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
+	// Schedule a Signal command in the queue.
+	const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
 
-    // Update the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Update the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-        WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+		WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	}
 
-    // Set the fence value for the next frame.
-    m_fenceValues[m_frameIndex] = currentFenceValue + 1;
+	// Set the fence value for the next frame.
+	m_fenceValues[m_frameIndex] = currentFenceValue + 1;
 }
 
 
@@ -950,7 +950,7 @@ void D3D12HDR::SetHDRMetaData(float MaxOutputNits /*=1000.0f*/, float MinOutputN
     if (!m_hdrSupport)
     {
         ThrowIfFailed(m_swapChain->SetHDRMetaData(DXGI_HDR_METADATA_TYPE_NONE, 0, nullptr));
-        return;
+		return;
     }
 
     static const DisplayChromacities DisplayChromacityList[] =

--- a/Samples/Desktop/D3D12HDR/src/D3D12HDR.h
+++ b/Samples/Desktop/D3D12HDR/src/D3D12HDR.h
@@ -28,56 +28,56 @@ class UILayer;
 class D3D12HDR : public DXSample
 {
 public:
-    D3D12HDR(UINT width, UINT height, std::wstring name);
+	D3D12HDR(UINT width, UINT height, std::wstring name);
 
-    inline ID3D12Device* GetDevice() { return m_device.Get(); }
+	inline ID3D12Device* GetDevice() { return m_device.Get(); }
     inline ID3D12CommandQueue* GetCommandQueue() { return m_commandQueue.Get(); }
-    inline ID3D12Resource* GetUIRenderTarget() { return m_UIRenderTarget.Get(); }
-    inline DXGI_FORMAT GetBackBufferFormat() { return m_swapChainFormats[m_currentSwapChainBitDepth]; }
-    inline std::wstring GetDisplayCurve()
-    {
-        return m_rootConstants[DisplayCurve] == sRGB ? L"sRGB" : m_rootConstants[DisplayCurve] == ST2084 ? L"ST.2084" : L"Linear";
-    }
-    inline bool GetHDRSupport() { return m_hdrSupport; }
-    inline float GetReferenceWhiteNits() { return m_referenceWhiteNits; }
+	inline ID3D12Resource* GetUIRenderTarget() { return m_UIRenderTarget.Get(); }
+	inline DXGI_FORMAT GetBackBufferFormat() { return m_swapChainFormats[m_currentSwapChainBitDepth]; }
+	inline std::wstring GetDisplayCurve()
+	{
+		return m_rootConstants[DisplayCurve] == sRGB ? L"sRGB" : m_rootConstants[DisplayCurve] == ST2084 ? L"ST.2084" : L"Linear";
+	}
+	inline bool GetHDRSupport() { return m_hdrSupport; }
+	inline float GetReferenceWhiteNits() { return m_referenceWhiteNits; }
     inline UINT GetHDRMetaDataPoolIndex() { return m_hdrMetaDataPoolIdx; }
 
     static const float HDRMetaDataPool[4][4];
-    static const UINT FrameCount = 2;
+	static const UINT FrameCount = 2;
 
 protected:
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
     virtual void OnWindowMoved(int xPos, int yPos);
-    virtual void OnDestroy();
-    virtual void OnKeyDown(UINT8 key);
+	virtual void OnDestroy();
+	virtual void OnKeyDown(UINT8 key);
     virtual void OnDisplayChanged();
     virtual IDXGISwapChain* GetSwapchain() { return m_swapChain.Get(); }
 
 private:
-    static const float ClearColor[4];
-    static const UINT TrianglesVertexCount = 18;
+	static const float ClearColor[4];
+	static const UINT TrianglesVertexCount = 18;
 
-    // Vertex definitions.
-    struct GradientVertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT3 color;
-    };
+	// Vertex definitions.
+	struct GradientVertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT3 color;
+	};
 
-    struct TrianglesVertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT2 uv;
-    };
+	struct TrianglesVertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT2 uv;
+	};
 
-    struct PresentVertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT2 uv;
-    };
+	struct PresentVertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT2 uv;
+	};
 
     struct DisplayChromacities
     {
@@ -91,101 +91,101 @@ private:
         float WhiteY;
     };
 
-    enum PipelineStates
-    {
-        GradientPSO = 0,
-        PalettePSO,
-        Present8bitPSO,
-        Present10bitPSO,
-        Present16bitPSO,
-        PipelineStateCount
-    };
+	enum PipelineStates
+	{
+		GradientPSO = 0,
+		PalettePSO,
+		Present8bitPSO,
+		Present10bitPSO,
+		Present16bitPSO,
+		PipelineStateCount
+	};
 
-    enum SwapChainBitDepth
-    {
-        _8 = 0,
-        _10,
-        _16,
-        SwapChainBitDepthCount
-    };
+	enum SwapChainBitDepth
+	{
+		_8 = 0,
+		_10,
+		_16,
+		SwapChainBitDepthCount
+	};
 
-    enum RootConstants
-    {
-        ReferenceWhiteNits = 0,
-        DisplayCurve,
-        RootConstantsCount
-    };
+	enum RootConstants
+	{
+		ReferenceWhiteNits = 0,
+		DisplayCurve,
+		RootConstantsCount
+	};
 
-    enum DisplayCurve
-    {
-        sRGB = 0,    // The display expects an sRGB signal.
-        ST2084,        // The display expects an HDR10 signal.
-        None        // The display expects a linear signal.
-    };
+	enum DisplayCurve
+	{
+		sRGB = 0,	// The display expects an sRGB signal.
+		ST2084,		// The display expects an HDR10 signal.
+		None		// The display expects a linear signal.
+	};
 
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGIFactory4> m_dxgiFactory;
-    ComPtr<IDXGISwapChain4> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12Resource> m_intermediateRenderTarget;
-    ComPtr<ID3D12Resource> m_UIRenderTarget;
-    ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_srvHeap;
-    UINT m_rtvDescriptorSize;
-    UINT m_srvDescriptorSize;
-    DXGI_FORMAT m_swapChainFormats[SwapChainBitDepthCount];
-    DXGI_COLOR_SPACE_TYPE m_currentSwapChainColorSpace;
-    SwapChainBitDepth m_currentSwapChainBitDepth;
-    bool m_swapChainFormatChanged;
-    DXGI_FORMAT m_intermediateRenderTargetFormat;
-    UINT m_dxgiFactoryFlags;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGIFactory4> m_dxgiFactory;
+	ComPtr<IDXGISwapChain4> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12Resource> m_intermediateRenderTarget;
+	ComPtr<ID3D12Resource> m_UIRenderTarget;
+	ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_srvHeap;
+	UINT m_rtvDescriptorSize;
+	UINT m_srvDescriptorSize;
+	DXGI_FORMAT m_swapChainFormats[SwapChainBitDepthCount];
+	DXGI_COLOR_SPACE_TYPE m_currentSwapChainColorSpace;
+	SwapChainBitDepth m_currentSwapChainBitDepth;
+	bool m_swapChainFormatChanged;
+	DXGI_FORMAT m_intermediateRenderTargetFormat;
+	UINT m_dxgiFactoryFlags;
 
-    // App resources.
-    ComPtr<ID3D12PipelineState> m_pipelineStates[PipelineStateCount];
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    ComPtr<ID3D12Resource> m_vertexBufferUpload;
-    D3D12_VERTEX_BUFFER_VIEW m_gradientVertexBufferView;
-    D3D12_VERTEX_BUFFER_VIEW m_trianglesVertexBufferView;
-    D3D12_VERTEX_BUFFER_VIEW m_presentVertexBufferView;
-    UINT m_rootConstants[RootConstantsCount];
-    float* m_rootConstantsF;
-    bool m_updateVertexBuffer;
-    std::shared_ptr<UILayer> m_uiLayer;
-    bool m_enableUI = true;
+	// App resources.
+	ComPtr<ID3D12PipelineState> m_pipelineStates[PipelineStateCount];
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	ComPtr<ID3D12Resource> m_vertexBufferUpload;
+	D3D12_VERTEX_BUFFER_VIEW m_gradientVertexBufferView;
+	D3D12_VERTEX_BUFFER_VIEW m_trianglesVertexBufferView;
+	D3D12_VERTEX_BUFFER_VIEW m_presentVertexBufferView;
+	UINT m_rootConstants[RootConstantsCount];
+	float* m_rootConstantsF;
+	bool m_updateVertexBuffer;
+	std::shared_ptr<UILayer> m_uiLayer;
+	bool m_enableUI = true;
     UINT m_hdrMetaDataPoolIdx = 0;
 
-    // Color.
-    bool m_hdrSupport = false;
-    bool m_enableST2084 = false;
-    float m_referenceWhiteNits = 80.0f;    // The reference brightness level of the display.
+	// Color.
+	bool m_hdrSupport = false;
+	bool m_enableST2084 = false;
+	float m_referenceWhiteNits = 80.0f;	// The reference brightness level of the display.
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValues[FrameCount];
+	// Synchronization objects.
+	UINT m_frameIndex;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValues[FrameCount];
 
-    // Track the state of the window.
-    // If it's minimized the app may decide not to render frames.
-    bool m_windowVisible;
-    bool m_windowedMode;
+	// Track the state of the window.
+	// If it's minimized the app may decide not to render frames.
+	bool m_windowVisible;
+	bool m_windowedMode;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void LoadSizeDependentResources();
-    XMFLOAT3 TransformVertex(XMFLOAT2 point, XMFLOAT2 offset);
-    void UpdateVertexBuffer();
-    void RenderScene();
-    void WaitForGpu();
-    void MoveToNextFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	void LoadSizeDependentResources();
+	XMFLOAT3 TransformVertex(XMFLOAT2 point, XMFLOAT2 offset);
+	void UpdateVertexBuffer();
+	void RenderScene();
+	void WaitForGpu();
+	void MoveToNextFrame();
     void EnsureSwapChainColorSpace(SwapChainBitDepth d, bool enableST2084);
     void CheckDisplayHDRSupport();
     void SetHDRMetaData(float MaxOutputNits = 1000.0f, float MinOutputNits = 0.001f, float MaxCLL = 2000.0f, float MaxFALL = 500.0f);

--- a/Samples/Desktop/D3D12HDR/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12HDR/src/DXSample.cpp
@@ -52,33 +52,78 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
+
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+            }
+#if !defined(_XBOX_ONE)
+        }
+#endif
 
     *ppAdapter = adapter.Detach();
-}
+    }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)

--- a/Samples/Desktop/D3D12HDR/src/DXSample.h
+++ b/Samples/Desktop/D3D12HDR/src/DXSample.h
@@ -49,7 +49,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/Desktop/D3D12HDR/src/Main.cpp
+++ b/Samples/Desktop/D3D12HDR/src/Main.cpp
@@ -28,6 +28,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
         FreeLibrary(hUser32);
     }
 
-    D3D12HDR sample(1280, 720, L"D3D12 HDR sample");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12HDR sample(1280, 720, L"D3D12 HDR sample");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12HDR/src/UILayer.cpp
+++ b/Samples/Desktop/D3D12HDR/src/UILayer.cpp
@@ -13,135 +13,135 @@
 #include "UILayer.h"
 
 UILayer::UILayer(D3D12HDR* pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
-    m_ui.resize(StringsCount);
-    m_labels.resize(StringsCount);
+	m_ui.resize(StringsCount);
+	m_labels.resize(StringsCount);
 
-    m_labels[Format] = L"Back Buffer Format";
-    m_labels[Signal] = L"Output Signal";
-    m_labels[HDRSupport] = L"Current Output HDR Support";
-    m_labels[StandardGradient] = L"SDR Gradient [0,1]";
-    m_labels[BrightGradient] = L"HDR Gradient [0,9]";
-    m_labels[Rec709] = L"Rec 709";
-    m_labels[Rec2020] = L"Rec 2020";
-    m_labels[ChangeFormat] = L"PgUp/PgDn\tChange back buffer format";
-    m_labels[ChangeCurve] = L"H\tToggle between sRGB and ST.2084 (10-bit swap chain only)";
-    m_labels[HideUI] = L"U\tToggle UI Visibility";
+	m_labels[Format] = L"Back Buffer Format";
+	m_labels[Signal] = L"Output Signal";
+	m_labels[HDRSupport] = L"Current Output HDR Support";
+	m_labels[StandardGradient] = L"SDR Gradient [0,1]";
+	m_labels[BrightGradient] = L"HDR Gradient [0,9]";
+	m_labels[Rec709] = L"Rec 709";
+	m_labels[Rec2020] = L"Rec 2020";
+	m_labels[ChangeFormat] = L"PgUp/PgDn\tChange back buffer format";
+	m_labels[ChangeCurve] = L"H\tToggle between sRGB and ST.2084 (10-bit swap chain only)";
+	m_labels[HideUI] = L"U\tToggle UI Visibility";
     m_labels[MetaData] = L"M\tToggle HDR Meta Data";
 
-    Initialize();
+	Initialize();
 }
 
 void UILayer::Initialize()
 {
-    UINT d3d11DeviceFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
-    D2D1_FACTORY_OPTIONS d2dFactoryOptions = {};
+	UINT d3d11DeviceFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
+	D2D1_FACTORY_OPTIONS d2dFactoryOptions = {};
 
 #if defined(_DEBUG)
-    // Enable the D2D debug layer.
-    d2dFactoryOptions.debugLevel = D2D1_DEBUG_LEVEL_INFORMATION;
+	// Enable the D2D debug layer.
+	d2dFactoryOptions.debugLevel = D2D1_DEBUG_LEVEL_INFORMATION;
 
-    // Enable the D3D11 debug layer.
-    d3d11DeviceFlags |= D3D11_CREATE_DEVICE_DEBUG;
+	// Enable the D3D11 debug layer.
+	d3d11DeviceFlags |= D3D11_CREATE_DEVICE_DEBUG;
 #endif
 
-    // Create an 11 device wrapped around the 12 device and share
-    // 12's command queue.
-    ComPtr<ID3D11Device> d3d11Device;
-    ID3D12CommandQueue* ppCommandQueues[] = { m_pSample->GetCommandQueue() };
-    ThrowIfFailed(D3D11On12CreateDevice(
-        m_pSample->GetDevice(),
-        d3d11DeviceFlags,
-        nullptr,
-        0,
-        reinterpret_cast<IUnknown**>(ppCommandQueues),
-        _countof(ppCommandQueues),
-        0,
-        &d3d11Device,
-        &m_d3d11DeviceContext,
-        nullptr
-        ));
+	// Create an 11 device wrapped around the 12 device and share
+	// 12's command queue.
+	ComPtr<ID3D11Device> d3d11Device;
+	ID3D12CommandQueue* ppCommandQueues[] = { m_pSample->GetCommandQueue() };
+	ThrowIfFailed(D3D11On12CreateDevice(
+		m_pSample->GetDevice(),
+		d3d11DeviceFlags,
+		nullptr,
+		0,
+		reinterpret_cast<IUnknown**>(ppCommandQueues),
+		_countof(ppCommandQueues),
+		0,
+		&d3d11Device,
+		&m_d3d11DeviceContext,
+		nullptr
+		));
 
-    // Query the 11On12 device from the 11 device.
-    ThrowIfFailed(d3d11Device.As(&m_d3d11On12Device));
+	// Query the 11On12 device from the 11 device.
+	ThrowIfFailed(d3d11Device.As(&m_d3d11On12Device));
 
 #if defined(_DEBUG)
-    // Filter a debug error coming from the 11on12 layer.
-    ComPtr<ID3D12InfoQueue> infoQueue;
-    if (SUCCEEDED(m_pSample->GetDevice()->QueryInterface(IID_PPV_ARGS(&infoQueue))))
-    {
-        // Suppress messages based on their severity level.
-        D3D12_MESSAGE_SEVERITY severities[] =
-        {
-            D3D12_MESSAGE_SEVERITY_INFO,
-        };
+	// Filter a debug error coming from the 11on12 layer.
+	ComPtr<ID3D12InfoQueue> infoQueue;
+	if (SUCCEEDED(m_pSample->GetDevice()->QueryInterface(IID_PPV_ARGS(&infoQueue))))
+	{
+		// Suppress messages based on their severity level.
+		D3D12_MESSAGE_SEVERITY severities[] =
+		{
+			D3D12_MESSAGE_SEVERITY_INFO,
+		};
 
-        // Suppress individual messages by their ID.
-        D3D12_MESSAGE_ID denyIds[] =
-        {
-            // This occurs when there are uninitialized descriptors in a descriptor table, even when a
-            // shader does not access the missing descriptors.
-            D3D12_MESSAGE_ID_INVALID_DESCRIPTOR_HANDLE,
-        };
+		// Suppress individual messages by their ID.
+		D3D12_MESSAGE_ID denyIds[] =
+		{
+			// This occurs when there are uninitialized descriptors in a descriptor table, even when a
+			// shader does not access the missing descriptors.
+			D3D12_MESSAGE_ID_INVALID_DESCRIPTOR_HANDLE,
+		};
 
-        D3D12_INFO_QUEUE_FILTER filter = {};
-        filter.DenyList.NumSeverities = _countof(severities);
-        filter.DenyList.pSeverityList = severities;
-        filter.DenyList.NumIDs = _countof(denyIds);
-        filter.DenyList.pIDList = denyIds;
+		D3D12_INFO_QUEUE_FILTER filter = {};
+		filter.DenyList.NumSeverities = _countof(severities);
+		filter.DenyList.pSeverityList = severities;
+		filter.DenyList.NumIDs = _countof(denyIds);
+		filter.DenyList.pIDList = denyIds;
 
-        ThrowIfFailed(infoQueue->PushStorageFilter(&filter));
-    }
+		ThrowIfFailed(infoQueue->PushStorageFilter(&filter));
+	}
 #endif
 
-    // Create D2D/DWrite components.
-    {
-        ComPtr<IDXGIDevice> dxgiDevice;
-        ThrowIfFailed(m_d3d11On12Device.As(&dxgiDevice));
+	// Create D2D/DWrite components.
+	{
+		ComPtr<IDXGIDevice> dxgiDevice;
+		ThrowIfFailed(m_d3d11On12Device.As(&dxgiDevice));
 
-        ThrowIfFailed(D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, __uuidof(ID2D1Factory3), &d2dFactoryOptions, &m_d2dFactory));
-        ThrowIfFailed(m_d2dFactory->CreateDevice(dxgiDevice.Get(), &m_d2dDevice));
-        ThrowIfFailed(m_d2dDevice->CreateDeviceContext(D2D1_DEVICE_CONTEXT_OPTIONS_NONE, &m_d2dDeviceContext));
+		ThrowIfFailed(D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, __uuidof(ID2D1Factory3), &d2dFactoryOptions, &m_d2dFactory));
+		ThrowIfFailed(m_d2dFactory->CreateDevice(dxgiDevice.Get(), &m_d2dDevice));
+		ThrowIfFailed(m_d2dDevice->CreateDeviceContext(D2D1_DEVICE_CONTEXT_OPTIONS_NONE, &m_d2dDeviceContext));
 
-        m_d2dDeviceContext->SetTextAntialiasMode(D2D1_TEXT_ANTIALIAS_MODE_GRAYSCALE);
-        ThrowIfFailed(m_d2dDeviceContext->CreateSolidColorBrush(D2D1::ColorF(D2D1::ColorF::White), &m_textBrush));
+		m_d2dDeviceContext->SetTextAntialiasMode(D2D1_TEXT_ANTIALIAS_MODE_GRAYSCALE);
+		ThrowIfFailed(m_d2dDeviceContext->CreateSolidColorBrush(D2D1::ColorF(D2D1::ColorF::White), &m_textBrush));
 
-        ThrowIfFailed(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &m_dwriteFactory));
-    }
+		ThrowIfFailed(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &m_dwriteFactory));
+	}
 
-    UpdateLabels();
-    Resize();
+	UpdateLabels();
+	Resize();
 }
 
 void UILayer::UpdateLabels()
 {
-    switch (m_pSample->GetBackBufferFormat())
-    {
-    case DXGI_FORMAT_R8G8B8A8_UNORM:
-        m_labels[Format] = L"Back Buffer Format = R8G8B8A8_UNORM";
-        break;
+	switch (m_pSample->GetBackBufferFormat())
+	{
+	case DXGI_FORMAT_R8G8B8A8_UNORM:
+		m_labels[Format] = L"Back Buffer Format = R8G8B8A8_UNORM";
+		break;
 
-    case DXGI_FORMAT_R10G10B10A2_UNORM:
-        m_labels[Format] = L"Back Buffer Format = R10G10B10A2_UNORM";
-        break;
+	case DXGI_FORMAT_R10G10B10A2_UNORM:
+		m_labels[Format] = L"Back Buffer Format = R10G10B10A2_UNORM";
+		break;
 
-    case DXGI_FORMAT_R16G16B16A16_FLOAT:
-        m_labels[Format] = L"Back Buffer Format = R16G16B16A16_FLOAT";
-        break;
+	case DXGI_FORMAT_R16G16B16A16_FLOAT:
+		m_labels[Format] = L"Back Buffer Format = R16G16B16A16_FLOAT";
+		break;
 
-    default:
-        m_labels[Format] = L"Back Buffer Format = Unknown";
-        break;
-    }
+	default:
+		m_labels[Format] = L"Back Buffer Format = Unknown";
+		break;
+	}
 
-    m_labels[Signal] = L"Output Signal = " + m_pSample->GetDisplayCurve();
-    m_labels[HDRSupport] = L"Current Output HDR Support = ";
-    m_labels[HDRSupport] += m_pSample->GetHDRSupport() ? L"true" : L"false";
+	m_labels[Signal] = L"Output Signal = " + m_pSample->GetDisplayCurve();
+	m_labels[HDRSupport] = L"Current Output HDR Support = ";
+	m_labels[HDRSupport] += m_pSample->GetHDRSupport() ? L"true" : L"false";
 
-    m_ui[Format].text = m_labels[Format];
-    m_ui[Signal].text = m_labels[Signal];
-    m_ui[HDRSupport].text = m_labels[HDRSupport];
+	m_ui[Format].text = m_labels[Format];
+	m_ui[Signal].text = m_labels[Signal];
+	m_ui[HDRSupport].text = m_labels[HDRSupport];
 
     float MaxOutputNits = D3D12HDR::HDRMetaDataPool[m_pSample->GetHDRMetaDataPoolIndex()][0];
     float MinOutputNits = D3D12HDR::HDRMetaDataPool[m_pSample->GetHDRMetaDataPoolIndex()][1];
@@ -157,111 +157,111 @@ void UILayer::UpdateLabels()
 // Render the UI.
 void UILayer::Render()
 {
-    ID3D11Resource* ppResources[] = { m_wrappedRenderTarget.Get() };
+	ID3D11Resource* ppResources[] = { m_wrappedRenderTarget.Get() };
 
-    // Acquire our wrapped render target resource for the current back buffer.
-    m_d3d11On12Device->AcquireWrappedResources(ppResources, _countof(ppResources));
+	// Acquire our wrapped render target resource for the current back buffer.
+	m_d3d11On12Device->AcquireWrappedResources(ppResources, _countof(ppResources));
 
-    m_d2dDeviceContext->BeginDraw();
-    m_d2dDeviceContext->Clear();
-    for (auto textBlock : m_ui)
-    {
-        m_d2dDeviceContext->DrawText(
-            textBlock.text.c_str(),
-            static_cast<UINT>(textBlock.text.length()),
-            textBlock.pFormat,
-            textBlock.layout,
-            m_textBrush.Get());
-    }
-    m_d2dDeviceContext->EndDraw();
+	m_d2dDeviceContext->BeginDraw();
+	m_d2dDeviceContext->Clear();
+	for (auto textBlock : m_ui)
+	{
+		m_d2dDeviceContext->DrawText(
+			textBlock.text.c_str(),
+			static_cast<UINT>(textBlock.text.length()),
+			textBlock.pFormat,
+			textBlock.layout,
+			m_textBrush.Get());
+	}
+	m_d2dDeviceContext->EndDraw();
 
-    // Release our wrapped render target resource. Releasing
-    // transitions the back buffer resource to the state specified
-    // as the OutState when the wrapped resource was created.
-    m_d3d11On12Device->ReleaseWrappedResources(ppResources, _countof(ppResources));
+	// Release our wrapped render target resource. Releasing
+	// transitions the back buffer resource to the state specified
+	// as the OutState when the wrapped resource was created.
+	m_d3d11On12Device->ReleaseWrappedResources(ppResources, _countof(ppResources));
 
-    // Flush to submit the 11 command list to the shared command queue.
-    m_d3d11DeviceContext->Flush();
+	// Flush to submit the 11 command list to the shared command queue.
+	m_d3d11DeviceContext->Flush();
 }
 
 // Releases resources that reference the DXGI swap chain so that it can be resized.
 void UILayer::ReleaseResources()
 {
-    m_wrappedRenderTarget.Reset();
-    m_d2dRenderTarget.Reset();
-    m_d2dDeviceContext->SetTarget(nullptr);
+	m_wrappedRenderTarget.Reset();
+	m_d2dRenderTarget.Reset();
+	m_d2dDeviceContext->SetTarget(nullptr);
 }
 
 void UILayer::Resize()
 {
-    // Query the desktop's dpi settings, which will be used to create
-    // D2D's render targets.
-    D2D1_BITMAP_PROPERTIES1 bitmapProperties = D2D1::BitmapProperties1(
-        D2D1_BITMAP_OPTIONS_TARGET | D2D1_BITMAP_OPTIONS_CANNOT_DRAW,
-        D2D1::PixelFormat(DXGI_FORMAT_UNKNOWN, D2D1_ALPHA_MODE_PREMULTIPLIED));
+	// Query the desktop's dpi settings, which will be used to create
+	// D2D's render targets.
+	D2D1_BITMAP_PROPERTIES1 bitmapProperties = D2D1::BitmapProperties1(
+		D2D1_BITMAP_OPTIONS_TARGET | D2D1_BITMAP_OPTIONS_CANNOT_DRAW,
+		D2D1::PixelFormat(DXGI_FORMAT_UNKNOWN, D2D1_ALPHA_MODE_PREMULTIPLIED));
 
-    // Create a wrapped 11On12 resource of this back buffer.
-    // When ReleaseWrappedResources() is called on the 11On12 device, the resource
-    // will be transitioned to the PIXEL_SHADER_RESOURCE state.
-    D3D11_RESOURCE_FLAGS d3d11Flags = { D3D11_BIND_RENDER_TARGET };
-    ThrowIfFailed(m_d3d11On12Device->CreateWrappedResource(
-        m_pSample->GetUIRenderTarget(),
-        &d3d11Flags,
-        D3D12_RESOURCE_STATE_RENDER_TARGET,
-        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-        IID_PPV_ARGS(&m_wrappedRenderTarget)));
+	// Create a wrapped 11On12 resource of this back buffer.
+	// When ReleaseWrappedResources() is called on the 11On12 device, the resource
+	// will be transitioned to the PIXEL_SHADER_RESOURCE state.
+	D3D11_RESOURCE_FLAGS d3d11Flags = { D3D11_BIND_RENDER_TARGET };
+	ThrowIfFailed(m_d3d11On12Device->CreateWrappedResource(
+		m_pSample->GetUIRenderTarget(),
+		&d3d11Flags,
+		D3D12_RESOURCE_STATE_RENDER_TARGET,
+		D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+		IID_PPV_ARGS(&m_wrappedRenderTarget)));
 
-    // Create a render target for D2D to draw directly to this back buffer.
-    ComPtr<IDXGISurface> surface;
-    ThrowIfFailed(m_wrappedRenderTarget.As(&surface));
-    ThrowIfFailed(m_d2dDeviceContext->CreateBitmapFromDxgiSurface(
-        surface.Get(),
-        &bitmapProperties,
-        &m_d2dRenderTarget));
+	// Create a render target for D2D to draw directly to this back buffer.
+	ComPtr<IDXGISurface> surface;
+	ThrowIfFailed(m_wrappedRenderTarget.As(&surface));
+	ThrowIfFailed(m_d2dDeviceContext->CreateBitmapFromDxgiSurface(
+		surface.Get(),
+		&bitmapProperties,
+		&m_d2dRenderTarget));
 
-    // Set the render target on the D2D context.
-    m_d2dDeviceContext->SetTarget(m_d2dRenderTarget.Get());
+	// Set the render target on the D2D context.
+	m_d2dDeviceContext->SetTarget(m_d2dRenderTarget.Get());
 
-    // Create DWrite text format objects.
-    float width = static_cast<float>(m_pSample->GetWidth());
-    float height = static_cast<float>(m_pSample->GetHeight());
-    const float fontSize = height / 30.0f;
-    const float smallFontSize = height / 40.0f;
+	// Create DWrite text format objects.
+	float width = static_cast<float>(m_pSample->GetWidth());
+	float height = static_cast<float>(m_pSample->GetHeight());
+	const float fontSize = height / 30.0f;
+	const float smallFontSize = height / 40.0f;
 
-    ThrowIfFailed(m_dwriteFactory->CreateTextFormat(
-        L"Arial",
-        nullptr,
-        DWRITE_FONT_WEIGHT_NORMAL,
-        DWRITE_FONT_STYLE_NORMAL,
-        DWRITE_FONT_STRETCH_NORMAL,
-        fontSize,
-        L"en-us",
-        &m_textFormat));
+	ThrowIfFailed(m_dwriteFactory->CreateTextFormat(
+		L"Arial",
+		nullptr,
+		DWRITE_FONT_WEIGHT_NORMAL,
+		DWRITE_FONT_STYLE_NORMAL,
+		DWRITE_FONT_STRETCH_NORMAL,
+		fontSize,
+		L"en-us",
+		&m_textFormat));
 
-    ThrowIfFailed(m_textFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER));
-    ThrowIfFailed(m_textFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_NEAR));
+	ThrowIfFailed(m_textFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER));
+	ThrowIfFailed(m_textFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_NEAR));
 
-    ThrowIfFailed(m_dwriteFactory->CreateTextFormat(
-        L"Arial",
-        nullptr,
-        DWRITE_FONT_WEIGHT_NORMAL,
-        DWRITE_FONT_STYLE_NORMAL,
-        DWRITE_FONT_STRETCH_NORMAL,
-        smallFontSize,
-        L"en-us",
-        &m_smallTextFormat));
+	ThrowIfFailed(m_dwriteFactory->CreateTextFormat(
+		L"Arial",
+		nullptr,
+		DWRITE_FONT_WEIGHT_NORMAL,
+		DWRITE_FONT_STYLE_NORMAL,
+		DWRITE_FONT_STRETCH_NORMAL,
+		smallFontSize,
+		L"en-us",
+		&m_smallTextFormat));
 
-    // Update the UI elements.
-    m_ui[Format] = { m_labels[Format], D2D1::RectF(0.0f, 0.0f, width, height), m_textFormat.Get() };
-    m_ui[Signal] = { m_labels[Signal], D2D1::RectF(0.0f, fontSize, width, height), m_textFormat.Get() };
-    m_ui[HDRSupport] = { m_labels[HDRSupport], D2D1::RectF(0.0f, fontSize * 2.0f, width, height), m_textFormat.Get() };
-    m_ui[StandardGradient] = { m_labels[StandardGradient], D2D1::RectF(0.0f, height * 0.25f + fontSize, width * 0.5f, height), m_textFormat.Get() };
-    m_ui[BrightGradient] = { m_labels[BrightGradient], D2D1::RectF(0.0f, height * 0.75f + fontSize, width * 0.5f, height), m_textFormat.Get() };
-    m_ui[Rec709] = { m_labels[Rec709], D2D1::RectF(width * 0.5f, height * 0.25f + fontSize, width * 0.8f, height), m_textFormat.Get() };
-    m_ui[Rec2020] = { m_labels[Rec2020], D2D1::RectF(width * 0.5f, height * 0.75f + fontSize, width * 0.8f, height), m_textFormat.Get() };
+	// Update the UI elements.
+	m_ui[Format] = { m_labels[Format], D2D1::RectF(0.0f, 0.0f, width, height), m_textFormat.Get() };
+	m_ui[Signal] = { m_labels[Signal], D2D1::RectF(0.0f, fontSize, width, height), m_textFormat.Get() };
+	m_ui[HDRSupport] = { m_labels[HDRSupport], D2D1::RectF(0.0f, fontSize * 2.0f, width, height), m_textFormat.Get() };
+	m_ui[StandardGradient] = { m_labels[StandardGradient], D2D1::RectF(0.0f, height * 0.25f + fontSize, width * 0.5f, height), m_textFormat.Get() };
+	m_ui[BrightGradient] = { m_labels[BrightGradient], D2D1::RectF(0.0f, height * 0.75f + fontSize, width * 0.5f, height), m_textFormat.Get() };
+	m_ui[Rec709] = { m_labels[Rec709], D2D1::RectF(width * 0.5f, height * 0.25f + fontSize, width * 0.8f, height), m_textFormat.Get() };
+	m_ui[Rec2020] = { m_labels[Rec2020], D2D1::RectF(width * 0.5f, height * 0.75f + fontSize, width * 0.8f, height), m_textFormat.Get() };
 
-    m_ui[ChangeFormat] = { m_labels[ChangeFormat], D2D1::RectF(smallFontSize, height - fontSize * 5.0f, width, height), m_smallTextFormat.Get() };
-    m_ui[ChangeCurve] = { m_labels[ChangeCurve], D2D1::RectF(smallFontSize, height - fontSize * 3.0f, width, height), m_smallTextFormat.Get() };
-    m_ui[HideUI] = { m_labels[HideUI], D2D1::RectF(smallFontSize, height - fontSize * 2.0f, width, height), m_smallTextFormat.Get() };
+	m_ui[ChangeFormat] = { m_labels[ChangeFormat], D2D1::RectF(smallFontSize, height - fontSize * 5.0f, width, height), m_smallTextFormat.Get() };
+	m_ui[ChangeCurve] = { m_labels[ChangeCurve], D2D1::RectF(smallFontSize, height - fontSize * 3.0f, width, height), m_smallTextFormat.Get() };
+	m_ui[HideUI] = { m_labels[HideUI], D2D1::RectF(smallFontSize, height - fontSize * 2.0f, width, height), m_smallTextFormat.Get() };
     m_ui[MetaData] = { m_labels[MetaData], D2D1::RectF(smallFontSize, height - fontSize * 1.0f, width, height), m_smallTextFormat.Get() };
 }

--- a/Samples/Desktop/D3D12HDR/src/UILayer.h
+++ b/Samples/Desktop/D3D12HDR/src/UILayer.h
@@ -16,53 +16,53 @@
 class UILayer
 {
 public:
-    UILayer(D3D12HDR* pSample);
+	UILayer(D3D12HDR* pSample);
 
-    void UpdateLabels();
-    void Render();
-    void ReleaseResources();
-    void Resize();
+	void UpdateLabels();
+	void Render();
+	void ReleaseResources();
+	void Resize();
 
 private:
-    struct TextBlock
-    {
-        std::wstring text;
-        D2D1_RECT_F layout;
-        IDWriteTextFormat* pFormat;
-    };
+	struct TextBlock
+	{
+		std::wstring text;
+		D2D1_RECT_F layout;
+		IDWriteTextFormat* pFormat;
+	};
 
-    enum Strings
-    {
-        Format = 0,
-        Signal,
-        HDRSupport,
-        StandardGradient,
-        BrightGradient,
-        Rec709,
-        Rec2020,
-        ChangeFormat,
-        ChangeCurve,
-        HideUI,
+	enum Strings
+	{
+		Format = 0,
+		Signal,
+		HDRSupport,
+		StandardGradient,
+		BrightGradient,
+		Rec709,
+		Rec2020,
+		ChangeFormat,
+		ChangeCurve,
+		HideUI,
         MetaData,
-        StringsCount
-    };
+		StringsCount
+	};
 
-    D3D12HDR* m_pSample;
-    ComPtr<ID3D11DeviceContext> m_d3d11DeviceContext;
-    ComPtr<ID3D11On12Device> m_d3d11On12Device;
-    ComPtr<IDWriteFactory> m_dwriteFactory;
-    ComPtr<ID2D1Factory3> m_d2dFactory;
-    ComPtr<ID2D1Device2> m_d2dDevice;
-    ComPtr<ID2D1DeviceContext2> m_d2dDeviceContext;
-    ComPtr<ID3D11Resource> m_wrappedRenderTarget;
-    ComPtr<ID2D1Bitmap1> m_d2dRenderTarget;
-    ComPtr<ID2D1SolidColorBrush> m_textBrush;
-    ComPtr<IDWriteTextFormat> m_textFormat;
-    ComPtr<IDWriteTextFormat> m_smallTextFormat;
+	D3D12HDR* m_pSample;
+	ComPtr<ID3D11DeviceContext> m_d3d11DeviceContext;
+	ComPtr<ID3D11On12Device> m_d3d11On12Device;
+	ComPtr<IDWriteFactory> m_dwriteFactory;
+	ComPtr<ID2D1Factory3> m_d2dFactory;
+	ComPtr<ID2D1Device2> m_d2dDevice;
+	ComPtr<ID2D1DeviceContext2> m_d2dDeviceContext;
+	ComPtr<ID3D11Resource> m_wrappedRenderTarget;
+	ComPtr<ID2D1Bitmap1> m_d2dRenderTarget;
+	ComPtr<ID2D1SolidColorBrush> m_textBrush;
+	ComPtr<IDWriteTextFormat> m_textFormat;
+	ComPtr<IDWriteTextFormat> m_smallTextFormat;
 
-    std::vector<std::wstring> m_labels;
-    std::vector<TextBlock> m_ui;
+	std::vector<std::wstring> m_labels;
+	std::vector<TextBlock> m_ui;
 
-    void Initialize();
+	void Initialize();
 };
 

--- a/Samples/Desktop/D3D12HDR/src/color.hlsli
+++ b/Samples/Desktop/D3D12HDR/src/color.hlsli
@@ -16,75 +16,75 @@
 
 float3 xyYToRec709(float2 xy, float Y = 1.0)
 {
-    // https://github.com/ampas/aces-dev/blob/v1.0.3/transforms/ctl/README-MATRIX.md
-    static const float3x3 XYZtoRGB =
-    {
-        3.2409699419, -1.5373831776, -0.4986107603,
-        -0.9692436363, 1.8759675015, 0.0415550574,
-        0.0556300797, -0.2039769589, 1.0569715142
-    };
-    float3 XYZ = Y * float3(xy.x / xy.y, 1.0, (1.0 - xy.x - xy.y) / xy.y);
-    float3 RGB = mul(XYZtoRGB, XYZ);
-    float maxChannel = max(RGB.r, max(RGB.g, RGB.b));
-    return RGB / max(maxChannel, 1.0);
+	// https://github.com/ampas/aces-dev/blob/v1.0.3/transforms/ctl/README-MATRIX.md
+	static const float3x3 XYZtoRGB =
+	{
+		3.2409699419, -1.5373831776, -0.4986107603,
+		-0.9692436363, 1.8759675015, 0.0415550574,
+		0.0556300797, -0.2039769589, 1.0569715142
+	};
+	float3 XYZ = Y * float3(xy.x / xy.y, 1.0, (1.0 - xy.x - xy.y) / xy.y);
+	float3 RGB = mul(XYZtoRGB, XYZ);
+	float maxChannel = max(RGB.r, max(RGB.g, RGB.b));
+	return RGB / max(maxChannel, 1.0);
 }
 
 float3 xyYToRec2020(float2 xy, float Y = 1.0)
 {
-    // https://github.com/ampas/aces-dev/blob/v1.0.3/transforms/ctl/README-MATRIX.md
-    static const float3x3 XYZtoRGB =
-    {
-        1.7166511880, -0.3556707838, -0.2533662814,
-        -0.6666843518, 1.6164812366, 0.0157685458,
-        0.0176398574, -0.0427706133, 0.9421031212
-    };
-    float3 XYZ = Y * float3(xy.x / xy.y, 1.0, (1.0 - xy.x - xy.y) / xy.y);
-    float3 RGB = mul(XYZtoRGB, XYZ);
-    float maxChannel = max(RGB.r, max(RGB.g, RGB.b));
-    return RGB / max(maxChannel, 1.0);
+	// https://github.com/ampas/aces-dev/blob/v1.0.3/transforms/ctl/README-MATRIX.md
+	static const float3x3 XYZtoRGB =
+	{
+		1.7166511880, -0.3556707838, -0.2533662814,
+		-0.6666843518, 1.6164812366, 0.0157685458,
+		0.0176398574, -0.0427706133, 0.9421031212
+	};
+	float3 XYZ = Y * float3(xy.x / xy.y, 1.0, (1.0 - xy.x - xy.y) / xy.y);
+	float3 RGB = mul(XYZtoRGB, XYZ);
+	float maxChannel = max(RGB.r, max(RGB.g, RGB.b));
+	return RGB / max(maxChannel, 1.0);
 }
 
 float3 LinearToSRGB(float3 color)
 {
-    // Approximately pow(color, 1.0 / 2.2)
-    return color < 0.0031308 ? 12.92 * color : 1.055 * pow(abs(color), 1.0 / 2.4) - 0.055;
+	// Approximately pow(color, 1.0 / 2.2)
+	return color < 0.0031308 ? 12.92 * color : 1.055 * pow(abs(color), 1.0 / 2.4) - 0.055;
 }
 
 float3 SRGBToLinear(float3 color)
 {
-    // Approximately pow(color, 2.2)
-    return color < 0.04045 ? color / 12.92 : pow(abs(color + 0.055) / 1.055, 2.4);
+	// Approximately pow(color, 2.2)
+	return color < 0.04045 ? color / 12.92 : pow(abs(color + 0.055) / 1.055, 2.4);
 }
 
 float3 Rec709ToRec2020(float3 color)
 {
-    static const float3x3 conversion =
-    {
-        0.627402, 0.329292, 0.043306,
-        0.069095, 0.919544, 0.011360,
-        0.016394, 0.088028, 0.895578
-    };
-    return mul(conversion, color);
+	static const float3x3 conversion =
+	{
+		0.627402, 0.329292, 0.043306,
+		0.069095, 0.919544, 0.011360,
+		0.016394, 0.088028, 0.895578
+	};
+	return mul(conversion, color);
 }
 
 float3 Rec2020ToRec709(float3 color)
 {
-    static const float3x3 conversion =
-    {
-        1.660496, -0.587656, -0.072840,
-        -0.124547, 1.132895, -0.008348,
-        -0.018154, -0.100597, 1.118751
-    };
-    return mul(conversion, color);
+	static const float3x3 conversion =
+	{
+		1.660496, -0.587656, -0.072840,
+		-0.124547, 1.132895, -0.008348,
+		-0.018154, -0.100597, 1.118751
+	};
+	return mul(conversion, color);
 }
 
 float3 LinearToST2084(float3 color)
 {
-    float m1 = 2610.0 / 4096.0 / 4;
-    float m2 = 2523.0 / 4096.0 * 128;
-    float c1 = 3424.0 / 4096.0;
-    float c2 = 2413.0 / 4096.0 * 32;
-    float c3 = 2392.0 / 4096.0 * 32;
-    float3 cp = pow(abs(color), m1);
-    return pow((c1 + c2 * cp) / (1 + c3 * cp), m2);
+	float m1 = 2610.0 / 4096.0 / 4;
+	float m2 = 2523.0 / 4096.0 * 128;
+	float c1 = 3424.0 / 4096.0;
+	float c2 = 2413.0 / 4096.0 * 32;
+	float c3 = 2392.0 / 4096.0 * 32;
+	float3 cp = pow(abs(color), m1);
+	return pow((c1 + c2 * cp) / (1 + c3 * cp), m2);
 }

--- a/Samples/Desktop/D3D12HDR/src/d3dx12.h
+++ b/Samples/Desktop/D3D12HDR/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12HDR/src/gradient.hlsli
+++ b/Samples/Desktop/D3D12HDR/src/gradient.hlsli
@@ -11,12 +11,12 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 cbuffer RootConstants : register(b0)
 {
-    float standardNits;        // The reference brightness level of the display.
-    uint displayCurve;        // The expected format of the output signal.
+	float standardNits;		// The reference brightness level of the display.
+	uint displayCurve;		// The expected format of the output signal.
 };

--- a/Samples/Desktop/D3D12HDR/src/gradientPS.hlsl
+++ b/Samples/Desktop/D3D12HDR/src/gradientPS.hlsl
@@ -14,6 +14,6 @@
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    // This draws a perceptual gradient rather than a linear gradient.
-    return float4(pow(abs(input.color.rgb), 2.2), input.color.a);
+	// This draws a perceptual gradient rather than a linear gradient.
+	return float4(pow(abs(input.color.rgb), 2.2), input.color.a);
 }

--- a/Samples/Desktop/D3D12HDR/src/gradientVS.hlsl
+++ b/Samples/Desktop/D3D12HDR/src/gradientVS.hlsl
@@ -13,10 +13,10 @@
 
 PSInput VSMain(float4 position : POSITION, float4 color : COLOR)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.color = color;
+	result.position = position;
+	result.color = color;
 
-    return result;
+	return result;
 }

--- a/Samples/Desktop/D3D12HDR/src/palette.hlsli
+++ b/Samples/Desktop/D3D12HDR/src/palette.hlsli
@@ -11,12 +11,12 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 cbuffer RootConstants : register(b0)
 {
-    float standardNits;        // The reference brightness level of the display.
-    uint displayCurve;        // The expected format of the output signal.
+	float standardNits;		// The reference brightness level of the display.
+	uint displayCurve;		// The expected format of the output signal.
 };

--- a/Samples/Desktop/D3D12HDR/src/palettePS.hlsl
+++ b/Samples/Desktop/D3D12HDR/src/palettePS.hlsl
@@ -14,6 +14,6 @@
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    // The triangle stores the data in CIE xyY color space. We convert the data to RGB format in Rec709 RGB color space.
-    return float4(xyYToRec709(input.uv), 1.0);
+	// The triangle stores the data in CIE xyY color space. We convert the data to RGB format in Rec709 RGB color space.
+	return float4(xyYToRec709(input.uv), 1.0);
 }

--- a/Samples/Desktop/D3D12HDR/src/paletteVS.hlsl
+++ b/Samples/Desktop/D3D12HDR/src/paletteVS.hlsl
@@ -13,10 +13,10 @@
 
 PSInput VSMain(float4 position : POSITION, float2 uv : TEXCOORD)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.uv = uv;
+	result.position = position;
+	result.uv = uv;
 
-    return result;
+	return result;
 }

--- a/Samples/Desktop/D3D12HDR/src/present.hlsli
+++ b/Samples/Desktop/D3D12HDR/src/present.hlsli
@@ -11,14 +11,14 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 cbuffer RootConstants : register(b0)
 {
-    float standardNits;        // The reference brightness level of the display.
-    uint displayCurve;        // The expected format of the output signal.
+	float standardNits;		// The reference brightness level of the display.
+	uint displayCurve;		// The expected format of the output signal.
 };
 
 Texture2D g_scene : register(t0);

--- a/Samples/Desktop/D3D12HDR/src/presentPS.hlsl
+++ b/Samples/Desktop/D3D12HDR/src/presentPS.hlsl
@@ -14,34 +14,34 @@
 
 float3 PSMain(PSInput input) : SV_TARGET
 {
-    // The scene, including brightness bars and color palettes, is rendered with linear gamma and Rec.709 primaries. (DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709) 
-    float3 scene = g_scene.Sample(g_sampler, input.uv).rgb;
+	// The scene, including brightness bars and color palettes, is rendered with linear gamma and Rec.709 primaries. (DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709) 
+	float3 scene = g_scene.Sample(g_sampler, input.uv).rgb;
 
-    // Direct2D renders the UI layer with gamma 2.2 in Rec.709 primaries. (DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709, known as sRGB)
-    float4 uiLayer = g_ui.Sample(g_sampler, input.uv);
+	// Direct2D renders the UI layer with gamma 2.2 in Rec.709 primaries. (DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709, known as sRGB)
+	float4 uiLayer = g_ui.Sample(g_sampler, input.uv);
 
-    // Compose the scene and UI layers. Note that we convert UI layer from gamma 2.2 to to linear gamma before composing so both UI layers and the scene are with linear gamma and Rec.709 primaries. 
-    float3 result = lerp(scene, SRGBToLinear(uiLayer.rgb), uiLayer.a);
+	// Compose the scene and UI layers. Note that we convert UI layer from gamma 2.2 to to linear gamma before composing so both UI layers and the scene are with linear gamma and Rec.709 primaries. 
+	float3 result = lerp(scene, SRGBToLinear(uiLayer.rgb), uiLayer.a);
 
-    if (displayCurve == DISPLAY_CURVE_SRGB)
-    {
-        result = LinearToSRGB(result);
-    }
-    else if (displayCurve == DISPLAY_CURVE_ST2084)
-    {
-        const float st2084max = 10000.0;
+	if (displayCurve == DISPLAY_CURVE_SRGB)
+	{
+		result = LinearToSRGB(result);
+	}
+	else if (displayCurve == DISPLAY_CURVE_ST2084)
+	{
+		const float st2084max = 10000.0;
         const float hdrScalar = standardNits / st2084max;
 
-        // The HDR scene is in Rec.709, but the display is Rec.2020
-        result = Rec709ToRec2020(result);
+		// The HDR scene is in Rec.709, but the display is Rec.2020
+		result = Rec709ToRec2020(result);
 
-        // Apply the ST.2084 curve to the scene.
-        result = LinearToST2084(result * hdrScalar);
-    }
-    else // displayCurve == DISPLAY_CURVE_LINEAR
-    {
-        // Just pass through
-    }
+		// Apply the ST.2084 curve to the scene.
+		result = LinearToST2084(result * hdrScalar);
+	}
+	else // displayCurve == DISPLAY_CURVE_LINEAR
+	{
+		// Just pass through
+	}
 
-    return result;
+	return result;
 }

--- a/Samples/Desktop/D3D12HDR/src/presentVS.hlsl
+++ b/Samples/Desktop/D3D12HDR/src/presentVS.hlsl
@@ -13,10 +13,10 @@
 
 PSInput VSMain(float4 position : POSITION, float2 uv : TEXCOORD)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.uv = uv;
+	result.position = position;
+	result.uv = uv;
 
-    return result;
+	return result;
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.cpp
@@ -13,253 +13,253 @@
 #include "D3D12HelloBundles.h"
 
 D3D12HelloBundles::D3D12HelloBundles(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0)
 {
 }
 
 void D3D12HelloBundles::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12HelloBundles::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    // This sample does not support fullscreen transitions.
-    ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
+	// This sample does not support fullscreen transitions.
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
-        }
-    }
+		// Create a RTV for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
+		}
+	}
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_BUNDLE, IID_PPV_ARGS(&m_bundleAllocator)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_BUNDLE, IID_PPV_ARGS(&m_bundleAllocator)));
 }
 
 // Load the sample assets.
 void D3D12HelloBundles::LoadAssets()
 {
-    // Create an empty root signature.
-    {
-        CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+	// Create an empty root signature.
+	{
+		CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Describe and create the graphics pipeline state object (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.SampleDesc.Count = 1;
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-    }
+		// Describe and create the graphics pipeline state object (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.SampleDesc.Count = 1;
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
 
-    // Command lists are created in the recording state, but there is nothing
-    // to record yet. The main loop expects it to be closed, so close it now.
-    ThrowIfFailed(m_commandList->Close());
+	// Command lists are created in the recording state, but there is nothing
+	// to record yet. The main loop expects it to be closed, so close it now.
+	ThrowIfFailed(m_commandList->Close());
 
-    // Create the vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        Vertex triangleVertices[] =
-        {
-            { { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
-            { { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
-            { { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
-        };
+	// Create the vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		Vertex triangleVertices[] =
+		{
+			{ { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
+			{ { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
+			{ { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
+		};
 
-        const UINT vertexBufferSize = sizeof(triangleVertices);
+		const UINT vertexBufferSize = sizeof(triangleVertices);
 
-        // Note: using upload heaps to transfer static data like vert buffers is not 
-        // recommended. Every time the GPU needs it, the upload heap will be marshalled 
-        // over. Please read up on Default Heap usage. An upload heap is used here for 
-        // code simplicity and because there are very few verts to actually transfer.
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		// Note: using upload heaps to transfer static data like vert buffers is not 
+		// recommended. Every time the GPU needs it, the upload heap will be marshalled 
+		// over. Please read up on Default Heap usage. An upload heap is used here for 
+		// code simplicity and because there are very few verts to actually transfer.
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        // Copy the triangle data to the vertex buffer.
-        UINT8* pVertexDataBegin;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
-        memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
-        m_vertexBuffer->Unmap(0, nullptr);
+		// Copy the triangle data to the vertex buffer.
+		UINT8* pVertexDataBegin;
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
+		memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
+		m_vertexBuffer->Unmap(0, nullptr);
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = vertexBufferSize;
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = vertexBufferSize;
+	}
 
-    // Create and record the bundle.
-    {
-        ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_BUNDLE, m_bundleAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_bundle)));
-        m_bundle->SetGraphicsRootSignature(m_rootSignature.Get());
-        m_bundle->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-        m_bundle->IASetVertexBuffers(0, 1, &m_vertexBufferView);
-        m_bundle->DrawInstanced(3, 1, 0, 0);
-        ThrowIfFailed(m_bundle->Close());
-    }
+	// Create and record the bundle.
+	{
+		ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_BUNDLE, m_bundleAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_bundle)));
+		m_bundle->SetGraphicsRootSignature(m_rootSignature.Get());
+		m_bundle->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+		m_bundle->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+		m_bundle->DrawInstanced(3, 1, 0, 0);
+		ThrowIfFailed(m_bundle->Close());
+	}
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValue = 1;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValue = 1;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForPreviousFrame();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForPreviousFrame();
+	}
 }
 
 // Update frame-based values.
@@ -270,82 +270,82 @@ void D3D12HelloBundles::OnUpdate()
 // Render the scene.
 void D3D12HelloBundles::OnRender()
 {
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+	// Present the frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    WaitForPreviousFrame();
+	WaitForPreviousFrame();
 }
 
 void D3D12HelloBundles::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForPreviousFrame();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForPreviousFrame();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12HelloBundles::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocator->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocator->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
 
-    // Execute the commands stored in the bundle.
-    m_commandList->ExecuteBundle(m_bundle.Get());
+	// Execute the commands stored in the bundle.
+	m_commandList->ExecuteBundle(m_bundle.Get());
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 void D3D12HelloBundles::WaitForPreviousFrame()
 {
-    // WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
-    // This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
-    // sample illustrates how to use fences for efficient resource usage and to
-    // maximize GPU utilization.
+	// WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
+	// This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
+	// sample illustrates how to use fences for efficient resource usage and to
+	// maximize GPU utilization.
 
-    // Signal and increment the fence value.
-    const UINT64 fence = m_fenceValue;
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
-    m_fenceValue++;
+	// Signal and increment the fence value.
+	const UINT64 fence = m_fenceValue;
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
+	m_fenceValue++;
 
-    // Wait until the previous frame is finished.
-    if (m_fence->GetCompletedValue() < fence)
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+	// Wait until the previous frame is finished.
+	if (m_fence->GetCompletedValue() < fence)
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.h
@@ -25,50 +25,50 @@ using Microsoft::WRL::ComPtr;
 class D3D12HelloBundles : public DXSample
 {
 public:
-    D3D12HelloBundles(UINT width, UINT height, std::wstring name);
+	D3D12HelloBundles(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    static const UINT FrameCount = 2;
+	static const UINT FrameCount = 2;
 
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT4 color;
-    };
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT4 color;
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandAllocator> m_bundleAllocator;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    ComPtr<ID3D12GraphicsCommandList> m_bundle;
-    UINT m_rtvDescriptorSize;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandAllocator> m_bundleAllocator;
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	ComPtr<ID3D12GraphicsCommandList> m_bundle;
+	UINT m_rtvDescriptorSize;
 
-    // App resources.
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	// App resources.
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValue;
+	// Synchronization objects.
+	UINT m_frameIndex;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValue;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void PopulateCommandList();
-    void WaitForPreviousFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	void PopulateCommandList();
+	void WaitForPreviousFrame();
 };

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/DXSample.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,58 +34,103 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title + L": " + text;
-    SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
+	std::wstring windowText = m_title + L": " + text;
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/DXSample.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/DXSample.h
@@ -17,42 +17,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/Main.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12HelloBundles sample(1280, 720, L"D3D12 Hello Bundles");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12HelloBundles sample(1280, 720, L"D3D12 Hello Bundles");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/Win32Application.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/Win32Application.cpp
@@ -16,104 +16,104 @@ HWND Win32Application::m_hwnd = nullptr;
 
 int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
 {
-    // Parse the command line parameters
-    int argc;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    pSample->ParseCommandLineArgs(argv, argc);
-    LocalFree(argv);
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
 
-    // Initialize the window class.
-    WNDCLASSEX windowClass = { 0 };
-    windowClass.cbSize = sizeof(WNDCLASSEX);
-    windowClass.style = CS_HREDRAW | CS_VREDRAW;
-    windowClass.lpfnWndProc = WindowProc;
-    windowClass.hInstance = hInstance;
-    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-    windowClass.lpszClassName = L"DXSampleClass";
-    RegisterClassEx(&windowClass);
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
 
-    RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
-    AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
 
-    // Create the window and store a handle to it.
-    m_hwnd = CreateWindow(
-        windowClass.lpszClassName,
-        pSample->GetTitle(),
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        windowRect.right - windowRect.left,
-        windowRect.bottom - windowRect.top,
-        nullptr,        // We have no parent window.
-        nullptr,        // We aren't using menus.
-        hInstance,
-        pSample);
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
 
-    // Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-    pSample->OnInit();
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
 
-    ShowWindow(m_hwnd, nCmdShow);
+	ShowWindow(m_hwnd, nCmdShow);
 
-    // Main sample loop.
-    MSG msg = {};
-    while (msg.message != WM_QUIT)
-    {
-        // Process any messages in the queue.
-        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
-    }
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
 
-    pSample->OnDestroy();
+	pSample->OnDestroy();
 
-    // Return this part of the WM_QUIT message to Windows.
-    return static_cast<char>(msg.wParam);
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
 }
 
 // Main message handler for the sample.
 LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
-    switch (message)
-    {
-    case WM_CREATE:
-        {
-            // Save the DXSample* passed in to CreateWindow.
-            LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
-            SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
-        }
-        return 0;
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
 
-    case WM_KEYDOWN:
-        if (pSample)
-        {
-            pSample->OnKeyDown(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_KEYUP:
-        if (pSample)
-        {
-            pSample->OnKeyUp(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_PAINT:
-        if (pSample)
-        {
-            pSample->OnUpdate();
-            pSample->OnRender();
-        }
-        return 0;
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
 
-    case WM_DESTROY:
-        PostQuitMessage(0);
-        return 0;
-    }
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
 
-    // Handle any messages the switch statement didn't.
-    return DefWindowProc(hWnd, message, wParam, lParam);
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/Win32Application.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/Win32Application.h
@@ -18,12 +18,12 @@ class DXSample;
 class Win32Application
 {
 public:
-    static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
-    static HWND GetHwnd() { return m_hwnd; }
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
 
 protected:
-    static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
-    static HWND m_hwnd;
+	static HWND m_hwnd;
 };

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/d3dx12.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/shaders.hlsl
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/shaders.hlsl
@@ -11,21 +11,21 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VSMain(float4 position : POSITION, float4 color : COLOR)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.color = color;
+	result.position = position;
+	result.color = color;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.cpp
@@ -13,402 +13,402 @@
 #include "D3D12HelloConstBuffers.h"
 
 D3D12HelloConstBuffers::D3D12HelloConstBuffers(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_pCbvDataBegin(nullptr),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0),
-    m_constantBufferData{}
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_pCbvDataBegin(nullptr),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0),
+	m_constantBufferData{}
 {
 }
 
 void D3D12HelloConstBuffers::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12HelloConstBuffers::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    // This sample does not support fullscreen transitions.
-    ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
+	// This sample does not support fullscreen transitions.
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
 
-        // Describe and create a constant buffer view (CBV) descriptor heap.
-        // Flags indicate that this descriptor heap can be bound to the pipeline 
-        // and that descriptors contained in it can be referenced by a root table.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
-        cbvHeapDesc.NumDescriptors = 1;
-        cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_cbvHeap)));
-    }
+		// Describe and create a constant buffer view (CBV) descriptor heap.
+		// Flags indicate that this descriptor heap can be bound to the pipeline 
+		// and that descriptors contained in it can be referenced by a root table.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
+		cbvHeapDesc.NumDescriptors = 1;
+		cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_cbvHeap)));
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
-        }
-    }
+		// Create a RTV for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
+		}
+	}
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
 }
 
 // Load the sample assets.
 void D3D12HelloConstBuffers::LoadAssets()
 {
-    // Create a root signature consisting of a descriptor table with a single CBV.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create a root signature consisting of a descriptor table with a single CBV.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
-        CD3DX12_ROOT_PARAMETER1 rootParameters[1];
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
+		CD3DX12_ROOT_PARAMETER1 rootParameters[1];
 
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_VERTEX);
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_VERTEX);
 
-        // Allow input layout and deny uneccessary access to certain pipeline stages.
-        D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
-            D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_PIXEL_SHADER_ROOT_ACCESS;
+		// Allow input layout and deny uneccessary access to certain pipeline stages.
+		D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
+			D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_PIXEL_SHADER_ROOT_ACCESS;
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, rootSignatureFlags);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, rootSignatureFlags);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Describe and create the graphics pipeline state object (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state object (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-    }
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
 
-    // Command lists are created in the recording state, but there is nothing
-    // to record yet. The main loop expects it to be closed, so close it now.
-    ThrowIfFailed(m_commandList->Close());
+	// Command lists are created in the recording state, but there is nothing
+	// to record yet. The main loop expects it to be closed, so close it now.
+	ThrowIfFailed(m_commandList->Close());
 
-    // Create the vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        Vertex triangleVertices[] =
-        {
-            { { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
-            { { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
-            { { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
-        };
+	// Create the vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		Vertex triangleVertices[] =
+		{
+			{ { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
+			{ { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
+			{ { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
+		};
 
-        const UINT vertexBufferSize = sizeof(triangleVertices);
+		const UINT vertexBufferSize = sizeof(triangleVertices);
 
-        // Note: using upload heaps to transfer static data like vert buffers is not 
-        // recommended. Every time the GPU needs it, the upload heap will be marshalled 
-        // over. Please read up on Default Heap usage. An upload heap is used here for 
-        // code simplicity and because there are very few verts to actually transfer.
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		// Note: using upload heaps to transfer static data like vert buffers is not 
+		// recommended. Every time the GPU needs it, the upload heap will be marshalled 
+		// over. Please read up on Default Heap usage. An upload heap is used here for 
+		// code simplicity and because there are very few verts to actually transfer.
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        // Copy the triangle data to the vertex buffer.
-        UINT8* pVertexDataBegin;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
-        memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
-        m_vertexBuffer->Unmap(0, nullptr);
+		// Copy the triangle data to the vertex buffer.
+		UINT8* pVertexDataBegin;
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
+		memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
+		m_vertexBuffer->Unmap(0, nullptr);
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = vertexBufferSize;
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = vertexBufferSize;
+	}
 
-    // Create the constant buffer.
-    {
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(1024 * 64),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_constantBuffer)));
+	// Create the constant buffer.
+	{
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(1024 * 64),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_constantBuffer)));
 
-        // Describe and create a constant buffer view.
-        D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
-        cbvDesc.BufferLocation = m_constantBuffer->GetGPUVirtualAddress();
-        cbvDesc.SizeInBytes = (sizeof(SceneConstantBuffer) + 255) & ~255;    // CB size is required to be 256-byte aligned.
-        m_device->CreateConstantBufferView(&cbvDesc, m_cbvHeap->GetCPUDescriptorHandleForHeapStart());
+		// Describe and create a constant buffer view.
+		D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
+		cbvDesc.BufferLocation = m_constantBuffer->GetGPUVirtualAddress();
+		cbvDesc.SizeInBytes = (sizeof(SceneConstantBuffer) + 255) & ~255;	// CB size is required to be 256-byte aligned.
+		m_device->CreateConstantBufferView(&cbvDesc, m_cbvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Map and initialize the constant buffer. We don't unmap this until the
-        // app closes. Keeping things mapped for the lifetime of the resource is okay.
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbvDataBegin)));
-        memcpy(m_pCbvDataBegin, &m_constantBufferData, sizeof(m_constantBufferData));
-    }
+		// Map and initialize the constant buffer. We don't unmap this until the
+		// app closes. Keeping things mapped for the lifetime of the resource is okay.
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbvDataBegin)));
+		memcpy(m_pCbvDataBegin, &m_constantBufferData, sizeof(m_constantBufferData));
+	}
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValue = 1;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValue = 1;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForPreviousFrame();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForPreviousFrame();
+	}
 }
 
 // Update frame-based values.
 void D3D12HelloConstBuffers::OnUpdate()
 {
-    const float translationSpeed = 0.005f;
-    const float offsetBounds = 1.25f;
+	const float translationSpeed = 0.005f;
+	const float offsetBounds = 1.25f;
 
-    m_constantBufferData.offset.x += translationSpeed;
-    if (m_constantBufferData.offset.x > offsetBounds)
-    {
-        m_constantBufferData.offset.x = -offsetBounds;
-    }
-    memcpy(m_pCbvDataBegin, &m_constantBufferData, sizeof(m_constantBufferData));
+	m_constantBufferData.offset.x += translationSpeed;
+	if (m_constantBufferData.offset.x > offsetBounds)
+	{
+		m_constantBufferData.offset.x = -offsetBounds;
+	}
+	memcpy(m_pCbvDataBegin, &m_constantBufferData, sizeof(m_constantBufferData));
 }
 
 // Render the scene.
 void D3D12HelloConstBuffers::OnRender()
 {
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+	// Present the frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    WaitForPreviousFrame();
+	WaitForPreviousFrame();
 }
 
 void D3D12HelloConstBuffers::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForPreviousFrame();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForPreviousFrame();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12HelloConstBuffers::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocator->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocator->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_cbvHeap.Get() };
-    m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_cbvHeap.Get() };
+	m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_commandList->SetGraphicsRootDescriptorTable(0, m_cbvHeap->GetGPUDescriptorHandleForHeapStart());
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	m_commandList->SetGraphicsRootDescriptorTable(0, m_cbvHeap->GetGPUDescriptorHandleForHeapStart());
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
-    m_commandList->DrawInstanced(3, 1, 0, 0);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+	m_commandList->DrawInstanced(3, 1, 0, 0);
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 void D3D12HelloConstBuffers::WaitForPreviousFrame()
 {
-    // WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
-    // This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
-    // sample illustrates how to use fences for efficient resource usage and to
-    // maximize GPU utilization.
+	// WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
+	// This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
+	// sample illustrates how to use fences for efficient resource usage and to
+	// maximize GPU utilization.
 
-    // Signal and increment the fence value.
-    const UINT64 fence = m_fenceValue;
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
-    m_fenceValue++;
+	// Signal and increment the fence value.
+	const UINT64 fence = m_fenceValue;
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
+	m_fenceValue++;
 
-    // Wait until the previous frame is finished.
-    if (m_fence->GetCompletedValue() < fence)
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+	// Wait until the previous frame is finished.
+	if (m_fence->GetCompletedValue() < fence)
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.h
@@ -25,57 +25,57 @@ using Microsoft::WRL::ComPtr;
 class D3D12HelloConstBuffers : public DXSample
 {
 public:
-    D3D12HelloConstBuffers(UINT width, UINT height, std::wstring name);
+	D3D12HelloConstBuffers(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    static const UINT FrameCount = 2;
+	static const UINT FrameCount = 2;
 
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT4 color;
-    };
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT4 color;
+	};
 
-    struct SceneConstantBuffer
-    {
-        XMFLOAT4 offset;
-    };
+	struct SceneConstantBuffer
+	{
+		XMFLOAT4 offset;
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_cbvHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    UINT m_rtvDescriptorSize;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_cbvHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	UINT m_rtvDescriptorSize;
 
-    // App resources.
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
-    ComPtr<ID3D12Resource> m_constantBuffer;
-    SceneConstantBuffer m_constantBufferData;
-    UINT8* m_pCbvDataBegin;
+	// App resources.
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	ComPtr<ID3D12Resource> m_constantBuffer;
+	SceneConstantBuffer m_constantBufferData;
+	UINT8* m_pCbvDataBegin;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValue;
+	// Synchronization objects.
+	UINT m_frameIndex;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValue;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void PopulateCommandList();
-    void WaitForPreviousFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	void PopulateCommandList();
+	void WaitForPreviousFrame();
 };

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/DXSample.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,58 +34,103 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title + L": " + text;
-    SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
+	std::wstring windowText = m_title + L": " + text;
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/DXSample.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/DXSample.h
@@ -17,42 +17,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/Main.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12HelloConstBuffers sample(1280, 720, L"D3D12 Hello Constant Buffers");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12HelloConstBuffers sample(1280, 720, L"D3D12 Hello Constant Buffers");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/Win32Application.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/Win32Application.cpp
@@ -16,104 +16,104 @@ HWND Win32Application::m_hwnd = nullptr;
 
 int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
 {
-    // Parse the command line parameters
-    int argc;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    pSample->ParseCommandLineArgs(argv, argc);
-    LocalFree(argv);
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
 
-    // Initialize the window class.
-    WNDCLASSEX windowClass = { 0 };
-    windowClass.cbSize = sizeof(WNDCLASSEX);
-    windowClass.style = CS_HREDRAW | CS_VREDRAW;
-    windowClass.lpfnWndProc = WindowProc;
-    windowClass.hInstance = hInstance;
-    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-    windowClass.lpszClassName = L"DXSampleClass";
-    RegisterClassEx(&windowClass);
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
 
-    RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
-    AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
 
-    // Create the window and store a handle to it.
-    m_hwnd = CreateWindow(
-        windowClass.lpszClassName,
-        pSample->GetTitle(),
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        windowRect.right - windowRect.left,
-        windowRect.bottom - windowRect.top,
-        nullptr,        // We have no parent window.
-        nullptr,        // We aren't using menus.
-        hInstance,
-        pSample);
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
 
-    // Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-    pSample->OnInit();
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
 
-    ShowWindow(m_hwnd, nCmdShow);
+	ShowWindow(m_hwnd, nCmdShow);
 
-    // Main sample loop.
-    MSG msg = {};
-    while (msg.message != WM_QUIT)
-    {
-        // Process any messages in the queue.
-        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
-    }
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
 
-    pSample->OnDestroy();
+	pSample->OnDestroy();
 
-    // Return this part of the WM_QUIT message to Windows.
-    return static_cast<char>(msg.wParam);
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
 }
 
 // Main message handler for the sample.
 LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
-    switch (message)
-    {
-    case WM_CREATE:
-        {
-            // Save the DXSample* passed in to CreateWindow.
-            LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
-            SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
-        }
-        return 0;
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
 
-    case WM_KEYDOWN:
-        if (pSample)
-        {
-            pSample->OnKeyDown(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_KEYUP:
-        if (pSample)
-        {
-            pSample->OnKeyUp(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_PAINT:
-        if (pSample)
-        {
-            pSample->OnUpdate();
-            pSample->OnRender();
-        }
-        return 0;
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
 
-    case WM_DESTROY:
-        PostQuitMessage(0);
-        return 0;
-    }
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
 
-    // Handle any messages the switch statement didn't.
-    return DefWindowProc(hWnd, message, wParam, lParam);
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/Win32Application.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/Win32Application.h
@@ -18,12 +18,12 @@ class DXSample;
 class Win32Application
 {
 public:
-    static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
-    static HWND GetHwnd() { return m_hwnd; }
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
 
 protected:
-    static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
-    static HWND m_hwnd;
+	static HWND m_hwnd;
 };

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/d3dx12.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/shaders.hlsl
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/shaders.hlsl
@@ -11,26 +11,26 @@
 
 cbuffer SceneConstantBuffer : register(b0)
 {
-    float4 offset;
+	float4 offset;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VSMain(float4 position : POSITION, float4 color : COLOR)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position + offset;
-    result.color = color;
+	result.position = position + offset;
+	result.color = color;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/D3D12HelloFrameBuffering.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/D3D12HelloFrameBuffering.cpp
@@ -13,243 +13,243 @@
 #include "D3D12HelloFrameBuffering.h"
 
 D3D12HelloFrameBuffering::D3D12HelloFrameBuffering(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_fenceValues{},
-    m_rtvDescriptorSize(0)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_fenceValues{},
+	m_rtvDescriptorSize(0)
 {
 }
 
 void D3D12HelloFrameBuffering::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12HelloFrameBuffering::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    // This sample does not support fullscreen transitions.
-    ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
+	// This sample does not support fullscreen transitions.
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV and a command allocator for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
+		// Create a RTV and a command allocator for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-            ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
-        }
-    }
+			ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
+		}
+	}
 }
 
 // Load the sample assets.
 void D3D12HelloFrameBuffering::LoadAssets()
 {
-    // Create an empty root signature.
-    {
-        CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+	// Create an empty root signature.
+	{
+		CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Describe and create the graphics pipeline state object (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.SampleDesc.Count = 1;
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-    }
+		// Describe and create the graphics pipeline state object (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.SampleDesc.Count = 1;
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
 
-    // Command lists are created in the recording state, but there is nothing
-    // to record yet. The main loop expects it to be closed, so close it now.
-    ThrowIfFailed(m_commandList->Close());
+	// Command lists are created in the recording state, but there is nothing
+	// to record yet. The main loop expects it to be closed, so close it now.
+	ThrowIfFailed(m_commandList->Close());
 
-    // Create the vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        Vertex triangleVertices[] =
-        {
-            { { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
-            { { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
-            { { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
-        };
+	// Create the vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		Vertex triangleVertices[] =
+		{
+			{ { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
+			{ { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
+			{ { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
+		};
 
-        const UINT vertexBufferSize = sizeof(triangleVertices);
+		const UINT vertexBufferSize = sizeof(triangleVertices);
 
-        // Note: using upload heaps to transfer static data like vert buffers is not 
-        // recommended. Every time the GPU needs it, the upload heap will be marshalled 
-        // over. Please read up on Default Heap usage. An upload heap is used here for 
-        // code simplicity and because there are very few verts to actually transfer.
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		// Note: using upload heaps to transfer static data like vert buffers is not 
+		// recommended. Every time the GPU needs it, the upload heap will be marshalled 
+		// over. Please read up on Default Heap usage. An upload heap is used here for 
+		// code simplicity and because there are very few verts to actually transfer.
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        // Copy the triangle data to the vertex buffer.
-        UINT8* pVertexDataBegin;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
-        memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
-        m_vertexBuffer->Unmap(0, nullptr);
+		// Copy the triangle data to the vertex buffer.
+		UINT8* pVertexDataBegin;
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
+		memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
+		m_vertexBuffer->Unmap(0, nullptr);
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = vertexBufferSize;
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = vertexBufferSize;
+	}
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValues[m_frameIndex]++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValues[m_frameIndex]++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForGpu();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForGpu();
+	}
 }
 
 // Update frame-based values.
@@ -260,95 +260,95 @@ void D3D12HelloFrameBuffering::OnUpdate()
 // Render the scene.
 void D3D12HelloFrameBuffering::OnRender()
 {
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+	// Present the frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    MoveToNextFrame();
+	MoveToNextFrame();
 }
 
 void D3D12HelloFrameBuffering::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForGpu();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForGpu();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12HelloFrameBuffering::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
-    m_commandList->DrawInstanced(3, 1, 0, 0);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+	m_commandList->DrawInstanced(3, 1, 0, 0);
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 // Wait for pending GPU work to complete.
 void D3D12HelloFrameBuffering::WaitForGpu()
 {
-    // Schedule a Signal command in the queue.
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
+	// Schedule a Signal command in the queue.
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
 
-    // Wait until the fence has been processed.
-    ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-    WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	// Wait until the fence has been processed.
+	ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+	WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
 
-    // Increment the fence value for the current frame.
-    m_fenceValues[m_frameIndex]++;
+	// Increment the fence value for the current frame.
+	m_fenceValues[m_frameIndex]++;
 }
 
 // Prepare to render the next frame.
 void D3D12HelloFrameBuffering::MoveToNextFrame()
 {
-    // Schedule a Signal command in the queue.
-    const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
+	// Schedule a Signal command in the queue.
+	const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
 
-    // Update the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Update the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-        WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+		WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	}
 
-    // Set the fence value for the next frame.
-    m_fenceValues[m_frameIndex] = currentFenceValue + 1;
+	// Set the fence value for the next frame.
+	m_fenceValues[m_frameIndex] = currentFenceValue + 1;
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/D3D12HelloFrameBuffering.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/D3D12HelloFrameBuffering.h
@@ -25,57 +25,57 @@ using Microsoft::WRL::ComPtr;
 class D3D12HelloFrameBuffering : public DXSample
 {
 public:
-    D3D12HelloFrameBuffering(UINT width, UINT height, std::wstring name);
+	D3D12HelloFrameBuffering(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    // In this sample we overload the meaning of FrameCount to mean both the maximum
-    // number of frames that will be queued to the GPU at a time, as well as the number
-    // of back buffers in the DXGI swap chain. For the majority of applications, this
-    // is convenient and works well. However, there will be certain cases where an
-    // application may want to queue up more frames than there are back buffers
-    // available.
-    // It should be noted that excessive buffering of frames dependent on user input
-    // may result in noticeable latency in your app.
-    static const UINT FrameCount = 2;
+	// In this sample we overload the meaning of FrameCount to mean both the maximum
+	// number of frames that will be queued to the GPU at a time, as well as the number
+	// of back buffers in the DXGI swap chain. For the majority of applications, this
+	// is convenient and works well. However, there will be certain cases where an
+	// application may want to queue up more frames than there are back buffers
+	// available.
+	// It should be noted that excessive buffering of frames dependent on user input
+	// may result in noticeable latency in your app.
+	static const UINT FrameCount = 2;
 
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT4 color;
-    };
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT4 color;
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    UINT m_rtvDescriptorSize;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	UINT m_rtvDescriptorSize;
 
-    // App resources.
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	// App resources.
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValues[FrameCount];
+	// Synchronization objects.
+	UINT m_frameIndex;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValues[FrameCount];
 
-    void LoadPipeline();
-    void LoadAssets();
-    void PopulateCommandList();
-    void MoveToNextFrame();
-    void WaitForGpu();
+	void LoadPipeline();
+	void LoadAssets();
+	void PopulateCommandList();
+	void MoveToNextFrame();
+	void WaitForGpu();
 };

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/DXSample.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,58 +34,103 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title + L": " + text;
-    SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
+	std::wstring windowText = m_title + L": " + text;
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/DXSample.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/DXSample.h
@@ -17,42 +17,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/Main.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12HelloFrameBuffering sample(1280, 720, L"D3D12 Hello Frame Buffering");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12HelloFrameBuffering sample(1280, 720, L"D3D12 Hello Frame Buffering");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/Win32Application.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/Win32Application.cpp
@@ -16,104 +16,104 @@ HWND Win32Application::m_hwnd = nullptr;
 
 int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
 {
-    // Parse the command line parameters
-    int argc;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    pSample->ParseCommandLineArgs(argv, argc);
-    LocalFree(argv);
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
 
-    // Initialize the window class.
-    WNDCLASSEX windowClass = { 0 };
-    windowClass.cbSize = sizeof(WNDCLASSEX);
-    windowClass.style = CS_HREDRAW | CS_VREDRAW;
-    windowClass.lpfnWndProc = WindowProc;
-    windowClass.hInstance = hInstance;
-    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-    windowClass.lpszClassName = L"DXSampleClass";
-    RegisterClassEx(&windowClass);
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
 
-    RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
-    AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
 
-    // Create the window and store a handle to it.
-    m_hwnd = CreateWindow(
-        windowClass.lpszClassName,
-        pSample->GetTitle(),
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        windowRect.right - windowRect.left,
-        windowRect.bottom - windowRect.top,
-        nullptr,        // We have no parent window.
-        nullptr,        // We aren't using menus.
-        hInstance,
-        pSample);
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
 
-    // Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-    pSample->OnInit();
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
 
-    ShowWindow(m_hwnd, nCmdShow);
+	ShowWindow(m_hwnd, nCmdShow);
 
-    // Main sample loop.
-    MSG msg = {};
-    while (msg.message != WM_QUIT)
-    {
-        // Process any messages in the queue.
-        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
-    }
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
 
-    pSample->OnDestroy();
+	pSample->OnDestroy();
 
-    // Return this part of the WM_QUIT message to Windows.
-    return static_cast<char>(msg.wParam);
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
 }
 
 // Main message handler for the sample.
 LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
-    switch (message)
-    {
-    case WM_CREATE:
-        {
-            // Save the DXSample* passed in to CreateWindow.
-            LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
-            SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
-        }
-        return 0;
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
 
-    case WM_KEYDOWN:
-        if (pSample)
-        {
-            pSample->OnKeyDown(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_KEYUP:
-        if (pSample)
-        {
-            pSample->OnKeyUp(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_PAINT:
-        if (pSample)
-        {
-            pSample->OnUpdate();
-            pSample->OnRender();
-        }
-        return 0;
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
 
-    case WM_DESTROY:
-        PostQuitMessage(0);
-        return 0;
-    }
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
 
-    // Handle any messages the switch statement didn't.
-    return DefWindowProc(hWnd, message, wParam, lParam);
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/Win32Application.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/Win32Application.h
@@ -18,12 +18,12 @@ class DXSample;
 class Win32Application
 {
 public:
-    static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
-    static HWND GetHwnd() { return m_hwnd; }
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
 
 protected:
-    static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
-    static HWND m_hwnd;
+	static HWND m_hwnd;
 };

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/d3dx12.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/shaders.hlsl
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/shaders.hlsl
@@ -11,21 +11,21 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VSMain(float4 position : POSITION, float4 color : COLOR)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.color = color;
+	result.position = position;
+	result.color = color;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.cpp
@@ -13,378 +13,378 @@
 #include "D3D12HelloTexture.h"
 
 D3D12HelloTexture::D3D12HelloTexture(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0)
 {
 }
 
 void D3D12HelloTexture::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12HelloTexture::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    // This sample does not support fullscreen transitions.
-    ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
+	// This sample does not support fullscreen transitions.
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a shader resource view (SRV) heap for the texture.
-        D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
-        srvHeapDesc.NumDescriptors = 1;
-        srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
+		// Describe and create a shader resource view (SRV) heap for the texture.
+		D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
+		srvHeapDesc.NumDescriptors = 1;
+		srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
-        }
-    }
+		// Create a RTV for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
+		}
+	}
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
 }
 
 // Load the sample assets.
 void D3D12HelloTexture::LoadAssets()
 {
-    // Create the root signature.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signature.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
 
-        CD3DX12_ROOT_PARAMETER1 rootParameters[1];
-        rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
+		CD3DX12_ROOT_PARAMETER1 rootParameters[1];
+		rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
 
-        D3D12_STATIC_SAMPLER_DESC sampler = {};
-        sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
-        sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.MipLODBias = 0;
-        sampler.MaxAnisotropy = 0;
-        sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
-        sampler.BorderColor = D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
-        sampler.MinLOD = 0.0f;
-        sampler.MaxLOD = D3D12_FLOAT32_MAX;
-        sampler.ShaderRegister = 0;
-        sampler.RegisterSpace = 0;
-        sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+		D3D12_STATIC_SAMPLER_DESC sampler = {};
+		sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
+		sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.MipLODBias = 0;
+		sampler.MaxAnisotropy = 0;
+		sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
+		sampler.BorderColor = D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
+		sampler.MinLOD = 0.0f;
+		sampler.MaxLOD = D3D12_FLOAT32_MAX;
+		sampler.ShaderRegister = 0;
+		sampler.RegisterSpace = 0;
+		sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &sampler, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &sampler, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Describe and create the graphics pipeline state object (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.SampleDesc.Count = 1;
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-    }
+		// Describe and create the graphics pipeline state object (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.SampleDesc.Count = 1;
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
 
-    // Create the vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        Vertex triangleVertices[] =
-        {
-            { { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 0.5f, 0.0f } },
-            { { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 1.0f, 1.0f } },
-            { { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f } }
-        };
+	// Create the vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		Vertex triangleVertices[] =
+		{
+			{ { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 0.5f, 0.0f } },
+			{ { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 1.0f, 1.0f } },
+			{ { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f } }
+		};
 
-        const UINT vertexBufferSize = sizeof(triangleVertices);
+		const UINT vertexBufferSize = sizeof(triangleVertices);
 
-        // Note: using upload heaps to transfer static data like vert buffers is not 
-        // recommended. Every time the GPU needs it, the upload heap will be marshalled 
-        // over. Please read up on Default Heap usage. An upload heap is used here for 
-        // code simplicity and because there are very few verts to actually transfer.
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		// Note: using upload heaps to transfer static data like vert buffers is not 
+		// recommended. Every time the GPU needs it, the upload heap will be marshalled 
+		// over. Please read up on Default Heap usage. An upload heap is used here for 
+		// code simplicity and because there are very few verts to actually transfer.
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        // Copy the triangle data to the vertex buffer.
-        UINT8* pVertexDataBegin;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
-        memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
-        m_vertexBuffer->Unmap(0, nullptr);
+		// Copy the triangle data to the vertex buffer.
+		UINT8* pVertexDataBegin;
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
+		memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
+		m_vertexBuffer->Unmap(0, nullptr);
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = vertexBufferSize;
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = vertexBufferSize;
+	}
 
-    // Note: ComPtr's are CPU objects but this resource needs to stay in scope until
-    // the command list that references it has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resource is not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> textureUploadHeap;
+	// Note: ComPtr's are CPU objects but this resource needs to stay in scope until
+	// the command list that references it has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resource is not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> textureUploadHeap;
 
-    // Create the texture.
-    {
-        // Describe and create a Texture2D.
-        D3D12_RESOURCE_DESC textureDesc = {};
-        textureDesc.MipLevels = 1;
-        textureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        textureDesc.Width = TextureWidth;
-        textureDesc.Height = TextureHeight;
-        textureDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
-        textureDesc.DepthOrArraySize = 1;
-        textureDesc.SampleDesc.Count = 1;
-        textureDesc.SampleDesc.Quality = 0;
-        textureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+	// Create the texture.
+	{
+		// Describe and create a Texture2D.
+		D3D12_RESOURCE_DESC textureDesc = {};
+		textureDesc.MipLevels = 1;
+		textureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+		textureDesc.Width = TextureWidth;
+		textureDesc.Height = TextureHeight;
+		textureDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
+		textureDesc.DepthOrArraySize = 1;
+		textureDesc.SampleDesc.Count = 1;
+		textureDesc.SampleDesc.Quality = 0;
+		textureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &textureDesc,
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_texture)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&textureDesc,
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_texture)));
 
-        const UINT64 uploadBufferSize = GetRequiredIntermediateSize(m_texture.Get(), 0, 1);
+		const UINT64 uploadBufferSize = GetRequiredIntermediateSize(m_texture.Get(), 0, 1);
 
-        // Create the GPU upload buffer.
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&textureUploadHeap)));
+		// Create the GPU upload buffer.
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&textureUploadHeap)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the Texture2D.
-        std::vector<UINT8> texture = GenerateTextureData();
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the Texture2D.
+		std::vector<UINT8> texture = GenerateTextureData();
 
-        D3D12_SUBRESOURCE_DATA textureData = {};
-        textureData.pData = &texture[0];
-        textureData.RowPitch = TextureWidth * TexturePixelSize;
-        textureData.SlicePitch = textureData.RowPitch * TextureHeight;
+		D3D12_SUBRESOURCE_DATA textureData = {};
+		textureData.pData = &texture[0];
+		textureData.RowPitch = TextureWidth * TexturePixelSize;
+		textureData.SlicePitch = textureData.RowPitch * TextureHeight;
 
-        UpdateSubresources(m_commandList.Get(), m_texture.Get(), textureUploadHeap.Get(), 0, 0, 1, &textureData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_texture.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
+		UpdateSubresources(m_commandList.Get(), m_texture.Get(), textureUploadHeap.Get(), 0, 0, 1, &textureData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_texture.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
 
-        // Describe and create a SRV for the texture.
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Format = textureDesc.Format;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = 1;
-        m_device->CreateShaderResourceView(m_texture.Get(), &srvDesc, m_srvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
-    
-    // Close the command list and execute it to begin the initial GPU setup.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+		// Describe and create a SRV for the texture.
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Format = textureDesc.Format;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = 1;
+		m_device->CreateShaderResourceView(m_texture.Get(), &srvDesc, m_srvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
+	
+	// Close the command list and execute it to begin the initial GPU setup.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValue = 1;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValue = 1;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForPreviousFrame();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForPreviousFrame();
+	}
 }
 
 // Generate a simple black and white checkerboard texture.
 std::vector<UINT8> D3D12HelloTexture::GenerateTextureData()
 {
-    const UINT rowPitch = TextureWidth * TexturePixelSize;
-    const UINT cellPitch = rowPitch >> 3;        // The width of a cell in the checkboard texture.
-    const UINT cellHeight = TextureWidth >> 3;    // The height of a cell in the checkerboard texture.
-    const UINT textureSize = rowPitch * TextureHeight;
+	const UINT rowPitch = TextureWidth * TexturePixelSize;
+	const UINT cellPitch = rowPitch >> 3;		// The width of a cell in the checkboard texture.
+	const UINT cellHeight = TextureWidth >> 3;	// The height of a cell in the checkerboard texture.
+	const UINT textureSize = rowPitch * TextureHeight;
 
-    std::vector<UINT8> data(textureSize);
-    UINT8* pData = &data[0];
+	std::vector<UINT8> data(textureSize);
+	UINT8* pData = &data[0];
 
-    for (UINT n = 0; n < textureSize; n += TexturePixelSize)
-    {
-        UINT x = n % rowPitch;
-        UINT y = n / rowPitch;
-        UINT i = x / cellPitch;
-        UINT j = y / cellHeight;
+	for (UINT n = 0; n < textureSize; n += TexturePixelSize)
+	{
+		UINT x = n % rowPitch;
+		UINT y = n / rowPitch;
+		UINT i = x / cellPitch;
+		UINT j = y / cellHeight;
 
-        if (i % 2 == j % 2)
-        {
-            pData[n] = 0x00;        // R
-            pData[n + 1] = 0x00;    // G
-            pData[n + 2] = 0x00;    // B
-            pData[n + 3] = 0xff;    // A
-        }
-        else
-        {
-            pData[n] = 0xff;        // R
-            pData[n + 1] = 0xff;    // G
-            pData[n + 2] = 0xff;    // B
-            pData[n + 3] = 0xff;    // A
-        }
-    }
+		if (i % 2 == j % 2)
+		{
+			pData[n] = 0x00;		// R
+			pData[n + 1] = 0x00;	// G
+			pData[n + 2] = 0x00;	// B
+			pData[n + 3] = 0xff;	// A
+		}
+		else
+		{
+			pData[n] = 0xff;		// R
+			pData[n + 1] = 0xff;	// G
+			pData[n + 2] = 0xff;	// B
+			pData[n + 3] = 0xff;	// A
+		}
+	}
 
-    return data;
+	return data;
 }
 
 // Update frame-based values.
@@ -395,87 +395,87 @@ void D3D12HelloTexture::OnUpdate()
 // Render the scene.
 void D3D12HelloTexture::OnRender()
 {
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+	// Present the frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    WaitForPreviousFrame();
+	WaitForPreviousFrame();
 }
 
 void D3D12HelloTexture::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForPreviousFrame();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForPreviousFrame();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12HelloTexture::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocator->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocator->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
-    m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
+	m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_commandList->SetGraphicsRootDescriptorTable(0, m_srvHeap->GetGPUDescriptorHandleForHeapStart());
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	m_commandList->SetGraphicsRootDescriptorTable(0, m_srvHeap->GetGPUDescriptorHandleForHeapStart());
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
-    m_commandList->DrawInstanced(3, 1, 0, 0);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+	m_commandList->DrawInstanced(3, 1, 0, 0);
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 void D3D12HelloTexture::WaitForPreviousFrame()
 {
-    // WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
-    // This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
-    // sample illustrates how to use fences for efficient resource usage and to
-    // maximize GPU utilization.
+	// WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
+	// This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
+	// sample illustrates how to use fences for efficient resource usage and to
+	// maximize GPU utilization.
 
-    // Signal and increment the fence value.
-    const UINT64 fence = m_fenceValue;
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
-    m_fenceValue++;
+	// Signal and increment the fence value.
+	const UINT64 fence = m_fenceValue;
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
+	m_fenceValue++;
 
-    // Wait until the previous frame is finished.
-    if (m_fence->GetCompletedValue() < fence)
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+	// Wait until the previous frame is finished.
+	if (m_fence->GetCompletedValue() < fence)
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.h
@@ -25,54 +25,54 @@ using Microsoft::WRL::ComPtr;
 class D3D12HelloTexture : public DXSample
 {
 public:
-    D3D12HelloTexture(UINT width, UINT height, std::wstring name);
+	D3D12HelloTexture(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    static const UINT FrameCount = 2;
-    static const UINT TextureWidth = 256;
-    static const UINT TextureHeight = 256;
-    static const UINT TexturePixelSize = 4;    // The number of bytes used to represent a pixel in the texture.
+	static const UINT FrameCount = 2;
+	static const UINT TextureWidth = 256;
+	static const UINT TextureHeight = 256;
+	static const UINT TexturePixelSize = 4;	// The number of bytes used to represent a pixel in the texture.
 
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT2 uv;
-    };
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT2 uv;
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_srvHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    UINT m_rtvDescriptorSize;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_srvHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	UINT m_rtvDescriptorSize;
 
-    // App resources.
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
-    ComPtr<ID3D12Resource> m_texture;
+	// App resources.
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	ComPtr<ID3D12Resource> m_texture;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValue;
+	// Synchronization objects.
+	UINT m_frameIndex;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValue;
 
-    void LoadPipeline();
-    void LoadAssets();
-    std::vector<UINT8> GenerateTextureData();
-    void PopulateCommandList();
-    void WaitForPreviousFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	std::vector<UINT8> GenerateTextureData();
+	void PopulateCommandList();
+	void WaitForPreviousFrame();
 };

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/DXSample.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,58 +34,103 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title + L": " + text;
-    SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
+	std::wstring windowText = m_title + L": " + text;
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/DXSample.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/DXSample.h
@@ -17,42 +17,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/Main.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12HelloTexture sample(1280, 720, L"D3D12 Hello Texture");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12HelloTexture sample(1280, 720, L"D3D12 Hello Texture");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/Win32Application.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/Win32Application.cpp
@@ -16,104 +16,104 @@ HWND Win32Application::m_hwnd = nullptr;
 
 int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
 {
-    // Parse the command line parameters
-    int argc;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    pSample->ParseCommandLineArgs(argv, argc);
-    LocalFree(argv);
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
 
-    // Initialize the window class.
-    WNDCLASSEX windowClass = { 0 };
-    windowClass.cbSize = sizeof(WNDCLASSEX);
-    windowClass.style = CS_HREDRAW | CS_VREDRAW;
-    windowClass.lpfnWndProc = WindowProc;
-    windowClass.hInstance = hInstance;
-    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-    windowClass.lpszClassName = L"DXSampleClass";
-    RegisterClassEx(&windowClass);
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
 
-    RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
-    AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
 
-    // Create the window and store a handle to it.
-    m_hwnd = CreateWindow(
-        windowClass.lpszClassName,
-        pSample->GetTitle(),
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        windowRect.right - windowRect.left,
-        windowRect.bottom - windowRect.top,
-        nullptr,        // We have no parent window.
-        nullptr,        // We aren't using menus.
-        hInstance,
-        pSample);
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
 
-    // Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-    pSample->OnInit();
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
 
-    ShowWindow(m_hwnd, nCmdShow);
+	ShowWindow(m_hwnd, nCmdShow);
 
-    // Main sample loop.
-    MSG msg = {};
-    while (msg.message != WM_QUIT)
-    {
-        // Process any messages in the queue.
-        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
-    }
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
 
-    pSample->OnDestroy();
+	pSample->OnDestroy();
 
-    // Return this part of the WM_QUIT message to Windows.
-    return static_cast<char>(msg.wParam);
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
 }
 
 // Main message handler for the sample.
 LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
-    switch (message)
-    {
-    case WM_CREATE:
-        {
-            // Save the DXSample* passed in to CreateWindow.
-            LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
-            SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
-        }
-        return 0;
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
 
-    case WM_KEYDOWN:
-        if (pSample)
-        {
-            pSample->OnKeyDown(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_KEYUP:
-        if (pSample)
-        {
-            pSample->OnKeyUp(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_PAINT:
-        if (pSample)
-        {
-            pSample->OnUpdate();
-            pSample->OnRender();
-        }
-        return 0;
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
 
-    case WM_DESTROY:
-        PostQuitMessage(0);
-        return 0;
-    }
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
 
-    // Handle any messages the switch statement didn't.
-    return DefWindowProc(hWnd, message, wParam, lParam);
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/Win32Application.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/Win32Application.h
@@ -18,12 +18,12 @@ class DXSample;
 class Win32Application
 {
 public:
-    static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
-    static HWND GetHwnd() { return m_hwnd; }
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
 
 protected:
-    static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
-    static HWND m_hwnd;
+	static HWND m_hwnd;
 };

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/d3dx12.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/shaders.hlsl
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/shaders.hlsl
@@ -11,8 +11,8 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 Texture2D g_texture : register(t0);
@@ -20,15 +20,15 @@ SamplerState g_sampler : register(s0);
 
 PSInput VSMain(float4 position : POSITION, float4 uv : TEXCOORD)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.uv = uv;
+	result.position = position;
+	result.uv = uv;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return g_texture.Sample(g_sampler, input.uv);
+	return g_texture.Sample(g_sampler, input.uv);
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.cpp
@@ -13,242 +13,242 @@
 #include "D3D12HelloTriangle.h"
 
 D3D12HelloTriangle::D3D12HelloTriangle(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0)
 {
 }
 
 void D3D12HelloTriangle::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12HelloTriangle::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    // This sample does not support fullscreen transitions.
-    ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
+	// This sample does not support fullscreen transitions.
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
-        }
-    }
+		// Create a RTV for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
+		}
+	}
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
 }
 
 // Load the sample assets.
 void D3D12HelloTriangle::LoadAssets()
 {
-    // Create an empty root signature.
-    {
-        CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+	// Create an empty root signature.
+	{
+		CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Describe and create the graphics pipeline state object (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.SampleDesc.Count = 1;
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-    }
+		// Describe and create the graphics pipeline state object (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.SampleDesc.Count = 1;
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
 
-    // Command lists are created in the recording state, but there is nothing
-    // to record yet. The main loop expects it to be closed, so close it now.
-    ThrowIfFailed(m_commandList->Close());
+	// Command lists are created in the recording state, but there is nothing
+	// to record yet. The main loop expects it to be closed, so close it now.
+	ThrowIfFailed(m_commandList->Close());
 
-    // Create the vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        Vertex triangleVertices[] =
-        {
-            { { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
-            { { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
-            { { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
-        };
+	// Create the vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		Vertex triangleVertices[] =
+		{
+			{ { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
+			{ { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
+			{ { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
+		};
 
-        const UINT vertexBufferSize = sizeof(triangleVertices);
+		const UINT vertexBufferSize = sizeof(triangleVertices);
 
-        // Note: using upload heaps to transfer static data like vert buffers is not 
-        // recommended. Every time the GPU needs it, the upload heap will be marshalled 
-        // over. Please read up on Default Heap usage. An upload heap is used here for 
-        // code simplicity and because there are very few verts to actually transfer.
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		// Note: using upload heaps to transfer static data like vert buffers is not 
+		// recommended. Every time the GPU needs it, the upload heap will be marshalled 
+		// over. Please read up on Default Heap usage. An upload heap is used here for 
+		// code simplicity and because there are very few verts to actually transfer.
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        // Copy the triangle data to the vertex buffer.
-        UINT8* pVertexDataBegin;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
-        memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
-        m_vertexBuffer->Unmap(0, nullptr);
+		// Copy the triangle data to the vertex buffer.
+		UINT8* pVertexDataBegin;
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
+		memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
+		m_vertexBuffer->Unmap(0, nullptr);
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = vertexBufferSize;
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = vertexBufferSize;
+	}
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValue = 1;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValue = 1;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForPreviousFrame();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForPreviousFrame();
+	}
 }
 
 // Update frame-based values.
@@ -259,82 +259,82 @@ void D3D12HelloTriangle::OnUpdate()
 // Render the scene.
 void D3D12HelloTriangle::OnRender()
 {
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+	// Present the frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    WaitForPreviousFrame();
+	WaitForPreviousFrame();
 }
 
 void D3D12HelloTriangle::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForPreviousFrame();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForPreviousFrame();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12HelloTriangle::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocator->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocator->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
-    m_commandList->DrawInstanced(3, 1, 0, 0);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+	m_commandList->DrawInstanced(3, 1, 0, 0);
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 void D3D12HelloTriangle::WaitForPreviousFrame()
 {
-    // WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
-    // This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
-    // sample illustrates how to use fences for efficient resource usage and to
-    // maximize GPU utilization.
+	// WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
+	// This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
+	// sample illustrates how to use fences for efficient resource usage and to
+	// maximize GPU utilization.
 
-    // Signal and increment the fence value.
-    const UINT64 fence = m_fenceValue;
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
-    m_fenceValue++;
+	// Signal and increment the fence value.
+	const UINT64 fence = m_fenceValue;
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
+	m_fenceValue++;
 
-    // Wait until the previous frame is finished.
-    if (m_fence->GetCompletedValue() < fence)
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+	// Wait until the previous frame is finished.
+	if (m_fence->GetCompletedValue() < fence)
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.h
@@ -25,48 +25,48 @@ using Microsoft::WRL::ComPtr;
 class D3D12HelloTriangle : public DXSample
 {
 public:
-    D3D12HelloTriangle(UINT width, UINT height, std::wstring name);
+	D3D12HelloTriangle(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    static const UINT FrameCount = 2;
+	static const UINT FrameCount = 2;
 
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT4 color;
-    };
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT4 color;
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    UINT m_rtvDescriptorSize;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	UINT m_rtvDescriptorSize;
 
-    // App resources.
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	// App resources.
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValue;
+	// Synchronization objects.
+	UINT m_frameIndex;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValue;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void PopulateCommandList();
-    void WaitForPreviousFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	void PopulateCommandList();
+	void WaitForPreviousFrame();
 };

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/DXSample.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,58 +34,103 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title + L": " + text;
-    SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
+	std::wstring windowText = m_title + L": " + text;
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/DXSample.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/DXSample.h
@@ -17,42 +17,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/Main.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12HelloTriangle sample(1280, 720, L"D3D12 Hello Triangle");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12HelloTriangle sample(1280, 720, L"D3D12 Hello Triangle");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/Win32Application.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/Win32Application.cpp
@@ -16,104 +16,104 @@ HWND Win32Application::m_hwnd = nullptr;
 
 int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
 {
-    // Parse the command line parameters
-    int argc;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    pSample->ParseCommandLineArgs(argv, argc);
-    LocalFree(argv);
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
 
-    // Initialize the window class.
-    WNDCLASSEX windowClass = { 0 };
-    windowClass.cbSize = sizeof(WNDCLASSEX);
-    windowClass.style = CS_HREDRAW | CS_VREDRAW;
-    windowClass.lpfnWndProc = WindowProc;
-    windowClass.hInstance = hInstance;
-    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-    windowClass.lpszClassName = L"DXSampleClass";
-    RegisterClassEx(&windowClass);
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
 
-    RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
-    AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
 
-    // Create the window and store a handle to it.
-    m_hwnd = CreateWindow(
-        windowClass.lpszClassName,
-        pSample->GetTitle(),
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        windowRect.right - windowRect.left,
-        windowRect.bottom - windowRect.top,
-        nullptr,        // We have no parent window.
-        nullptr,        // We aren't using menus.
-        hInstance,
-        pSample);
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
 
-    // Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-    pSample->OnInit();
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
 
-    ShowWindow(m_hwnd, nCmdShow);
+	ShowWindow(m_hwnd, nCmdShow);
 
-    // Main sample loop.
-    MSG msg = {};
-    while (msg.message != WM_QUIT)
-    {
-        // Process any messages in the queue.
-        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
-    }
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
 
-    pSample->OnDestroy();
+	pSample->OnDestroy();
 
-    // Return this part of the WM_QUIT message to Windows.
-    return static_cast<char>(msg.wParam);
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
 }
 
 // Main message handler for the sample.
 LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
-    switch (message)
-    {
-    case WM_CREATE:
-        {
-            // Save the DXSample* passed in to CreateWindow.
-            LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
-            SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
-        }
-        return 0;
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
 
-    case WM_KEYDOWN:
-        if (pSample)
-        {
-            pSample->OnKeyDown(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_KEYUP:
-        if (pSample)
-        {
-            pSample->OnKeyUp(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_PAINT:
-        if (pSample)
-        {
-            pSample->OnUpdate();
-            pSample->OnRender();
-        }
-        return 0;
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
 
-    case WM_DESTROY:
-        PostQuitMessage(0);
-        return 0;
-    }
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
 
-    // Handle any messages the switch statement didn't.
-    return DefWindowProc(hWnd, message, wParam, lParam);
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/Win32Application.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/Win32Application.h
@@ -18,12 +18,12 @@ class DXSample;
 class Win32Application
 {
 public:
-    static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
-    static HWND GetHwnd() { return m_hwnd; }
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
 
 protected:
-    static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
-    static HWND m_hwnd;
+	static HWND m_hwnd;
 };

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/d3dx12.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/shaders.hlsl
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/shaders.hlsl
@@ -11,21 +11,21 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VSMain(float4 position : POSITION, float4 color : COLOR)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.color = color;
+	result.position = position;
+	result.color = color;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.cpp
@@ -13,147 +13,147 @@
 #include "D3D12HelloWindow.h"
 
 D3D12HelloWindow::D3D12HelloWindow(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_rtvDescriptorSize(0)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_rtvDescriptorSize(0)
 {
 }
 
 void D3D12HelloWindow::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12HelloWindow::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    // This sample does not support fullscreen transitions.
-    ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
+	// This sample does not support fullscreen transitions.
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
-        }
-    }
+		// Create a RTV for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
+		}
+	}
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
 }
 
 // Load the sample assets.
 void D3D12HelloWindow::LoadAssets()
 {
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), nullptr, IID_PPV_ARGS(&m_commandList)));
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), nullptr, IID_PPV_ARGS(&m_commandList)));
 
-    // Command lists are created in the recording state, but there is nothing
-    // to record yet. The main loop expects it to be closed, so close it now.
-    ThrowIfFailed(m_commandList->Close());
+	// Command lists are created in the recording state, but there is nothing
+	// to record yet. The main loop expects it to be closed, so close it now.
+	ThrowIfFailed(m_commandList->Close());
 
-    // Create synchronization objects.
-    {
-        ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValue = 1;
+	// Create synchronization objects.
+	{
+		ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValue = 1;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
-    }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
+	}
 }
 
 // Update frame-based values.
@@ -164,73 +164,73 @@ void D3D12HelloWindow::OnUpdate()
 // Render the scene.
 void D3D12HelloWindow::OnRender()
 {
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+	// Present the frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    WaitForPreviousFrame();
+	WaitForPreviousFrame();
 }
 
 void D3D12HelloWindow::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForPreviousFrame();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForPreviousFrame();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12HelloWindow::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocator->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocator->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()));
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 void D3D12HelloWindow::WaitForPreviousFrame()
 {
-    // WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
-    // This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
-    // sample illustrates how to use fences for efficient resource usage and to
-    // maximize GPU utilization.
+	// WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
+	// This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
+	// sample illustrates how to use fences for efficient resource usage and to
+	// maximize GPU utilization.
 
-    // Signal and increment the fence value.
-    const UINT64 fence = m_fenceValue;
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
-    m_fenceValue++;
+	// Signal and increment the fence value.
+	const UINT64 fence = m_fenceValue;
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
+	m_fenceValue++;
 
-    // Wait until the previous frame is finished.
-    if (m_fence->GetCompletedValue() < fence)
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+	// Wait until the previous frame is finished.
+	if (m_fence->GetCompletedValue() < fence)
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.h
@@ -23,35 +23,35 @@ using Microsoft::WRL::ComPtr;
 class D3D12HelloWindow : public DXSample
 {
 public:
-    D3D12HelloWindow(UINT width, UINT height, std::wstring name);
+	D3D12HelloWindow(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    static const UINT FrameCount = 2;
+	static const UINT FrameCount = 2;
 
-    // Pipeline objects.
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    UINT m_rtvDescriptorSize;
+	// Pipeline objects.
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	UINT m_rtvDescriptorSize;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValue;
+	// Synchronization objects.
+	UINT m_frameIndex;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValue;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void PopulateCommandList();
-    void WaitForPreviousFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	void PopulateCommandList();
+	void WaitForPreviousFrame();
 };

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/DXSample.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,58 +34,103 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title + L": " + text;
-    SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
+	std::wstring windowText = m_title + L": " + text;
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/DXSample.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/DXSample.h
@@ -17,42 +17,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/Main.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12HelloWindow sample(1280, 720, L"D3D12 Hello Window");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12HelloWindow sample(1280, 720, L"D3D12 Hello Window");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/Win32Application.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/Win32Application.cpp
@@ -16,104 +16,104 @@ HWND Win32Application::m_hwnd = nullptr;
 
 int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
 {
-    // Parse the command line parameters
-    int argc;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    pSample->ParseCommandLineArgs(argv, argc);
-    LocalFree(argv);
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
 
-    // Initialize the window class.
-    WNDCLASSEX windowClass = { 0 };
-    windowClass.cbSize = sizeof(WNDCLASSEX);
-    windowClass.style = CS_HREDRAW | CS_VREDRAW;
-    windowClass.lpfnWndProc = WindowProc;
-    windowClass.hInstance = hInstance;
-    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-    windowClass.lpszClassName = L"DXSampleClass";
-    RegisterClassEx(&windowClass);
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
 
-    RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
-    AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
 
-    // Create the window and store a handle to it.
-    m_hwnd = CreateWindow(
-        windowClass.lpszClassName,
-        pSample->GetTitle(),
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        windowRect.right - windowRect.left,
-        windowRect.bottom - windowRect.top,
-        nullptr,        // We have no parent window.
-        nullptr,        // We aren't using menus.
-        hInstance,
-        pSample);
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
 
-    // Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-    pSample->OnInit();
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
 
-    ShowWindow(m_hwnd, nCmdShow);
+	ShowWindow(m_hwnd, nCmdShow);
 
-    // Main sample loop.
-    MSG msg = {};
-    while (msg.message != WM_QUIT)
-    {
-        // Process any messages in the queue.
-        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
-    }
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
 
-    pSample->OnDestroy();
+	pSample->OnDestroy();
 
-    // Return this part of the WM_QUIT message to Windows.
-    return static_cast<char>(msg.wParam);
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
 }
 
 // Main message handler for the sample.
 LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
-    switch (message)
-    {
-    case WM_CREATE:
-        {
-            // Save the DXSample* passed in to CreateWindow.
-            LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
-            SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
-        }
-        return 0;
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
 
-    case WM_KEYDOWN:
-        if (pSample)
-        {
-            pSample->OnKeyDown(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_KEYUP:
-        if (pSample)
-        {
-            pSample->OnKeyUp(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_PAINT:
-        if (pSample)
-        {
-            pSample->OnUpdate();
-            pSample->OnRender();
-        }
-        return 0;
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
 
-    case WM_DESTROY:
-        PostQuitMessage(0);
-        return 0;
-    }
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
 
-    // Handle any messages the switch statement didn't.
-    return DefWindowProc(hWnd, message, wParam, lParam);
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/Win32Application.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/Win32Application.h
@@ -18,12 +18,12 @@ class DXSample;
 class Win32Application
 {
 public:
-    static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
-    static HWND GetHwnd() { return m_hwnd; }
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
 
 protected:
-    static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
-    static HWND m_hwnd;
+	static HWND m_hwnd;
 };

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/d3dx12.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/D3D12HeterogeneousMultiadapter.cpp
+++ b/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/D3D12HeterogeneousMultiadapter.cpp
@@ -17,1241 +17,1310 @@ const float D3D12HeterogeneousMultiadapter::TriangleDepth = 1.0f;
 const float D3D12HeterogeneousMultiadapter::ClearColor[4] = { 0.0f, 0.2f, 0.3f, 1.0f };
 
 D3D12HeterogeneousMultiadapter::D3D12HeterogeneousMultiadapter(int width, int height, LPCWSTR name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_triangleCount(MaxTriangleCount / 2),
-    m_psLoopCount(0),
-    m_blurPSLoopCount(0),
-    m_currentTimesIndex(0),
-    m_drawTimeMovingAverage(0),
-    m_blurTimeMovingAverage(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_currentPresentFenceValue(1),
-    m_currentRenderFenceValue(1),
-    m_currentCrossAdapterFenceValue(1),
-    m_workloadConstantBufferData(),
-    m_blurWorkloadConstantBufferData(),
-    m_crossAdapterTextureSupport(false),
-    m_rtvDescriptorSizes{},
-    m_srvDescriptorSizes{},
-    m_drawTimes{},
-    m_blurTimes{},
-    m_frameFenceValues{}
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_triangleCount(MaxTriangleCount / 2),
+	m_psLoopCount(0),
+	m_blurPSLoopCount(0),
+	m_currentTimesIndex(0),
+	m_drawTimeMovingAverage(0),
+	m_blurTimeMovingAverage(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_currentPresentFenceValue(1),
+	m_currentRenderFenceValue(1),
+	m_currentCrossAdapterFenceValue(1),
+	m_workloadConstantBufferData(),
+	m_blurWorkloadConstantBufferData(),
+	m_crossAdapterTextureSupport(false),
+	m_rtvDescriptorSizes{},
+	m_srvDescriptorSizes{},
+	m_drawTimes{},
+	m_blurTimes{},
+	m_frameFenceValues{}
 {
-    m_constantBufferData.resize(MaxTriangleCount);
+	m_constantBufferData.resize(MaxTriangleCount);
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
 }
 
 void D3D12HeterogeneousMultiadapter::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
-    UpdateWindowTitle();
+	LoadPipeline();
+	LoadAssets();
+	UpdateWindowTitle();
 }
 
 // Enumerate adapters to use for heterogeneous multiadaper.
 _Use_decl_annotations_
 HRESULT D3D12HeterogeneousMultiadapter::GetHardwareAdapters(IDXGIFactory2* pFactory, IDXGIAdapter1** ppPrimaryAdapter, IDXGIAdapter1** ppSecondaryAdapter)
 {
-    if (pFactory == nullptr)
-    {
-        return E_POINTER;
-    }
+	if (pFactory == nullptr)
+	{
+		return E_POINTER;
+	}
 
-    // Adapter 0 is the adapter that Presents frames to the display. It is assigned as
-    // the "secondary" adapter because it is the adapter that performs the second set
-    // of operations (the blur effect) in this sample.
-    // Adapter 1 is an additional GPU that the app can take advantage of, but it does
-    // not own the presentation step. It is assigned as the "primary" adapter because
-    // it is the adapter that performs the first set of operations (rendering triangles)
-    // in this sample.
+	// Adapter 0 is the adapter that Presents frames to the display. It is assigned as
+	// the "secondary" adapter because it is the adapter that performs the second set
+	// of operations (the blur effect) in this sample.
+	// Adapter 1 is an additional GPU that the app can take advantage of, but it does
+	// not own the presentation step. It is assigned as the "primary" adapter because
+	// it is the adapter that performs the first set of operations (rendering triangles)
+	// in this sample.
 
     ThrowIfFailed(pFactory->EnumAdapters1(0, ppSecondaryAdapter));
-    ThrowIfFailed(pFactory->EnumAdapters1(1, ppPrimaryAdapter));
+    DXGI_ADAPTER_DESC1 descSecondary;
+    ThrowIfFailed((*ppSecondaryAdapter)->GetDesc1(&descSecondary));
 
-    return S_OK;
+    *ppPrimaryAdapter = nullptr;
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(adapterIndex, DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE, IID_PPV_ARGS(&adapter)); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 descPrimary;
+            ThrowIfFailed(adapter->GetDesc1(&descPrimary));
+            if (descPrimary.AdapterLuid.HighPart != descSecondary.AdapterLuid.HighPart || descPrimary.AdapterLuid.LowPart != descSecondary.AdapterLuid.LowPart)
+            {
+                break;
+            }
+        }
+        *ppPrimaryAdapter = adapter.Detach();
+    }
+    else
+    {
+        ThrowIfFailed(pFactory->EnumAdapters1(1, ppPrimaryAdapter));
+    }
+	return S_OK;
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12HeterogeneousMultiadapter::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    ComPtr<IDXGIAdapter1> primaryAdapter;
-    ComPtr<IDXGIAdapter1> secondaryAdapter;
-    if (m_useWarpDevice)
-    {
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&primaryAdapter)));
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&secondaryAdapter)));
-    }
-    else
-    {
-        ThrowIfFailed(GetHardwareAdapters(factory.Get(), &primaryAdapter, &secondaryAdapter));
-    }
+	ComPtr<IDXGIAdapter1> primaryAdapter;
+	ComPtr<IDXGIAdapter1> secondaryAdapter;
+	if (m_useWarpDevice)
+	{
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&primaryAdapter)));
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&secondaryAdapter)));
+	}
+	else
+	{
+		ThrowIfFailed(GetHardwareAdapters(factory.Get(), &primaryAdapter, &secondaryAdapter));
+	}
 
-    DXGI_ADAPTER_DESC1 desc;
-    primaryAdapter->GetDesc1(&desc);
-    if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
-    {
-        // There is actually only one physical GPU on the system.
-        // Reduce the starting triangle count to make the sample run better.
-        m_triangleCount = MaxTriangleCount / 50;
-    }
+	DXGI_ADAPTER_DESC1 desc;
+	primaryAdapter->GetDesc1(&desc);
+	if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+	{
+		// There is actually only one physical GPU on the system.
+		// Reduce the starting triangle count to make the sample run better.
+		m_triangleCount = MaxTriangleCount / 50;
+	}
 
-    IDXGIAdapter1* ppAdapters[] = { primaryAdapter.Get(), secondaryAdapter.Get() };
-    for (UINT i = 0; i < GraphicsAdaptersCount; i++)
-    {
-        ThrowIfFailed(D3D12CreateDevice(ppAdapters[i], D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&m_devices[i])));
-        ThrowIfFailed(ppAdapters[i]->GetDesc1(&m_adapterDescs[i]));
-    }
+	IDXGIAdapter1* ppAdapters[] = { primaryAdapter.Get(), secondaryAdapter.Get() };
+	for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+	{
+		ThrowIfFailed(D3D12CreateDevice(ppAdapters[i], D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&m_devices[i])));
+		ThrowIfFailed(ppAdapters[i]->GetDesc1(&m_adapterDescs[i]));
+	}
 
-    // Describe and create the command queues and get their timestamp frequency.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queues and get their timestamp frequency.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    for (UINT i = 0; i < GraphicsAdaptersCount; i++)
-    {
-        ThrowIfFailed(m_devices[i]->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_directCommandQueues[i])));
-        ThrowIfFailed(m_directCommandQueues[i]->GetTimestampFrequency(&m_directCommandQueueTimestampFrequencies[i]));
-    }
+	for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+	{
+		ThrowIfFailed(m_devices[i]->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_directCommandQueues[i])));
+		ThrowIfFailed(m_directCommandQueues[i]->GetTimestampFrequency(&m_directCommandQueueTimestampFrequencies[i]));
+	}
 
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_COPY;
-    ThrowIfFailed(m_devices[Primary]->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_copyCommandQueue)));
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_COPY;
+	ThrowIfFailed(m_devices[Primary]->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_copyCommandQueue)));
 
-    // Describe and create the swap chain on the secondary device because that's where we present from.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain on the secondary device because that's where we present from.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_directCommandQueues[Secondary].Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_directCommandQueues[Secondary].Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    // This sample does not support fullscreen transitions.
-    ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
+	// This sample does not support fullscreen transitions.
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heaps.
-        for (UINT i = 0; i < GraphicsAdaptersCount; i++)
-        {
-            D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-            rtvHeapDesc.NumDescriptors = FrameCount;
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heaps.
+		for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+		{
+			D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+			rtvHeapDesc.NumDescriptors = FrameCount;
 
-            if (i == Secondary)
-            {
-                // Add space for the intermediate render target.
-                rtvHeapDesc.NumDescriptors++;
-            }
+			if (i == Secondary)
+			{
+				// Add space for the intermediate render target.
+				rtvHeapDesc.NumDescriptors++;
+			}
 
-            rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-            rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-            ThrowIfFailed(m_devices[i]->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeaps[i])));
-        }
+			rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+			rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+			ThrowIfFailed(m_devices[i]->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeaps[i])));
+		}
 
-        // Describe and create a depth stencil view (DSV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
-        dsvHeapDesc.NumDescriptors = 1;
-        dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-        dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_devices[Primary]->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
+		// Describe and create a depth stencil view (DSV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
+		dsvHeapDesc.NumDescriptors = 1;
+		dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+		dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_devices[Primary]->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
 
-        // Describe and create a shader resource view (SRV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvSrvUavHeapDesc = {};
-        cbvSrvUavHeapDesc.NumDescriptors = FrameCount + 1;    // +1 for the intermediate blur render target.
-        cbvSrvUavHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        cbvSrvUavHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_devices[Secondary]->CreateDescriptorHeap(&cbvSrvUavHeapDesc, IID_PPV_ARGS(&m_cbvSrvUavHeap)));
+		// Describe and create a shader resource view (SRV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvSrvUavHeapDesc = {};
+		cbvSrvUavHeapDesc.NumDescriptors = FrameCount + 1;	// +1 for the intermediate blur render target.
+		cbvSrvUavHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		cbvSrvUavHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_devices[Secondary]->CreateDescriptorHeap(&cbvSrvUavHeapDesc, IID_PPV_ARGS(&m_cbvSrvUavHeap)));
 
-        for (UINT i = 0; i < GraphicsAdaptersCount; i++)
-        {
-            m_rtvDescriptorSizes[i] = m_devices[i]->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-            m_srvDescriptorSizes[i] = m_devices[i]->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-        }
-    }
+		for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+		{
+			m_rtvDescriptorSizes[i] = m_devices[i]->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+			m_srvDescriptorSizes[i] = m_devices[i]->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+		}
+	}
 
-    // Create query heaps and result buffers.
-    {
-        // Two timestamps for each frame.
-        const UINT resultCount = 2 * FrameCount;
-        const UINT resultBufferSize = resultCount * sizeof(UINT64);
+	// Create query heaps and result buffers.
+	{
+		// Two timestamps for each frame.
+		const UINT resultCount = 2 * FrameCount;
+		const UINT resultBufferSize = resultCount * sizeof(UINT64);
 
-        D3D12_QUERY_HEAP_DESC timestampHeapDesc = {};
-        timestampHeapDesc.Type = D3D12_QUERY_HEAP_TYPE_TIMESTAMP;
-        timestampHeapDesc.Count = resultCount;
+		D3D12_QUERY_HEAP_DESC timestampHeapDesc = {};
+		timestampHeapDesc.Type = D3D12_QUERY_HEAP_TYPE_TIMESTAMP;
+		timestampHeapDesc.Count = resultCount;
 
-        for (UINT i = 0; i < GraphicsAdaptersCount; i++)
-        {
-            ThrowIfFailed(m_devices[i]->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK),
-                D3D12_HEAP_FLAG_NONE,
-                &CD3DX12_RESOURCE_DESC::Buffer(resultBufferSize),
-                D3D12_RESOURCE_STATE_COPY_DEST,
-                nullptr,
-                IID_PPV_ARGS(&m_timestampResultBuffers[i])));
+		for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+		{
+			ThrowIfFailed(m_devices[i]->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK),
+				D3D12_HEAP_FLAG_NONE,
+				&CD3DX12_RESOURCE_DESC::Buffer(resultBufferSize),
+				D3D12_RESOURCE_STATE_COPY_DEST,
+				nullptr,
+				IID_PPV_ARGS(&m_timestampResultBuffers[i])));
 
-            ThrowIfFailed(m_devices[i]->CreateQueryHeap(&timestampHeapDesc, IID_PPV_ARGS(&m_timestampQueryHeaps[i])));
-        }
-    }
+			ThrowIfFailed(m_devices[i]->CreateQueryHeap(&timestampHeapDesc, IID_PPV_ARGS(&m_timestampQueryHeaps[i])));
+		}
+	}
 
-    // Create frame resources.
-    {
-        const CD3DX12_CLEAR_VALUE clearValue(swapChainDesc.Format, ClearColor);
-        const CD3DX12_RESOURCE_DESC renderTargetDesc = CD3DX12_RESOURCE_DESC::Tex2D(
-            swapChainDesc.Format,
-            swapChainDesc.Width,
-            swapChainDesc.Height,
-            1u, 1u,
-            swapChainDesc.SampleDesc.Count,
-            swapChainDesc.SampleDesc.Quality,
-            D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET,
-            D3D12_TEXTURE_LAYOUT_UNKNOWN, 0u);
+	// Create frame resources.
+	{
+		const CD3DX12_CLEAR_VALUE clearValue(swapChainDesc.Format, ClearColor);
+		const CD3DX12_RESOURCE_DESC renderTargetDesc = CD3DX12_RESOURCE_DESC::Tex2D(
+			swapChainDesc.Format,
+			swapChainDesc.Width,
+			swapChainDesc.Height,
+			1u, 1u,
+			swapChainDesc.SampleDesc.Count,
+			swapChainDesc.SampleDesc.Quality,
+			D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET,
+			D3D12_TEXTURE_LAYOUT_UNKNOWN, 0u);
 
-        for (UINT i = 0; i < GraphicsAdaptersCount; i++)
-        {
-            CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeaps[i]->GetCPUDescriptorHandleForHeapStart());
+		for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+		{
+			CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeaps[i]->GetCPUDescriptorHandleForHeapStart());
 
-            // Create a RTV and a command allocator for each frame.
-            for (UINT n = 0; n < FrameCount; n++)
-            {
-                if (i == Secondary)
-                {
-                    ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[i][n])));
-                }
-                else
-                {
-                    ThrowIfFailed(m_devices[i]->CreateCommittedResource(
-                        &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-                        D3D12_HEAP_FLAG_NONE,
-                        &renderTargetDesc,
-                        D3D12_RESOURCE_STATE_COMMON,
-                        &clearValue,
-                        IID_PPV_ARGS(&m_renderTargets[i][n])));
-                }
-                
-                m_devices[i]->CreateRenderTargetView(m_renderTargets[i][n].Get(), nullptr, rtvHandle);
-                rtvHandle.Offset(1, m_rtvDescriptorSizes[i]);
+			// Create a RTV and a command allocator for each frame.
+			for (UINT n = 0; n < FrameCount; n++)
+			{
+				if (i == Secondary)
+				{
+					ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[i][n])));
+				}
+				else
+				{
+					ThrowIfFailed(m_devices[i]->CreateCommittedResource(
+						&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+						D3D12_HEAP_FLAG_NONE,
+						&renderTargetDesc,
+						D3D12_RESOURCE_STATE_COMMON,
+						&clearValue,
+						IID_PPV_ARGS(&m_renderTargets[i][n])));
+				}
+				
+				m_devices[i]->CreateRenderTargetView(m_renderTargets[i][n].Get(), nullptr, rtvHandle);
+				rtvHandle.Offset(1, m_rtvDescriptorSizes[i]);
 
-                ThrowIfFailed(m_devices[i]->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_directCommandAllocators[i][n])));
+				ThrowIfFailed(m_devices[i]->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_directCommandAllocators[i][n])));
 
-                if (i == Primary)
-                {
-                    ThrowIfFailed(m_devices[i]->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_COPY, IID_PPV_ARGS(&m_copyCommandAllocators[n])));
-                }
-            }
-        }
+				if (i == Primary)
+				{
+					ThrowIfFailed(m_devices[i]->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_COPY, IID_PPV_ARGS(&m_copyCommandAllocators[n])));
+				}
+			}
+		}
 
-        // Create cross-adapter shared resources on the primary adapter, and open the shared handles on the secondary adapter.
-        {
-            // Check whether shared row-major textures can be directly sampled by the
-            // secondary adapter. Support of this feature (or the lack thereof) will
-            // determine our sharing strategy for the resource in question.
-            D3D12_FEATURE_DATA_D3D12_OPTIONS options = {};
-            ThrowIfFailed(m_devices[Secondary]->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, reinterpret_cast<void*>(&options), sizeof(options)));
-            m_crossAdapterTextureSupport = options.CrossAdapterRowMajorTextureSupported;
+		// Create cross-adapter shared resources on the primary adapter, and open the shared handles on the secondary adapter.
+		{
+			// Check whether shared row-major textures can be directly sampled by the
+			// secondary adapter. Support of this feature (or the lack thereof) will
+			// determine our sharing strategy for the resource in question.
+			D3D12_FEATURE_DATA_D3D12_OPTIONS options = {};
+			ThrowIfFailed(m_devices[Secondary]->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, reinterpret_cast<void*>(&options), sizeof(options)));
+			m_crossAdapterTextureSupport = options.CrossAdapterRowMajorTextureSupported;
 
-            UINT64 textureSize = 0;
-            D3D12_RESOURCE_DESC crossAdapterDesc;
+			UINT64 textureSize = 0;
+			D3D12_RESOURCE_DESC crossAdapterDesc;
 
-            if (m_crossAdapterTextureSupport)
-            {
-                // If cross-adapter row-major textures are supported by the adapter,
-                // then they can be sampled directly.
-                crossAdapterDesc = renderTargetDesc;
-                crossAdapterDesc.Flags = D3D12_RESOURCE_FLAG_ALLOW_CROSS_ADAPTER;
-                crossAdapterDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+			if (m_crossAdapterTextureSupport)
+			{
+				// If cross-adapter row-major textures are supported by the adapter,
+				// then they can be sampled directly.
+				crossAdapterDesc = renderTargetDesc;
+				crossAdapterDesc.Flags = D3D12_RESOURCE_FLAG_ALLOW_CROSS_ADAPTER;
+				crossAdapterDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
 
-                D3D12_RESOURCE_ALLOCATION_INFO textureInfo = m_devices[Primary]->GetResourceAllocationInfo(0, 1, &crossAdapterDesc);
-                textureSize = textureInfo.SizeInBytes;
-            }
-            else
-            {
-                // If cross-adapter row-major textures are not supported by the adapter,
-                // then they will be shared as buffers and then copied to a destination
-                // texture on the secondary adapter.
+				D3D12_RESOURCE_ALLOCATION_INFO textureInfo = m_devices[Primary]->GetResourceAllocationInfo(0, 1, &crossAdapterDesc);
+				textureSize = textureInfo.SizeInBytes;
+			}
+			else
+			{
+				// If cross-adapter row-major textures are not supported by the adapter,
+				// then they will be shared as buffers and then copied to a destination
+				// texture on the secondary adapter.
 
-                D3D12_PLACED_SUBRESOURCE_FOOTPRINT layout;
-                m_devices[Primary]->GetCopyableFootprints(&renderTargetDesc, 0, 1, 0, &layout, nullptr, nullptr, nullptr);
-                textureSize = Align(layout.Footprint.RowPitch * layout.Footprint.Height);
+				D3D12_PLACED_SUBRESOURCE_FOOTPRINT layout;
+				m_devices[Primary]->GetCopyableFootprints(&renderTargetDesc, 0, 1, 0, &layout, nullptr, nullptr, nullptr);
+				textureSize = Align(layout.Footprint.RowPitch * layout.Footprint.Height);
 
-                // Create a buffer with the same layout as the render target texture.
-                crossAdapterDesc = CD3DX12_RESOURCE_DESC::Buffer(textureSize, D3D12_RESOURCE_FLAG_ALLOW_CROSS_ADAPTER);
-            }
+				// Create a buffer with the same layout as the render target texture.
+				crossAdapterDesc = CD3DX12_RESOURCE_DESC::Buffer(textureSize, D3D12_RESOURCE_FLAG_ALLOW_CROSS_ADAPTER);
+			}
 
-            // Create a heap that will be shared by both adapters.
-            CD3DX12_HEAP_DESC heapDesc(
-                textureSize * FrameCount,
-                D3D12_HEAP_TYPE_DEFAULT,
-                0,
-                D3D12_HEAP_FLAG_SHARED | D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER);
+			// Create a heap that will be shared by both adapters.
+			CD3DX12_HEAP_DESC heapDesc(
+				textureSize * FrameCount,
+				D3D12_HEAP_TYPE_DEFAULT,
+				0,
+				D3D12_HEAP_FLAG_SHARED | D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER);
 
-            ThrowIfFailed(m_devices[Primary]->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_crossAdapterResourceHeaps[Primary])));
+			ThrowIfFailed(m_devices[Primary]->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_crossAdapterResourceHeaps[Primary])));
 
-            HANDLE heapHandle = nullptr;
-            ThrowIfFailed(m_devices[Primary]->CreateSharedHandle(
-                m_crossAdapterResourceHeaps[Primary].Get(),
-                nullptr,
-                GENERIC_ALL,
-                nullptr,
-                &heapHandle));
+			HANDLE heapHandle = nullptr;
+			ThrowIfFailed(m_devices[Primary]->CreateSharedHandle(
+				m_crossAdapterResourceHeaps[Primary].Get(),
+				nullptr,
+				GENERIC_ALL,
+				nullptr,
+				&heapHandle));
 
-            HRESULT openSharedHandleResult = m_devices[Secondary]->OpenSharedHandle(heapHandle, IID_PPV_ARGS(&m_crossAdapterResourceHeaps[Secondary]));
+			HRESULT openSharedHandleResult = m_devices[Secondary]->OpenSharedHandle(heapHandle, IID_PPV_ARGS(&m_crossAdapterResourceHeaps[Secondary]));
 
-            // We can close the handle after opening the cross-adapter shared resource.
-            CloseHandle(heapHandle);
+			// We can close the handle after opening the cross-adapter shared resource.
+			CloseHandle(heapHandle);
 
-            ThrowIfFailed(openSharedHandleResult);
+			ThrowIfFailed(openSharedHandleResult);
 
-            // Create placed resources for each frame per adapter in the shared heap.
-            for (UINT n = 0; n < FrameCount; n++)
-            {
-                ThrowIfFailed(m_devices[Primary]->CreatePlacedResource(
-                    m_crossAdapterResourceHeaps[Primary].Get(),
-                    textureSize * n,
-                    &crossAdapterDesc,
-                    D3D12_RESOURCE_STATE_COPY_DEST,
-                    nullptr,
-                    IID_PPV_ARGS(&m_crossAdapterResources[Primary][n])));
+			// Create placed resources for each frame per adapter in the shared heap.
+			for (UINT n = 0; n < FrameCount; n++)
+			{
+				ThrowIfFailed(m_devices[Primary]->CreatePlacedResource(
+					m_crossAdapterResourceHeaps[Primary].Get(),
+					textureSize * n,
+					&crossAdapterDesc,
+					D3D12_RESOURCE_STATE_COPY_DEST,
+					nullptr,
+					IID_PPV_ARGS(&m_crossAdapterResources[Primary][n])));
 
-                ThrowIfFailed(m_devices[Secondary]->CreatePlacedResource(
-                    m_crossAdapterResourceHeaps[Secondary].Get(),
-                    textureSize * n,
-                    &crossAdapterDesc,
-                    m_crossAdapterTextureSupport ? D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_COPY_SOURCE,
-                    nullptr,
-                    IID_PPV_ARGS(&m_crossAdapterResources[Secondary][n])));
+				ThrowIfFailed(m_devices[Secondary]->CreatePlacedResource(
+					m_crossAdapterResourceHeaps[Secondary].Get(),
+					textureSize * n,
+					&crossAdapterDesc,
+					m_crossAdapterTextureSupport ? D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_COPY_SOURCE,
+					nullptr,
+					IID_PPV_ARGS(&m_crossAdapterResources[Secondary][n])));
 
-                if (!m_crossAdapterTextureSupport)
-                {
-                    // If the primary adapter's render target must be shared as a buffer,
-                    // create a texture resource to copy it into on the secondary adapter.
-                    ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
-                        &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-                        D3D12_HEAP_FLAG_NONE,
-                        &renderTargetDesc,
-                        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                        nullptr,
-                        IID_PPV_ARGS(&m_secondaryAdapterTextures[n])));
-                }
-            }
-        }
+				if (!m_crossAdapterTextureSupport)
+				{
+					// If the primary adapter's render target must be shared as a buffer,
+					// create a texture resource to copy it into on the secondary adapter.
+					ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
+						&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+						D3D12_HEAP_FLAG_NONE,
+						&renderTargetDesc,
+						D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+						nullptr,
+						IID_PPV_ARGS(&m_secondaryAdapterTextures[n])));
+				}
+			}
+		}
 
-        // Create an intermediate render target and view on the secondary adapter.
-        {
-            const D3D12_RESOURCE_DESC intermediateRenderTargetDesc = m_renderTargets[Primary][0]->GetDesc();
+		// Create an intermediate render target and view on the secondary adapter.
+		{
+			const D3D12_RESOURCE_DESC intermediateRenderTargetDesc = m_renderTargets[Primary][0]->GetDesc();
 
-            ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-                D3D12_HEAP_FLAG_NONE,
-                &intermediateRenderTargetDesc,
-                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                nullptr,
-                IID_PPV_ARGS(&m_intermediateBlurRenderTarget)));
+			ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+				D3D12_HEAP_FLAG_NONE,
+				&intermediateRenderTargetDesc,
+				D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+				nullptr,
+				IID_PPV_ARGS(&m_intermediateBlurRenderTarget)));
 
-            CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeaps[Secondary]->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSizes[Secondary]);
-            m_devices[Secondary]->CreateRenderTargetView(m_intermediateBlurRenderTarget.Get(), nullptr, rtvHandle);
-        }
-        
-        // Create SRVs for the shared resources and intermediate render target on the secondary adapter.
-        {
-            CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_cbvSrvUavHeap->GetCPUDescriptorHandleForHeapStart());
-            for (UINT n = 0; n < FrameCount; n++)
-            {
-                ID3D12Resource* pSrvResource = m_crossAdapterTextureSupport ? m_crossAdapterResources[Secondary][n].Get() : m_secondaryAdapterTextures[n].Get();
-                m_devices[Secondary]->CreateShaderResourceView(pSrvResource, nullptr, srvHandle);
-                srvHandle.Offset(m_srvDescriptorSizes[Secondary]);
-            }
+			CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeaps[Secondary]->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSizes[Secondary]);
+			m_devices[Secondary]->CreateRenderTargetView(m_intermediateBlurRenderTarget.Get(), nullptr, rtvHandle);
+		}
+		
+		// Create SRVs for the shared resources and intermediate render target on the secondary adapter.
+		{
+			CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_cbvSrvUavHeap->GetCPUDescriptorHandleForHeapStart());
+			for (UINT n = 0; n < FrameCount; n++)
+			{
+				ID3D12Resource* pSrvResource = m_crossAdapterTextureSupport ? m_crossAdapterResources[Secondary][n].Get() : m_secondaryAdapterTextures[n].Get();
+				m_devices[Secondary]->CreateShaderResourceView(pSrvResource, nullptr, srvHandle);
+				srvHandle.Offset(m_srvDescriptorSizes[Secondary]);
+			}
 
-            m_devices[Secondary]->CreateShaderResourceView(m_intermediateBlurRenderTarget.Get(), nullptr, srvHandle);
-        }
-    }
+			m_devices[Secondary]->CreateShaderResourceView(m_intermediateBlurRenderTarget.Get(), nullptr, srvHandle);
+		}
+	}
 }
 
 // Load the sample assets.
 void D3D12HeterogeneousMultiadapter::LoadAssets()
 {
-    // Create the root signatures.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signatures.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_devices[Primary]->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_devices[Primary]->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        CD3DX12_ROOT_PARAMETER1 rootParameters[2];
-        rootParameters[0].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_VERTEX);
-        rootParameters[1].InitAsConstantBufferView(1, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_PIXEL);
+		CD3DX12_ROOT_PARAMETER1 rootParameters[2];
+		rootParameters[0].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_VERTEX);
+		rootParameters[1].InitAsConstantBufferView(1, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_PIXEL);
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_devices[Primary]->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_devices[Primary]->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
 
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_devices[Secondary]->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_devices[Secondary]->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        // We don't modify the SRV in the command list after SetGraphicsRootDescriptorTable
-        // is executed on the GPU so we can use the default range behavior:
-        // D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0);
+		// We don't modify the SRV in the command list after SetGraphicsRootDescriptorTable
+		// is executed on the GPU so we can use the default range behavior:
+		// D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0);
 
-        CD3DX12_ROOT_PARAMETER1 blurRootParameters[3];
-        blurRootParameters[0].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_PIXEL);
-        blurRootParameters[1].InitAsDescriptorTable(_countof(ranges), ranges, D3D12_SHADER_VISIBILITY_PIXEL);
-        blurRootParameters[2].InitAsConstantBufferView(1, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_PIXEL);
+		CD3DX12_ROOT_PARAMETER1 blurRootParameters[3];
+		blurRootParameters[0].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_PIXEL);
+		blurRootParameters[1].InitAsDescriptorTable(_countof(ranges), ranges, D3D12_SHADER_VISIBILITY_PIXEL);
+		blurRootParameters[2].InitAsConstantBufferView(1, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_PIXEL);
 
-        CD3DX12_STATIC_SAMPLER_DESC staticPointSampler(0);
-        staticPointSampler.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
-        staticPointSampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+		CD3DX12_STATIC_SAMPLER_DESC staticPointSampler(0);
+		staticPointSampler.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
+		staticPointSampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
 
-        CD3DX12_STATIC_SAMPLER_DESC staticLinearSampler(1);
-        staticLinearSampler.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-        staticLinearSampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+		CD3DX12_STATIC_SAMPLER_DESC staticLinearSampler(1);
+		staticLinearSampler.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		staticLinearSampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
 
-        D3D12_STATIC_SAMPLER_DESC staticSamplers[] = { staticPointSampler, staticLinearSampler };
-        rootSignatureDesc.Init_1_1(_countof(blurRootParameters), blurRootParameters, _countof(staticSamplers), staticSamplers, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+		D3D12_STATIC_SAMPLER_DESC staticSamplers[] = { staticPointSampler, staticLinearSampler };
+		rootSignatureDesc.Init_1_1(_countof(blurRootParameters), blurRootParameters, _countof(staticSamplers), staticSamplers, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_devices[Secondary]->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_blurRootSignature)));
-    }
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_devices[Secondary]->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_blurRootSignature)));
+	}
 
-    // Create the pipeline states, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
-        ComPtr<ID3DBlob> vertexShaderBlur;
-        ComPtr<ID3DBlob> pixelShaderBlurU;
-        ComPtr<ID3DBlob> pixelShaderBlurV;
-        ComPtr<ID3DBlob> error;
+	// Create the pipeline states, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
+		ComPtr<ID3DBlob> vertexShaderBlur;
+		ComPtr<ID3DBlob> pixelShaderBlurU;
+		ComPtr<ID3DBlob> pixelShaderBlurV;
+		ComPtr<ID3DBlob> error;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VShader", "vs_5_0", compileFlags, 0, &vertexShader, &error));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PShader", "ps_5_0", compileFlags, 0, &pixelShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VShader", "vs_5_0", compileFlags, 0, &vertexShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PShader", "ps_5_0", compileFlags, 0, &pixelShader, &error));
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"blurShaders.hlsl").c_str(), nullptr, nullptr, "VSSimpleBlur", "vs_5_0", compileFlags, 0, &vertexShaderBlur, &error));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"blurShaders.hlsl").c_str(), nullptr, nullptr, "PSSimpleBlurU", "ps_5_0", compileFlags, 0, &pixelShaderBlurU, &error));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"blurShaders.hlsl").c_str(), nullptr, nullptr, "PSSimpleBlurV", "ps_5_0", compileFlags, 0, &pixelShaderBlurV, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"blurShaders.hlsl").c_str(), nullptr, nullptr, "VSSimpleBlur", "vs_5_0", compileFlags, 0, &vertexShaderBlur, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"blurShaders.hlsl").c_str(), nullptr, nullptr, "PSSimpleBlurU", "ps_5_0", compileFlags, 0, &pixelShaderBlurU, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"blurShaders.hlsl").c_str(), nullptr, nullptr, "PSSimpleBlurV", "ps_5_0", compileFlags, 0, &pixelShaderBlurV, &error));
 
-        // Define the vertex input layouts.
-        const D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+		// Define the vertex input layouts.
+		const D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        const D3D12_INPUT_ELEMENT_DESC blurInputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+		const D3D12_INPUT_ELEMENT_DESC blurInputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        // Describe and create the graphics pipeline state objects (PSOs).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
-        psoDesc.SampleDesc.Count = 1;
-        ThrowIfFailed(m_devices[Primary]->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+		// Describe and create the graphics pipeline state objects (PSOs).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+		psoDesc.SampleDesc.Count = 1;
+		ThrowIfFailed(m_devices[Primary]->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
 
-        psoDesc.InputLayout = { blurInputElementDescs, _countof(blurInputElementDescs) };
-        psoDesc.pRootSignature = m_blurRootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShaderBlur.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShaderBlurU.Get());
-        psoDesc.DepthStencilState.DepthEnable = false;
-        psoDesc.DSVFormat = DXGI_FORMAT_UNKNOWN;
-        ThrowIfFailed(m_devices[Secondary]->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_blurPipelineStates[0])));
+		psoDesc.InputLayout = { blurInputElementDescs, _countof(blurInputElementDescs) };
+		psoDesc.pRootSignature = m_blurRootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShaderBlur.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShaderBlurU.Get());
+		psoDesc.DepthStencilState.DepthEnable = false;
+		psoDesc.DSVFormat = DXGI_FORMAT_UNKNOWN;
+		ThrowIfFailed(m_devices[Secondary]->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_blurPipelineStates[0])));
 
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShaderBlurV.Get());
-        ThrowIfFailed(m_devices[Secondary]->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_blurPipelineStates[1])));
-    }
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShaderBlurV.Get());
+		ThrowIfFailed(m_devices[Secondary]->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_blurPipelineStates[1])));
+	}
 
-    // Create the command lists.
-    ThrowIfFailed(m_devices[Primary]->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_directCommandAllocators[Primary][m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_directCommandLists[Primary])));
-    ThrowIfFailed(m_devices[Primary]->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_COPY, m_copyCommandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_copyCommandList)));
-    ThrowIfFailed(m_copyCommandList->Close());
+	// Create the command lists.
+	ThrowIfFailed(m_devices[Primary]->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_directCommandAllocators[Primary][m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_directCommandLists[Primary])));
+	ThrowIfFailed(m_devices[Primary]->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_COPY, m_copyCommandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_copyCommandList)));
+	ThrowIfFailed(m_copyCommandList->Close());
 
-    ThrowIfFailed(m_devices[Secondary]->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_directCommandAllocators[Secondary][m_frameIndex].Get(), m_blurPipelineStates[0].Get(), IID_PPV_ARGS(&m_directCommandLists[Secondary])));
+	ThrowIfFailed(m_devices[Secondary]->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_directCommandAllocators[Secondary][m_frameIndex].Get(), m_blurPipelineStates[0].Get(), IID_PPV_ARGS(&m_directCommandLists[Secondary])));
 
-    // Note: ComPtr's are CPU objects but these resources need to stay in scope until
-    // the command list that references them has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resources are not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> vertexBufferUpload;
-    ComPtr<ID3D12Resource> fullscreenQuadVertexBufferUpload;
+	// Note: ComPtr's are CPU objects but these resources need to stay in scope until
+	// the command list that references them has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resources are not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> vertexBufferUpload;
+	ComPtr<ID3D12Resource> fullscreenQuadVertexBufferUpload;
 
-    // Create the vertex buffer for the primary adapter.
-    {
-        // Define the geometry for a triangle.
-        Vertex triangleVertices[] =
-        {
-            { { 0.0f, TriangleHalfWidth, TriangleDepth } },
-            { { TriangleHalfWidth, -TriangleHalfWidth, TriangleDepth } },
-            { { -TriangleHalfWidth, -TriangleHalfWidth, TriangleDepth } }
-        };
+	// Create the vertex buffer for the primary adapter.
+	{
+		// Define the geometry for a triangle.
+		Vertex triangleVertices[] =
+		{
+			{ { 0.0f, TriangleHalfWidth, TriangleDepth } },
+			{ { TriangleHalfWidth, -TriangleHalfWidth, TriangleDepth } },
+			{ { -TriangleHalfWidth, -TriangleHalfWidth, TriangleDepth } }
+		};
 
-        const UINT vertexBufferSize = sizeof(triangleVertices);
+		const UINT vertexBufferSize = sizeof(triangleVertices);
 
-        ThrowIfFailed(m_devices[Primary]->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		ThrowIfFailed(m_devices[Primary]->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        ThrowIfFailed(m_devices[Primary]->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&vertexBufferUpload)));
+		ThrowIfFailed(m_devices[Primary]->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&vertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(triangleVertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(triangleVertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(m_directCommandLists[Primary].Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        m_directCommandLists[Primary]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(m_directCommandLists[Primary].Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		m_directCommandLists[Primary]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = sizeof(triangleVertices);
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = sizeof(triangleVertices);
+	}
 
-    // Create the vertex buffer for the secondary adapter.
-    {
-        // Define the geometry for a fullscreen triangle.
-        VertexPositionUV quadVertices[] =
-        {
-            { { -1.0f, -1.0f, 0.0f, 1.0f }, { 0.0f, 0.0f } },    // Bottom left.
-            { { -1.0f, 1.0f, 0.0f, 1.0f }, { 0.0f, 1.0f } },    // Top left.
-            { { 1.0f, -1.0f, 0.0f, 1.0f }, { 1.0f, 0.0f } },    // Bottom right.
-            { { 1.0f, 1.0f, 0.0f, 1.0f }, { 1.0f, 1.0f } },        // Top right.
-        };
+	// Create the vertex buffer for the secondary adapter.
+	{
+		// Define the geometry for a fullscreen triangle.
+		VertexPositionUV quadVertices[] =
+		{
+			{ { -1.0f, -1.0f, 0.0f, 1.0f }, { 0.0f, 0.0f } },	// Bottom left.
+			{ { -1.0f, 1.0f, 0.0f, 1.0f }, { 0.0f, 1.0f } },	// Top left.
+			{ { 1.0f, -1.0f, 0.0f, 1.0f }, { 1.0f, 0.0f } },	// Bottom right.
+			{ { 1.0f, 1.0f, 0.0f, 1.0f }, { 1.0f, 1.0f } },		// Top right.
+		};
 
-        const UINT vertexBufferSize = sizeof(quadVertices);
+		const UINT vertexBufferSize = sizeof(quadVertices);
 
-        ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_fullscreenQuadVertexBuffer)));
+		ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_fullscreenQuadVertexBuffer)));
 
-        ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&fullscreenQuadVertexBufferUpload)));
+		ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&fullscreenQuadVertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(quadVertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(quadVertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(m_directCommandLists[Secondary].Get(), m_fullscreenQuadVertexBuffer.Get(), fullscreenQuadVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        m_directCommandLists[Secondary]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_fullscreenQuadVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(m_directCommandLists[Secondary].Get(), m_fullscreenQuadVertexBuffer.Get(), fullscreenQuadVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		m_directCommandLists[Secondary]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_fullscreenQuadVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_fullscreenQuadVertexBufferView.BufferLocation = m_fullscreenQuadVertexBuffer->GetGPUVirtualAddress();
-        m_fullscreenQuadVertexBufferView.StrideInBytes = sizeof(VertexPositionUV);
-        m_fullscreenQuadVertexBufferView.SizeInBytes = sizeof(quadVertices);
-    }
+		// Initialize the vertex buffer view.
+		m_fullscreenQuadVertexBufferView.BufferLocation = m_fullscreenQuadVertexBuffer->GetGPUVirtualAddress();
+		m_fullscreenQuadVertexBufferView.StrideInBytes = sizeof(VertexPositionUV);
+		m_fullscreenQuadVertexBufferView.SizeInBytes = sizeof(quadVertices);
+	}
 
-    // Create the depth stencil view.
-    {
-        D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
-        depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
-        depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
-        depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
+	// Create the depth stencil view.
+	{
+		D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
+		depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
+		depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+		depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
 
-        const CD3DX12_CLEAR_VALUE clearValue(DXGI_FORMAT_D32_FLOAT, 1.0f, 0);
+		const CD3DX12_CLEAR_VALUE clearValue(DXGI_FORMAT_D32_FLOAT, 1.0f, 0);
 
-        ThrowIfFailed(m_devices[Primary]->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
-            D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            &clearValue,
-            IID_PPV_ARGS(&m_depthStencil)
-            ));
+		ThrowIfFailed(m_devices[Primary]->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
+			D3D12_RESOURCE_STATE_DEPTH_WRITE,
+			&clearValue,
+			IID_PPV_ARGS(&m_depthStencil)
+			));
 
-        m_devices[Primary]->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		m_devices[Primary]->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    // Create the constant buffers.
-    {
-        {
-            const UINT64 constantBufferSize = sizeof(SceneConstantBuffer) * MaxTriangleCount * FrameCount;
+	// Create the constant buffers.
+	{
+		{
+			const UINT64 constantBufferSize = sizeof(SceneConstantBuffer) * MaxTriangleCount * FrameCount;
 
-            ThrowIfFailed(m_devices[Primary]->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-                D3D12_HEAP_FLAG_NONE,
-                &CD3DX12_RESOURCE_DESC::Buffer(constantBufferSize),
-                D3D12_RESOURCE_STATE_GENERIC_READ,
-                nullptr,
-                IID_PPV_ARGS(&m_constantBuffer)));
+			ThrowIfFailed(m_devices[Primary]->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+				D3D12_HEAP_FLAG_NONE,
+				&CD3DX12_RESOURCE_DESC::Buffer(constantBufferSize),
+				D3D12_RESOURCE_STATE_GENERIC_READ,
+				nullptr,
+				IID_PPV_ARGS(&m_constantBuffer)));
 
-            // Setup constant buffer data.
-            for (UINT n = 0; n < MaxTriangleCount; n++)
-            {
-                m_constantBufferData[n].velocity = XMFLOAT4(GetRandomFloat(0.01f, 0.02f), 0.0f, 0.0f, 0.0f);
-                m_constantBufferData[n].offset = XMFLOAT4(GetRandomFloat(-5.0f, -1.5f), GetRandomFloat(-1.0f, 1.0f), GetRandomFloat(0.0f, 2.0f), 0.0f);
-                m_constantBufferData[n].color = XMFLOAT4(GetRandomFloat(0.5f, 1.0f), GetRandomFloat(0.5f, 1.0f), GetRandomFloat(0.5f, 1.0f), 1.0f);
-                XMStoreFloat4x4(&m_constantBufferData[n].projection, XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f)));
-            }
+			// Setup constant buffer data.
+			for (UINT n = 0; n < MaxTriangleCount; n++)
+			{
+				m_constantBufferData[n].velocity = XMFLOAT4(GetRandomFloat(0.01f, 0.02f), 0.0f, 0.0f, 0.0f);
+				m_constantBufferData[n].offset = XMFLOAT4(GetRandomFloat(-5.0f, -1.5f), GetRandomFloat(-1.0f, 1.0f), GetRandomFloat(0.0f, 2.0f), 0.0f);
+				m_constantBufferData[n].color = XMFLOAT4(GetRandomFloat(0.5f, 1.0f), GetRandomFloat(0.5f, 1.0f), GetRandomFloat(0.5f, 1.0f), 1.0f);
+				XMStoreFloat4x4(&m_constantBufferData[n].projection, XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f)));
+			}
 
-            // Map and initialize the constant buffer. We don't unmap this until the
-            // app closes. Keeping things mapped for the lifetime of the resource is okay.
-            CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-            ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbvDataBegin)));
-            memcpy(m_pCbvDataBegin, &m_constantBufferData[0], constantBufferSize / FrameCount);
-        }
+			// Map and initialize the constant buffer. We don't unmap this until the
+			// app closes. Keeping things mapped for the lifetime of the resource is okay.
+			CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+			ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbvDataBegin)));
+			memcpy(m_pCbvDataBegin, &m_constantBufferData[0], constantBufferSize / FrameCount);
+		}
 
-        {
-            const UINT64 workloadConstantBufferSize = sizeof(WorkloadConstantBufferData) * FrameCount;
+		{
+			const UINT64 workloadConstantBufferSize = sizeof(WorkloadConstantBufferData) * FrameCount;
 
-            ThrowIfFailed(m_devices[Primary]->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-                D3D12_HEAP_FLAG_NONE,
-                &CD3DX12_RESOURCE_DESC::Buffer(workloadConstantBufferSize),
-                D3D12_RESOURCE_STATE_GENERIC_READ,
-                nullptr,
-                IID_PPV_ARGS(&m_workloadConstantBuffer)));
+			ThrowIfFailed(m_devices[Primary]->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+				D3D12_HEAP_FLAG_NONE,
+				&CD3DX12_RESOURCE_DESC::Buffer(workloadConstantBufferSize),
+				D3D12_RESOURCE_STATE_GENERIC_READ,
+				nullptr,
+				IID_PPV_ARGS(&m_workloadConstantBuffer)));
 
-            // Setup constant buffer data.
-            m_workloadConstantBufferData.loopCount = m_psLoopCount;
+			// Setup constant buffer data.
+			m_workloadConstantBufferData.loopCount = m_psLoopCount;
 
-            // Map and initialize the constant buffer. We don't unmap this until the
-            // app closes. Keeping things mapped for the lifetime of the resource is okay.
-            CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-            ThrowIfFailed(m_workloadConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pWorkloadCbvDataBegin)));
-            memcpy(m_pWorkloadCbvDataBegin, &m_workloadConstantBufferData, workloadConstantBufferSize / FrameCount);
-        }
+			// Map and initialize the constant buffer. We don't unmap this until the
+			// app closes. Keeping things mapped for the lifetime of the resource is okay.
+			CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+			ThrowIfFailed(m_workloadConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pWorkloadCbvDataBegin)));
+			memcpy(m_pWorkloadCbvDataBegin, &m_workloadConstantBufferData, workloadConstantBufferSize / FrameCount);
+		}
 
-        {
-            const UINT64 blurWorkloadConstantBufferSize = sizeof(WorkloadConstantBufferData) * FrameCount;
+		{
+			const UINT64 blurWorkloadConstantBufferSize = sizeof(WorkloadConstantBufferData) * FrameCount;
 
-            ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-                D3D12_HEAP_FLAG_NONE,
-                &CD3DX12_RESOURCE_DESC::Buffer(blurWorkloadConstantBufferSize),
-                D3D12_RESOURCE_STATE_GENERIC_READ,
-                nullptr,
-                IID_PPV_ARGS(&m_blurWorkloadConstantBuffer)));
+			ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+				D3D12_HEAP_FLAG_NONE,
+				&CD3DX12_RESOURCE_DESC::Buffer(blurWorkloadConstantBufferSize),
+				D3D12_RESOURCE_STATE_GENERIC_READ,
+				nullptr,
+				IID_PPV_ARGS(&m_blurWorkloadConstantBuffer)));
 
-            // Setup constant buffer data.
-            m_blurWorkloadConstantBufferData.loopCount = m_blurPSLoopCount;
+			// Setup constant buffer data.
+			m_blurWorkloadConstantBufferData.loopCount = m_blurPSLoopCount;
 
-            // Map and initialize the constant buffer. We don't unmap this until the
-            // app closes. Keeping things mapped for the lifetime of the resource is okay.
-            CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-            ThrowIfFailed(m_blurWorkloadConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pBlurWorkloadCbvDataBegin)));
-            memcpy(m_pBlurWorkloadCbvDataBegin, &m_blurWorkloadConstantBufferData, blurWorkloadConstantBufferSize / FrameCount);
-        }
+			// Map and initialize the constant buffer. We don't unmap this until the
+			// app closes. Keeping things mapped for the lifetime of the resource is okay.
+			CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+			ThrowIfFailed(m_blurWorkloadConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pBlurWorkloadCbvDataBegin)));
+			memcpy(m_pBlurWorkloadCbvDataBegin, &m_blurWorkloadConstantBufferData, blurWorkloadConstantBufferSize / FrameCount);
+		}
 
-        {
-            ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-                D3D12_HEAP_FLAG_NONE,
-                &CD3DX12_RESOURCE_DESC::Buffer(sizeof(BlurConstantBufferData)),
-                D3D12_RESOURCE_STATE_GENERIC_READ,
-                nullptr,
-                IID_PPV_ARGS(&m_blurConstantBuffer)));
+		{
+			ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+				D3D12_HEAP_FLAG_NONE,
+				&CD3DX12_RESOURCE_DESC::Buffer(sizeof(BlurConstantBufferData)),
+				D3D12_RESOURCE_STATE_GENERIC_READ,
+				nullptr,
+				IID_PPV_ARGS(&m_blurConstantBuffer)));
 
-            // Map the constant buffer.
-            CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-            ThrowIfFailed(m_blurConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pBlurCbvDataBegin)));
+			// Map the constant buffer.
+			CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+			ThrowIfFailed(m_blurConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pBlurCbvDataBegin)));
 
-            // Setup constant buffer data.
-            m_pBlurCbvDataBegin[0].offset = 0.5f;
-            m_pBlurCbvDataBegin[0].textureDimensions.x = static_cast<float>(m_width);
-            m_pBlurCbvDataBegin[0].textureDimensions.y = static_cast<float>(m_height);
+			// Setup constant buffer data.
+			m_pBlurCbvDataBegin[0].offset = 0.5f;
+			m_pBlurCbvDataBegin[0].textureDimensions.x = static_cast<float>(m_width);
+			m_pBlurCbvDataBegin[0].textureDimensions.y = static_cast<float>(m_height);
 
-            // Unmap the constant buffer because we don't update this again.
-            // If we ever do, it should be buffered by the number of frames like other constant buffers.
-            const CD3DX12_RANGE emptyRange(0, 0);
-            m_blurConstantBuffer->Unmap(0, &emptyRange);
-            m_pBlurCbvDataBegin = nullptr;
-        }
-    }
+			// Unmap the constant buffer because we don't update this again.
+			// If we ever do, it should be buffered by the number of frames like other constant buffers.
+			const CD3DX12_RANGE emptyRange(0, 0);
+			m_blurConstantBuffer->Unmap(0, &emptyRange);
+			m_pBlurCbvDataBegin = nullptr;
+		}
+	}
 
-    // Close the command lists and execute them to begin the vertex buffer copies into the default heaps.
-    for (UINT i = 0; i < GraphicsAdaptersCount; i++)
-    {
-        ThrowIfFailed(m_directCommandLists[i]->Close());
-        ID3D12CommandList* ppCommandLists[] = { m_directCommandLists[i].Get() };
-        m_directCommandQueues[i]->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
-    }
+	// Close the command lists and execute them to begin the vertex buffer copies into the default heaps.
+	for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+	{
+		ThrowIfFailed(m_directCommandLists[i]->Close());
+		ID3D12CommandList* ppCommandLists[] = { m_directCommandLists[i].Get() };
+		m_directCommandQueues[i]->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	}
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    // We use a cross-adapter fence for handling Signals and Waits between adapters.
-    // We use regular fences for things that don't need to be cross adapter because they don't need the additional overhead associated with being cross-adapter.
-    {
-        // Fence used to control CPU pacing.
-        ThrowIfFailed(m_devices[Secondary]->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_frameFence)));
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	// We use a cross-adapter fence for handling Signals and Waits between adapters.
+	// We use regular fences for things that don't need to be cross adapter because they don't need the additional overhead associated with being cross-adapter.
+	{
+		// Fence used to control CPU pacing.
+		ThrowIfFailed(m_devices[Secondary]->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_frameFence)));
 
-        // Fence used by the primary adapter to signal its copy queue that it has completed rendering.
-        // When this is signaled, the primary adapter's copy queue can begin copying to the cross-adapter shared resource.
-        ThrowIfFailed(m_devices[Primary]->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_renderFence)));
+		// Fence used by the primary adapter to signal its copy queue that it has completed rendering.
+		// When this is signaled, the primary adapter's copy queue can begin copying to the cross-adapter shared resource.
+		ThrowIfFailed(m_devices[Primary]->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_renderFence)));
 
-        // Cross-adapter shared fence used by both adapters.
-        // Used by the primary adapter to signal the secondary adapter that it has completed copying to the cross-adapter shared resource.
-        // When this is signaled, the secondary adapter can begin its work.
-        ThrowIfFailed(m_devices[Primary]->CreateFence(0, D3D12_FENCE_FLAG_SHARED | D3D12_FENCE_FLAG_SHARED_CROSS_ADAPTER, IID_PPV_ARGS(&m_crossAdapterFences[Primary]))); 
+		// Cross-adapter shared fence used by both adapters.
+		// Used by the primary adapter to signal the secondary adapter that it has completed copying to the cross-adapter shared resource.
+		// When this is signaled, the secondary adapter can begin its work.
+		ThrowIfFailed(m_devices[Primary]->CreateFence(0, D3D12_FENCE_FLAG_SHARED | D3D12_FENCE_FLAG_SHARED_CROSS_ADAPTER, IID_PPV_ARGS(&m_crossAdapterFences[Primary]))); 
 
-        // For now, require GENERIC_ALL access.
-        HANDLE fenceHandle = nullptr;
-        ThrowIfFailed(m_devices[Primary]->CreateSharedHandle(
-            m_crossAdapterFences[Primary].Get(),
-            nullptr,
-            GENERIC_ALL,
-            nullptr,
-            &fenceHandle));
+		// For now, require GENERIC_ALL access.
+		HANDLE fenceHandle = nullptr;
+		ThrowIfFailed(m_devices[Primary]->CreateSharedHandle(
+			m_crossAdapterFences[Primary].Get(),
+			nullptr,
+			GENERIC_ALL,
+			nullptr,
+			&fenceHandle));
 
-        HRESULT openSharedHandleResult = m_devices[Secondary]->OpenSharedHandle(fenceHandle, IID_PPV_ARGS(&m_crossAdapterFences[Secondary]));
+		HRESULT openSharedHandleResult = m_devices[Secondary]->OpenSharedHandle(fenceHandle, IID_PPV_ARGS(&m_crossAdapterFences[Secondary]));
 
-        // We can close the handle after opening the cross-adapter shared fence.
-        CloseHandle(fenceHandle);
+		// We can close the handle after opening the cross-adapter shared fence.
+		CloseHandle(fenceHandle);
 
-        ThrowIfFailed(openSharedHandleResult);
+		ThrowIfFailed(openSharedHandleResult);
 
-        for (UINT i = 0; i < GraphicsAdaptersCount; i++)
-        {
-            // Create an event handle to use for frame synchronization.
-            m_fenceEvents[i] = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-            if (m_fenceEvents == nullptr)
-            {
-                ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-            }
+		for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+		{
+			// Create an event handle to use for frame synchronization.
+			m_fenceEvents[i] = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+			if (m_fenceEvents == nullptr)
+			{
+				ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+			}
 
-            // Wait for the command list to execute; we are reusing the same command 
-            // list in our main loop but for now, we just want to wait for setup to 
-            // complete before continuing.
-            WaitForGpu(static_cast<GraphicsAdapter>(i));
-        }
-    }
+			// Wait for the command list to execute; we are reusing the same command 
+			// list in our main loop but for now, we just want to wait for setup to 
+			// complete before continuing.
+			WaitForGpu(static_cast<GraphicsAdapter>(i));
+		}
+	}
 }
 
 // Get a random float value between min and max.
 float D3D12HeterogeneousMultiadapter::GetRandomFloat(float min, float max)
 {
-    float scale = static_cast<float>(rand()) / RAND_MAX;
-    float range = max - min;
-    return scale * range + min;
+	float scale = static_cast<float>(rand()) / RAND_MAX;
+	float range = max - min;
+	return scale * range + min;
 }
 
 // Update frame-based values.
 void D3D12HeterogeneousMultiadapter::OnUpdate()
 {
-    // Add the oldest timestamp data to our moving average counters.
-    // Use the oldest timestamp index to limit CPU waits.
-    {
-        // The oldest frame is the current frame index and it will always be complete due to the wait in MoveToNextFrame().
-        const UINT oldestFrameIndex = m_frameIndex;
-        assert(m_frameFenceValues[oldestFrameIndex] <= m_frameFence->GetCompletedValue());
+	// Add the oldest timestamp data to our moving average counters.
+	// Use the oldest timestamp index to limit CPU waits.
+	{
+		// The oldest frame is the current frame index and it will always be complete due to the wait in MoveToNextFrame().
+		const UINT oldestFrameIndex = m_frameIndex;
+		assert(m_frameFenceValues[oldestFrameIndex] <= m_frameFence->GetCompletedValue());
 
-        // Get the timestamp values from the result buffers.
-        D3D12_RANGE readRange = {};
-        const D3D12_RANGE emptyRange = {};
+		// Get the timestamp values from the result buffers.
+		D3D12_RANGE readRange = {};
+		const D3D12_RANGE emptyRange = {};
 
-        UINT64* ppMovingAverage[] = { m_drawTimes, m_blurTimes };
-        for (UINT i = 0; i < GraphicsAdaptersCount; i++)
-        {
-            readRange.Begin = 2 * oldestFrameIndex * sizeof(UINT64);
-            readRange.End = readRange.Begin + 2 * sizeof(UINT64);
+		UINT64* ppMovingAverage[] = { m_drawTimes, m_blurTimes };
+		for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+		{
+			readRange.Begin = 2 * oldestFrameIndex * sizeof(UINT64);
+			readRange.End = readRange.Begin + 2 * sizeof(UINT64);
 
-            void* pData = nullptr;
-            ThrowIfFailed(m_timestampResultBuffers[i]->Map(0, &readRange, &pData));
+			void* pData = nullptr;
+			ThrowIfFailed(m_timestampResultBuffers[i]->Map(0, &readRange, &pData));
 
-            const UINT64* pTimestamps = reinterpret_cast<UINT64*>(static_cast<UINT8*>(pData) + readRange.Begin);
-            const UINT64 timeStampDelta = pTimestamps[1] - pTimestamps[0];
+			const UINT64* pTimestamps = reinterpret_cast<UINT64*>(static_cast<UINT8*>(pData) + readRange.Begin);
+			const UINT64 timeStampDelta = pTimestamps[1] - pTimestamps[0];
 
-            // Unmap with an empty range (written range).
-            m_timestampResultBuffers[i]->Unmap(0, &emptyRange);
+			// Unmap with an empty range (written range).
+			m_timestampResultBuffers[i]->Unmap(0, &emptyRange);
 
-            // Calculate the GPU execution time in microseconds.
-            const UINT64 gpuTimeUS =  (timeStampDelta * 1000000) / m_directCommandQueueTimestampFrequencies[i];
-            ppMovingAverage[i][m_currentTimesIndex] = gpuTimeUS;
-        }
+			// Calculate the GPU execution time in microseconds.
+			const UINT64 gpuTimeUS =  (timeStampDelta * 1000000) / m_directCommandQueueTimestampFrequencies[i];
+			ppMovingAverage[i][m_currentTimesIndex] = gpuTimeUS;
+		}
 
-        // Move to the next index.
-        m_currentTimesIndex = (m_currentTimesIndex + 1) % MovingAverageFrameCount;
-    }
+		// Move to the next index.
+		m_currentTimesIndex = (m_currentTimesIndex + 1) % MovingAverageFrameCount;
+	}
 
-    // Dynamically change the workload on the primary adapter. This is a VERY naive implementation.
-    // The point here is to show that applications have a choice with how to spend their extra cycles.
-    // Note: If copies take longer then you should take that into account as well.
-    {
-        static UINT64 framesSinceLastUpdate = 0;
-        framesSinceLastUpdate++;
-        if (framesSinceLastUpdate > MovingAverageFrameCount)
-        {
-            // Calculate the average draw and blur times for last few frames.
-            m_drawTimeMovingAverage = 0;
-            m_blurTimeMovingAverage = 0;
-            for (UINT i = 0; i < MovingAverageFrameCount; i++)
-            {
-                m_drawTimeMovingAverage += m_drawTimes[i];
-                m_blurTimeMovingAverage += m_blurTimes[i];
-            }
+	// Dynamically change the workload on the primary adapter. This is a VERY naive implementation.
+	// The point here is to show that applications have a choice with how to spend their extra cycles.
+	// Note: If copies take longer then you should take that into account as well.
+	{
+		static UINT64 framesSinceLastUpdate = 0;
+		framesSinceLastUpdate++;
+		if (framesSinceLastUpdate > MovingAverageFrameCount)
+		{
+			// Calculate the average draw and blur times for last few frames.
+			m_drawTimeMovingAverage = 0;
+			m_blurTimeMovingAverage = 0;
+			for (UINT i = 0; i < MovingAverageFrameCount; i++)
+			{
+				m_drawTimeMovingAverage += m_drawTimes[i];
+				m_blurTimeMovingAverage += m_blurTimes[i];
+			}
 
-            m_drawTimeMovingAverage /= MovingAverageFrameCount;
-            m_blurTimeMovingAverage /= MovingAverageFrameCount;
-            framesSinceLastUpdate = 0;
+			m_drawTimeMovingAverage /= MovingAverageFrameCount;
+			m_blurTimeMovingAverage /= MovingAverageFrameCount;
+			framesSinceLastUpdate = 0;
 
-            // Adjust the shader blur time to be at least 20ms/frame.
-            // Note: This is just done to show that we can reach ~100% utilization of both adapters.
-            if (AllowShaderDynamicWorkload)
-            {
-                const UINT64 desiredBlurPSTimeUS = 20000;    // 20 ms
-                if (m_blurTimeMovingAverage < desiredBlurPSTimeUS || m_blurPSLoopCount != 0)
-                {
-                    // Adjust the PS blur time based on the moving average.
-                    const float timeDelta = (static_cast<float>(desiredBlurPSTimeUS) - static_cast<float>(m_blurTimeMovingAverage)) / static_cast<float>(m_blurTimeMovingAverage);
-                    if (timeDelta < -.05f || timeDelta > .01f)
-                    {
-                        const float stepSize = max(1.0f, m_blurPSLoopCount);
-                        m_blurPSLoopCount += static_cast<INT>(stepSize * timeDelta);
-                    }
-                }
-            }
+			// Adjust the shader blur time to be at least 20ms/frame.
+			// Note: This is just done to show that we can reach ~100% utilization of both adapters.
+			if (AllowShaderDynamicWorkload)
+			{
+				const UINT64 desiredBlurPSTimeUS = 20000;	// 20 ms
+				if (m_blurTimeMovingAverage < desiredBlurPSTimeUS || m_blurPSLoopCount != 0)
+				{
+					// Adjust the PS blur time based on the moving average.
+					const float timeDelta = (static_cast<float>(desiredBlurPSTimeUS) - static_cast<float>(m_blurTimeMovingAverage)) / static_cast<float>(m_blurTimeMovingAverage);
+					if (timeDelta < -.05f || timeDelta > .01f)
+					{
+						const float stepSize = max(1.0f, m_blurPSLoopCount);
+						m_blurPSLoopCount += static_cast<INT>(stepSize * timeDelta);
+					}
+				}
+			}
 
-            // Adjust the render time to be greater than the blur time.
-            {
-                const UINT64 desiredDrawPSTimeUS = m_blurTimeMovingAverage + static_cast<UINT64>(m_blurTimeMovingAverage * .10f);
-                const float timeDelta = (static_cast<float>(desiredDrawPSTimeUS) - static_cast<float>(m_drawTimeMovingAverage)) / static_cast<float>(m_drawTimeMovingAverage);
-                if (timeDelta < -.10f || timeDelta > .01f)
-                {
-                    if (AllowDrawDynamicWorkload)
-                    {
-                        // Adjust the number of triangles drawn.
-                        const float stepSize = max(1.0f, m_triangleCount);
-                        m_triangleCount = min(m_triangleCount + static_cast<INT>(stepSize * timeDelta), MaxTriangleCount);
-                    }
-                    else if (AllowShaderDynamicWorkload)
-                    {
-                        // Adjust the number of the PS loop count based on the moving average.
-                        const float stepSize = max(1.0f, m_psLoopCount);
-                        m_psLoopCount += static_cast<INT>(stepSize * timeDelta);
-                    }
-                }
-            }
-        }
+			// Adjust the render time to be greater than the blur time.
+			{
+				const UINT64 desiredDrawPSTimeUS = m_blurTimeMovingAverage + static_cast<UINT64>(m_blurTimeMovingAverage * .10f);
+				const float timeDelta = (static_cast<float>(desiredDrawPSTimeUS) - static_cast<float>(m_drawTimeMovingAverage)) / static_cast<float>(m_drawTimeMovingAverage);
+				if (timeDelta < -.10f || timeDelta > .01f)
+				{
+					if (AllowDrawDynamicWorkload)
+					{
+						// Adjust the number of triangles drawn.
+						const float stepSize = max(1.0f, m_triangleCount);
+						m_triangleCount = min(m_triangleCount + static_cast<INT>(stepSize * timeDelta), MaxTriangleCount);
+					}
+					else if (AllowShaderDynamicWorkload)
+					{
+						// Adjust the number of the PS loop count based on the moving average.
+						const float stepSize = max(1.0f, m_psLoopCount);
+						m_psLoopCount += static_cast<INT>(stepSize * timeDelta);
+					}
+				}
+			}
+		}
 
-        // Conditionally update the window's title.
-        if (framesSinceLastUpdate % WindowTextUpdateFrequency == 0)
-        {
-            UpdateWindowTitle();
-        }
-    }
+		// Conditionally update the window's title.
+		if (framesSinceLastUpdate % WindowTextUpdateFrequency == 0)
+		{
+			UpdateWindowTitle();
+		}
+	}
 
-    // Update the workloads.
-    {
-        WorkloadConstantBufferData* pWorkloadDst = m_pWorkloadCbvDataBegin + m_frameIndex;
-        WorkloadConstantBufferData* pWorkloadSrc = &m_workloadConstantBufferData;
-        pWorkloadSrc->loopCount = m_psLoopCount;
-        memcpy(pWorkloadDst, pWorkloadSrc, sizeof(WorkloadConstantBufferData));
+	// Update the workloads.
+	{
+		WorkloadConstantBufferData* pWorkloadDst = m_pWorkloadCbvDataBegin + m_frameIndex;
+		WorkloadConstantBufferData* pWorkloadSrc = &m_workloadConstantBufferData;
+		pWorkloadSrc->loopCount = m_psLoopCount;
+		memcpy(pWorkloadDst, pWorkloadSrc, sizeof(WorkloadConstantBufferData));
 
-        WorkloadConstantBufferData* pBlurWorkloadDst = m_pBlurWorkloadCbvDataBegin + m_frameIndex;
-        WorkloadConstantBufferData* pBlurWorkloadSrc = &m_blurWorkloadConstantBufferData;
-        pBlurWorkloadSrc->loopCount = m_blurPSLoopCount;
-        memcpy(pBlurWorkloadDst, pBlurWorkloadSrc, sizeof(WorkloadConstantBufferData));
-    }
+		WorkloadConstantBufferData* pBlurWorkloadDst = m_pBlurWorkloadCbvDataBegin + m_frameIndex;
+		WorkloadConstantBufferData* pBlurWorkloadSrc = &m_blurWorkloadConstantBufferData;
+		pBlurWorkloadSrc->loopCount = m_blurPSLoopCount;
+		memcpy(pBlurWorkloadDst, pBlurWorkloadSrc, sizeof(WorkloadConstantBufferData));
+	}
 
-    // Update the triangles.
-    {
-        const float offsetBounds = 2.5f;
+	// Update the triangles.
+	{
+		const float offsetBounds = 2.5f;
 
-        for (UINT n = 0; n < m_triangleCount; n++)
-        {
-            // Animate the triangles.
-            m_constantBufferData[n].offset.x += m_constantBufferData[n].velocity.x;
-            if (m_constantBufferData[n].offset.x > offsetBounds)
-            {
-                m_constantBufferData[n].velocity.x = GetRandomFloat(0.01f, 0.02f);
-                m_constantBufferData[n].offset.x = -offsetBounds;
-            }
-        }
+		for (UINT n = 0; n < m_triangleCount; n++)
+		{
+			// Animate the triangles.
+			m_constantBufferData[n].offset.x += m_constantBufferData[n].velocity.x;
+			if (m_constantBufferData[n].offset.x > offsetBounds)
+			{
+				m_constantBufferData[n].velocity.x = GetRandomFloat(0.01f, 0.02f);
+				m_constantBufferData[n].offset.x = -offsetBounds;
+			}
+		}
 
-        SceneConstantBuffer* dst = m_pCbvDataBegin + (m_frameIndex * MaxTriangleCount);
-        memcpy(dst, &m_constantBufferData[0], m_triangleCount * sizeof(SceneConstantBuffer));
-    }
+		SceneConstantBuffer* dst = m_pCbvDataBegin + (m_frameIndex * MaxTriangleCount);
+		memcpy(dst, &m_constantBufferData[0], m_triangleCount * sizeof(SceneConstantBuffer));
+	}
 }
 
 // Render the scene.
 void D3D12HeterogeneousMultiadapter::OnRender()
 {
-    // Record all the commands we need to render the scene into the command lists.
-    PopulateCommandLists();
-
-    // Execute the command lists.
+    try
     {
-        {
-            ID3D12CommandList* ppRenderCommandLists[] = { m_directCommandLists[Primary].Get() };
-            m_directCommandQueues[Primary]->ExecuteCommandLists(_countof(ppRenderCommandLists), ppRenderCommandLists);
+        // Record all the commands we need to render the scene into the command lists.
+        PopulateCommandLists();
 
-            // Signal the copy queue to indicate render is complete.
-            ThrowIfFailed(m_directCommandQueues[Primary]->Signal(m_renderFence.Get(), m_currentRenderFenceValue));
+        // Execute the command lists.
+        {
+            {
+                ID3D12CommandList* ppRenderCommandLists[] = { m_directCommandLists[Primary].Get() };
+                m_directCommandQueues[Primary]->ExecuteCommandLists(_countof(ppRenderCommandLists), ppRenderCommandLists);
+
+                // Signal the copy queue to indicate render is complete.
+                ThrowIfFailed(m_directCommandQueues[Primary]->Signal(m_renderFence.Get(), m_currentRenderFenceValue));
+            }
+
+            {
+                // GPU Wait for the primary adapter to finish rendering.
+                ThrowIfFailed(m_copyCommandQueue->Wait(m_renderFence.Get(), m_currentRenderFenceValue));
+                m_currentRenderFenceValue++;
+
+                ID3D12CommandList* ppCopyCommandLists[] = { m_copyCommandList.Get() };
+                m_copyCommandQueue->ExecuteCommandLists(_countof(ppCopyCommandLists), ppCopyCommandLists);
+
+                // Signal the secondary adapter to indicate the copy is complete.
+                ThrowIfFailed(m_copyCommandQueue->Signal(m_crossAdapterFences[Primary].Get(), m_currentCrossAdapterFenceValue));
+            }
+
+            {
+                // GPU Wait for the primary adapter to finish copying.
+                ThrowIfFailed(m_directCommandQueues[Secondary]->Wait(m_crossAdapterFences[Secondary].Get(), m_currentCrossAdapterFenceValue));
+                m_currentCrossAdapterFenceValue++;
+
+                ID3D12CommandList* ppBlurCommandLists[] = { m_directCommandLists[Secondary].Get() };
+                m_directCommandQueues[Secondary]->ExecuteCommandLists(_countof(ppBlurCommandLists), ppBlurCommandLists);
+            }
         }
 
+        // Present the frame.
+        ThrowIfFailed(m_swapChain->Present(1, 0));
+
+        // Signal the frame is complete.
+        ThrowIfFailed(m_directCommandQueues[Secondary]->Signal(m_frameFence.Get(), m_currentPresentFenceValue));
+        m_frameFenceValues[m_frameIndex] = m_currentPresentFenceValue;
+        m_currentPresentFenceValue++;
+
+        MoveToNextFrame();
+    }
+    catch (HrException& e)
+    {
+        if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
         {
-            // GPU Wait for the primary adapter to finish rendering.
-            ThrowIfFailed(m_copyCommandQueue->Wait(m_renderFence.Get(), m_currentRenderFenceValue));
-            m_currentRenderFenceValue++;
-
-            ID3D12CommandList* ppCopyCommandLists[] = { m_copyCommandList.Get() };
-            m_copyCommandQueue->ExecuteCommandLists(_countof(ppCopyCommandLists), ppCopyCommandLists);
-
-            // Signal the secondary adapter to indicate the copy is complete.
-            ThrowIfFailed(m_copyCommandQueue->Signal(m_crossAdapterFences[Primary].Get(), m_currentCrossAdapterFenceValue));
+            RestoreD3DResources();
         }
-
+        else
         {
-            // GPU Wait for the primary adapter to finish copying.
-            ThrowIfFailed(m_directCommandQueues[Secondary]->Wait(m_crossAdapterFences[Secondary].Get(), m_currentCrossAdapterFenceValue));
-            m_currentCrossAdapterFenceValue++;
-
-            ID3D12CommandList* ppBlurCommandLists[] = { m_directCommandLists[Secondary].Get() };
-            m_directCommandQueues[Secondary]->ExecuteCommandLists(_countof(ppBlurCommandLists), ppBlurCommandLists);
+            throw;
         }
     }
+}
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+// Release sample's D3D objects.
+void D3D12HeterogeneousMultiadapter::ReleaseD3DResources()
+{
+    m_frameFence.Reset();
+    m_swapChain.Reset();
+    ResetComPtrArray(&m_devices);
+    ResetComPtrArray(&m_directCommandQueues);
+    for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+    {
+        ResetComPtrArray(&m_renderTargets[i]);
+    }
+}
 
-    // Signal the frame is complete.
-    ThrowIfFailed(m_directCommandQueues[Secondary]->Signal(m_frameFence.Get(), m_currentPresentFenceValue));
-    m_frameFenceValues[m_frameIndex] = m_currentPresentFenceValue;
-    m_currentPresentFenceValue++;
-
-    MoveToNextFrame();
+// Tears down D3D resources and reinitializes them.
+void D3D12HeterogeneousMultiadapter::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
+    {
+        for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+        {
+            WaitForGpu(static_cast<GraphicsAdapter>(i));
+        }
+    }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
 }
 
 void D3D12HeterogeneousMultiadapter::OnDestroy()
 {
-    // Ensure that the GPUs are no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    for (UINT i = 0; i < GraphicsAdaptersCount; i++)
-    {
-        WaitForGpu(static_cast<GraphicsAdapter>(i));
-        CloseHandle(m_fenceEvents[i]);
-    }
+	// Ensure that the GPUs are no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+	{
+		WaitForGpu(static_cast<GraphicsAdapter>(i));
+		CloseHandle(m_fenceEvents[i]);
+	}
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12HeterogeneousMultiadapter::PopulateCommandLists()
 {
-    // Command list to render target the triangles on the primary adapter.
-    {
-        const GraphicsAdapter adapter = Primary;
+	// Command list to render target the triangles on the primary adapter.
+	{
+		const GraphicsAdapter adapter = Primary;
 
-        // Command list allocators can only be reset when the associated 
-        // command lists have finished execution on the GPU; apps should use 
-        // fences to determine GPU execution progress.
-        ThrowIfFailed(m_directCommandAllocators[adapter][m_frameIndex]->Reset());
+		// Command list allocators can only be reset when the associated 
+		// command lists have finished execution on the GPU; apps should use 
+		// fences to determine GPU execution progress.
+		ThrowIfFailed(m_directCommandAllocators[adapter][m_frameIndex]->Reset());
 
-        // However, when ExecuteCommandList() is called on a particular command 
-        // list, that command list can then be reset at any time and must be before 
-        // re-recording.
-        ThrowIfFailed(m_directCommandLists[adapter]->Reset(m_directCommandAllocators[adapter][m_frameIndex].Get(), m_pipelineState.Get()));
+		// However, when ExecuteCommandList() is called on a particular command 
+		// list, that command list can then be reset at any time and must be before 
+		// re-recording.
+		ThrowIfFailed(m_directCommandLists[adapter]->Reset(m_directCommandAllocators[adapter][m_frameIndex].Get(), m_pipelineState.Get()));
 
-        // Get a timestamp at the start of the command list.
-        const UINT timestampHeapIndex = 2 * m_frameIndex;
-        m_directCommandLists[adapter]->EndQuery(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex);
+		// Get a timestamp at the start of the command list.
+		const UINT timestampHeapIndex = 2 * m_frameIndex;
+		m_directCommandLists[adapter]->EndQuery(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex);
 
-        // Set necessary state.
-        m_directCommandLists[adapter]->SetGraphicsRootSignature(m_rootSignature.Get());
+		// Set necessary state.
+		m_directCommandLists[adapter]->SetGraphicsRootSignature(m_rootSignature.Get());
 
-        m_directCommandLists[adapter]->RSSetViewports(1, &m_viewport);
-        m_directCommandLists[adapter]->RSSetScissorRects(1, &m_scissorRect);
+		m_directCommandLists[adapter]->RSSetViewports(1, &m_viewport);
+		m_directCommandLists[adapter]->RSSetScissorRects(1, &m_scissorRect);
 
-        // Indicate that the render target will be used as a render target.
-        m_directCommandLists[adapter]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[adapter][m_frameIndex].Get(), D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_RENDER_TARGET));
+		// Indicate that the render target will be used as a render target.
+		m_directCommandLists[adapter]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[adapter][m_frameIndex].Get(), D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeaps[adapter]->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSizes[adapter]);
-        CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-        m_directCommandLists[adapter]->OMSetRenderTargets(1, &rtvHandle, false, &dsvHandle);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeaps[adapter]->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSizes[adapter]);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+		m_directCommandLists[adapter]->OMSetRenderTargets(1, &rtvHandle, false, &dsvHandle);
 
-        // Record commands.
-        m_directCommandLists[adapter]->ClearRenderTargetView(rtvHandle, ClearColor, 0, nullptr);
-        m_directCommandLists[adapter]->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+		// Record commands.
+		m_directCommandLists[adapter]->ClearRenderTargetView(rtvHandle, ClearColor, 0, nullptr);
+		m_directCommandLists[adapter]->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
 
-        // Draw the triangles.
-        m_directCommandLists[adapter]->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-        m_directCommandLists[adapter]->IASetVertexBuffers(0, 1, &m_vertexBufferView);
-        m_directCommandLists[adapter]->SetGraphicsRootConstantBufferView(1, m_workloadConstantBuffer->GetGPUVirtualAddress() + (m_frameIndex * sizeof(WorkloadConstantBufferData)));
+		// Draw the triangles.
+		m_directCommandLists[adapter]->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+		m_directCommandLists[adapter]->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+		m_directCommandLists[adapter]->SetGraphicsRootConstantBufferView(1, m_workloadConstantBuffer->GetGPUVirtualAddress() + (m_frameIndex * sizeof(WorkloadConstantBufferData)));
 
-        const D3D12_GPU_VIRTUAL_ADDRESS cbVirtualAddress = m_constantBuffer->GetGPUVirtualAddress();
-        for (UINT n = 0; n < m_triangleCount; n++)
-        {
-            const D3D12_GPU_VIRTUAL_ADDRESS cbLocation = cbVirtualAddress + (m_frameIndex * MaxTriangleCount * sizeof(SceneConstantBuffer)) + (n * sizeof(SceneConstantBuffer));
-            m_directCommandLists[adapter]->SetGraphicsRootConstantBufferView(0, cbLocation);
-            m_directCommandLists[adapter]->DrawInstanced(3, 1, 0, 0);
-        }
+		const D3D12_GPU_VIRTUAL_ADDRESS cbVirtualAddress = m_constantBuffer->GetGPUVirtualAddress();
+		for (UINT n = 0; n < m_triangleCount; n++)
+		{
+			const D3D12_GPU_VIRTUAL_ADDRESS cbLocation = cbVirtualAddress + (m_frameIndex * MaxTriangleCount * sizeof(SceneConstantBuffer)) + (n * sizeof(SceneConstantBuffer));
+			m_directCommandLists[adapter]->SetGraphicsRootConstantBufferView(0, cbLocation);
+			m_directCommandLists[adapter]->DrawInstanced(3, 1, 0, 0);
+		}
 
-        // Indicate that the render target will now be used to copy.
-        m_directCommandLists[adapter]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[adapter][m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COMMON));
+		// Indicate that the render target will now be used to copy.
+		m_directCommandLists[adapter]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[adapter][m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COMMON));
 
-        // Get a timestamp at the end of the command list and resolve the query data.
-        m_directCommandLists[adapter]->EndQuery(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex + 1);
-        m_directCommandLists[adapter]->ResolveQueryData(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex, 2, m_timestampResultBuffers[adapter].Get(), timestampHeapIndex * sizeof(UINT64));
+		// Get a timestamp at the end of the command list and resolve the query data.
+		m_directCommandLists[adapter]->EndQuery(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex + 1);
+		m_directCommandLists[adapter]->ResolveQueryData(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex, 2, m_timestampResultBuffers[adapter].Get(), timestampHeapIndex * sizeof(UINT64));
 
-        ThrowIfFailed(m_directCommandLists[adapter]->Close());
-    }
+		ThrowIfFailed(m_directCommandLists[adapter]->Close());
+	}
 
-    // Command list to copy the render target to the shared heap on the primary adapter.
-    {
-        const GraphicsAdapter adapter = Primary;
+	// Command list to copy the render target to the shared heap on the primary adapter.
+	{
+		const GraphicsAdapter adapter = Primary;
 
-        // Reset the copy command allocator and command list.
-        ThrowIfFailed(m_copyCommandAllocators[m_frameIndex]->Reset());
-        ThrowIfFailed(m_copyCommandList->Reset(m_copyCommandAllocators[m_frameIndex].Get(), nullptr));
+		// Reset the copy command allocator and command list.
+		ThrowIfFailed(m_copyCommandAllocators[m_frameIndex]->Reset());
+		ThrowIfFailed(m_copyCommandList->Reset(m_copyCommandAllocators[m_frameIndex].Get(), nullptr));
 
-        // Copy the intermediate render target to the cross-adapter shared resource.
-        // Transition barriers are not required since there are fences guarding against
-        // concurrent read/write access to the shared heap.
-        if (m_crossAdapterTextureSupport)
-        {
-            // If cross-adapter row-major textures are supported by the adapter,
-            // simply copy the texture into the cross-adapter texture.
-            m_copyCommandList->CopyResource(m_crossAdapterResources[adapter][m_frameIndex].Get(), m_renderTargets[adapter][m_frameIndex].Get());
-        }
-        else
-        {
-            // If cross-adapter row-major textures are not supported by the adapter,
-            // the texture will be copied over as a buffer so that the texture row
-            // pitch can be explicitly managed.
+		// Copy the intermediate render target to the cross-adapter shared resource.
+		// Transition barriers are not required since there are fences guarding against
+		// concurrent read/write access to the shared heap.
+		if (m_crossAdapterTextureSupport)
+		{
+			// If cross-adapter row-major textures are supported by the adapter,
+			// simply copy the texture into the cross-adapter texture.
+			m_copyCommandList->CopyResource(m_crossAdapterResources[adapter][m_frameIndex].Get(), m_renderTargets[adapter][m_frameIndex].Get());
+		}
+		else
+		{
+			// If cross-adapter row-major textures are not supported by the adapter,
+			// the texture will be copied over as a buffer so that the texture row
+			// pitch can be explicitly managed.
 
-            // Copy the intermediate render target into the shared buffer using the
-            // memory layout prescribed by the render target.
-            D3D12_RESOURCE_DESC renderTargetDesc = m_renderTargets[adapter][m_frameIndex]->GetDesc();
-            D3D12_PLACED_SUBRESOURCE_FOOTPRINT renderTargetLayout;
+			// Copy the intermediate render target into the shared buffer using the
+			// memory layout prescribed by the render target.
+			D3D12_RESOURCE_DESC renderTargetDesc = m_renderTargets[adapter][m_frameIndex]->GetDesc();
+			D3D12_PLACED_SUBRESOURCE_FOOTPRINT renderTargetLayout;
 
-            m_devices[adapter]->GetCopyableFootprints(&renderTargetDesc, 0, 1, 0, &renderTargetLayout, nullptr, nullptr, nullptr);
+			m_devices[adapter]->GetCopyableFootprints(&renderTargetDesc, 0, 1, 0, &renderTargetLayout, nullptr, nullptr, nullptr);
 
-            CD3DX12_TEXTURE_COPY_LOCATION dest(m_crossAdapterResources[adapter][m_frameIndex].Get(), renderTargetLayout);
-            CD3DX12_TEXTURE_COPY_LOCATION src(m_renderTargets[adapter][m_frameIndex].Get(), 0);
-            CD3DX12_BOX box(0, 0, m_width, m_height);
+			CD3DX12_TEXTURE_COPY_LOCATION dest(m_crossAdapterResources[adapter][m_frameIndex].Get(), renderTargetLayout);
+			CD3DX12_TEXTURE_COPY_LOCATION src(m_renderTargets[adapter][m_frameIndex].Get(), 0);
+			CD3DX12_BOX box(0, 0, m_width, m_height);
 
-            m_copyCommandList->CopyTextureRegion(&dest, 0, 0, 0, &src, &box);
-        }
+			m_copyCommandList->CopyTextureRegion(&dest, 0, 0, 0, &src, &box);
+		}
 
-        ThrowIfFailed(m_copyCommandList->Close());
-    }
+		ThrowIfFailed(m_copyCommandList->Close());
+	}
 
-    // Command list to blur the render target and present.
-    {
-        const GraphicsAdapter adapter = Secondary;
+	// Command list to blur the render target and present.
+	{
+		const GraphicsAdapter adapter = Secondary;
 
-        // Command list allocators can only be reset when the associated 
-        // command lists have finished execution on the GPU; apps should use 
-        // fences to determine GPU execution progress.
-        ThrowIfFailed(m_directCommandAllocators[adapter][m_frameIndex]->Reset());
+		// Command list allocators can only be reset when the associated 
+		// command lists have finished execution on the GPU; apps should use 
+		// fences to determine GPU execution progress.
+		ThrowIfFailed(m_directCommandAllocators[adapter][m_frameIndex]->Reset());
 
-        // However, when ExecuteCommandList() is called on a particular command 
-        // list, that command list can then be reset at any time and must be before 
-        // re-recording.
-        ThrowIfFailed(m_directCommandLists[adapter]->Reset(m_directCommandAllocators[adapter][m_frameIndex].Get(), m_blurPipelineStates[0].Get()));
+		// However, when ExecuteCommandList() is called on a particular command 
+		// list, that command list can then be reset at any time and must be before 
+		// re-recording.
+		ThrowIfFailed(m_directCommandLists[adapter]->Reset(m_directCommandAllocators[adapter][m_frameIndex].Get(), m_blurPipelineStates[0].Get()));
 
-        if (!m_crossAdapterTextureSupport)
-        {
-            // Copy the buffer in the shared heap into a texture that the secondary
-            // adapter can sample from.
-            D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(
-                m_secondaryAdapterTextures[m_frameIndex].Get(),
-                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_COPY_DEST);
-            m_directCommandLists[adapter]->ResourceBarrier(1, &barrier);
+		if (!m_crossAdapterTextureSupport)
+		{
+			// Copy the buffer in the shared heap into a texture that the secondary
+			// adapter can sample from.
+			D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(
+				m_secondaryAdapterTextures[m_frameIndex].Get(),
+				D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+				D3D12_RESOURCE_STATE_COPY_DEST);
+			m_directCommandLists[adapter]->ResourceBarrier(1, &barrier);
 
-            // Copy the shared buffer contents into the texture using the memory
-            // layout prescribed by the texture.
-            D3D12_RESOURCE_DESC secondaryAdapterTexture = m_secondaryAdapterTextures[m_frameIndex]->GetDesc();
-            D3D12_PLACED_SUBRESOURCE_FOOTPRINT textureLayout;
+			// Copy the shared buffer contents into the texture using the memory
+			// layout prescribed by the texture.
+			D3D12_RESOURCE_DESC secondaryAdapterTexture = m_secondaryAdapterTextures[m_frameIndex]->GetDesc();
+			D3D12_PLACED_SUBRESOURCE_FOOTPRINT textureLayout;
 
-            m_devices[adapter]->GetCopyableFootprints(&secondaryAdapterTexture, 0, 1, 0, &textureLayout, nullptr, nullptr, nullptr);
+			m_devices[adapter]->GetCopyableFootprints(&secondaryAdapterTexture, 0, 1, 0, &textureLayout, nullptr, nullptr, nullptr);
 
-            CD3DX12_TEXTURE_COPY_LOCATION dest(m_secondaryAdapterTextures[m_frameIndex].Get(), 0);
-            CD3DX12_TEXTURE_COPY_LOCATION src(m_crossAdapterResources[adapter][m_frameIndex].Get(), textureLayout);
-            CD3DX12_BOX box(0, 0, m_width, m_height);
+			CD3DX12_TEXTURE_COPY_LOCATION dest(m_secondaryAdapterTextures[m_frameIndex].Get(), 0);
+			CD3DX12_TEXTURE_COPY_LOCATION src(m_crossAdapterResources[adapter][m_frameIndex].Get(), textureLayout);
+			CD3DX12_BOX box(0, 0, m_width, m_height);
 
-            m_directCommandLists[adapter]->CopyTextureRegion(&dest, 0, 0, 0, &src, &box);
+			m_directCommandLists[adapter]->CopyTextureRegion(&dest, 0, 0, 0, &src, &box);
 
-            barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
-            barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-            m_directCommandLists[adapter]->ResourceBarrier(1, &barrier);
-        }
+			barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
+			barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+			m_directCommandLists[adapter]->ResourceBarrier(1, &barrier);
+		}
 
-        // Get a timestamp at the start of the command list.
-        const UINT timestampHeapIndex = 2 * m_frameIndex;
-        m_directCommandLists[adapter]->EndQuery(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex);
+		// Get a timestamp at the start of the command list.
+		const UINT timestampHeapIndex = 2 * m_frameIndex;
+		m_directCommandLists[adapter]->EndQuery(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex);
 
-        // Set necessary state.
-        m_directCommandLists[adapter]->SetGraphicsRootSignature(m_blurRootSignature.Get());
+		// Set necessary state.
+		m_directCommandLists[adapter]->SetGraphicsRootSignature(m_blurRootSignature.Get());
 
-        ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvUavHeap.Get() };
-        m_directCommandLists[adapter]->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+		ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvUavHeap.Get() };
+		m_directCommandLists[adapter]->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-        m_directCommandLists[adapter]->RSSetViewports(1, &m_viewport);
-        m_directCommandLists[adapter]->RSSetScissorRects(1, &m_scissorRect);
+		m_directCommandLists[adapter]->RSSetViewports(1, &m_viewport);
+		m_directCommandLists[adapter]->RSSetScissorRects(1, &m_scissorRect);
 
-        // Indicate that the intermediate render target will be used as a render target.
-        m_directCommandLists[adapter]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_intermediateBlurRenderTarget.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET));
+		// Indicate that the intermediate render target will be used as a render target.
+		m_directCommandLists[adapter]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_intermediateBlurRenderTarget.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-        // Record commands.
-        m_directCommandLists[adapter]->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-        m_directCommandLists[adapter]->IASetVertexBuffers(0, 1, &m_fullscreenQuadVertexBufferView);
-        m_directCommandLists[adapter]->SetGraphicsRootConstantBufferView(0, m_blurConstantBuffer->GetGPUVirtualAddress());
-        m_directCommandLists[adapter]->SetGraphicsRootConstantBufferView(2, m_blurWorkloadConstantBuffer->GetGPUVirtualAddress() + (m_frameIndex * sizeof(WorkloadConstantBufferData)));
+		// Record commands.
+		m_directCommandLists[adapter]->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+		m_directCommandLists[adapter]->IASetVertexBuffers(0, 1, &m_fullscreenQuadVertexBufferView);
+		m_directCommandLists[adapter]->SetGraphicsRootConstantBufferView(0, m_blurConstantBuffer->GetGPUVirtualAddress());
+		m_directCommandLists[adapter]->SetGraphicsRootConstantBufferView(2, m_blurWorkloadConstantBuffer->GetGPUVirtualAddress() + (m_frameIndex * sizeof(WorkloadConstantBufferData)));
 
-        // Draw the fullscreen quad - Blur pass #1.
-        {
-            CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_cbvSrvUavHeap->GetGPUDescriptorHandleForHeapStart(), m_frameIndex, m_srvDescriptorSizes[adapter]);
-            m_directCommandLists[adapter]->SetGraphicsRootDescriptorTable(1, srvHandle);
+		// Draw the fullscreen quad - Blur pass #1.
+		{
+			CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_cbvSrvUavHeap->GetGPUDescriptorHandleForHeapStart(), m_frameIndex, m_srvDescriptorSizes[adapter]);
+			m_directCommandLists[adapter]->SetGraphicsRootDescriptorTable(1, srvHandle);
 
-            CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeaps[adapter]->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSizes[adapter]);
-            m_directCommandLists[adapter]->OMSetRenderTargets(1, &rtvHandle, false, nullptr);
+			CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeaps[adapter]->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSizes[adapter]);
+			m_directCommandLists[adapter]->OMSetRenderTargets(1, &rtvHandle, false, nullptr);
 
-            m_directCommandLists[adapter]->DrawInstanced(4, 1, 0, 0);
-        }
+			m_directCommandLists[adapter]->DrawInstanced(4, 1, 0, 0);
+		}
 
-        // Draw the fullscreen quad - Blur pass #2.
-        {
-            m_directCommandLists[adapter]->SetPipelineState(m_blurPipelineStates[1].Get());
+		// Draw the fullscreen quad - Blur pass #2.
+		{
+			m_directCommandLists[adapter]->SetPipelineState(m_blurPipelineStates[1].Get());
 
-            // Indicate that the back buffer will be used as a render target and the
-            // intermediate render target will be used as a SRV.
-            D3D12_RESOURCE_BARRIER barriers[] = {
-                CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[adapter][m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET),
-                CD3DX12_RESOURCE_BARRIER::Transition(m_intermediateBlurRenderTarget.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE)
-            };
+			// Indicate that the back buffer will be used as a render target and the
+			// intermediate render target will be used as a SRV.
+			D3D12_RESOURCE_BARRIER barriers[] = {
+				CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[adapter][m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET),
+				CD3DX12_RESOURCE_BARRIER::Transition(m_intermediateBlurRenderTarget.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE)
+			};
 
-            m_directCommandLists[adapter]->ResourceBarrier(_countof(barriers), barriers);
+			m_directCommandLists[adapter]->ResourceBarrier(_countof(barriers), barriers);
 
-            CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_cbvSrvUavHeap->GetGPUDescriptorHandleForHeapStart(), FrameCount, m_srvDescriptorSizes[adapter]);
-            m_directCommandLists[adapter]->SetGraphicsRootDescriptorTable(1, srvHandle);
+			CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_cbvSrvUavHeap->GetGPUDescriptorHandleForHeapStart(), FrameCount, m_srvDescriptorSizes[adapter]);
+			m_directCommandLists[adapter]->SetGraphicsRootDescriptorTable(1, srvHandle);
 
-            CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeaps[adapter]->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSizes[adapter]);
-            m_directCommandLists[adapter]->OMSetRenderTargets(1, &rtvHandle, false, nullptr);
+			CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeaps[adapter]->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSizes[adapter]);
+			m_directCommandLists[adapter]->OMSetRenderTargets(1, &rtvHandle, false, nullptr);
 
-            m_directCommandLists[adapter]->DrawInstanced(4, 1, 0, 0);
-        }
+			m_directCommandLists[adapter]->DrawInstanced(4, 1, 0, 0);
+		}
 
-        // Indicate that the back buffer will now be used to present.
-        m_directCommandLists[adapter]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[adapter][m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+		// Indicate that the back buffer will now be used to present.
+		m_directCommandLists[adapter]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[adapter][m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-        // Get a timestamp at the end of the command list and resolve the query data.
-        m_directCommandLists[adapter]->EndQuery(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex + 1);
-        m_directCommandLists[adapter]->ResolveQueryData(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex, 2, m_timestampResultBuffers[adapter].Get(), timestampHeapIndex * sizeof(UINT64));
+		// Get a timestamp at the end of the command list and resolve the query data.
+		m_directCommandLists[adapter]->EndQuery(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex + 1);
+		m_directCommandLists[adapter]->ResolveQueryData(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex, 2, m_timestampResultBuffers[adapter].Get(), timestampHeapIndex * sizeof(UINT64));
 
-        ThrowIfFailed(m_directCommandLists[adapter]->Close());
-    }
+		ThrowIfFailed(m_directCommandLists[adapter]->Close());
+	}
 }
 
 void D3D12HeterogeneousMultiadapter::UpdateWindowTitle()
 {
-    std::wstringstream stringStream;
+	std::wstringstream stringStream;
 
-    stringStream << L"[" << m_triangleCount << L" triangles]";
-    stringStream << L" [Render, " << m_adapterDescs[Primary].Description << ": " << m_drawTimeMovingAverage << L"us" << L" (PS loop count : " << m_psLoopCount<< ")]";
-    stringStream << L" [Blur, " << m_adapterDescs[Secondary].Description << ": " << m_blurTimeMovingAverage << L"us" << L" (PS loop count : " << m_blurPSLoopCount << ")]";
+	stringStream << L"[" << m_triangleCount << L" triangles]";
+	stringStream << L" [Render, " << m_adapterDescs[Primary].Description << ": " << m_drawTimeMovingAverage << L"us" << L" (PS loop count : " << m_psLoopCount<< ")]";
+	stringStream << L" [Blur, " << m_adapterDescs[Secondary].Description << ": " << m_blurTimeMovingAverage << L"us" << L" (PS loop count : " << m_blurPSLoopCount << ")]";
 
-    SetCustomWindowText(stringStream.str().c_str());
+	SetCustomWindowText(stringStream.str().c_str());
 }
 
 // Wait for pending GPU work to complete.
 void D3D12HeterogeneousMultiadapter::WaitForGpu(GraphicsAdapter adapter)
 {
-    // Schedule a Signal command in the queue.
-    // Note we just re-use the cross adapter fence for convenience.
-    ThrowIfFailed(m_directCommandQueues[adapter]->Signal(m_crossAdapterFences[adapter].Get(), m_currentCrossAdapterFenceValue));
+	// Schedule a Signal command in the queue.
+	// Note we just re-use the cross adapter fence for convenience.
+	ThrowIfFailed(m_directCommandQueues[adapter]->Signal(m_crossAdapterFences[adapter].Get(), m_currentCrossAdapterFenceValue));
 
-    // Wait until the fence has been processed.
-    ThrowIfFailed(m_crossAdapterFences[adapter]->SetEventOnCompletion(m_currentCrossAdapterFenceValue, m_fenceEvents[adapter]));
-    WaitForSingleObject(m_fenceEvents[adapter], INFINITE);
-    m_currentCrossAdapterFenceValue++;
+	// Wait until the fence has been processed.
+	ThrowIfFailed(m_crossAdapterFences[adapter]->SetEventOnCompletion(m_currentCrossAdapterFenceValue, m_fenceEvents[adapter]));
+	WaitForSingleObject(m_fenceEvents[adapter], INFINITE);
+	m_currentCrossAdapterFenceValue++;
 }
 
 // Prepare to render the next frame.
 void D3D12HeterogeneousMultiadapter::MoveToNextFrame()
 {
-    // Get the current the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Get the current the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    const UINT64 completedFenceValue = m_frameFence->GetCompletedValue();
-    if (completedFenceValue < m_frameFenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_frameFence->SetEventOnCompletion(m_frameFenceValues[m_frameIndex], m_fenceEvents[Secondary]));
-        WaitForSingleObject(m_fenceEvents[Secondary], INFINITE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	const UINT64 completedFenceValue = m_frameFence->GetCompletedValue();
+	if (completedFenceValue < m_frameFenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_frameFence->SetEventOnCompletion(m_frameFenceValues[m_frameIndex], m_fenceEvents[Secondary]));
+		WaitForSingleObject(m_fenceEvents[Secondary], INFINITE);
+	}
 }

--- a/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/D3D12HeterogeneousMultiadapter.h
+++ b/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/D3D12HeterogeneousMultiadapter.h
@@ -25,159 +25,161 @@ using Microsoft::WRL::ComPtr;
 class D3D12HeterogeneousMultiadapter : public DXSample
 {
 public:
-    D3D12HeterogeneousMultiadapter(int width, int height, LPCWSTR name);
+	D3D12HeterogeneousMultiadapter(int width, int height, LPCWSTR name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    static const bool AllowDrawDynamicWorkload = false;        // Allow the sample to change the number of triangles drawn, in an attempt to balance the workload between adapters.
-    static const bool AllowShaderDynamicWorkload = true;    // Allow the sample to change PS complexity (simulated), in an attempt to balance the workload between adapters.
+	static const bool AllowDrawDynamicWorkload = false;		// Allow the sample to change the number of triangles drawn, in an attempt to balance the workload between adapters.
+	static const bool AllowShaderDynamicWorkload = true;	// Allow the sample to change PS complexity (simulated), in an attempt to balance the workload between adapters.
 
-    static const UINT FrameCount = 3;
-    static const float ClearColor[4];
-    static const UINT MovingAverageFrameCount = 20;
-    static const UINT WindowTextUpdateFrequency = 20;    // Update the window title every x frames.
-    static const UINT MaxTriangleCount = 15000;            // The max number of triangles per frame.
-    static const float TriangleHalfWidth;                // The x and y offsets used by the triangle vertices.
-    static const float TriangleDepth;                    // The z offset used by the triangle vertices.
+	static const UINT FrameCount = 3;
+	static const float ClearColor[4];
+	static const UINT MovingAverageFrameCount = 20;
+	static const UINT WindowTextUpdateFrequency = 20;	// Update the window title every x frames.
+	static const UINT MaxTriangleCount = 15000;			// The max number of triangles per frame.
+	static const float TriangleHalfWidth;				// The x and y offsets used by the triangle vertices.
+	static const float TriangleDepth;					// The z offset used by the triangle vertices.
 
-    UINT m_frameIndex;
-    UINT m_triangleCount;
-    UINT m_psLoopCount;
-    UINT m_blurPSLoopCount;
-    UINT m_currentTimesIndex;
-    UINT64 m_drawTimes[MovingAverageFrameCount];
-    UINT64 m_blurTimes[MovingAverageFrameCount];
-    UINT64 m_drawTimeMovingAverage;
-    UINT64 m_blurTimeMovingAverage;
+	UINT m_frameIndex;
+	UINT m_triangleCount;
+	UINT m_psLoopCount;
+	UINT m_blurPSLoopCount;
+	UINT m_currentTimesIndex;
+	UINT64 m_drawTimes[MovingAverageFrameCount];
+	UINT64 m_blurTimes[MovingAverageFrameCount];
+	UINT64 m_drawTimeMovingAverage;
+	UINT64 m_blurTimeMovingAverage;
 
-    // Vertex definitions.
-    struct Vertex
-    {
-        XMFLOAT3 position;
-    };
+	// Vertex definitions.
+	struct Vertex
+	{
+		XMFLOAT3 position;
+	};
 
-    struct VertexPositionUV
-    {
-        XMFLOAT4 position;
-        XMFLOAT2 uv;
-    };
+	struct VertexPositionUV
+	{
+		XMFLOAT4 position;
+		XMFLOAT2 uv;
+	};
 
-    // Constant buffer definitions.
-    struct SceneConstantBuffer
-    {
-        XMFLOAT4 velocity;
-        XMFLOAT4 offset;
-        XMFLOAT4 color;
-        XMFLOAT4X4 projection;
+	// Constant buffer definitions.
+	struct SceneConstantBuffer
+	{
+		XMFLOAT4 velocity;
+		XMFLOAT4 offset;
+		XMFLOAT4 color;
+		XMFLOAT4X4 projection;
 
-        // Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
-        // to be array-indexed.
-        float padding[36];
-    };
+		// Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
+		// to be array-indexed.
+		float padding[36];
+	};
 
-    struct BlurConstantBufferData
-    {
-        XMFLOAT2 textureDimensions;
+	struct BlurConstantBufferData
+	{
+		XMFLOAT2 textureDimensions;
 
-        // Controls how much of the render target is blurred along X axis [0.0. 1.0]. 
-        // E.g. 1 = all of the RT is blurred, 0.5 = half of the RT is blurred, 0.0 = none of the RT is blurred
-        FLOAT offset;
+		// Controls how much of the render target is blurred along X axis [0.0. 1.0]. 
+		// E.g. 1 = all of the RT is blurred, 0.5 = half of the RT is blurred, 0.0 = none of the RT is blurred
+		FLOAT offset;
 
-        // Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
-        // to be array-indexed.
-        float padding[61];
-    };
+		// Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
+		// to be array-indexed.
+		float padding[61];
+	};
 
-    struct WorkloadConstantBufferData
-    {
-        UINT loopCount;
+	struct WorkloadConstantBufferData
+	{
+		UINT loopCount;
 
-        // Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
-        // to be array-indexed.
-        float padding[63];
-    };
+		// Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
+		// to be array-indexed.
+		float padding[63];
+	};
 
-    enum GraphicsAdapter
-    {
-        Primary, // Note: Not necessarily the OS's primary adapter (adapter enumerated at index 0).
-        Secondary,
-        GraphicsAdaptersCount
-    };
+	enum GraphicsAdapter
+	{
+		Primary, // Note: Not necessarily the OS's primary adapter (adapter enumerated at index 0).
+		Secondary,
+		GraphicsAdaptersCount
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    UINT m_rtvDescriptorSizes[GraphicsAdaptersCount];
-    UINT m_srvDescriptorSizes[GraphicsAdaptersCount];
-    DXGI_ADAPTER_DESC1 m_adapterDescs[GraphicsAdaptersCount];
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_devices[GraphicsAdaptersCount];
-    ComPtr<ID3D12CommandAllocator> m_directCommandAllocators[GraphicsAdaptersCount][FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_copyCommandAllocators[FrameCount];
-    ComPtr<ID3D12CommandQueue> m_directCommandQueues[GraphicsAdaptersCount];
-    ComPtr<ID3D12CommandQueue> m_copyCommandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12RootSignature> m_blurRootSignature;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12PipelineState> m_blurPipelineStates[2];
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeaps[GraphicsAdaptersCount];
-    ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_cbvSrvUavHeap;
-    ComPtr<ID3D12GraphicsCommandList> m_directCommandLists[GraphicsAdaptersCount];
-    ComPtr<ID3D12GraphicsCommandList> m_copyCommandList;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	UINT m_rtvDescriptorSizes[GraphicsAdaptersCount];
+	UINT m_srvDescriptorSizes[GraphicsAdaptersCount];
+	DXGI_ADAPTER_DESC1 m_adapterDescs[GraphicsAdaptersCount];
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_devices[GraphicsAdaptersCount];
+	ComPtr<ID3D12CommandAllocator> m_directCommandAllocators[GraphicsAdaptersCount][FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_copyCommandAllocators[FrameCount];
+	ComPtr<ID3D12CommandQueue> m_directCommandQueues[GraphicsAdaptersCount];
+	ComPtr<ID3D12CommandQueue> m_copyCommandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12RootSignature> m_blurRootSignature;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12PipelineState> m_blurPipelineStates[2];
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeaps[GraphicsAdaptersCount];
+	ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_cbvSrvUavHeap;
+	ComPtr<ID3D12GraphicsCommandList> m_directCommandLists[GraphicsAdaptersCount];
+	ComPtr<ID3D12GraphicsCommandList> m_copyCommandList;
 
-    // Synchronization objects.
-    ComPtr<ID3D12Fence> m_frameFence;
-    ComPtr<ID3D12Fence> m_renderFence;
-    ComPtr<ID3D12Fence> m_crossAdapterFences[GraphicsAdaptersCount];
-    UINT64 m_currentPresentFenceValue;
-    UINT64 m_currentRenderFenceValue;
-    UINT64 m_currentCrossAdapterFenceValue;
-    UINT64 m_frameFenceValues[FrameCount];
-    HANDLE m_fenceEvents[GraphicsAdaptersCount];
+	// Synchronization objects.
+	ComPtr<ID3D12Fence> m_frameFence;
+	ComPtr<ID3D12Fence> m_renderFence;
+	ComPtr<ID3D12Fence> m_crossAdapterFences[GraphicsAdaptersCount];
+	UINT64 m_currentPresentFenceValue;
+	UINT64 m_currentRenderFenceValue;
+	UINT64 m_currentCrossAdapterFenceValue;
+	UINT64 m_frameFenceValues[FrameCount];
+	HANDLE m_fenceEvents[GraphicsAdaptersCount];
 
-    // Asset objects.
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    ComPtr<ID3D12Resource> m_fullscreenQuadVertexBuffer;
-    ComPtr<ID3D12Resource> m_constantBuffer;
-    ComPtr<ID3D12Resource> m_workloadConstantBuffer;
-    ComPtr<ID3D12Resource> m_blurWorkloadConstantBuffer;
-    ComPtr<ID3D12Resource> m_blurConstantBuffer;
-    ComPtr<ID3D12Resource> m_depthStencil;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
-    D3D12_VERTEX_BUFFER_VIEW m_fullscreenQuadVertexBufferView;
-    std::vector<SceneConstantBuffer> m_constantBufferData;
-    SceneConstantBuffer* m_pCbvDataBegin;
-    BlurConstantBufferData* m_pBlurCbvDataBegin;
-    WorkloadConstantBufferData m_workloadConstantBufferData;
-    WorkloadConstantBufferData* m_pWorkloadCbvDataBegin;
-    WorkloadConstantBufferData m_blurWorkloadConstantBufferData;
-    WorkloadConstantBufferData* m_pBlurWorkloadCbvDataBegin;
-    ComPtr<ID3D12Heap> m_crossAdapterResourceHeaps[GraphicsAdaptersCount];
-    ComPtr<ID3D12Resource> m_crossAdapterResources[GraphicsAdaptersCount][FrameCount];
-    BOOL m_crossAdapterTextureSupport;
-    ComPtr<ID3D12Resource> m_secondaryAdapterTextures[FrameCount];            // Only used if cross adapter texture support is unavailable.
-    ComPtr<ID3D12Resource> m_renderTargets[GraphicsAdaptersCount][FrameCount];
-    ComPtr<ID3D12Resource> m_intermediateBlurRenderTarget;
-    ComPtr<ID3D12QueryHeap> m_timestampQueryHeaps[GraphicsAdaptersCount];
-    ComPtr<ID3D12Resource> m_timestampResultBuffers[GraphicsAdaptersCount];
-    UINT64 m_directCommandQueueTimestampFrequencies[GraphicsAdaptersCount];
+	// Asset objects.
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	ComPtr<ID3D12Resource> m_fullscreenQuadVertexBuffer;
+	ComPtr<ID3D12Resource> m_constantBuffer;
+	ComPtr<ID3D12Resource> m_workloadConstantBuffer;
+	ComPtr<ID3D12Resource> m_blurWorkloadConstantBuffer;
+	ComPtr<ID3D12Resource> m_blurConstantBuffer;
+	ComPtr<ID3D12Resource> m_depthStencil;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	D3D12_VERTEX_BUFFER_VIEW m_fullscreenQuadVertexBufferView;
+	std::vector<SceneConstantBuffer> m_constantBufferData;
+	SceneConstantBuffer* m_pCbvDataBegin;
+	BlurConstantBufferData* m_pBlurCbvDataBegin;
+	WorkloadConstantBufferData m_workloadConstantBufferData;
+	WorkloadConstantBufferData* m_pWorkloadCbvDataBegin;
+	WorkloadConstantBufferData m_blurWorkloadConstantBufferData;
+	WorkloadConstantBufferData* m_pBlurWorkloadCbvDataBegin;
+	ComPtr<ID3D12Heap> m_crossAdapterResourceHeaps[GraphicsAdaptersCount];
+	ComPtr<ID3D12Resource> m_crossAdapterResources[GraphicsAdaptersCount][FrameCount];
+	BOOL m_crossAdapterTextureSupport;
+	ComPtr<ID3D12Resource> m_secondaryAdapterTextures[FrameCount];			// Only used if cross adapter texture support is unavailable.
+	ComPtr<ID3D12Resource> m_renderTargets[GraphicsAdaptersCount][FrameCount];
+	ComPtr<ID3D12Resource> m_intermediateBlurRenderTarget;
+	ComPtr<ID3D12QueryHeap> m_timestampQueryHeaps[GraphicsAdaptersCount];
+	ComPtr<ID3D12Resource> m_timestampResultBuffers[GraphicsAdaptersCount];
+	UINT64 m_directCommandQueueTimestampFrequencies[GraphicsAdaptersCount];
 
-    HRESULT GetHardwareAdapters(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppPrimaryAdapter, _Outptr_result_maybenull_ IDXGIAdapter1** ppSecondaryAdapter);
-    void LoadPipeline();
-    void LoadAssets();
-    float GetRandomFloat(float min, float max);
-    void PopulateCommandLists();
-    void UpdateWindowTitle();
-    void WaitForGpu(GraphicsAdapter adapter);
-    void MoveToNextFrame();
+	HRESULT GetHardwareAdapters(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppPrimaryAdapter, _Outptr_result_maybenull_ IDXGIAdapter1** ppSecondaryAdapter);
+	void LoadPipeline();
+	void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
+	float GetRandomFloat(float min, float max);
+	void PopulateCommandLists();
+	void UpdateWindowTitle();
+	void WaitForGpu(GraphicsAdapter adapter);
+	void MoveToNextFrame();
 
-    static inline UINT Align(UINT size, UINT alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT)
-    {
-        return (size + alignment - 1) & ~(alignment - 1);
-    }
+	static inline UINT Align(UINT size, UINT alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT)
+	{
+		return (size + alignment - 1) & ~(alignment - 1);
+	}
 };

--- a/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,58 +34,103 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title + L": " + text;
-    SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
+	std::wstring windowText = m_title + L": " + text;
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/DXSample.h
+++ b/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/DXSample.h
@@ -17,42 +17,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/Main.cpp
+++ b/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12HeterogeneousMultiadapter sample(1280, 720, L"D3D12 Heterogeneous multiadapter with shared heaps");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12HeterogeneousMultiadapter sample(1280, 720, L"D3D12 Heterogeneous multiadapter with shared heaps");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/Win32Application.cpp
+++ b/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/Win32Application.cpp
@@ -16,104 +16,104 @@ HWND Win32Application::m_hwnd = nullptr;
 
 int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
 {
-    // Parse the command line parameters
-    int argc;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    pSample->ParseCommandLineArgs(argv, argc);
-    LocalFree(argv);
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
 
-    // Initialize the window class.
-    WNDCLASSEX windowClass = { 0 };
-    windowClass.cbSize = sizeof(WNDCLASSEX);
-    windowClass.style = CS_HREDRAW | CS_VREDRAW;
-    windowClass.lpfnWndProc = WindowProc;
-    windowClass.hInstance = hInstance;
-    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-    windowClass.lpszClassName = L"DXSampleClass";
-    RegisterClassEx(&windowClass);
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
 
-    RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
-    AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
 
-    // Create the window and store a handle to it.
-    m_hwnd = CreateWindow(
-        windowClass.lpszClassName,
-        pSample->GetTitle(),
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        windowRect.right - windowRect.left,
-        windowRect.bottom - windowRect.top,
-        nullptr,        // We have no parent window.
-        nullptr,        // We aren't using menus.
-        hInstance,
-        pSample);
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
 
-    // Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-    pSample->OnInit();
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
 
-    ShowWindow(m_hwnd, nCmdShow);
+	ShowWindow(m_hwnd, nCmdShow);
 
-    // Main sample loop.
-    MSG msg = {};
-    while (msg.message != WM_QUIT)
-    {
-        // Process any messages in the queue.
-        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
-    }
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
 
-    pSample->OnDestroy();
+	pSample->OnDestroy();
 
-    // Return this part of the WM_QUIT message to Windows.
-    return static_cast<char>(msg.wParam);
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
 }
 
 // Main message handler for the sample.
 LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
-    switch (message)
-    {
-    case WM_CREATE:
-        {
-            // Save the DXSample* passed in to CreateWindow.
-            LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
-            SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
-        }
-        return 0;
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
 
-    case WM_KEYDOWN:
-        if (pSample)
-        {
-            pSample->OnKeyDown(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_KEYUP:
-        if (pSample)
-        {
-            pSample->OnKeyUp(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_PAINT:
-        if (pSample)
-        {
-            pSample->OnUpdate();
-            pSample->OnRender();
-        }
-        return 0;
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
 
-    case WM_DESTROY:
-        PostQuitMessage(0);
-        return 0;
-    }
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
 
-    // Handle any messages the switch statement didn't.
-    return DefWindowProc(hWnd, message, wParam, lParam);
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/Win32Application.h
+++ b/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/Win32Application.h
@@ -18,12 +18,12 @@ class DXSample;
 class Win32Application
 {
 public:
-    static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
-    static HWND GetHwnd() { return m_hwnd; }
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
 
 protected:
-    static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
-    static HWND m_hwnd;
+	static HWND m_hwnd;
 };

--- a/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/blurShaders.hlsl
+++ b/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/blurShaders.hlsl
@@ -11,23 +11,23 @@
 
 struct VSInput
 {
-    float4 position : POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : POSITION;
+	float2 uv : TEXCOORD;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 // A pass-through function for the texture coordinate data.
 PSInput VSSimpleBlur(VSInput input)
 {
-    PSInput output;
-    output.position = input.position;
-    output.uv = input.uv;
-    return output;
+	PSInput output;
+	output.position = input.position;
+	output.uv = input.uv;
+	return output;
 }
 
 static const float KernelOffsets[3] = { 0.0f, 1.3846153846f, 3.2307692308f };
@@ -40,81 +40,81 @@ SamplerState linearSampler : register(s1);
 
 cbuffer GaussianBlurConstantBuffer : register(b0)
 {
-    float2 textureDimensions;    // The render target width/height.
-    float blurXOffset;            // Controls how much of the render target is blurred along X axis [0.0. 1.0]. E.g. 1 = all of the RT is blurred, 0.5 = half of the RT is blurred, 0.0 = none of the RT is blurred.
+	float2 textureDimensions;	// The render target width/height.
+	float blurXOffset;			// Controls how much of the render target is blurred along X axis [0.0. 1.0]. E.g. 1 = all of the RT is blurred, 0.5 = half of the RT is blurred, 0.0 = none of the RT is blurred.
 };
 
 cbuffer WorkloadConstantBuffer : register(b1)
 {
-    uint loopCount;
+	uint loopCount;
 };
 
 // Simple gaussian blur in the vertical direction.
 float4 PSSimpleBlurV(PSInput input) : SV_TARGET
 {
-    float3 textureColor = float3(1.0f, 0.0f, 0.0f);
-    float2 uv = input.uv;
-    if (uv.x > (blurXOffset + 0.005f))
-    {
-        textureColor = tex.Sample(linearSampler, uv).xyz * BlurWeights[0];
-        for (int i = 1; i < 3; i++)
-        {
-            float2 normalizedOffset = float2(0.0f, KernelOffsets[i]) / textureDimensions.y;
-            textureColor += tex.Sample(linearSampler, uv + normalizedOffset).xyz * BlurWeights[i];
-            textureColor += tex.Sample(linearSampler, uv - normalizedOffset).xyz * BlurWeights[i];
-        }
-    }
-    else if (uv.x <= (blurXOffset - 0.005f))
-    {
-        textureColor = tex.Sample(pointSampler, uv).xyz;
-    }
+	float3 textureColor = float3(1.0f, 0.0f, 0.0f);
+	float2 uv = input.uv;
+	if (uv.x > (blurXOffset + 0.005f))
+	{
+		textureColor = tex.Sample(linearSampler, uv).xyz * BlurWeights[0];
+		for (int i = 1; i < 3; i++)
+		{
+			float2 normalizedOffset = float2(0.0f, KernelOffsets[i]) / textureDimensions.y;
+			textureColor += tex.Sample(linearSampler, uv + normalizedOffset).xyz * BlurWeights[i];
+			textureColor += tex.Sample(linearSampler, uv - normalizedOffset).xyz * BlurWeights[i];
+		}
+	}
+	else if (uv.x <= (blurXOffset - 0.005f))
+	{
+		textureColor = tex.Sample(pointSampler, uv).xyz;
+	}
 
-    // Artificially increase the workload to simulate a more complex shader.
-    const float3 textureColorOrig = textureColor;
-    for (uint i = 0; i < loopCount; i++)
-    {
-        textureColor += textureColorOrig;
-    }
+	// Artificially increase the workload to simulate a more complex shader.
+	const float3 textureColorOrig = textureColor;
+	for (uint i = 0; i < loopCount; i++)
+	{
+		textureColor += textureColorOrig;
+	}
 
-    if (loopCount > 0)
-    {
-        textureColor /= loopCount + 1;
-    }
+	if (loopCount > 0)
+	{
+		textureColor /= loopCount + 1;
+	}
 
-    return float4(textureColor, 1.0);
+	return float4(textureColor, 1.0);
 }
 
 // Simple gaussian blur in the horizontal direction.
 float4 PSSimpleBlurU(PSInput input) : SV_TARGET
 {
-    float3 textureColor = float3(1.0f, 0.0f, 0.0f);
-    float2 uv = input.uv;
-    if (uv.x > (blurXOffset + 0.005f))
-    {
-        textureColor = tex.Sample(linearSampler, uv).xyz * BlurWeights[0];
-        for (int i = 1; i < 3; i++)
-        {
-            float2 normalizedOffset = float2(KernelOffsets[i], 0.0f) / textureDimensions.x;
-            textureColor += tex.Sample(linearSampler, uv + normalizedOffset).xyz * BlurWeights[i];
-            textureColor += tex.Sample(linearSampler, uv - normalizedOffset).xyz * BlurWeights[i];
-        }
-    }
-    else if (uv.x <= (blurXOffset - 0.005f))
-    {
-        textureColor = tex.Sample(pointSampler, uv).xyz;
-    }
+	float3 textureColor = float3(1.0f, 0.0f, 0.0f);
+	float2 uv = input.uv;
+	if (uv.x > (blurXOffset + 0.005f))
+	{
+		textureColor = tex.Sample(linearSampler, uv).xyz * BlurWeights[0];
+		for (int i = 1; i < 3; i++)
+		{
+			float2 normalizedOffset = float2(KernelOffsets[i], 0.0f) / textureDimensions.x;
+			textureColor += tex.Sample(linearSampler, uv + normalizedOffset).xyz * BlurWeights[i];
+			textureColor += tex.Sample(linearSampler, uv - normalizedOffset).xyz * BlurWeights[i];
+		}
+	}
+	else if (uv.x <= (blurXOffset - 0.005f))
+	{
+		textureColor = tex.Sample(pointSampler, uv).xyz;
+	}
 
-    // Artificially increase the workload to simulate a more complex shader.
-    const float3 textureColorOrig = textureColor;
-    for (uint i = 0; i < loopCount; i++)
-    {
-        textureColor += textureColorOrig;
-    }
+	// Artificially increase the workload to simulate a more complex shader.
+	const float3 textureColorOrig = textureColor;
+	for (uint i = 0; i < loopCount; i++)
+	{
+		textureColor += textureColorOrig;
+	}
 
-    if (loopCount > 0)
-    {
-        textureColor /= loopCount + 1;
-    }
+	if (loopCount > 0)
+	{
+		textureColor /= loopCount + 1;
+	}
 
-    return float4(textureColor, 1.0);
+	return float4(textureColor, 1.0);
 }

--- a/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/d3dx12.h
+++ b/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/shaders.hlsl
+++ b/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/shaders.hlsl
@@ -11,49 +11,49 @@
 
 cbuffer SceneConstantBuffer : register(b0)
 {
-    float4 velocity;
-    float4 offset;
-    float4 color;
-    float4x4 projection;
+	float4 velocity;
+	float4 offset;
+	float4 color;
+	float4x4 projection;
 };
 
 cbuffer WorkloadConstantBuffer : register(b1)
 {
-    uint loopCount;
+	uint loopCount;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VShader(float4 position : POSITION)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = mul(position + offset, projection);
+	result.position = mul(position + offset, projection);
 
-    float intensity = saturate((4.0f - result.position.z) / 2.0f);
-    result.color = float4(color.xyz * intensity, 1.0f);
+	float intensity = saturate((4.0f - result.position.z) / 2.0f);
+	result.color = float4(color.xyz * intensity, 1.0f);
 
-    return result;
+	return result;
 }
 
 float4 PShader(PSInput input) : SV_TARGET
 {
-    float4 result = input.color;
+	float4 result = input.color;
 
-    // Artificially increase the workload to simulate a more complex shader.
-    for (uint i = 0; i < loopCount; i++)
-    {
-        result += input.color;
-    }
+	// Artificially increase the workload to simulate a more complex shader.
+	for (uint i = 0; i < loopCount; i++)
+	{
+		result += input.color;
+	}
 
-    if (loopCount > 0)
-    {
-        result /= loopCount + 1;
-    }
-    
-    return result;
+	if (loopCount > 0)
+	{
+		result /= loopCount + 1;
+	}
+	
+	return result;
 }

--- a/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/stdafx.h
+++ b/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include "d3dx12.h"

--- a/Samples/Desktop/D3D12LinkedGpus/src/D3DX12AffinityLayer/d3dx12.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/D3DX12AffinityLayer/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/CrossNodeResources.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/CrossNodeResources.cpp
@@ -22,245 +22,245 @@
 
 CrossNodeResources::CrossNodeResources(IDXGIFactory4* pFactory, ID3D12Device* pDevice)
 {
-    pFactory->QueryInterface(IID_PPV_ARGS(&m_factory));
-    pDevice->QueryInterface(IID_PPV_ARGS(&m_device));
+	pFactory->QueryInterface(IID_PPV_ARGS(&m_factory));
+	pDevice->QueryInterface(IID_PPV_ARGS(&m_device));
 
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 void CrossNodeResources::LoadPipeline()
 {
-    // Describe and create the command queues.
-    // Each GPU node needs its own command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queues.
+	// Each GPU node needs its own command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    std::vector<IUnknown*> ppQueues(Settings::BackBufferCount);
-    std::vector<UINT> creationNodes(Settings::BackBufferCount);
-    for (UINT n = 0; n < Settings::BackBufferCount; n++)
-    {
-        UINT nodeIndex = n % Settings::NodeCount;
-        creationNodes[n] = 1 << nodeIndex;
-        queueDesc.NodeMask = creationNodes[n];
+	std::vector<IUnknown*> ppQueues(Settings::BackBufferCount);
+	std::vector<UINT> creationNodes(Settings::BackBufferCount);
+	for (UINT n = 0; n < Settings::BackBufferCount; n++)
+	{
+		UINT nodeIndex = n % Settings::NodeCount;
+		creationNodes[n] = 1 << nodeIndex;
+		queueDesc.NodeMask = creationNodes[n];
 
-        if (!m_queues[nodeIndex])
-        {
-            ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_queues[nodeIndex])));
-        }
-        ppQueues[n] = m_queues[nodeIndex].Get();
-    }
+		if (!m_queues[nodeIndex])
+		{
+			ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_queues[nodeIndex])));
+		}
+		ppQueues[n] = m_queues[nodeIndex].Get();
+	}
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = Settings::BackBufferCount;
-    swapChainDesc.Width = Settings::Width;
-    swapChainDesc.Height = Settings::Height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = Settings::BackBufferCount;
+	swapChainDesc.Width = Settings::Width;
+	swapChainDesc.Height = Settings::Height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    // It is recommended to always use the tearing flag when it is available.
-    swapChainDesc.Flags = Settings::TearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
+	// It is recommended to always use the tearing flag when it is available.
+	swapChainDesc.Flags = Settings::TearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(m_factory->CreateSwapChainForHwnd(
-        ppQueues[0],        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(m_factory->CreateSwapChainForHwnd(
+		ppQueues[0],		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    if (Settings::TearingSupport)
-    {
-        // When tearing support is enabled we will handle ALT+Enter key presses in the
-        // window message loop rather than let DXGI handle it by calling SetFullscreenState.
-        m_factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER);
-    }
+	if (Settings::TearingSupport)
+	{
+		// When tearing support is enabled we will handle ALT+Enter key presses in the
+		// window message loop rather than let DXGI handle it by calling SetFullscreenState.
+		m_factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER);
+	}
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
+	ThrowIfFailed(swapChain.As(&m_swapChain));
 
-    if (Settings::NodeCount > 1)
-    {
-        // Set up the swap chain to allow back buffers to live on multiple GPU nodes.
-        ThrowIfFailed(m_swapChain->ResizeBuffers1(
-            swapChainDesc.BufferCount,
-            swapChainDesc.Width,
-            swapChainDesc.Height,
-            DXGI_FORMAT_R8G8B8A8_UNORM,
-            swapChainDesc.Flags,
-            creationNodes.data(),
-            ppQueues.data()));
-    }
+	if (Settings::NodeCount > 1)
+	{
+		// Set up the swap chain to allow back buffers to live on multiple GPU nodes.
+		ThrowIfFailed(m_swapChain->ResizeBuffers1(
+			swapChainDesc.BufferCount,
+			swapChainDesc.Width,
+			swapChainDesc.Height,
+			DXGI_FORMAT_R8G8B8A8_UNORM,
+			swapChainDesc.Flags,
+			creationNodes.data(),
+			ppQueues.data()));
+	}
 }
 
 void CrossNodeResources::LoadAssets()
 {
-    // Create the root signatures.
-    // Root signatures may be shared across GPU nodes.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signatures.
+	// Root signatures may be shared across GPU nodes.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        // Create a root signature for rendering the triangle scene.
-        {
-            CD3DX12_DESCRIPTOR_RANGE1 sceneRanges[1];
-            sceneRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		// Create a root signature for rendering the triangle scene.
+		{
+			CD3DX12_DESCRIPTOR_RANGE1 sceneRanges[1];
+			sceneRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
 
-            CD3DX12_ROOT_PARAMETER1 sceneRootParameters[2];
-            sceneRootParameters[0].InitAsDescriptorTable(1, &sceneRanges[0], D3D12_SHADER_VISIBILITY_VERTEX);
-            sceneRootParameters[1].InitAsConstants(1, 1, 0, D3D12_SHADER_VISIBILITY_VERTEX);
+			CD3DX12_ROOT_PARAMETER1 sceneRootParameters[2];
+			sceneRootParameters[0].InitAsDescriptorTable(1, &sceneRanges[0], D3D12_SHADER_VISIBILITY_VERTEX);
+			sceneRootParameters[1].InitAsConstants(1, 1, 0, D3D12_SHADER_VISIBILITY_VERTEX);
 
-            CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC sceneRootSignatureDesc;
-            sceneRootSignatureDesc.Init_1_1(_countof(sceneRootParameters), sceneRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+			CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC sceneRootSignatureDesc;
+			sceneRootSignatureDesc.Init_1_1(_countof(sceneRootParameters), sceneRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-            ComPtr<ID3DBlob> signature;
-            ComPtr<ID3DBlob> error;
-            ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&sceneRootSignatureDesc, featureData.HighestVersion, &signature, &error));
-            ThrowIfFailed(m_device->CreateRootSignature(Settings::SharedNodeMask, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_sceneRootSignature)));
-        }
+			ComPtr<ID3DBlob> signature;
+			ComPtr<ID3DBlob> error;
+			ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&sceneRootSignatureDesc, featureData.HighestVersion, &signature, &error));
+			ThrowIfFailed(m_device->CreateRootSignature(Settings::SharedNodeMask, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_sceneRootSignature)));
+		}
 
-        // Create a root signature for the post-process pass.
-        {
-            // We don't modify the SRV in the post-processing command list after
-            // SetGraphicsRootDescriptorTable is executed on the GPU so we can use the default
-            // range behavior: D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
-            CD3DX12_DESCRIPTOR_RANGE1 postRanges[2];
-            postRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, Settings::SceneHistoryCount, 0);
-            postRanges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
+		// Create a root signature for the post-process pass.
+		{
+			// We don't modify the SRV in the post-processing command list after
+			// SetGraphicsRootDescriptorTable is executed on the GPU so we can use the default
+			// range behavior: D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
+			CD3DX12_DESCRIPTOR_RANGE1 postRanges[2];
+			postRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, Settings::SceneHistoryCount, 0);
+			postRanges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
 
-            CD3DX12_ROOT_PARAMETER1 postRootParameters[3];
-            postRootParameters[0].InitAsDescriptorTable(1, &postRanges[0], D3D12_SHADER_VISIBILITY_PIXEL);
-            postRootParameters[1].InitAsDescriptorTable(1, &postRanges[1], D3D12_SHADER_VISIBILITY_PIXEL);
-            postRootParameters[2].InitAsConstants(2, 0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
+			CD3DX12_ROOT_PARAMETER1 postRootParameters[3];
+			postRootParameters[0].InitAsDescriptorTable(1, &postRanges[0], D3D12_SHADER_VISIBILITY_PIXEL);
+			postRootParameters[1].InitAsDescriptorTable(1, &postRanges[1], D3D12_SHADER_VISIBILITY_PIXEL);
+			postRootParameters[2].InitAsConstants(2, 0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
 
-            CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC postRootSignatureDesc;
-            postRootSignatureDesc.Init_1_1(_countof(postRootParameters), postRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+			CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC postRootSignatureDesc;
+			postRootSignatureDesc.Init_1_1(_countof(postRootParameters), postRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-            ComPtr<ID3DBlob> signature;
-            ComPtr<ID3DBlob> error;
-            ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&postRootSignatureDesc, featureData.HighestVersion, &signature, &error));
-            ThrowIfFailed(m_device->CreateRootSignature(Settings::SharedNodeMask, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_postRootSignature)));
-        }
-    }
+			ComPtr<ID3DBlob> signature;
+			ComPtr<ID3DBlob> error;
+			ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&postRootSignatureDesc, featureData.HighestVersion, &signature, &error));
+			ThrowIfFailed(m_device->CreateRootSignature(Settings::SharedNodeMask, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_postRootSignature)));
+		}
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    // Pipeline states may be shared across GPU nodes.
-    {
-        // Define the vertex input layout for the triangle scene.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+	// Create the pipeline state, which includes compiling and loading shaders.
+	// Pipeline states may be shared across GPU nodes.
+	{
+		// Define the vertex input layout for the triangle scene.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        // Describe and create the graphics pipeline state objects (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_sceneRootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_SceneVS, sizeof(g_SceneVS));
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_ScenePS, sizeof(g_ScenePS));
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
-        psoDesc.SampleDesc.Count = 1;
-        psoDesc.NodeMask = Settings::SharedNodeMask;
+		// Describe and create the graphics pipeline state objects (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_sceneRootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_SceneVS, sizeof(g_SceneVS));
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_ScenePS, sizeof(g_ScenePS));
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+		psoDesc.SampleDesc.Count = 1;
+		psoDesc.NodeMask = Settings::SharedNodeMask;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_scenePipelineState)));
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_scenePipelineState)));
 
-        // Define the vertex input layout for the post-process fullscreen quad.
-        D3D12_INPUT_ELEMENT_DESC postInputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+		// Define the vertex input layout for the post-process fullscreen quad.
+		D3D12_INPUT_ELEMENT_DESC postInputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        // Describe and create the PSO for the post-process pass.
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC postPsoDesc = {};
-        postPsoDesc.InputLayout = { postInputElementDescs, _countof(postInputElementDescs) };
-        postPsoDesc.pRootSignature = m_postRootSignature.Get();
-        postPsoDesc.VS = CD3DX12_SHADER_BYTECODE(g_PostVS, sizeof(g_PostVS));
-        postPsoDesc.PS = CD3DX12_SHADER_BYTECODE(g_PostPS, sizeof(g_PostPS));
-        postPsoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        postPsoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        postPsoDesc.DepthStencilState.DepthEnable = FALSE;
-        postPsoDesc.DepthStencilState.StencilEnable = FALSE;
-        postPsoDesc.SampleMask = UINT_MAX;
-        postPsoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        postPsoDesc.NumRenderTargets = 1;
-        postPsoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        postPsoDesc.SampleDesc.Count = 1;
-        postPsoDesc.NodeMask = Settings::SharedNodeMask;
+		// Describe and create the PSO for the post-process pass.
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC postPsoDesc = {};
+		postPsoDesc.InputLayout = { postInputElementDescs, _countof(postInputElementDescs) };
+		postPsoDesc.pRootSignature = m_postRootSignature.Get();
+		postPsoDesc.VS = CD3DX12_SHADER_BYTECODE(g_PostVS, sizeof(g_PostVS));
+		postPsoDesc.PS = CD3DX12_SHADER_BYTECODE(g_PostPS, sizeof(g_PostPS));
+		postPsoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		postPsoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		postPsoDesc.DepthStencilState.DepthEnable = FALSE;
+		postPsoDesc.DepthStencilState.StencilEnable = FALSE;
+		postPsoDesc.SampleMask = UINT_MAX;
+		postPsoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		postPsoDesc.NumRenderTargets = 1;
+		postPsoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		postPsoDesc.SampleDesc.Count = 1;
+		postPsoDesc.NodeMask = Settings::SharedNodeMask;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&postPsoDesc, IID_PPV_ARGS(&m_postPipelineState)));
-    }
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&postPsoDesc, IID_PPV_ARGS(&m_postPipelineState)));
+	}
 
-    // Create and map the constant buffers.
-    // Upload heaps live in system memory and can be made visible to all GPU nodes.
-    {
-        const UINT constantBufferDataSize = Settings::TriangleCount * Settings::SceneConstantBufferFrames * sizeof(SceneConstantBuffer);
+	// Create and map the constant buffers.
+	// Upload heaps live in system memory and can be made visible to all GPU nodes.
+	{
+		const UINT constantBufferDataSize = Settings::TriangleCount * Settings::SceneConstantBufferFrames * sizeof(SceneConstantBuffer);
 
-        D3D12_HEAP_PROPERTIES uploadHeapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
-        uploadHeapProps.VisibleNodeMask = Settings::SharedNodeMask;
+		D3D12_HEAP_PROPERTIES uploadHeapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+		uploadHeapProps.VisibleNodeMask = Settings::SharedNodeMask;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &uploadHeapProps,
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(constantBufferDataSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_sceneConstantBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&uploadHeapProps,
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(constantBufferDataSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_sceneConstantBuffer)));
 
-        // Map and initialize the constant buffer. We don't unmap this until the
-        // app closes. Keeping things mapped for the lifetime of the resource is okay.
-        ThrowIfFailed(m_sceneConstantBuffer->Map(0, nullptr, reinterpret_cast<void**>(&m_mappedConstantBuffer)));
-        ZeroMemory(m_mappedConstantBuffer, constantBufferDataSize);
-    }
+		// Map and initialize the constant buffer. We don't unmap this until the
+		// app closes. Keeping things mapped for the lifetime of the resource is okay.
+		ThrowIfFailed(m_sceneConstantBuffer->Map(0, nullptr, reinterpret_cast<void**>(&m_mappedConstantBuffer)));
+		ZeroMemory(m_mappedConstantBuffer, constantBufferDataSize);
+	}
 }
 
 void CrossNodeResources::UpdateConstantBuffer(UINT8* data, UINT dataSize, UINT64 frameId)
 {
-    UINT index = frameId % Settings::SceneConstantBufferFrames;
-    UINT offset = Settings::TriangleCount * index * sizeof(SceneConstantBuffer);
+	UINT index = frameId % Settings::SceneConstantBufferFrames;
+	UINT offset = Settings::TriangleCount * index * sizeof(SceneConstantBuffer);
 
-    memcpy(m_mappedConstantBuffer + offset, data, dataSize);
+	memcpy(m_mappedConstantBuffer + offset, data, dataSize);
 }
 
 void CrossNodeResources::ResizeSwapChain()
 {
-    DXGI_SWAP_CHAIN_DESC desc = {};
-    m_swapChain->GetDesc(&desc);
+	DXGI_SWAP_CHAIN_DESC desc = {};
+	m_swapChain->GetDesc(&desc);
 
-    if (Settings::NodeCount > 1)
-    {
-        std::vector<IUnknown*> ppQueues(Settings::BackBufferCount);
-        std::vector<UINT> creationNodes(Settings::BackBufferCount);
-        for (UINT n = 0; n < Settings::BackBufferCount; n++)
-        {
-            UINT nodeIndex = n % Settings::NodeCount;
-            creationNodes[n] = 1 << nodeIndex;
-            ppQueues[n] = m_queues[nodeIndex].Get();
-        }
+	if (Settings::NodeCount > 1)
+	{
+		std::vector<IUnknown*> ppQueues(Settings::BackBufferCount);
+		std::vector<UINT> creationNodes(Settings::BackBufferCount);
+		for (UINT n = 0; n < Settings::BackBufferCount; n++)
+		{
+			UINT nodeIndex = n % Settings::NodeCount;
+			creationNodes[n] = 1 << nodeIndex;
+			ppQueues[n] = m_queues[nodeIndex].Get();
+		}
 
-        ThrowIfFailed(m_swapChain->ResizeBuffers1(Settings::BackBufferCount, Settings::Width, Settings::Height, desc.BufferDesc.Format, desc.Flags, creationNodes.data(), ppQueues.data()));
-    }
-    else
-    {
-        ThrowIfFailed(m_swapChain->ResizeBuffers(Settings::BackBufferCount, Settings::Width, Settings::Height, desc.BufferDesc.Format, desc.Flags));
-    }
+		ThrowIfFailed(m_swapChain->ResizeBuffers1(Settings::BackBufferCount, Settings::Width, Settings::Height, desc.BufferDesc.Format, desc.Flags, creationNodes.data(), ppQueues.data()));
+	}
+	else
+	{
+		ThrowIfFailed(m_swapChain->ResizeBuffers(Settings::BackBufferCount, Settings::Width, Settings::Height, desc.BufferDesc.Format, desc.Flags));
+	}
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/CrossNodeResources.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/CrossNodeResources.h
@@ -18,57 +18,57 @@ using Microsoft::WRL::ComPtr;
 // Constant buffer definition.
 struct SceneConstantBuffer
 {
-    DirectX::XMFLOAT4 velocity;
-    DirectX::XMFLOAT4 offset;
-    DirectX::XMFLOAT4 color;
-    DirectX::XMMATRIX projection;
+	DirectX::XMFLOAT4 velocity;
+	DirectX::XMFLOAT4 offset;
+	DirectX::XMFLOAT4 color;
+	DirectX::XMMATRIX projection;
 
-    // Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
-    // to be array-indexed.
-    float padding[36];
+	// Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
+	// to be array-indexed.
+	float padding[36];
 };
 
 // Container for resources that are shareable across GPU nodes.
 class CrossNodeResources
 {
 public:
-    CrossNodeResources(IDXGIFactory4* pFactory, ID3D12Device* pDevice);
+	CrossNodeResources(IDXGIFactory4* pFactory, ID3D12Device* pDevice);
 
-    void LoadPipeline();
-    void LoadAssets();
+	void LoadPipeline();
+	void LoadAssets();
 
-    void UpdateConstantBuffer(UINT8* data, UINT dataSize, UINT64 frameId);
-    void ResizeSwapChain();
+	void UpdateConstantBuffer(UINT8* data, UINT dataSize, UINT64 frameId);
+	void ResizeSwapChain();
 
-    inline ID3D12Device* GetDevice()                             { return m_device.Get(); }
-    inline ID3D12CommandQueue* GetCommandQueue(UINT nodeIndex)   { return m_queues[nodeIndex].Get(); }
-    inline IDXGISwapChain3* GetSwapChain()                       { return m_swapChain.Get(); }
-    inline ID3D12RootSignature* GetSceneRootSignature()          { return m_sceneRootSignature.Get(); }
-    inline ID3D12PipelineState* GetScenePipelineState()          { return m_scenePipelineState.Get(); }
-    inline ID3D12RootSignature* GetPostRootSignature()           { return m_postRootSignature.Get(); }
-    inline ID3D12PipelineState* GetPostPipelineState()           { return m_postPipelineState.Get(); }
+	inline ID3D12Device* GetDevice()                             { return m_device.Get(); }
+	inline ID3D12CommandQueue* GetCommandQueue(UINT nodeIndex)   { return m_queues[nodeIndex].Get(); }
+	inline IDXGISwapChain3* GetSwapChain()                       { return m_swapChain.Get(); }
+	inline ID3D12RootSignature* GetSceneRootSignature()          { return m_sceneRootSignature.Get(); }
+	inline ID3D12PipelineState* GetScenePipelineState()          { return m_scenePipelineState.Get(); }
+	inline ID3D12RootSignature* GetPostRootSignature()           { return m_postRootSignature.Get(); }
+	inline ID3D12PipelineState* GetPostPipelineState()           { return m_postPipelineState.Get(); }
 
-    inline D3D12_GPU_VIRTUAL_ADDRESS GetSceneConstantBufferGpuVirtualAddress()
-    {
-        return m_sceneConstantBuffer->GetGPUVirtualAddress();
-    }
+	inline D3D12_GPU_VIRTUAL_ADDRESS GetSceneConstantBufferGpuVirtualAddress()
+	{
+		return m_sceneConstantBuffer->GetGPUVirtualAddress();
+	}
 
 private:
-    // Objects that are visible across all GPU nodes.
-    ComPtr<IDXGIFactory4> m_factory;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12RootSignature> m_sceneRootSignature;
-    ComPtr<ID3D12PipelineState> m_scenePipelineState;
-    ComPtr<ID3D12RootSignature> m_postRootSignature;
-    ComPtr<ID3D12PipelineState> m_postPipelineState;
+	// Objects that are visible across all GPU nodes.
+	ComPtr<IDXGIFactory4> m_factory;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12RootSignature> m_sceneRootSignature;
+	ComPtr<ID3D12PipelineState> m_scenePipelineState;
+	ComPtr<ID3D12RootSignature> m_postRootSignature;
+	ComPtr<ID3D12PipelineState> m_postPipelineState;
 
-    // We use an Upload heap for the constant buffers.
-    // Upload heaps reside in system memory and can be accessed by any available node.
-    ComPtr<ID3D12Resource> m_sceneConstantBuffer;
-    UINT8* m_mappedConstantBuffer;
+	// We use an Upload heap for the constant buffers.
+	// Upload heaps reside in system memory and can be accessed by any available node.
+	ComPtr<ID3D12Resource> m_sceneConstantBuffer;
+	UINT8* m_mappedConstantBuffer;
 
-    // The command queues are actually tied to specific GPU nodes, but are placed here
-    // for convenience since all queues are needed for swap chain creation and resizing.
-    ComPtr<ID3D12CommandQueue> m_queues[Settings::MaxNodeCount];
+	// The command queues are actually tied to specific GPU nodes, but are placed here
+	// for convenience since all queues are needed for swap chain creation and resizing.
+	ComPtr<ID3D12CommandQueue> m_queues[Settings::MaxNodeCount];
 };

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/D3D12LinkedGpus.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/D3D12LinkedGpus.cpp
@@ -15,312 +15,312 @@
 using namespace DirectX;
 
 D3D12LinkedGpus::D3D12LinkedGpus(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_nodeIndex(0),
-    m_frameId(0),
-    m_simulatedGpuLoad(0x1000),
-    m_syncInterval(0),
-    m_windowVisible(true),
-    m_windowedMode(true)
+	DXSample(width, height, name),
+	m_nodeIndex(0),
+	m_frameId(0),
+	m_simulatedGpuLoad(0x1000),
+	m_syncInterval(0),
+	m_windowVisible(true),
+	m_windowedMode(true)
 {
-    m_sceneData.resize(Settings::TriangleCount);
+	m_sceneData.resize(Settings::TriangleCount);
 }
 
 void D3D12LinkedGpus::OnInit()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<ID3D12Device> device;
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<ID3D12Device> device;
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&device)
+			));
+	}
 
-    // Query capabilities of the device to configure the sample.
-    Settings::Initialize(device.Get(), m_width, m_height, m_tearingSupport);
+	// Query capabilities of the device to configure the sample.
+	Settings::Initialize(device.Get(), m_width, m_height, m_tearingSupport);
 
-    // Initialize resources for the sample.
-    m_crossNodeResources = std::make_shared<CrossNodeResources>(factory.Get(), device.Get());
+	// Initialize resources for the sample.
+	m_crossNodeResources = std::make_shared<CrossNodeResources>(factory.Get(), device.Get());
 
-    for (UINT n = 0; n < Settings::NodeCount; n++)
-    {
-        m_nodes[n] = std::make_shared<GpuNode>(n, m_crossNodeResources);
-    }
+	for (UINT n = 0; n < Settings::NodeCount; n++)
+	{
+		m_nodes[n] = std::make_shared<GpuNode>(n, m_crossNodeResources);
+	}
 
-    for (UINT n = 0; n < Settings::NodeCount; n++)
-    {
-        m_nodes[n]->LinkSharedResources(m_nodes, Settings::NodeCount);
-    }
+	for (UINT n = 0; n < Settings::NodeCount; n++)
+	{
+		m_nodes[n]->LinkSharedResources(m_nodes, Settings::NodeCount);
+	}
 
-    LoadSceneData();
-    UpdateWindowTitle();
+	LoadSceneData();
+	UpdateWindowTitle();
 }
 
 // Generate data for the scene triangles.
 void D3D12LinkedGpus::LoadSceneData()
 {
-    for (UINT n = 0; n < Settings::TriangleCount; n++)
-    {
-        m_sceneData[n].velocity = XMFLOAT4(GetRandomFloat(0.005f, 0.01f), 0.0f, 0.0f, 0.0f);
-        m_sceneData[n].offset = XMFLOAT4(GetRandomFloat(-6.0f, -1.5f), GetRandomFloat(-1.0f, 1.0f), GetRandomFloat(0.0f, 2.0f), 0.0f);
-        m_sceneData[n].color = XMFLOAT4(GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), 1.0f);
-        m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
-    }
+	for (UINT n = 0; n < Settings::TriangleCount; n++)
+	{
+		m_sceneData[n].velocity = XMFLOAT4(GetRandomFloat(0.005f, 0.01f), 0.0f, 0.0f, 0.0f);
+		m_sceneData[n].offset = XMFLOAT4(GetRandomFloat(-6.0f, -1.5f), GetRandomFloat(-1.0f, 1.0f), GetRandomFloat(0.0f, 2.0f), 0.0f);
+		m_sceneData[n].color = XMFLOAT4(GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), 1.0f);
+		m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
+	}
 }
 
 // Get a random float value between min and max.
 float D3D12LinkedGpus::GetRandomFloat(float min, float max)
 {
-    float scale = static_cast<float>(rand()) / RAND_MAX;
-    float range = max - min;
-    return scale * range + min;
+	float scale = static_cast<float>(rand()) / RAND_MAX;
+	float range = max - min;
+	return scale * range + min;
 }
 
 void D3D12LinkedGpus::UpdateWindowTitle()
 {
-    WCHAR nodeText[100];
-    if (Settings::NodeCount == 1)
-    {
-        swprintf_s(nodeText, L"Node Count = 1 | SyncInterval = %u | SimulatedLoad = %u", m_syncInterval, m_simulatedGpuLoad);
-    }
-    else
-    {
-        swprintf_s(
-            nodeText,
-            L"Node Count = %u | Cross Node Sharing Tier = %d | SyncInterval = %u | SimulatedLoad = %u",
-            Settings::NodeCount,
-            Settings::Tier2Support ? 2 : 1,
-            m_syncInterval,
-            m_simulatedGpuLoad);
-    }
-    SetCustomWindowText(nodeText);
+	WCHAR nodeText[100];
+	if (Settings::NodeCount == 1)
+	{
+		swprintf_s(nodeText, L"Node Count = 1 | SyncInterval = %u | SimulatedLoad = %u", m_syncInterval, m_simulatedGpuLoad);
+	}
+	else
+	{
+		swprintf_s(
+			nodeText,
+			L"Node Count = %u | Cross Node Sharing Tier = %d | SyncInterval = %u | SimulatedLoad = %u",
+			Settings::NodeCount,
+			Settings::Tier2Support ? 2 : 1,
+			m_syncInterval,
+			m_simulatedGpuLoad);
+	}
+	SetCustomWindowText(nodeText);
 }
 
 // Update frame-based values.
 void D3D12LinkedGpus::OnUpdate()
 {
-    for (UINT n = 0; n < Settings::TriangleCount; n++)
-    {
-        const float offsetBounds = 1.5f * m_aspectRatio;
-    
-        // Animate the triangles.
-        m_sceneData[n].offset.x += m_sceneData[n].velocity.x;
-        if (m_sceneData[n].offset.x > offsetBounds)
-        {
-            m_sceneData[n].velocity.x = GetRandomFloat(0.005f, 0.01f);
-            m_sceneData[n].offset.x = -offsetBounds;
-        }
-    }
+	for (UINT n = 0; n < Settings::TriangleCount; n++)
+	{
+		const float offsetBounds = 1.5f * m_aspectRatio;
+	
+		// Animate the triangles.
+		m_sceneData[n].offset.x += m_sceneData[n].velocity.x;
+		if (m_sceneData[n].offset.x > offsetBounds)
+		{
+			m_sceneData[n].velocity.x = GetRandomFloat(0.005f, 0.01f);
+			m_sceneData[n].offset.x = -offsetBounds;
+		}
+	}
 
-    m_nodes[m_nodeIndex]->OnUpdate(m_sceneData.data(), Settings::TriangleCount, m_frameId);
+	m_nodes[m_nodeIndex]->OnUpdate(m_sceneData.data(), Settings::TriangleCount, m_frameId);
 }
 
 // Render the scene.
 void D3D12LinkedGpus::OnRender()
 {
-    if (m_windowVisible)
-    {
-        auto currentNode = m_nodes[m_nodeIndex];
+	if (m_windowVisible)
+	{
+		auto currentNode = m_nodes[m_nodeIndex];
 
-        // Render and present the current frame.
-        currentNode->RenderScene(m_frameId, m_simulatedGpuLoad);
-        currentNode->RenderPost(m_frameId);
-        currentNode->Present(m_syncInterval, m_windowedMode);
+		// Render and present the current frame.
+		currentNode->RenderScene(m_frameId, m_simulatedGpuLoad);
+		currentNode->RenderPost(m_frameId);
+		currentNode->Present(m_syncInterval, m_windowedMode);
 
-        MoveToNextFrame();
-    }
+		MoveToNextFrame();
+	}
 }
 
 void D3D12LinkedGpus::OnSizeChanged(UINT width, UINT height, bool minimized)
 {
-    // Determine if the swap buffers and other resources need to be resized or not.
-    if ((width != m_width || height != m_height) && !minimized)
-    {
-        // Flush all current GPU commands.
-        WaitForGpus();
+	// Determine if the swap buffers and other resources need to be resized or not.
+	if ((width != m_width || height != m_height) && !minimized)
+	{
+		// Flush all current GPU commands.
+		WaitForGpus();
 
-        // Release buffers tied to the swap chain and update the global Settings
-        // for the new size.
-        for (UINT n = 0; n < Settings::NodeCount; n++)
-        {
-            m_nodes[n]->ReleaseBackBuffers();
-        }
-        Settings::OnSizeChanged(width, height);
+		// Release buffers tied to the swap chain and update the global Settings
+		// for the new size.
+		for (UINT n = 0; n < Settings::NodeCount; n++)
+		{
+			m_nodes[n]->ReleaseBackBuffers();
+		}
+		Settings::OnSizeChanged(width, height);
 
-        // Resize the swap chain to the desired dimensions.
-        m_crossNodeResources->ResizeSwapChain();
+		// Resize the swap chain to the desired dimensions.
+		m_crossNodeResources->ResizeSwapChain();
 
-        BOOL fullscreenState;
-        ThrowIfFailed(m_crossNodeResources->GetSwapChain()->GetFullscreenState(&fullscreenState, nullptr));
-        m_windowedMode = !fullscreenState;
+		BOOL fullscreenState;
+		ThrowIfFailed(m_crossNodeResources->GetSwapChain()->GetFullscreenState(&fullscreenState, nullptr));
+		m_windowedMode = !fullscreenState;
 
-        // Re-create and re-link render targets.
-        for (UINT n = 0; n < Settings::NodeCount; n++)
-        {
-            m_nodes[n]->LoadSizeDependentResources();
-        }
-        for (UINT n = 0; n < Settings::NodeCount; n++)
-        {
-            m_nodes[n]->LinkSharedResources(m_nodes, Settings::NodeCount);
-        }
+		// Re-create and re-link render targets.
+		for (UINT n = 0; n < Settings::NodeCount; n++)
+		{
+			m_nodes[n]->LoadSizeDependentResources();
+		}
+		for (UINT n = 0; n < Settings::NodeCount; n++)
+		{
+			m_nodes[n]->LinkSharedResources(m_nodes, Settings::NodeCount);
+		}
 
-        // Reset the node index and align the frameId so that assumptions in post-processing hold.
-        m_nodeIndex = m_crossNodeResources->GetSwapChain()->GetCurrentBackBufferIndex() % Settings::NodeCount;
-        m_frameId += (Settings::SceneHistoryCount - (m_frameId % Settings::SceneHistoryCount));
+		// Reset the node index and align the frameId so that assumptions in post-processing hold.
+		m_nodeIndex = m_crossNodeResources->GetSwapChain()->GetCurrentBackBufferIndex() % Settings::NodeCount;
+		m_frameId += (Settings::SceneHistoryCount - (m_frameId % Settings::SceneHistoryCount));
 
-        // Update the m_width, m_height, and m_aspectRatio member variables.
-        UpdateForSizeChange(width, height);
+		// Update the m_width, m_height, and m_aspectRatio member variables.
+		UpdateForSizeChange(width, height);
 
-        // Update the scene projection matrix.
-        for (UINT n = 0; n < Settings::TriangleCount; n++)
-        {
-            m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
-        }
-    }
+		// Update the scene projection matrix.
+		for (UINT n = 0; n < Settings::TriangleCount; n++)
+		{
+			m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
+		}
+	}
 
-    m_windowVisible = !minimized;
+	m_windowVisible = !minimized;
 }
 
 void D3D12LinkedGpus::OnKeyDown(UINT8 key)
 {
-    switch (key)
-    {
-    // Instrument the Space Bar to toggle between fullscreen states.
-    // The window message loop callback will receive a WM_SIZE message once the
-    // window is in the fullscreen state. At that point, the IDXGISwapChain should
-    // be resized to match the new window size.
-    //
-    // NOTE: ALT+Enter will perform a similar operation; the code below is not
-    // required to enable that key combination.
-    case VK_SPACE:
-    {
-        if (Settings::TearingSupport)
-        {
-            Win32Application::ToggleFullscreenWindow();
-        }
-        else
-        {
-            auto pSwapChain = m_crossNodeResources->GetSwapChain();
-            BOOL fullscreenState;
+	switch (key)
+	{
+	// Instrument the Space Bar to toggle between fullscreen states.
+	// The window message loop callback will receive a WM_SIZE message once the
+	// window is in the fullscreen state. At that point, the IDXGISwapChain should
+	// be resized to match the new window size.
+	//
+	// NOTE: ALT+Enter will perform a similar operation; the code below is not
+	// required to enable that key combination.
+	case VK_SPACE:
+	{
+		if (Settings::TearingSupport)
+		{
+			Win32Application::ToggleFullscreenWindow();
+		}
+		else
+		{
+			auto pSwapChain = m_crossNodeResources->GetSwapChain();
+			BOOL fullscreenState;
 
-            ThrowIfFailed(pSwapChain->GetFullscreenState(&fullscreenState, nullptr));
-            if (FAILED(pSwapChain->SetFullscreenState(!fullscreenState, nullptr)))
-            {
-                // Transitions to fullscreen mode can fail when running apps over
-                // terminal services or for some other unexpected reason.  Consider
-                // notifying the user in some way when this happens.
-                OutputDebugString(L"Fullscreen transition failed");
-                _ASSERT(false);
-            }
-        }
-        break;
-    }
+			ThrowIfFailed(pSwapChain->GetFullscreenState(&fullscreenState, nullptr));
+			if (FAILED(pSwapChain->SetFullscreenState(!fullscreenState, nullptr)))
+			{
+				// Transitions to fullscreen mode can fail when running apps over
+				// terminal services or for some other unexpected reason.  Consider
+				// notifying the user in some way when this happens.
+				OutputDebugString(L"Fullscreen transition failed");
+				_ASSERT(false);
+			}
+		}
+		break;
+	}
 
-    case VK_LEFT:
-    case VK_RIGHT:
-        m_syncInterval = (m_syncInterval > 0) ? 0 : 1;
-        UpdateWindowTitle();
-        break;
+	case VK_LEFT:
+	case VK_RIGHT:
+		m_syncInterval = (m_syncInterval > 0) ? 0 : 1;
+		UpdateWindowTitle();
+		break;
 
-    case VK_UP:
-        if (m_simulatedGpuLoad > 0)
-        {
-            if (m_simulatedGpuLoad < 0x80000)
-            {
-                m_simulatedGpuLoad <<= 1;
-            }
-        }
-        else
-        {
-            m_simulatedGpuLoad = 1;
-        }
-        UpdateWindowTitle();
-        break;
+	case VK_UP:
+		if (m_simulatedGpuLoad > 0)
+		{
+			if (m_simulatedGpuLoad < 0x80000)
+			{
+				m_simulatedGpuLoad <<= 1;
+			}
+		}
+		else
+		{
+			m_simulatedGpuLoad = 1;
+		}
+		UpdateWindowTitle();
+		break;
 
-    case VK_DOWN:
-        if (m_simulatedGpuLoad != 0)
-        {
-            m_simulatedGpuLoad >>= 1;
-        }
-        UpdateWindowTitle();
-        break;
-    }
+	case VK_DOWN:
+		if (m_simulatedGpuLoad != 0)
+		{
+			m_simulatedGpuLoad >>= 1;
+		}
+		UpdateWindowTitle();
+		break;
+	}
 }
 
 void D3D12LinkedGpus::OnDestroy()
 {
-    // Wait for the GPUs to be done with all their resources.
-    WaitForGpus();
+	// Wait for the GPUs to be done with all their resources.
+	WaitForGpus();
 
-    if (!Settings::TearingSupport)
-    {
-        m_crossNodeResources->GetSwapChain()->SetFullscreenState(FALSE, nullptr);
-    }
+	if (!Settings::TearingSupport)
+	{
+		m_crossNodeResources->GetSwapChain()->SetFullscreenState(FALSE, nullptr);
+	}
 }
 
 // Wait for pending GPU work to complete.
 void D3D12LinkedGpus::WaitForGpus()
 {
-    for (UINT n = 0; n < Settings::NodeCount; n++)
-    {
-        m_nodes[n]->WaitForGpu();
-    }
+	for (UINT n = 0; n < Settings::NodeCount; n++)
+	{
+		m_nodes[n]->WaitForGpu();
+	}
 }
 
 // Prepare to render the next frame.
 void D3D12LinkedGpus::MoveToNextFrame()
 {
-    UINT nextNode = m_crossNodeResources->GetSwapChain()->GetCurrentBackBufferIndex() % Settings::NodeCount;
+	UINT nextNode = m_crossNodeResources->GetSwapChain()->GetCurrentBackBufferIndex() % Settings::NodeCount;
 
-    if (Settings::NodeCount > 1 && nextNode == m_nodeIndex)
-    {
-        // If a WM_SIZE event was processed during Present, we will already be in the
-        // correct state. Do not update the node index or advance the node's frame.
-    }
-    else
-    {
-        // Advance the frame on the current node.
-        m_nodes[m_nodeIndex]->MoveToNextFrame();
+	if (Settings::NodeCount > 1 && nextNode == m_nodeIndex)
+	{
+		// If a WM_SIZE event was processed during Present, we will already be in the
+		// correct state. Do not update the node index or advance the node's frame.
+	}
+	else
+	{
+		// Advance the frame on the current node.
+		m_nodes[m_nodeIndex]->MoveToNextFrame();
 
-        // Advance to the next node.
-        m_nodeIndex = nextNode;
+		// Advance to the next node.
+		m_nodeIndex = nextNode;
 
-        m_frameId++;
-    }
+		m_frameId++;
+	}
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/D3D12LinkedGpus.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/D3D12LinkedGpus.h
@@ -32,33 +32,33 @@ using Microsoft::WRL::ComPtr;
 class D3D12LinkedGpus : public DXSample
 {
 public:
-    D3D12LinkedGpus(UINT width, UINT height, std::wstring name);
+	D3D12LinkedGpus(UINT width, UINT height, std::wstring name);
 
 protected:
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
-    virtual void OnKeyDown(UINT8 key);
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
+	virtual void OnKeyDown(UINT8 key);
+	virtual void OnDestroy();
 
 private:
-    // Data about each of the triangles in the scene.
-    std::vector<SceneConstantBuffer> m_sceneData;
+	// Data about each of the triangles in the scene.
+	std::vector<SceneConstantBuffer> m_sceneData;
 
-    std::shared_ptr<CrossNodeResources> m_crossNodeResources;
-    std::shared_ptr<GpuNode> m_nodes[Settings::MaxNodeCount];
+	std::shared_ptr<CrossNodeResources> m_crossNodeResources;
+	std::shared_ptr<GpuNode> m_nodes[Settings::MaxNodeCount];
 
-    UINT64 m_frameId;
-    UINT m_simulatedGpuLoad;
-    UINT m_nodeIndex;
-    UINT m_syncInterval;
-    bool m_windowVisible;
-    bool m_windowedMode;
+	UINT64 m_frameId;
+	UINT m_simulatedGpuLoad;
+	UINT m_nodeIndex;
+	UINT m_syncInterval;
+	bool m_windowVisible;
+	bool m_windowedMode;
 
-    void LoadSceneData();
-    float GetRandomFloat(float min, float max);
-    void UpdateWindowTitle();
-    void WaitForGpus();
-    void MoveToNextFrame();
+	void LoadSceneData();
+	float GetRandomFloat(float min, float max);
+	void UpdateWindowTitle();
+	void WaitForGpus();
+	void MoveToNextFrame();
 };

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/DXSample.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/DXSample.cpp
@@ -52,33 +52,78 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
+
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+            }
+#if !defined(_XBOX_ONE)
+        }
+#endif
 
     *ppAdapter = adapter.Detach();
-}
+    }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/DXSample.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/DXSample.h
@@ -49,7 +49,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/Fence.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/Fence.h
@@ -18,133 +18,133 @@
 class Fence
 {
 public:
-    // Create a fence and associate it with the specified command queue for
-    // convenience in working with fences.
-    Fence(ID3D12CommandQueue* pQueue) :
-        m_currentFenceValue(0)
-    {
-        ThrowIfFailed(pQueue->QueryInterface(IID_PPV_ARGS(&m_queue)));
+	// Create a fence and associate it with the specified command queue for
+	// convenience in working with fences.
+	Fence(ID3D12CommandQueue* pQueue) :
+		m_currentFenceValue(0)
+	{
+		ThrowIfFailed(pQueue->QueryInterface(IID_PPV_ARGS(&m_queue)));
 
-        ComPtr<ID3D12Device> device;
-        ThrowIfFailed(m_queue->GetDevice(IID_PPV_ARGS(&device)));
+		ComPtr<ID3D12Device> device;
+		ThrowIfFailed(m_queue->GetDevice(IID_PPV_ARGS(&device)));
 
-        ThrowIfFailed(device->CreateFence(m_currentFenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		ThrowIfFailed(device->CreateFence(m_currentFenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
 
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
-    }
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
+	}
 
-    ~Fence()
-    {
-        if (m_fenceEvent)
-        {
-            CloseHandle(m_fenceEvent);
-            m_fenceEvent = nullptr;
-        }
-    }
+	~Fence()
+	{
+		if (m_fenceEvent)
+		{
+			CloseHandle(m_fenceEvent);
+			m_fenceEvent = nullptr;
+		}
+	}
 
-    // Drain the GPU command queue.
-    // (Blocks the calling CPU thread)
-    inline void FlushGpuQueue()
-    {
-        Signal();
-        CpuWait(m_currentFenceValue);
-    }
+	// Drain the GPU command queue.
+	// (Blocks the calling CPU thread)
+	inline void FlushGpuQueue()
+	{
+		Signal();
+		CpuWait(m_currentFenceValue);
+	}
 
-    // Issue a Signal command on the command queue.
-    // Use the current value of the fence or override it with your own value.
-    inline void Signal(UINT64 value = UnspecifiedFenceValue)
-    {
-        if (value == UnspecifiedFenceValue)
-        {
-            m_currentFenceValue++;
-        }
-        else
-        {
-            _ASSERT(value > m_currentFenceValue);
-            m_currentFenceValue = value;
-        }
+	// Issue a Signal command on the command queue.
+	// Use the current value of the fence or override it with your own value.
+	inline void Signal(UINT64 value = UnspecifiedFenceValue)
+	{
+		if (value == UnspecifiedFenceValue)
+		{
+			m_currentFenceValue++;
+		}
+		else
+		{
+			_ASSERT(value > m_currentFenceValue);
+			m_currentFenceValue = value;
+		}
 
-        ThrowIfFailed(m_queue->Signal(m_fence.Get(), m_currentFenceValue));
-    }
+		ThrowIfFailed(m_queue->Signal(m_fence.Get(), m_currentFenceValue));
+	}
 
-    // Instruct the GPU queue associated with this fence to wait for a value to be signaled.
-    // Use the current value of the fence or override it with your own value.
-    // (Does not block the calling CPU thread)
-    inline void GpuWait(UINT64 value = UnspecifiedFenceValue)
-    {
-        GpuWait(m_queue.Get(), this, value);
-    }
+	// Instruct the GPU queue associated with this fence to wait for a value to be signaled.
+	// Use the current value of the fence or override it with your own value.
+	// (Does not block the calling CPU thread)
+	inline void GpuWait(UINT64 value = UnspecifiedFenceValue)
+	{
+		GpuWait(m_queue.Get(), this, value);
+	}
 
-    // Instruct a GPU queue on a specific node to wait for a specific node's fence.
-    // Use the current value of the fence or override it with your own value.
-    // (Does not block the calling CPU thread)
-    inline static void GpuWait(ID3D12CommandQueue* pQueue, Fence* pFence, UINT64 value = UnspecifiedFenceValue)
-    {
-        if (value == UnspecifiedFenceValue)
-        {
-            value = pFence->m_currentFenceValue;
-        }
+	// Instruct a GPU queue on a specific node to wait for a specific node's fence.
+	// Use the current value of the fence or override it with your own value.
+	// (Does not block the calling CPU thread)
+	inline static void GpuWait(ID3D12CommandQueue* pQueue, Fence* pFence, UINT64 value = UnspecifiedFenceValue)
+	{
+		if (value == UnspecifiedFenceValue)
+		{
+			value = pFence->m_currentFenceValue;
+		}
 
-        ThrowIfFailed(pQueue->Wait(pFence->m_fence.Get(), value));
-    }
+		ThrowIfFailed(pQueue->Wait(pFence->m_fence.Get(), value));
+	}
 
 protected:
-    // Block the calling CPU thread until the GPU has signaled the specified fence.
-    inline void CpuWait(UINT64 fenceValue = UnspecifiedFenceValue)
-    {
-        if (fenceValue == UnspecifiedFenceValue)
-        {
-            fenceValue = m_currentFenceValue;
-        }
+	// Block the calling CPU thread until the GPU has signaled the specified fence.
+	inline void CpuWait(UINT64 fenceValue = UnspecifiedFenceValue)
+	{
+		if (fenceValue == UnspecifiedFenceValue)
+		{
+			fenceValue = m_currentFenceValue;
+		}
 
-        if (m_fence->GetCompletedValue() < fenceValue)
-        {
-            ThrowIfFailed(m_fence->SetEventOnCompletion(fenceValue, m_fenceEvent));
-            WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-        }
-    }
+		if (m_fence->GetCompletedValue() < fenceValue)
+		{
+			ThrowIfFailed(m_fence->SetEventOnCompletion(fenceValue, m_fenceEvent));
+			WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+		}
+	}
 
-    static const UINT64 UnspecifiedFenceValue = UINT64_MAX;
+	static const UINT64 UnspecifiedFenceValue = UINT64_MAX;
 
-    ComPtr<ID3D12Fence> m_fence;            // The D3D12 fence object.
-    ComPtr<ID3D12CommandQueue> m_queue;        // The command queue associated with this fence.
-    UINT64 m_currentFenceValue;                // The last value signaled by this fence.
-    HANDLE m_fenceEvent;                    // CPU-waitable event handle.
+	ComPtr<ID3D12Fence> m_fence;			// The D3D12 fence object.
+	ComPtr<ID3D12CommandQueue> m_queue;		// The command queue associated with this fence.
+	UINT64 m_currentFenceValue;				// The last value signaled by this fence.
+	HANDLE m_fenceEvent;					// CPU-waitable event handle.
 };
 
 class LinearFence : public Fence
 {
 public:
-    // This fence implementation manages a ring buffer of issued Signal events.
-    // The "Next" API instructs the Fence to move to the next slot in the ring buffer.
-    // If the next slot represents a fence value that has not yet been signaled by
-    // the GPU, then the CPU will wait until that fence is signaled before continuing.
-    // 
-    // In this sample, LinearFences are used to guard against premature resetting
-    // of command allocators and modifying of upload heaps that might currently be
-    // in use by the GPU.
-    LinearFence(ID3D12CommandQueue* pQueue, UINT count) :
-        Fence(pQueue),
-        m_signalIndex(0)
-    {
-        m_signalHistory.resize(count);
-    }
+	// This fence implementation manages a ring buffer of issued Signal events.
+	// The "Next" API instructs the Fence to move to the next slot in the ring buffer.
+	// If the next slot represents a fence value that has not yet been signaled by
+	// the GPU, then the CPU will wait until that fence is signaled before continuing.
+	// 
+	// In this sample, LinearFences are used to guard against premature resetting
+	// of command allocators and modifying of upload heaps that might currently be
+	// in use by the GPU.
+	LinearFence(ID3D12CommandQueue* pQueue, UINT count) :
+		Fence(pQueue),
+		m_signalIndex(0)
+	{
+		m_signalHistory.resize(count);
+	}
 
-    // If the oldest Signal event in the ring buffer has not yet been processed by
-    // the GPU, block the calling CPU thread until it is.
-    inline void Next()
-    {
-        m_signalHistory[m_signalIndex] = m_currentFenceValue;
-        m_signalIndex = (m_signalIndex + 1) % m_signalHistory.size();
+	// If the oldest Signal event in the ring buffer has not yet been processed by
+	// the GPU, block the calling CPU thread until it is.
+	inline void Next()
+	{
+		m_signalHistory[m_signalIndex] = m_currentFenceValue;
+		m_signalIndex = (m_signalIndex + 1) % m_signalHistory.size();
 
-        Fence::CpuWait(m_signalHistory[m_signalIndex]);
-    }
+		Fence::CpuWait(m_signalHistory[m_signalIndex]);
+	}
 
 private:
-    std::vector<UINT64> m_signalHistory;    // The history of signal events.
-    UINT m_signalIndex;                        // The index to the next slot in the signal history ring buffer.
+	std::vector<UINT64> m_signalHistory;	// The history of signal events.
+	UINT m_signalIndex;						// The index to the next slot in the signal history ring buffer.
 };

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/GpuNode.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/GpuNode.cpp
@@ -13,652 +13,652 @@
 #include "GpuNode.h"
 
 GpuNode::GpuNode(UINT nodeIndex, std::shared_ptr<CrossNodeResources> crossNodeResources) :
-    m_frameIndex(0),
-    m_nodeIndex(nodeIndex),
-    m_nodeMask(1 << nodeIndex),
-    m_crossNodeResources(crossNodeResources),
-    m_sceneRenderTargetIndex(0)
+	m_frameIndex(0),
+	m_nodeIndex(nodeIndex),
+	m_nodeMask(1 << nodeIndex),
+	m_crossNodeResources(crossNodeResources),
+	m_sceneRenderTargetIndex(0)
 {
-    m_sceneCommandAllocators.resize(Settings::FrameCount);
-    m_postCommandAllocators.resize(Settings::FrameCount);
-    m_postRenderTargets.resize(Settings::BackBuffersPerNode);
+	m_sceneCommandAllocators.resize(Settings::FrameCount);
+	m_postCommandAllocators.resize(Settings::FrameCount);
+	m_postRenderTargets.resize(Settings::BackBuffersPerNode);
 
-    ThrowIfFailed(crossNodeResources->GetCommandQueue(nodeIndex)->QueryInterface(IID_PPV_ARGS(&m_graphicsQueue)));
-    m_sceneFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
-    m_postFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
+	ThrowIfFailed(crossNodeResources->GetCommandQueue(nodeIndex)->QueryInterface(IID_PPV_ARGS(&m_graphicsQueue)));
+	m_sceneFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
+	m_postFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
 
-    if (Settings::NodeCount > 1)
-    {
-        m_nodeSync = std::make_unique<NodeSynchronization>();
-    }
+	if (Settings::NodeCount > 1)
+	{
+		m_nodeSync = std::make_unique<NodeSynchronization>();
+	}
 
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 void GpuNode::LoadPipeline()
 {
-    auto pDevice = m_crossNodeResources->GetDevice();
+	auto pDevice = m_crossNodeResources->GetDevice();
 
-    // Scene descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        rtvHeapDesc.NodeMask = m_nodeMask;
-        ThrowIfFailed(pDevice->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_sceneRtvHeap)));
+	// Scene descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		rtvHeapDesc.NodeMask = m_nodeMask;
+		ThrowIfFailed(pDevice->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_sceneRtvHeap)));
 
-        // Describe and create a depth stencil view (DSV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
-        dsvHeapDesc.NumDescriptors = 1;
-        dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-        dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        dsvHeapDesc.NodeMask = m_nodeMask;
-        ThrowIfFailed(pDevice->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_sceneDsvHeap)));
+		// Describe and create a depth stencil view (DSV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
+		dsvHeapDesc.NumDescriptors = 1;
+		dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+		dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		dsvHeapDesc.NodeMask = m_nodeMask;
+		ThrowIfFailed(pDevice->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_sceneDsvHeap)));
 
-        // Describe and create a constant buffer view (CBV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
-        cbvHeapDesc.NumDescriptors = Settings::TriangleCount * Settings::SceneConstantBufferFrames;
-        cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        cbvHeapDesc.NodeMask = m_nodeMask;
-        ThrowIfFailed(pDevice->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_sceneCbvHeap)));
-    }
+		// Describe and create a constant buffer view (CBV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
+		cbvHeapDesc.NumDescriptors = Settings::TriangleCount * Settings::SceneConstantBufferFrames;
+		cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		cbvHeapDesc.NodeMask = m_nodeMask;
+		ThrowIfFailed(pDevice->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_sceneCbvHeap)));
+	}
 
-    // Post-process descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap for 
-        // the final output.
-        D3D12_DESCRIPTOR_HEAP_DESC postRtvHeapDesc = {};
-        postRtvHeapDesc.NumDescriptors = Settings::BackBuffersPerNode;
-        postRtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        postRtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        postRtvHeapDesc.NodeMask = m_nodeMask;
-        ThrowIfFailed(pDevice->CreateDescriptorHeap(&postRtvHeapDesc, IID_PPV_ARGS(&m_postRtvHeap)));
+	// Post-process descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap for 
+		// the final output.
+		D3D12_DESCRIPTOR_HEAP_DESC postRtvHeapDesc = {};
+		postRtvHeapDesc.NumDescriptors = Settings::BackBuffersPerNode;
+		postRtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		postRtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		postRtvHeapDesc.NodeMask = m_nodeMask;
+		ThrowIfFailed(pDevice->CreateDescriptorHeap(&postRtvHeapDesc, IID_PPV_ARGS(&m_postRtvHeap)));
 
-        // Describe and create a shader resource view (SRV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
-        srvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
-        srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        srvHeapDesc.NodeMask = m_nodeMask;
-        ThrowIfFailed(pDevice->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_postSrvHeap)));
+		// Describe and create a shader resource view (SRV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
+		srvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
+		srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		srvHeapDesc.NodeMask = m_nodeMask;
+		ThrowIfFailed(pDevice->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_postSrvHeap)));
 
-        // Describe and create a sampler descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
-        samplerHeapDesc.NumDescriptors = 1;
-        samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
-        samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        samplerHeapDesc.NodeMask = m_nodeMask;
-        ThrowIfFailed(pDevice->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_postSamplerHeap)));
-    }
+		// Describe and create a sampler descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
+		samplerHeapDesc.NumDescriptors = 1;
+		samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
+		samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		samplerHeapDesc.NodeMask = m_nodeMask;
+		ThrowIfFailed(pDevice->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_postSamplerHeap)));
+	}
 
-    // Create command allocators for each frame.
-    for (UINT n = 0; n < Settings::FrameCount; n++)
-    {
-        ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[n])));
-        ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_postCommandAllocators[n])));
-    }
+	// Create command allocators for each frame.
+	for (UINT n = 0; n < Settings::FrameCount; n++)
+	{
+		ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[n])));
+		ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_postCommandAllocators[n])));
+	}
 }
 
 void GpuNode::LoadAssets()
 {
-    auto pDevice = m_crossNodeResources->GetDevice();
+	auto pDevice = m_crossNodeResources->GetDevice();
 
-    // Single-use command allocator/list for resource initialization.
-    ComPtr<ID3D12CommandAllocator> commandAllocator;
-    ComPtr<ID3D12GraphicsCommandList> commandList;
+	// Single-use command allocator/list for resource initialization.
+	ComPtr<ID3D12CommandAllocator> commandAllocator;
+	ComPtr<ID3D12GraphicsCommandList> commandList;
 
-    ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator)));
-    ThrowIfFailed(pDevice->CreateCommandList(m_nodeMask, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
+	ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator)));
+	ThrowIfFailed(pDevice->CreateCommandList(m_nodeMask, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
 
-    // Create the command lists.
-    {
-        ThrowIfFailed(pDevice->CreateCommandList(
-            m_nodeMask,
-            D3D12_COMMAND_LIST_TYPE_DIRECT,
-            m_sceneCommandAllocators[m_frameIndex].Get(),
-            m_crossNodeResources->GetScenePipelineState(),
-            IID_PPV_ARGS(&m_sceneCommandList)));
+	// Create the command lists.
+	{
+		ThrowIfFailed(pDevice->CreateCommandList(
+			m_nodeMask,
+			D3D12_COMMAND_LIST_TYPE_DIRECT,
+			m_sceneCommandAllocators[m_frameIndex].Get(),
+			m_crossNodeResources->GetScenePipelineState(),
+			IID_PPV_ARGS(&m_sceneCommandList)));
 
-        ThrowIfFailed(pDevice->CreateCommandList(
-            m_nodeMask,
-            D3D12_COMMAND_LIST_TYPE_DIRECT,
-            m_postCommandAllocators[m_frameIndex].Get(),
-            m_crossNodeResources->GetPostPipelineState(),
-            IID_PPV_ARGS(&m_postCommandList)));
+		ThrowIfFailed(pDevice->CreateCommandList(
+			m_nodeMask,
+			D3D12_COMMAND_LIST_TYPE_DIRECT,
+			m_postCommandAllocators[m_frameIndex].Get(),
+			m_crossNodeResources->GetPostPipelineState(),
+			IID_PPV_ARGS(&m_postCommandList)));
 
-        // Command lists are created in the 'recording' state. We always call Reset
-        // as the first thing when populating command lists, so we need to close
-        // these here for the first frame.
-        ThrowIfFailed(m_sceneCommandList->Close());
-        ThrowIfFailed(m_postCommandList->Close());
-    }
+		// Command lists are created in the 'recording' state. We always call Reset
+		// as the first thing when populating command lists, so we need to close
+		// these here for the first frame.
+		ThrowIfFailed(m_sceneCommandList->Close());
+		ThrowIfFailed(m_postCommandList->Close());
+	}
 
-    ComPtr<ID3D12Resource> triangleVertexBufferUpload;
-    ComPtr<ID3D12Resource> quadVertexBufferUpload;
+	ComPtr<ID3D12Resource> triangleVertexBufferUpload;
+	ComPtr<ID3D12Resource> quadVertexBufferUpload;
 
-    // Create the triangle vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        SceneVertex vertices[] =
-        {
-            { { 0.0f, Settings::TriangleHalfWidth, Settings::TriangleDepth } },
-            { { Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } },
-            { { -Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } }
-        };
+	// Create the triangle vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		SceneVertex vertices[] =
+		{
+			{ { 0.0f, Settings::TriangleHalfWidth, Settings::TriangleDepth } },
+			{ { Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } },
+			{ { -Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } }
+		};
 
-        const UINT vertexBufferSize = sizeof(vertices);
+		const UINT vertexBufferSize = sizeof(vertices);
 
-        D3D12_HEAP_PROPERTIES heapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
-        heapProps.CreationNodeMask = m_nodeMask;
-        heapProps.VisibleNodeMask = m_nodeMask;
+		D3D12_HEAP_PROPERTIES heapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+		heapProps.CreationNodeMask = m_nodeMask;
+		heapProps.VisibleNodeMask = m_nodeMask;
 
-        ThrowIfFailed(pDevice->CreateCommittedResource(
-            &heapProps,
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_sceneVertexBuffer)));
+		ThrowIfFailed(pDevice->CreateCommittedResource(
+			&heapProps,
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_sceneVertexBuffer)));
 
-        D3D12_HEAP_PROPERTIES uploadHeapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
-        uploadHeapProps.CreationNodeMask = m_nodeMask;
-        uploadHeapProps.VisibleNodeMask = m_nodeMask;        // Upload heap is single-use and doesn't need to be shared.
+		D3D12_HEAP_PROPERTIES uploadHeapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+		uploadHeapProps.CreationNodeMask = m_nodeMask;
+		uploadHeapProps.VisibleNodeMask = m_nodeMask;		// Upload heap is single-use and doesn't need to be shared.
 
-        ThrowIfFailed(pDevice->CreateCommittedResource(
-            &uploadHeapProps,
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&triangleVertexBufferUpload)));
+		ThrowIfFailed(pDevice->CreateCommittedResource(
+			&uploadHeapProps,
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&triangleVertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(vertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(vertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(commandList.Get(), m_sceneVertexBuffer.Get(), triangleVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_sceneVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(commandList.Get(), m_sceneVertexBuffer.Get(), triangleVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_sceneVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_sceneVertexBufferView.BufferLocation = m_sceneVertexBuffer->GetGPUVirtualAddress();
-        m_sceneVertexBufferView.StrideInBytes = sizeof(SceneVertex);
-        m_sceneVertexBufferView.SizeInBytes = sizeof(vertices);
-    }
+		// Initialize the vertex buffer view.
+		m_sceneVertexBufferView.BufferLocation = m_sceneVertexBuffer->GetGPUVirtualAddress();
+		m_sceneVertexBufferView.StrideInBytes = sizeof(SceneVertex);
+		m_sceneVertexBufferView.SizeInBytes = sizeof(vertices);
+	}
 
-    // Create the quad vertex buffer.
-    {
-        // Define the geometry for a quad.
-        PostVertex vertices[] =
-        {
-            { { -1.0f, -1.0f, 0.0f },{ 0.0f, 1.0f } },    // Bottom Left
-            { { -1.0f, 1.0f, 0.0f },{ 0.0f, 0.0f } },    // Top Left
-            { { 1.0f, -1.0f, 0.0f },{ 1.0f, 1.0f } },    // Bottom Right
-            { { 1.0f, 1.0f, 0.0f },{ 1.0f, 0.0f } },    // Top Right
-        };
+	// Create the quad vertex buffer.
+	{
+		// Define the geometry for a quad.
+		PostVertex vertices[] =
+		{
+			{ { -1.0f, -1.0f, 0.0f },{ 0.0f, 1.0f } },	// Bottom Left
+			{ { -1.0f, 1.0f, 0.0f },{ 0.0f, 0.0f } },	// Top Left
+			{ { 1.0f, -1.0f, 0.0f },{ 1.0f, 1.0f } },	// Bottom Right
+			{ { 1.0f, 1.0f, 0.0f },{ 1.0f, 0.0f } },	// Top Right
+		};
 
-        const UINT vertexBufferSize = sizeof(vertices);
+		const UINT vertexBufferSize = sizeof(vertices);
 
-        D3D12_HEAP_PROPERTIES heapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
-        heapProps.CreationNodeMask = m_nodeMask;
-        heapProps.VisibleNodeMask = m_nodeMask;
+		D3D12_HEAP_PROPERTIES heapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+		heapProps.CreationNodeMask = m_nodeMask;
+		heapProps.VisibleNodeMask = m_nodeMask;
 
-        ThrowIfFailed(pDevice->CreateCommittedResource(
-            &heapProps,
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_postVertexBuffer)));
+		ThrowIfFailed(pDevice->CreateCommittedResource(
+			&heapProps,
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_postVertexBuffer)));
 
-        D3D12_HEAP_PROPERTIES uploadHeapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
-        uploadHeapProps.CreationNodeMask = m_nodeMask;
-        uploadHeapProps.VisibleNodeMask = m_nodeMask;        // Upload heap is single-use and doesn't need to be shared.
+		D3D12_HEAP_PROPERTIES uploadHeapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+		uploadHeapProps.CreationNodeMask = m_nodeMask;
+		uploadHeapProps.VisibleNodeMask = m_nodeMask;		// Upload heap is single-use and doesn't need to be shared.
 
-        ThrowIfFailed(pDevice->CreateCommittedResource(
-            &uploadHeapProps,
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&quadVertexBufferUpload)));
+		ThrowIfFailed(pDevice->CreateCommittedResource(
+			&uploadHeapProps,
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&quadVertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(vertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(vertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(commandList.Get(), m_postVertexBuffer.Get(), quadVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_postVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(commandList.Get(), m_postVertexBuffer.Get(), quadVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_postVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_postVertexBufferView.BufferLocation = m_postVertexBuffer->GetGPUVirtualAddress();
-        m_postVertexBufferView.StrideInBytes = sizeof(PostVertex);
-        m_postVertexBufferView.SizeInBytes = sizeof(vertices);
-    }
+		// Initialize the vertex buffer view.
+		m_postVertexBufferView.BufferLocation = m_postVertexBuffer->GetGPUVirtualAddress();
+		m_postVertexBufferView.StrideInBytes = sizeof(PostVertex);
+		m_postVertexBufferView.SizeInBytes = sizeof(vertices);
+	}
 
-    // Create constant buffer views.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_sceneCbvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create constant buffer views.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_sceneCbvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
-        cbvDesc.SizeInBytes = sizeof(SceneConstantBuffer);
-        cbvDesc.BufferLocation = m_crossNodeResources->GetSceneConstantBufferGpuVirtualAddress();
+		D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
+		cbvDesc.SizeInBytes = sizeof(SceneConstantBuffer);
+		cbvDesc.BufferLocation = m_crossNodeResources->GetSceneConstantBufferGpuVirtualAddress();
 
-        for (UINT frame = 0; frame < Settings::SceneConstantBufferFrames; frame++)
-        {
-            for (UINT n = 0; n < Settings::TriangleCount; n++)
-            {
-                pDevice->CreateConstantBufferView(&cbvDesc, cpuHandle);
+		for (UINT frame = 0; frame < Settings::SceneConstantBufferFrames; frame++)
+		{
+			for (UINT n = 0; n < Settings::TriangleCount; n++)
+			{
+				pDevice->CreateConstantBufferView(&cbvDesc, cpuHandle);
 
-                cpuHandle.Offset(Settings::CbvSrvDescriptorSize);
-                cbvDesc.BufferLocation += cbvDesc.SizeInBytes;
-            }
-        }
-    }
+				cpuHandle.Offset(Settings::CbvSrvDescriptorSize);
+				cbvDesc.BufferLocation += cbvDesc.SizeInBytes;
+			}
+		}
+	}
 
-    // Describe and create a sampler.
-    {
-        D3D12_SAMPLER_DESC samplerDesc = {};
-        samplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-        samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.MinLOD = 0;
-        samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
-        samplerDesc.MipLODBias = 0.0f;
-        samplerDesc.MaxAnisotropy = 1;
-        samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
+	// Describe and create a sampler.
+	{
+		D3D12_SAMPLER_DESC samplerDesc = {};
+		samplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.MinLOD = 0;
+		samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
+		samplerDesc.MipLODBias = 0.0f;
+		samplerDesc.MaxAnisotropy = 1;
+		samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
 
-        pDevice->CreateSampler(&samplerDesc, m_postSamplerHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		pDevice->CreateSampler(&samplerDesc, m_postSamplerHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    ThrowIfFailed(commandList->Close());
+	ThrowIfFailed(commandList->Close());
 
-    // Submit the initialization work to the GPU.
-    ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Submit the initialization work to the GPU.
+	ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Wait for the graphics queue to finish executing the commands.
-    Fence fence(m_graphicsQueue.Get());
-    fence.FlushGpuQueue();
+	// Wait for the graphics queue to finish executing the commands.
+	Fence fence(m_graphicsQueue.Get());
+	fence.FlushGpuQueue();
 
-    LoadSizeDependentResources();
+	LoadSizeDependentResources();
 }
 
 void GpuNode::LoadSizeDependentResources()
 {
-    auto pDevice = m_crossNodeResources->GetDevice();
-    auto pSwapChain = m_crossNodeResources->GetSwapChain();
+	auto pDevice = m_crossNodeResources->GetDevice();
+	auto pSwapChain = m_crossNodeResources->GetSwapChain();
 
-    // Single-use command allocator/list for resource initialization.
-    ComPtr<ID3D12CommandAllocator> commandAllocator;
-    ComPtr<ID3D12GraphicsCommandList> commandList;
+	// Single-use command allocator/list for resource initialization.
+	ComPtr<ID3D12CommandAllocator> commandAllocator;
+	ComPtr<ID3D12GraphicsCommandList> commandList;
 
-    ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator)));
-    ThrowIfFailed(pDevice->CreateCommandList(m_nodeMask, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
+	ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator)));
+	ThrowIfFailed(pDevice->CreateCommandList(m_nodeMask, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
 
-    // Create RTVs for back buffers assigned to this node.
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart());
-    for (UINT n = 0; n < Settings::BackBuffersPerNode; n++)
-    {
-        UINT backBufferIndex = (n * Settings::NodeCount) + m_nodeIndex;
+	// Create RTVs for back buffers assigned to this node.
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart());
+	for (UINT n = 0; n < Settings::BackBuffersPerNode; n++)
+	{
+		UINT backBufferIndex = (n * Settings::NodeCount) + m_nodeIndex;
 
-        // Create an RTV for the swap chain back buffer assigned to this node.
-        ThrowIfFailed(pSwapChain->GetBuffer(backBufferIndex, IID_PPV_ARGS(&m_postRenderTargets[n])));
+		// Create an RTV for the swap chain back buffer assigned to this node.
+		ThrowIfFailed(pSwapChain->GetBuffer(backBufferIndex, IID_PPV_ARGS(&m_postRenderTargets[n])));
 
-        pDevice->CreateRenderTargetView(m_postRenderTargets[n].Get(), nullptr, rtvHandle);
-        rtvHandle.Offset(Settings::RtvDescriptorSize);
-    }
+		pDevice->CreateRenderTargetView(m_postRenderTargets[n].Get(), nullptr, rtvHandle);
+		rtvHandle.Offset(Settings::RtvDescriptorSize);
+	}
 
-    m_frameIndex = 0;
-    m_sceneRenderTargetIndex = m_nodeIndex;
+	m_frameIndex = 0;
+	m_sceneRenderTargetIndex = m_nodeIndex;
 
-    // Create the render targets used to draw the scene.
-    // These will be sampled from during the post-processing step.
-    {
-        D3D12_RESOURCE_DESC renderTargetDesc = m_postRenderTargets[0]->GetDesc();
-        D3D12_RESOURCE_ALLOCATION_INFO info = pDevice->GetResourceAllocationInfo(m_nodeMask, 1, &renderTargetDesc);
-        const UINT64 alignedRenderTargetSize = AlignResource(info.SizeInBytes, info.Alignment);
+	// Create the render targets used to draw the scene.
+	// These will be sampled from during the post-processing step.
+	{
+		D3D12_RESOURCE_DESC renderTargetDesc = m_postRenderTargets[0]->GetDesc();
+		D3D12_RESOURCE_ALLOCATION_INFO info = pDevice->GetResourceAllocationInfo(m_nodeMask, 1, &renderTargetDesc);
+		const UINT64 alignedRenderTargetSize = AlignResource(info.SizeInBytes, info.Alignment);
 
-        D3D12_HEAP_DESC heapDesc = {};
-        heapDesc.SizeInBytes = alignedRenderTargetSize * Settings::SceneHistoryCount;
-        heapDesc.Alignment = info.Alignment;
-        heapDesc.Properties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT, m_nodeMask, Settings::SharedNodeMask);
-        heapDesc.Flags = D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES | D3D12_HEAP_FLAG_DENY_BUFFERS;
+		D3D12_HEAP_DESC heapDesc = {};
+		heapDesc.SizeInBytes = alignedRenderTargetSize * Settings::SceneHistoryCount;
+		heapDesc.Alignment = info.Alignment;
+		heapDesc.Properties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT, m_nodeMask, Settings::SharedNodeMask);
+		heapDesc.Flags = D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES | D3D12_HEAP_FLAG_DENY_BUFFERS;
 
-        ThrowIfFailed(pDevice->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_sceneRenderTargetHeap)));
+		ThrowIfFailed(pDevice->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_sceneRenderTargetHeap)));
 
-        CD3DX12_CLEAR_VALUE clearValue(DXGI_FORMAT_R8G8B8A8_UNORM, Settings::ClearColor);
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart());
-        CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_postSrvHeap->GetCPUDescriptorHandleForHeapStart());
+		CD3DX12_CLEAR_VALUE clearValue(DXGI_FORMAT_R8G8B8A8_UNORM, Settings::ClearColor);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart());
+		CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_postSrvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = 1;
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = 1;
 
-        D3D12_RESOURCE_BARRIER barriers[Settings::SceneHistoryCount];
+		D3D12_RESOURCE_BARRIER barriers[Settings::SceneHistoryCount];
 
-        for (UINT n = 0; n < Settings::SceneHistoryCount; n++)
-        {
-            // The post-processing pass expects that a previous post-processing pass has
-            // transitioned the next frame's dependencies into the COPY_DEST state.
-            // Since these resources were created with the PIXEL_SHADER_RESOURCE state,
-            // we need to transition them to COPY_DEST.
+		for (UINT n = 0; n < Settings::SceneHistoryCount; n++)
+		{
+			// The post-processing pass expects that a previous post-processing pass has
+			// transitioned the next frame's dependencies into the COPY_DEST state.
+			// Since these resources were created with the PIXEL_SHADER_RESOURCE state,
+			// we need to transition them to COPY_DEST.
 
-            UINT firstResource = (m_nodeIndex + Settings::SceneHistoryCount - (Settings::NodeCount - 1)) % Settings::SceneHistoryCount;
-            UINT lastResource = (m_nodeIndex + Settings::SceneHistoryCount - 1) % Settings::SceneHistoryCount;
-            bool initCopyDest = false;
-            if (firstResource <= lastResource)
-            {
-                initCopyDest = m_nodeSync && (firstResource <= n && n <= lastResource);
-            }
-            else
-            {
-                initCopyDest = m_nodeSync && (n <= lastResource || firstResource <= n);
-            }
+			UINT firstResource = (m_nodeIndex + Settings::SceneHistoryCount - (Settings::NodeCount - 1)) % Settings::SceneHistoryCount;
+			UINT lastResource = (m_nodeIndex + Settings::SceneHistoryCount - 1) % Settings::SceneHistoryCount;
+			bool initCopyDest = false;
+			if (firstResource <= lastResource)
+			{
+				initCopyDest = m_nodeSync && (firstResource <= n && n <= lastResource);
+			}
+			else
+			{
+				initCopyDest = m_nodeSync && (n <= lastResource || firstResource <= n);
+			}
 
-            ThrowIfFailed(pDevice->CreatePlacedResource(
-                m_sceneRenderTargetHeap.Get(),
-                alignedRenderTargetSize * n,
-                &renderTargetDesc,
-                initCopyDest ? D3D12_RESOURCE_STATE_COPY_DEST : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                &clearValue,
-                IID_PPV_ARGS(&m_sceneRenderTargets[n])));
+			ThrowIfFailed(pDevice->CreatePlacedResource(
+				m_sceneRenderTargetHeap.Get(),
+				alignedRenderTargetSize * n,
+				&renderTargetDesc,
+				initCopyDest ? D3D12_RESOURCE_STATE_COPY_DEST : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+				&clearValue,
+				IID_PPV_ARGS(&m_sceneRenderTargets[n])));
 
-            barriers[n] = CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, m_sceneRenderTargets[n].Get());
+			barriers[n] = CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, m_sceneRenderTargets[n].Get());
 
-            pDevice->CreateRenderTargetView(m_sceneRenderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(Settings::RtvDescriptorSize);
+			pDevice->CreateRenderTargetView(m_sceneRenderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(Settings::RtvDescriptorSize);
 
-            pDevice->CreateShaderResourceView(m_sceneRenderTargets[n].Get(), &srvDesc, srvHandle);
-            srvHandle.Offset(Settings::CbvSrvDescriptorSize);
-        }
+			pDevice->CreateShaderResourceView(m_sceneRenderTargets[n].Get(), &srvDesc, srvHandle);
+			srvHandle.Offset(Settings::CbvSrvDescriptorSize);
+		}
 
-        commandList->ResourceBarrier(_countof(barriers), barriers);
-    }
+		commandList->ResourceBarrier(_countof(barriers), barriers);
+	}
 
-    // Create the depth stencil and its view.
-    {
-        D3D12_HEAP_PROPERTIES heapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT, m_nodeMask, m_nodeMask);
-        D3D12_CLEAR_VALUE depthOptimizedClearValue = CD3DX12_CLEAR_VALUE(DXGI_FORMAT_D32_FLOAT, 1.0f, 0);
+	// Create the depth stencil and its view.
+	{
+		D3D12_HEAP_PROPERTIES heapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT, m_nodeMask, m_nodeMask);
+		D3D12_CLEAR_VALUE depthOptimizedClearValue = CD3DX12_CLEAR_VALUE(DXGI_FORMAT_D32_FLOAT, 1.0f, 0);
 
-        ThrowIfFailed(pDevice->CreateCommittedResource(
-            &heapProps,
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, Settings::Width, Settings::Height, 1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
-            D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            &depthOptimizedClearValue,
-            IID_PPV_ARGS(&m_sceneDepthStencil)
-            ));
+		ThrowIfFailed(pDevice->CreateCommittedResource(
+			&heapProps,
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, Settings::Width, Settings::Height, 1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
+			D3D12_RESOURCE_STATE_DEPTH_WRITE,
+			&depthOptimizedClearValue,
+			IID_PPV_ARGS(&m_sceneDepthStencil)
+			));
 
-        D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
-        depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
-        depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+		D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
+		depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
+		depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
 
-        pDevice->CreateDepthStencilView(m_sceneDepthStencil.Get(), &depthStencilDesc, m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		pDevice->CreateDepthStencilView(m_sceneDepthStencil.Get(), &depthStencilDesc, m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    ThrowIfFailed(commandList->Close());
+	ThrowIfFailed(commandList->Close());
 
-    // Submit the resource barrier changes to the GPU.
-    ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Submit the resource barrier changes to the GPU.
+	ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Wait for the graphics queue to finish executing the commands.
-    Fence fence(m_graphicsQueue.Get());
-    fence.FlushGpuQueue();
+	// Wait for the graphics queue to finish executing the commands.
+	Fence fence(m_graphicsQueue.Get());
+	fence.FlushGpuQueue();
 }
 
 // Get references to scene render targets and post-processing fences on other nodes.
 void GpuNode::LinkSharedResources(std::shared_ptr<GpuNode>* ppNodes, UINT nodeCount)
 {
-    if (m_nodeSync)
-    {
-        // We need to store a reference to the other nodes' render targets so that
-        // this node can copy rendered scenes to them.
-        for (UINT nodeIndex = 0; nodeIndex < nodeCount; nodeIndex++)
-        {
-            if (nodeIndex == m_nodeIndex)
-            {
-                // This node already has references to its own render targets.
-                continue;
-            }
+	if (m_nodeSync)
+	{
+		// We need to store a reference to the other nodes' render targets so that
+		// this node can copy rendered scenes to them.
+		for (UINT nodeIndex = 0; nodeIndex < nodeCount; nodeIndex++)
+		{
+			if (nodeIndex == m_nodeIndex)
+			{
+				// This node already has references to its own render targets.
+				continue;
+			}
 
-            for (UINT n = 0; n < Settings::SceneHistoryCount; n++)
-            {
-                ThrowIfFailed(ppNodes[nodeIndex]->m_sceneRenderTargets[n].As(&m_nodeSync->sceneRenderTargets[nodeIndex][n]));
-            }
+			for (UINT n = 0; n < Settings::SceneHistoryCount; n++)
+			{
+				ThrowIfFailed(ppNodes[nodeIndex]->m_sceneRenderTargets[n].As(&m_nodeSync->sceneRenderTargets[nodeIndex][n]));
+			}
 
-            // Cross-node copies are only done when all nodes are finished with their
-            // post-processing pass (which includes transitioning resources into the
-            // correct states so that they may be copied into).
-            // Keep a reference to the other nodes' fences so this node can wait to
-            // perform the copy until the resource barriers are correctly set.
-            m_nodeSync->postFences[nodeIndex] = ppNodes[nodeIndex]->m_postFence;
-        }
-    }
+			// Cross-node copies are only done when all nodes are finished with their
+			// post-processing pass (which includes transitioning resources into the
+			// correct states so that they may be copied into).
+			// Keep a reference to the other nodes' fences so this node can wait to
+			// perform the copy until the resource barriers are correctly set.
+			m_nodeSync->postFences[nodeIndex] = ppNodes[nodeIndex]->m_postFence;
+		}
+	}
 }
 
 void GpuNode::OnUpdate(SceneConstantBuffer* pBuffers, UINT bufferCount, UINT64 frameId)
 {
-    m_crossNodeResources->UpdateConstantBuffer(reinterpret_cast<UINT8*>(pBuffers), bufferCount * sizeof(SceneConstantBuffer), frameId);
+	m_crossNodeResources->UpdateConstantBuffer(reinterpret_cast<UINT8*>(pBuffers), bufferCount * sizeof(SceneConstantBuffer), frameId);
 }
 
 // Fill the command list with all the render commands and dependent state.
 void GpuNode::RenderScene(UINT64 frameId, UINT simulatedGpuLoad)
 {
-    UINT cbvDescriptorTableOffset = Settings::TriangleCount * (frameId % Settings::SceneConstantBufferFrames);
-    CD3DX12_GPU_DESCRIPTOR_HANDLE cbvHandle(m_sceneCbvHeap->GetGPUDescriptorHandleForHeapStart(), cbvDescriptorTableOffset, Settings::CbvSrvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart(), m_sceneRenderTargetIndex, Settings::RtvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
+	UINT cbvDescriptorTableOffset = Settings::TriangleCount * (frameId % Settings::SceneConstantBufferFrames);
+	CD3DX12_GPU_DESCRIPTOR_HANDLE cbvHandle(m_sceneCbvHeap->GetGPUDescriptorHandleForHeapStart(), cbvDescriptorTableOffset, Settings::CbvSrvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart(), m_sceneRenderTargetIndex, Settings::RtvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
 
-    m_sceneFence->Next();
+	m_sceneFence->Next();
 
-    // Record the rendering commands.
-    ThrowIfFailed(m_sceneCommandAllocators[m_frameIndex]->Reset());
-    ThrowIfFailed(m_sceneCommandList->Reset(m_sceneCommandAllocators[m_frameIndex].Get(), m_crossNodeResources->GetScenePipelineState()));
+	// Record the rendering commands.
+	ThrowIfFailed(m_sceneCommandAllocators[m_frameIndex]->Reset());
+	ThrowIfFailed(m_sceneCommandList->Reset(m_sceneCommandAllocators[m_frameIndex].Get(), m_crossNodeResources->GetScenePipelineState()));
 
-    // Set necessary state.
-    m_sceneCommandList->SetGraphicsRootSignature(m_crossNodeResources->GetSceneRootSignature());
-    m_sceneCommandList->SetGraphicsRoot32BitConstant(1, simulatedGpuLoad, 0);
-    
-    ID3D12DescriptorHeap* ppHeaps[] = { m_sceneCbvHeap.Get() };
-    m_sceneCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	// Set necessary state.
+	m_sceneCommandList->SetGraphicsRootSignature(m_crossNodeResources->GetSceneRootSignature());
+	m_sceneCommandList->SetGraphicsRoot32BitConstant(1, simulatedGpuLoad, 0);
+	
+	ID3D12DescriptorHeap* ppHeaps[] = { m_sceneCbvHeap.Get() };
+	m_sceneCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_sceneCommandList->RSSetViewports(1, &Settings::Viewport);
-    m_sceneCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
-    m_sceneCommandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
+	m_sceneCommandList->RSSetViewports(1, &Settings::Viewport);
+	m_sceneCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
+	m_sceneCommandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
 
-    // Record commands.
-    D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET);
-    m_sceneCommandList->ResourceBarrier(1, &barrier);
-    m_sceneCommandList->ClearRenderTargetView(rtvHandle, Settings::ClearColor, 0, nullptr);
-    m_sceneCommandList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
-    
-    m_sceneCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    m_sceneCommandList->IASetVertexBuffers(0, 1, &m_sceneVertexBufferView);
+	// Record commands.
+	D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET);
+	m_sceneCommandList->ResourceBarrier(1, &barrier);
+	m_sceneCommandList->ClearRenderTargetView(rtvHandle, Settings::ClearColor, 0, nullptr);
+	m_sceneCommandList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+	
+	m_sceneCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_sceneCommandList->IASetVertexBuffers(0, 1, &m_sceneVertexBufferView);
 
-    for (UINT m = 0; m < Settings::TriangleCount; m++)
-    {
-        m_sceneCommandList->SetGraphicsRootDescriptorTable(0, cbvHandle);
-        m_sceneCommandList->DrawInstanced(3, 1, 0, 0);
+	for (UINT m = 0; m < Settings::TriangleCount; m++)
+	{
+		m_sceneCommandList->SetGraphicsRootDescriptorTable(0, cbvHandle);
+		m_sceneCommandList->DrawInstanced(3, 1, 0, 0);
 
-        cbvHandle.Offset(Settings::CbvSrvDescriptorSize);
-    }
+		cbvHandle.Offset(Settings::CbvSrvDescriptorSize);
+	}
 
-    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barrier.Transition.StateAfter = m_nodeSync ? D3D12_RESOURCE_STATE_COPY_SOURCE : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-    m_sceneCommandList->ResourceBarrier(1, &barrier);
+	barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barrier.Transition.StateAfter = m_nodeSync ? D3D12_RESOURCE_STATE_COPY_SOURCE : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	m_sceneCommandList->ResourceBarrier(1, &barrier);
 
-    ThrowIfFailed(m_sceneCommandList->Close());
+	ThrowIfFailed(m_sceneCommandList->Close());
 
-    ID3D12CommandList* ppSceneCommandLists[] = { m_sceneCommandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppSceneCommandLists), ppSceneCommandLists);
+	ID3D12CommandList* ppSceneCommandLists[] = { m_sceneCommandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppSceneCommandLists), ppSceneCommandLists);
 
-    m_sceneFence->Signal();
+	m_sceneFence->Signal();
 }
 
 void GpuNode::RenderPost(UINT64 frameId)
 {
-    UINT backBufferIndex = m_crossNodeResources->GetSwapChain()->GetCurrentBackBufferIndex() / Settings::NodeCount;
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle = CD3DX12_CPU_DESCRIPTOR_HANDLE(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart(), backBufferIndex, Settings::RtvDescriptorSize);
+	UINT backBufferIndex = m_crossNodeResources->GetSwapChain()->GetCurrentBackBufferIndex() / Settings::NodeCount;
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle = CD3DX12_CPU_DESCRIPTOR_HANDLE(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart(), backBufferIndex, Settings::RtvDescriptorSize);
 
-    m_postFence->Next();
+	m_postFence->Next();
 
-    ThrowIfFailed(m_postCommandAllocators[m_frameIndex]->Reset());
-    ThrowIfFailed(m_postCommandList->Reset(m_postCommandAllocators[m_frameIndex].Get(), m_crossNodeResources->GetPostPipelineState()));
+	ThrowIfFailed(m_postCommandAllocators[m_frameIndex]->Reset());
+	ThrowIfFailed(m_postCommandList->Reset(m_postCommandAllocators[m_frameIndex].Get(), m_crossNodeResources->GetPostPipelineState()));
 
-    if (m_nodeSync)
-    {
-        // If the rendered scenes need to be copied across nodes, we need to wait
-        // until the other nodes are done with their post processing passes (which
-        // includes transitioning the state of the next render targets in the
-        // history to the COPY_DEST state).
-        if (frameId > 0)
-        {
-            for (UINT node = 0; node < Settings::NodeCount; node++)
-            {
-                if (node != m_nodeIndex)
-                {
-                    Fence::GpuWait(m_graphicsQueue.Get(), m_nodeSync->postFences[node].get());
-                }
-            }
-        }
+	if (m_nodeSync)
+	{
+		// If the rendered scenes need to be copied across nodes, we need to wait
+		// until the other nodes are done with their post processing passes (which
+		// includes transitioning the state of the next render targets in the
+		// history to the COPY_DEST state).
+		if (frameId > 0)
+		{
+			for (UINT node = 0; node < Settings::NodeCount; node++)
+			{
+				if (node != m_nodeIndex)
+				{
+					Fence::GpuWait(m_graphicsQueue.Get(), m_nodeSync->postFences[node].get());
+				}
+			}
+		}
 
-        // Copy the render target from the scene pass to all other nodes.
-        for (UINT n = 0; n < Settings::NodeCount; n++)
-        {
-            // We only keep references to the render targets that we need to copy to.
-            if (m_nodeSync->sceneRenderTargets[n][m_sceneRenderTargetIndex])
-            {
-                m_postCommandList->CopyResource(
-                    m_nodeSync->sceneRenderTargets[n][m_sceneRenderTargetIndex].Get(),
-                    m_sceneRenderTargets[m_sceneRenderTargetIndex].Get());
-            }
-        }
+		// Copy the render target from the scene pass to all other nodes.
+		for (UINT n = 0; n < Settings::NodeCount; n++)
+		{
+			// We only keep references to the render targets that we need to copy to.
+			if (m_nodeSync->sceneRenderTargets[n][m_sceneRenderTargetIndex])
+			{
+				m_postCommandList->CopyResource(
+					m_nodeSync->sceneRenderTargets[n][m_sceneRenderTargetIndex].Get(),
+					m_sceneRenderTargets[m_sceneRenderTargetIndex].Get());
+			}
+		}
 
-        // Transition all render target resources into the PIXEL_SHADER_RESOURCE
-        // state to prepare for rendering the post-process effect.
-        D3D12_RESOURCE_BARRIER barriers[Settings::MaxNodeCount];
+		// Transition all render target resources into the PIXEL_SHADER_RESOURCE
+		// state to prepare for rendering the post-process effect.
+		D3D12_RESOURCE_BARRIER barriers[Settings::MaxNodeCount];
 
-        for (UINT index = 0; index < Settings::NodeCount - 1; index++)
-        {
-            UINT offset = Settings::SceneHistoryCount - Settings::NodeCount + 1 + index;
-            UINT renderTargetIndex = (m_sceneRenderTargetIndex + offset) % Settings::SceneHistoryCount;
+		for (UINT index = 0; index < Settings::NodeCount - 1; index++)
+		{
+			UINT offset = Settings::SceneHistoryCount - Settings::NodeCount + 1 + index;
+			UINT renderTargetIndex = (m_sceneRenderTargetIndex + offset) % Settings::SceneHistoryCount;
 
-            barriers[index] = CD3DX12_RESOURCE_BARRIER::Transition(
-                m_sceneRenderTargets[renderTargetIndex].Get(),
-                D3D12_RESOURCE_STATE_COPY_DEST,
-                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
-        }
+			barriers[index] = CD3DX12_RESOURCE_BARRIER::Transition(
+				m_sceneRenderTargets[renderTargetIndex].Get(),
+				D3D12_RESOURCE_STATE_COPY_DEST,
+				D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+		}
 
-        barriers[Settings::NodeCount - 1] = CD3DX12_RESOURCE_BARRIER::Transition(
-            m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(),
-            D3D12_RESOURCE_STATE_COPY_SOURCE,
-            D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+		barriers[Settings::NodeCount - 1] = CD3DX12_RESOURCE_BARRIER::Transition(
+			m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(),
+			D3D12_RESOURCE_STATE_COPY_SOURCE,
+			D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
 
-        m_postCommandList->ResourceBarrier(Settings::NodeCount, barriers);
-    }
+		m_postCommandList->ResourceBarrier(Settings::NodeCount, barriers);
+	}
 
-    m_postCommandList->SetGraphicsRootSignature(m_crossNodeResources->GetPostRootSignature());
+	m_postCommandList->SetGraphicsRootSignature(m_crossNodeResources->GetPostRootSignature());
 
-    ID3D12DescriptorHeap* ppPostHeaps[] = { m_postSrvHeap.Get(), m_postSamplerHeap.Get() };
-    m_postCommandList->SetDescriptorHeaps(_countof(ppPostHeaps), ppPostHeaps);
+	ID3D12DescriptorHeap* ppPostHeaps[] = { m_postSrvHeap.Get(), m_postSamplerHeap.Get() };
+	m_postCommandList->SetDescriptorHeaps(_countof(ppPostHeaps), ppPostHeaps);
 
-    m_postCommandList->RSSetViewports(1, &Settings::Viewport);
-    m_postCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
+	m_postCommandList->RSSetViewports(1, &Settings::Viewport);
+	m_postCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
 
-    D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(m_postRenderTargets[backBufferIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET);
-    m_postCommandList->ResourceBarrier(1, &barrier);
+	D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(m_postRenderTargets[backBufferIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET);
+	m_postCommandList->ResourceBarrier(1, &barrier);
 
-    m_postCommandList->OMSetRenderTargets(1, &rtvHandle, false, nullptr);
+	m_postCommandList->OMSetRenderTargets(1, &rtvHandle, false, nullptr);
 
-    m_postCommandList->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-    m_postCommandList->IASetVertexBuffers(0, 1, &m_postVertexBufferView);
+	m_postCommandList->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+	m_postCommandList->IASetVertexBuffers(0, 1, &m_postVertexBufferView);
 
-    m_postCommandList->SetGraphicsRootDescriptorTable(0, m_postSrvHeap->GetGPUDescriptorHandleForHeapStart());
-    m_postCommandList->SetGraphicsRootDescriptorTable(1, m_postSamplerHeap->GetGPUDescriptorHandleForHeapStart());
-    m_postCommandList->SetGraphicsRoot32BitConstant(2, frameId % Settings::SceneHistoryCount, 0);
-    m_postCommandList->SetGraphicsRoot32BitConstant(2, static_cast<UINT>(min(frameId + 1, Settings::SceneHistoryCount)), 1);
+	m_postCommandList->SetGraphicsRootDescriptorTable(0, m_postSrvHeap->GetGPUDescriptorHandleForHeapStart());
+	m_postCommandList->SetGraphicsRootDescriptorTable(1, m_postSamplerHeap->GetGPUDescriptorHandleForHeapStart());
+	m_postCommandList->SetGraphicsRoot32BitConstant(2, frameId % Settings::SceneHistoryCount, 0);
+	m_postCommandList->SetGraphicsRoot32BitConstant(2, static_cast<UINT>(min(frameId + 1, Settings::SceneHistoryCount)), 1);
 
-    m_postCommandList->DrawInstanced(4, 1, 0, 0);
+	m_postCommandList->DrawInstanced(4, 1, 0, 0);
 
-    // Indicate that the back buffer will now be used to present.
-    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
+	// Indicate that the back buffer will now be used to present.
+	barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
 
-    D3D12_RESOURCE_BARRIER barriers[Settings::MaxNodeCount];
-    barriers[0] = barrier;
+	D3D12_RESOURCE_BARRIER barriers[Settings::MaxNodeCount];
+	barriers[0] = barrier;
 
-    if (m_nodeSync)
-    {
-        // Transition render target resources rendered by the next nodes into the
-        // COPY_DEST state to prepare them to be copied to during those nodes'
-        // post-process passes.
-        for (UINT offset = 1; offset < Settings::NodeCount; offset++)
-        {
-            UINT renderTargetIndex = (m_sceneRenderTargetIndex + offset) % Settings::SceneHistoryCount;
+	if (m_nodeSync)
+	{
+		// Transition render target resources rendered by the next nodes into the
+		// COPY_DEST state to prepare them to be copied to during those nodes'
+		// post-process passes.
+		for (UINT offset = 1; offset < Settings::NodeCount; offset++)
+		{
+			UINT renderTargetIndex = (m_sceneRenderTargetIndex + offset) % Settings::SceneHistoryCount;
 
-            barriers[offset] = CD3DX12_RESOURCE_BARRIER::Transition(
-                m_sceneRenderTargets[renderTargetIndex].Get(),
-                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_COPY_DEST);
-        }
-    }
+			barriers[offset] = CD3DX12_RESOURCE_BARRIER::Transition(
+				m_sceneRenderTargets[renderTargetIndex].Get(),
+				D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+				D3D12_RESOURCE_STATE_COPY_DEST);
+		}
+	}
 
-    m_postCommandList->ResourceBarrier(Settings::NodeCount, barriers);
+	m_postCommandList->ResourceBarrier(Settings::NodeCount, barriers);
 
-    ThrowIfFailed(m_postCommandList->Close());
+	ThrowIfFailed(m_postCommandList->Close());
 
-    ID3D12CommandList* ppPostCommandLists[] = { m_postCommandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppPostCommandLists), ppPostCommandLists);
+	ID3D12CommandList* ppPostCommandLists[] = { m_postCommandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppPostCommandLists), ppPostCommandLists);
 }
 
 void GpuNode::Present(UINT syncInterval, bool windowedMode)
 {
-    // When using sync interval 0, it is recommended to always pass the tearing
-    // flag when it is supported, even if not presenting to a fullscreen window.
-    // This flag cannot be used if the app is in "exclusive" fullscreen mode as
-    // a result of calling SetFullscreenState.
+	// When using sync interval 0, it is recommended to always pass the tearing
+	// flag when it is supported, even if not presenting to a fullscreen window.
+	// This flag cannot be used if the app is in "exclusive" fullscreen mode as
+	// a result of calling SetFullscreenState.
 
-    UINT presentFlags = (syncInterval == 0 && Settings::TearingSupport && windowedMode) ? DXGI_PRESENT_ALLOW_TEARING : 0;
+	UINT presentFlags = (syncInterval == 0 && Settings::TearingSupport && windowedMode) ? DXGI_PRESENT_ALLOW_TEARING : 0;
 
-    ThrowIfFailed(m_crossNodeResources->GetSwapChain()->Present(syncInterval, presentFlags));
+	ThrowIfFailed(m_crossNodeResources->GetSwapChain()->Present(syncInterval, presentFlags));
 }
 
 void GpuNode::ReleaseBackBuffers()
 {
-    // Release the resources holding references to the swap chain (requirement of
-    // IDXGISwapChain::ResizeBuffers).
+	// Release the resources holding references to the swap chain (requirement of
+	// IDXGISwapChain::ResizeBuffers).
 
-    for (UINT n = 0; n < Settings::BackBuffersPerNode; n++)
-    {
-        m_postRenderTargets[n].Reset();
-    }
+	for (UINT n = 0; n < Settings::BackBuffersPerNode; n++)
+	{
+		m_postRenderTargets[n].Reset();
+	}
 }
 
 void GpuNode::WaitForGpu()
 {
-    m_postFence->FlushGpuQueue();
+	m_postFence->FlushGpuQueue();
 }
 
 void GpuNode::MoveToNextFrame()
 {
-    m_postFence->Signal();
+	m_postFence->Signal();
 
-    m_frameIndex = (m_frameIndex + 1) % Settings::FrameCount;
+	m_frameIndex = (m_frameIndex + 1) % Settings::FrameCount;
 
-    // We render to every nth render target.
-    m_sceneRenderTargetIndex = (m_sceneRenderTargetIndex + Settings::NodeCount) % Settings::SceneHistoryCount;
+	// We render to every nth render target.
+	m_sceneRenderTargetIndex = (m_sceneRenderTargetIndex + Settings::NodeCount) % Settings::SceneHistoryCount;
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/GpuNode.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/GpuNode.h
@@ -21,84 +21,84 @@ using Microsoft::WRL::ComPtr;
 class GpuNode
 {
 public:
-    GpuNode(UINT nodeIndex, std::shared_ptr<CrossNodeResources> crossNodeResources);
-    void LoadPipeline();
-    void LoadAssets();
-    void LoadSizeDependentResources();
-    void LinkSharedResources(std::shared_ptr<GpuNode>* ppNodes, UINT nodeCount);
-    void OnUpdate(SceneConstantBuffer* pBuffers, UINT bufferCount, UINT64 frameId);
-    void RenderScene(UINT64 frameId, UINT simulatedGpuLoad);
-    void RenderPost(UINT64 frameId);
-    void Present(UINT syncInterval, bool windowedMode);
+	GpuNode(UINT nodeIndex, std::shared_ptr<CrossNodeResources> crossNodeResources);
+	void LoadPipeline();
+	void LoadAssets();
+	void LoadSizeDependentResources();
+	void LinkSharedResources(std::shared_ptr<GpuNode>* ppNodes, UINT nodeCount);
+	void OnUpdate(SceneConstantBuffer* pBuffers, UINT bufferCount, UINT64 frameId);
+	void RenderScene(UINT64 frameId, UINT simulatedGpuLoad);
+	void RenderPost(UINT64 frameId);
+	void Present(UINT syncInterval, bool windowedMode);
 
-    void ReleaseBackBuffers();
-    void WaitForGpu();
-    void MoveToNextFrame();
+	void ReleaseBackBuffers();
+	void WaitForGpu();
+	void MoveToNextFrame();
 
 private:
-    UINT m_frameIndex;
-    UINT m_nodeIndex;
-    UINT m_nodeMask;
+	UINT m_frameIndex;
+	UINT m_nodeIndex;
+	UINT m_nodeMask;
 
-    std::shared_ptr<CrossNodeResources> m_crossNodeResources;
+	std::shared_ptr<CrossNodeResources> m_crossNodeResources;
 
-    ComPtr<ID3D12CommandQueue> m_graphicsQueue;
-    std::vector<ComPtr<ID3D12CommandAllocator>> m_sceneCommandAllocators;
-    std::vector<ComPtr<ID3D12CommandAllocator>> m_postCommandAllocators;
-    ComPtr<ID3D12DescriptorHeap> m_sceneRtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_sceneDsvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_sceneCbvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_postRtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_postSrvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_postSamplerHeap;
+	ComPtr<ID3D12CommandQueue> m_graphicsQueue;
+	std::vector<ComPtr<ID3D12CommandAllocator>> m_sceneCommandAllocators;
+	std::vector<ComPtr<ID3D12CommandAllocator>> m_postCommandAllocators;
+	ComPtr<ID3D12DescriptorHeap> m_sceneRtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_sceneDsvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_sceneCbvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_postRtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_postSrvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_postSamplerHeap;
 
-    // Vertex definitions.
-    struct SceneVertex
-    {
-        DirectX::XMFLOAT3 position;
-    };
+	// Vertex definitions.
+	struct SceneVertex
+	{
+		DirectX::XMFLOAT3 position;
+	};
 
-    struct PostVertex
-    {
-        DirectX::XMFLOAT3 position;
-        DirectX::XMFLOAT2 uv;
-    };
+	struct PostVertex
+	{
+		DirectX::XMFLOAT3 position;
+		DirectX::XMFLOAT2 uv;
+	};
 
-    // Scene objects.
-    ComPtr<ID3D12Resource> m_sceneVertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_sceneVertexBufferView;
-    ComPtr<ID3D12GraphicsCommandList> m_sceneCommandList;
-    ComPtr<ID3D12Heap> m_sceneRenderTargetHeap;
-    ComPtr<ID3D12Resource> m_sceneDepthStencil;
+	// Scene objects.
+	ComPtr<ID3D12Resource> m_sceneVertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_sceneVertexBufferView;
+	ComPtr<ID3D12GraphicsCommandList> m_sceneCommandList;
+	ComPtr<ID3D12Heap> m_sceneRenderTargetHeap;
+	ComPtr<ID3D12Resource> m_sceneDepthStencil;
 
-    // The motion blur shader samples from the number of render targets specified by
-    // Settings::SceneHistoryCount. A copy of these render targets will exist on each
-    // node.
-    ComPtr<ID3D12Resource> m_sceneRenderTargets[Settings::SceneHistoryCount];
+	// The motion blur shader samples from the number of render targets specified by
+	// Settings::SceneHistoryCount. A copy of these render targets will exist on each
+	// node.
+	ComPtr<ID3D12Resource> m_sceneRenderTargets[Settings::SceneHistoryCount];
 
-    // The index of the current render target used in the scene pass.
-    // This value increases by Settings::NodeCount each frame.
-    UINT m_sceneRenderTargetIndex;
+	// The index of the current render target used in the scene pass.
+	// This value increases by Settings::NodeCount each frame.
+	UINT m_sceneRenderTargetIndex;
 
-    // Post-process objects.
-    ComPtr<ID3D12Resource> m_postVertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_postVertexBufferView;
-    ComPtr<ID3D12GraphicsCommandList> m_postCommandList;
-    std::vector<ComPtr<ID3D12Resource>> m_postRenderTargets;
+	// Post-process objects.
+	ComPtr<ID3D12Resource> m_postVertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_postVertexBufferView;
+	ComPtr<ID3D12GraphicsCommandList> m_postCommandList;
+	std::vector<ComPtr<ID3D12Resource>> m_postRenderTargets;
 
-    // Objects used to support synchronizing render target contents across GPU nodes.
-    struct NodeSynchronization
-    {
-        ComPtr<ID3D12Resource> sceneRenderTargets[Settings::MaxNodeCount][Settings::SceneHistoryCount];
-        std::shared_ptr<Fence> postFences[Settings::MaxNodeCount];
-    };
-    std::unique_ptr<NodeSynchronization> m_nodeSync;
+	// Objects used to support synchronizing render target contents across GPU nodes.
+	struct NodeSynchronization
+	{
+		ComPtr<ID3D12Resource> sceneRenderTargets[Settings::MaxNodeCount][Settings::SceneHistoryCount];
+		std::shared_ptr<Fence> postFences[Settings::MaxNodeCount];
+	};
+	std::unique_ptr<NodeSynchronization> m_nodeSync;
 
-    std::shared_ptr<LinearFence> m_sceneFence;
-    std::shared_ptr<LinearFence> m_postFence;
+	std::shared_ptr<LinearFence> m_sceneFence;
+	std::shared_ptr<LinearFence> m_postFence;
 
-    static inline UINT64 AlignResource(UINT64 size, UINT64 alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT)
-    {
-        return (size + alignment - 1) & ~(alignment - 1);
-    }
+	static inline UINT64 AlignResource(UINT64 size, UINT64 alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT)
+	{
+		return (size + alignment - 1) & ~(alignment - 1);
+	}
 };

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/Main.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12LinkedGpus sample(1280, 720, L"D3D12 Linked GPUs Sample");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12LinkedGpus sample(1280, 720, L"D3D12 Linked GPUs Sample");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/Post.hlsli
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/Post.hlsli
@@ -11,14 +11,14 @@
 
 struct VSInput
 {
-    float4 position : POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : POSITION;
+	float2 uv : TEXCOORD;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 Texture2D g_renderTargets[6] : register(t0);
@@ -26,6 +26,6 @@ SamplerState g_sampler : register(s0);
 
 cbuffer ShaderConstants : register(b0)
 {
-    uint currentRenderTarget;
-    uint renderTargetCount;
+	uint currentRenderTarget;
+	uint renderTargetCount;
 };

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/PostPS.hlsl
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/PostPS.hlsl
@@ -13,18 +13,18 @@
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    // This adds up to more than 1.0f, but creates a decent effect
-    // that doesn't make the triangles look too transparent.
-    float blurWeights[6] = { 0.80f, 0.25f, 0.15f, 0.075f, 0.025f, 0.0125f };
+	// This adds up to more than 1.0f, but creates a decent effect
+	// that doesn't make the triangles look too transparent.
+	float blurWeights[6] = { 0.80f, 0.25f, 0.15f, 0.075f, 0.025f, 0.0125f };
 
-    float4 result = float4(0.0f, 0.0f, 0.0f, 0.0f);
-    uint index = currentRenderTarget;
+	float4 result = float4(0.0f, 0.0f, 0.0f, 0.0f);
+	uint index = currentRenderTarget;
 
-    for (uint n = 0; n < renderTargetCount; n++)
-    {
-        result += blurWeights[n] * g_renderTargets[index].Sample(g_sampler, input.uv);
-        index = (index == 0) ? renderTargetCount - 1 : index - 1;
-    }
+	for (uint n = 0; n < renderTargetCount; n++)
+	{
+		result += blurWeights[n] * g_renderTargets[index].Sample(g_sampler, input.uv);
+		index = (index == 0) ? renderTargetCount - 1 : index - 1;
+	}
 
-    return saturate(result);
+	return saturate(result);
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/PostVS.hlsl
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/PostVS.hlsl
@@ -13,10 +13,10 @@
 
 PSInput VSMain(VSInput input)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = input.position;
-    result.uv = input.uv;
+	result.position = input.position;
+	result.uv = input.uv;
 
-    return result;
+	return result;
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/Scene.hlsli
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/Scene.hlsli
@@ -11,19 +11,19 @@
 
 cbuffer SceneConstantBuffer : register(b0)
 {
-    float4 velocity;
-    float4 offset;
-    float4 color;
-    float4x4 projection;
+	float4 velocity;
+	float4 offset;
+	float4 color;
+	float4x4 projection;
 };
 
 cbuffer SceneRootConstants : register(b1)
 {
-    uint simulatedGpuLoad;
+	uint simulatedGpuLoad;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/ScenePS.hlsl
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/ScenePS.hlsl
@@ -13,5 +13,5 @@
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/SceneVS.hlsl
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/SceneVS.hlsl
@@ -13,29 +13,29 @@
 
 PSInput VSMain(float4 position : POSITION)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = mul(position + offset, projection);
+	result.position = mul(position + offset, projection);
 
-    float intensity = saturate((4.0f - result.position.z) / 2.0f);
-    float4 c = float4(color.xyz * intensity, 1.0f);
+	float intensity = saturate((4.0f - result.position.z) / 2.0f);
+	float4 c = float4(color.xyz * intensity, 1.0f);
 
-    if (simulatedGpuLoad > 0)
-    {
-        float4 total = float4(0.0f, 0.0f, 0.0f, 0.0f);
+	if (simulatedGpuLoad > 0)
+	{
+		float4 total = float4(0.0f, 0.0f, 0.0f, 0.0f);
 
-        // Simulate additional workload on the GPU.
-        for (uint x = 0; x < simulatedGpuLoad; x++)
-        {
-            total += c;
-        }
+		// Simulate additional workload on the GPU.
+		for (uint x = 0; x < simulatedGpuLoad; x++)
+		{
+			total += c;
+		}
 
-        result.color = total / simulatedGpuLoad;
-    }
-    else
-    {
-        result.color = c;
-    }
+		result.color = total / simulatedGpuLoad;
+	}
+	else
+	{
+		result.color = c;
+	}
 
-    return result;
+	return result;
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/Settings.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/Settings.cpp
@@ -15,8 +15,8 @@
 
 using Microsoft::WRL::ComPtr;
 
-const float Settings::TriangleHalfWidth = 0.05f;    // The x and y offsets used by the triangle vertices.
-const float Settings::TriangleDepth = 1.0f;            // The z offset used by the triangle vertices.
+const float Settings::TriangleHalfWidth = 0.05f;	// The x and y offsets used by the triangle vertices.
+const float Settings::TriangleDepth = 1.0f;			// The z offset used by the triangle vertices.
 const float Settings::ClearColor[4] = { 0.0f, 0.2f, 0.4f, 1.0f };
 
 UINT Settings::NodeCount;
@@ -36,34 +36,34 @@ D3D12_RECT Settings::ScissorRect;
 
 void Settings::Initialize(ID3D12Device* pDevice, UINT width, UINT height, bool tearingSupport)
 {
-    NodeCount = pDevice->GetNodeCount();
-    _ASSERT(NodeCount <= MaxNodeCount);
+	NodeCount = pDevice->GetNodeCount();
+	_ASSERT(NodeCount <= MaxNodeCount);
 
-    BackBuffersPerNode = (NodeCount > 1) ? 1 : 2;
-    FrameCount = (NodeCount > 1) ? 1 : 2;
-    _ASSERT(FrameCount * NodeCount <= SceneConstantBufferFrames);
+	BackBuffersPerNode = (NodeCount > 1) ? 1 : 2;
+	FrameCount = (NodeCount > 1) ? 1 : 2;
+	_ASSERT(FrameCount * NodeCount <= SceneConstantBufferFrames);
 
-    D3D12_FEATURE_DATA_D3D12_OPTIONS featureOptions;
-    ThrowIfFailed(pDevice->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &featureOptions, sizeof(featureOptions)));
-    Tier2Support = (featureOptions.CrossNodeSharingTier == D3D12_CROSS_NODE_SHARING_TIER_2);
-    TearingSupport = tearingSupport;
+	D3D12_FEATURE_DATA_D3D12_OPTIONS featureOptions;
+	ThrowIfFailed(pDevice->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &featureOptions, sizeof(featureOptions)));
+	Tier2Support = (featureOptions.CrossNodeSharingTier == D3D12_CROSS_NODE_SHARING_TIER_2);
+	TearingSupport = tearingSupport;
 
-    RtvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    CbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	RtvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	CbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 
-    SharedNodeMask = (1 << NodeCount) - 1;
-    BackBufferCount = NodeCount * BackBuffersPerNode;
+	SharedNodeMask = (1 << NodeCount) - 1;
+	BackBufferCount = NodeCount * BackBuffersPerNode;
 
-    // We assume that each node will be assigned the same number of render targets.
-    _ASSERT(SceneHistoryCount % NodeCount == 0);
+	// We assume that each node will be assigned the same number of render targets.
+	_ASSERT(SceneHistoryCount % NodeCount == 0);
 
-    OnSizeChanged(width, height);
+	OnSizeChanged(width, height);
 }
 
 void Settings::OnSizeChanged(UINT width, UINT height)
 {
-    Width = width;
-    Height = height;
-    Viewport = CD3DX12_VIEWPORT(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 0.0f, 1.0f);
-    ScissorRect = CD3DX12_RECT(0, 0, static_cast<LONG>(width), static_cast<LONG>(height));
+	Width = width;
+	Height = height;
+	Viewport = CD3DX12_VIEWPORT(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 0.0f, 1.0f);
+	ScissorRect = CD3DX12_RECT(0, 0, static_cast<LONG>(width), static_cast<LONG>(height));
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/Settings.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/Settings.h
@@ -15,30 +15,30 @@
 // for the lifetime of the sample.
 struct Settings
 {
-    static void Initialize(ID3D12Device* pDevice, UINT width, UINT height, bool tearingSupport);
-    static void OnSizeChanged(UINT width, UINT height);
+	static void Initialize(ID3D12Device* pDevice, UINT width, UINT height, bool tearingSupport);
+	static void OnSizeChanged(UINT width, UINT height);
 
-    static const UINT MaxNodeCount = 2;
-    static UINT BackBuffersPerNode;
-    static UINT FrameCount;                                // The maximum number of frames that will be buffered on each node.
+	static const UINT MaxNodeCount = 2;
+	static UINT BackBuffersPerNode;
+	static UINT FrameCount;								// The maximum number of frames that will be buffered on each node.
 
-    static const UINT SceneHistoryCount = 6;            // The number of frames used in the motion blur effect.
-    static const UINT SceneConstantBufferFrames = 10;    // The number of frames that can be buffered in the constant buffer heap.
-    static const UINT TriangleCount = 1024;                // The number of triangles drawn per frame.
-    static const float TriangleHalfWidth;                // The x and y offsets used by the triangle vertices.
-    static const float TriangleDepth;                    // The z offset used by the triangle vertices.
-    static const float ClearColor[4];
+	static const UINT SceneHistoryCount = 6;			// The number of frames used in the motion blur effect.
+	static const UINT SceneConstantBufferFrames = 10;	// The number of frames that can be buffered in the constant buffer heap.
+	static const UINT TriangleCount = 1024;				// The number of triangles drawn per frame.
+	static const float TriangleHalfWidth;				// The x and y offsets used by the triangle vertices.
+	static const float TriangleDepth;					// The z offset used by the triangle vertices.
+	static const float ClearColor[4];
 
-    static UINT NodeCount;                                // The number of linked GPUs on the system.
-    static UINT SharedNodeMask;                            // The mask representing all GPUs on the system.
-    static bool Tier2Support;
-    static bool TearingSupport;
-    static UINT BackBufferCount;
-    static UINT RtvDescriptorSize;
-    static UINT CbvSrvDescriptorSize;
+	static UINT NodeCount;								// The number of linked GPUs on the system.
+	static UINT SharedNodeMask;							// The mask representing all GPUs on the system.
+	static bool Tier2Support;
+	static bool TearingSupport;
+	static UINT BackBufferCount;
+	static UINT RtvDescriptorSize;
+	static UINT CbvSrvDescriptorSize;
 
-    static UINT Width;
-    static UINT Height;
-    static D3D12_VIEWPORT Viewport;
-    static D3D12_RECT ScissorRect;
+	static UINT Width;
+	static UINT Height;
+	static D3D12_VIEWPORT Viewport;
+	static D3D12_RECT ScissorRect;
 };

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/d3dx12.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/D3D12LinkedGpusAffinity.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/D3D12LinkedGpusAffinity.cpp
@@ -21,1018 +21,1018 @@
 using namespace DirectX;
 
 D3D12LinkedGpusAffinity::D3D12LinkedGpusAffinity(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_frameId(0),
-    m_simulatedGpuLoad(0x1000),
-    m_syncInterval(0),
-    m_windowVisible(true),
-    m_windowedMode(true),
-    m_syncSceneRenderTargets(false)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_frameId(0),
+	m_simulatedGpuLoad(0x1000),
+	m_syncInterval(0),
+	m_windowVisible(true),
+	m_windowedMode(true),
+	m_syncSceneRenderTargets(false)
 {
-    m_sceneData.resize(Settings::TriangleCount);
+	m_sceneData.resize(Settings::TriangleCount);
 }
 
 void D3D12LinkedGpusAffinity::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 
-    UpdateWindowTitle();
+	UpdateWindowTitle();
 }
 
 void D3D12LinkedGpusAffinity::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<ID3D12Device> device;
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<ID3D12Device> device;
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&device)
+			));
+	}
 
-    ThrowIfFailed(D3DX12AffinityCreateLDADevice(device.Get(), &m_device));
+	ThrowIfFailed(D3DX12AffinityCreateLDADevice(device.Get(), &m_device));
 
-    // Query capabilities of the device to configure the sample.
-    Settings::Initialize(m_device.Get(), m_width, m_height);
+	// Query capabilities of the device to configure the sample.
+	Settings::Initialize(m_device.Get(), m_width, m_height);
 
-    // Initialize member variables dependent on the Settings.
-    m_syncSceneRenderTargets = (Settings::NodeCount > 1);
-    m_sceneRenderTargets.resize(Settings::SceneHistoryCount);
-    m_postRenderTargets.resize(Settings::BackBufferCount);
-    m_sceneCommandAllocators.resize(Settings::FrameCount);
-    m_postCommandAllocators.resize(Settings::FrameCount);
+	// Initialize member variables dependent on the Settings.
+	m_syncSceneRenderTargets = (Settings::NodeCount > 1);
+	m_sceneRenderTargets.resize(Settings::SceneHistoryCount);
+	m_postRenderTargets.resize(Settings::BackBufferCount);
+	m_sceneCommandAllocators.resize(Settings::FrameCount);
+	m_postCommandAllocators.resize(Settings::FrameCount);
 
-    // Describe and create the command queues.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queues.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_graphicsQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_graphicsQueue)));
 
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = Settings::BackBufferCount;
-    swapChainDesc.Width = Settings::Width;
-    swapChainDesc.Height = Settings::Height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
-    swapChainDesc.Flags = m_tearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = Settings::BackBufferCount;
+	swapChainDesc.Width = Settings::Width;
+	swapChainDesc.Height = Settings::Height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
+	swapChainDesc.Flags = m_tearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_graphicsQueue->GetChildObject(0),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_graphicsQueue->GetChildObject(0),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    if (m_tearingSupport)
-    {
-        factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER);
-    }
+	if (m_tearingSupport)
+	{
+		factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER);
+	}
 
-    DXGIXAffinityCreateLDASwapChain(swapChain.Get(), m_graphicsQueue.Get(), m_device.Get(), &m_swapChain);
+	DXGIXAffinityCreateLDASwapChain(swapChain.Get(), m_graphicsQueue.Get(), m_device.Get(), &m_swapChain);
 
-    // Scene descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_sceneRtvHeap)));
+	// Scene descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_sceneRtvHeap)));
 
-        // Describe and create a depth stencil view (DSV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
-        dsvHeapDesc.NumDescriptors = 1;
-        dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-        dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_sceneDsvHeap)));
+		// Describe and create a depth stencil view (DSV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
+		dsvHeapDesc.NumDescriptors = 1;
+		dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+		dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_sceneDsvHeap)));
 
-        // Describe and create a constant buffer view (CBV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
-        cbvHeapDesc.NumDescriptors = Settings::TriangleCount * Settings::SceneConstantBufferFrames;
-        cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_sceneCbvHeap)));
-    }
+		// Describe and create a constant buffer view (CBV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
+		cbvHeapDesc.NumDescriptors = Settings::TriangleCount * Settings::SceneConstantBufferFrames;
+		cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_sceneCbvHeap)));
+	}
 
-    // Post-process descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap for 
-        // the final output.
-        D3D12_DESCRIPTOR_HEAP_DESC postRtvHeapDesc = {};
-        postRtvHeapDesc.NumDescriptors = Settings::BackBufferCount;
-        postRtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        postRtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&postRtvHeapDesc, IID_PPV_ARGS(&m_postRtvHeap)));
+	// Post-process descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap for 
+		// the final output.
+		D3D12_DESCRIPTOR_HEAP_DESC postRtvHeapDesc = {};
+		postRtvHeapDesc.NumDescriptors = Settings::BackBufferCount;
+		postRtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		postRtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&postRtvHeapDesc, IID_PPV_ARGS(&m_postRtvHeap)));
 
-        // Describe and create a shader resource view (SRV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
-        srvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
-        srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_postSrvHeap)));
+		// Describe and create a shader resource view (SRV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
+		srvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
+		srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_postSrvHeap)));
 
-        // Describe and create a sampler descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
-        samplerHeapDesc.NumDescriptors = 1;
-        samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
-        samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_postSamplerHeap)));
-    }
+		// Describe and create a sampler descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
+		samplerHeapDesc.NumDescriptors = 1;
+		samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
+		samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_postSamplerHeap)));
+	}
 
-    // Create command allocators for each buffered frame.
-    for (UINT n = 0; n < Settings::FrameCount; n++)
-    {
-        ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[n])));
-        ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_postCommandAllocators[n])));
-    }
+	// Create command allocators for each buffered frame.
+	for (UINT n = 0; n < Settings::FrameCount; n++)
+	{
+		ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[n])));
+		ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_postCommandAllocators[n])));
+	}
 }
 
 // Generate data for the scene triangles.
 void D3D12LinkedGpusAffinity::LoadAssets()
 {
-    // Create the root signatures.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signatures.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        // Create a root signature for rendering the triangle scene.
-        {
-            CD3DX12_DESCRIPTOR_RANGE1 sceneRanges[1];
-            sceneRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		// Create a root signature for rendering the triangle scene.
+		{
+			CD3DX12_DESCRIPTOR_RANGE1 sceneRanges[1];
+			sceneRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
 
-            CD3DX12_ROOT_PARAMETER1 sceneRootParameters[2];
-            sceneRootParameters[0].InitAsDescriptorTable(1, &sceneRanges[0], D3D12_SHADER_VISIBILITY_VERTEX);
-            sceneRootParameters[1].InitAsConstants(1, 1, 0, D3D12_SHADER_VISIBILITY_VERTEX);
+			CD3DX12_ROOT_PARAMETER1 sceneRootParameters[2];
+			sceneRootParameters[0].InitAsDescriptorTable(1, &sceneRanges[0], D3D12_SHADER_VISIBILITY_VERTEX);
+			sceneRootParameters[1].InitAsConstants(1, 1, 0, D3D12_SHADER_VISIBILITY_VERTEX);
 
-            CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC sceneRootSignatureDesc;
-            sceneRootSignatureDesc.Init_1_1(_countof(sceneRootParameters), sceneRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+			CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC sceneRootSignatureDesc;
+			sceneRootSignatureDesc.Init_1_1(_countof(sceneRootParameters), sceneRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-            ComPtr<ID3DBlob> signature;
-            ComPtr<ID3DBlob> error;
-            ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&sceneRootSignatureDesc, featureData.HighestVersion, &signature, &error));
-            ThrowIfFailed(m_device->CreateRootSignature(Settings::SharedNodeMask, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_sceneRootSignature)));
-        }
+			ComPtr<ID3DBlob> signature;
+			ComPtr<ID3DBlob> error;
+			ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&sceneRootSignatureDesc, featureData.HighestVersion, &signature, &error));
+			ThrowIfFailed(m_device->CreateRootSignature(Settings::SharedNodeMask, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_sceneRootSignature)));
+		}
 
-        // Create a root signature for the post-process pass.
-        {
-            // We don't modify the SRV in the post-processing command list after
-            // SetGraphicsRootDescriptorTable is executed on the GPU so we can use the default
-            // range behavior: D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
-            CD3DX12_DESCRIPTOR_RANGE1 postRanges[2];
-            postRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, Settings::SceneHistoryCount, 0);
-            postRanges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
+		// Create a root signature for the post-process pass.
+		{
+			// We don't modify the SRV in the post-processing command list after
+			// SetGraphicsRootDescriptorTable is executed on the GPU so we can use the default
+			// range behavior: D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
+			CD3DX12_DESCRIPTOR_RANGE1 postRanges[2];
+			postRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, Settings::SceneHistoryCount, 0);
+			postRanges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
 
-            CD3DX12_ROOT_PARAMETER1 postRootParameters[3];
-            postRootParameters[0].InitAsDescriptorTable(1, &postRanges[0], D3D12_SHADER_VISIBILITY_PIXEL);
-            postRootParameters[1].InitAsDescriptorTable(1, &postRanges[1], D3D12_SHADER_VISIBILITY_PIXEL);
-            postRootParameters[2].InitAsConstants(2, 0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
+			CD3DX12_ROOT_PARAMETER1 postRootParameters[3];
+			postRootParameters[0].InitAsDescriptorTable(1, &postRanges[0], D3D12_SHADER_VISIBILITY_PIXEL);
+			postRootParameters[1].InitAsDescriptorTable(1, &postRanges[1], D3D12_SHADER_VISIBILITY_PIXEL);
+			postRootParameters[2].InitAsConstants(2, 0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
 
-            CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC postRootSignatureDesc;
-            postRootSignatureDesc.Init_1_1(_countof(postRootParameters), postRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+			CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC postRootSignatureDesc;
+			postRootSignatureDesc.Init_1_1(_countof(postRootParameters), postRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-            ComPtr<ID3DBlob> signature;
-            ComPtr<ID3DBlob> error;
-            ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&postRootSignatureDesc, featureData.HighestVersion, &signature, &error));
-            ThrowIfFailed(m_device->CreateRootSignature(Settings::SharedNodeMask, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_postRootSignature)));
-        }
-    }
+			ComPtr<ID3DBlob> signature;
+			ComPtr<ID3DBlob> error;
+			ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&postRootSignatureDesc, featureData.HighestVersion, &signature, &error));
+			ThrowIfFailed(m_device->CreateRootSignature(Settings::SharedNodeMask, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_postRootSignature)));
+		}
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        // Define the vertex input layout for the triangle scene.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		// Define the vertex input layout for the triangle scene.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        // Describe and create the graphics pipeline state objects (PSO).
-        D3DX12_AFFINITY_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_sceneRootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_SceneVS, sizeof(g_SceneVS));
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_ScenePS, sizeof(g_ScenePS));
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state objects (PSO).
+		D3DX12_AFFINITY_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_sceneRootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_SceneVS, sizeof(g_SceneVS));
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_ScenePS, sizeof(g_ScenePS));
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_scenePipelineState)));
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_scenePipelineState)));
 
-        // Define the vertex input layout for the post-process fullscreen quad.
-        D3D12_INPUT_ELEMENT_DESC postInputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+		// Define the vertex input layout for the post-process fullscreen quad.
+		D3D12_INPUT_ELEMENT_DESC postInputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        // Describe and create the PSO for the post-process pass.
-        D3DX12_AFFINITY_GRAPHICS_PIPELINE_STATE_DESC postPsoDesc = {};
-        postPsoDesc.InputLayout = { postInputElementDescs, _countof(postInputElementDescs) };
-        postPsoDesc.pRootSignature = m_postRootSignature.Get();
-        postPsoDesc.VS = CD3DX12_SHADER_BYTECODE(g_PostVS, sizeof(g_PostVS));
-        postPsoDesc.PS = CD3DX12_SHADER_BYTECODE(g_PostPS, sizeof(g_PostPS));
-        postPsoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        postPsoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        postPsoDesc.DepthStencilState.DepthEnable = FALSE;
-        postPsoDesc.DepthStencilState.StencilEnable = FALSE;
-        postPsoDesc.SampleMask = UINT_MAX;
-        postPsoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        postPsoDesc.NumRenderTargets = 1;
-        postPsoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        postPsoDesc.SampleDesc.Count = 1;
+		// Describe and create the PSO for the post-process pass.
+		D3DX12_AFFINITY_GRAPHICS_PIPELINE_STATE_DESC postPsoDesc = {};
+		postPsoDesc.InputLayout = { postInputElementDescs, _countof(postInputElementDescs) };
+		postPsoDesc.pRootSignature = m_postRootSignature.Get();
+		postPsoDesc.VS = CD3DX12_SHADER_BYTECODE(g_PostVS, sizeof(g_PostVS));
+		postPsoDesc.PS = CD3DX12_SHADER_BYTECODE(g_PostPS, sizeof(g_PostPS));
+		postPsoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		postPsoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		postPsoDesc.DepthStencilState.DepthEnable = FALSE;
+		postPsoDesc.DepthStencilState.StencilEnable = FALSE;
+		postPsoDesc.SampleMask = UINT_MAX;
+		postPsoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		postPsoDesc.NumRenderTargets = 1;
+		postPsoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		postPsoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&postPsoDesc, IID_PPV_ARGS(&m_postPipelineState)));
-    }
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&postPsoDesc, IID_PPV_ARGS(&m_postPipelineState)));
+	}
 
-    // Single-use command allocator/list for resource initialization.
-    ComPtr<CD3DX12AffinityCommandAllocator> commandAllocator;
-    ComPtr<CD3DX12AffinityGraphicsCommandList> commandList;
+	// Single-use command allocator/list for resource initialization.
+	ComPtr<CD3DX12AffinityCommandAllocator> commandAllocator;
+	ComPtr<CD3DX12AffinityGraphicsCommandList> commandList;
 
-    // Set the AffinityMask to Settings::SharedNodeMask to make the Affinity layer
-    // create n allocators and n command lists and execute the following setup commands
-    // on all GPU nodes.
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator), Settings::SharedNodeMask));
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList), Settings::SharedNodeMask));
+	// Set the AffinityMask to Settings::SharedNodeMask to make the Affinity layer
+	// create n allocators and n command lists and execute the following setup commands
+	// on all GPU nodes.
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator), Settings::SharedNodeMask));
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList), Settings::SharedNodeMask));
 
-    // Create command lists for the scene and post-processing passes.
-    {
-        ThrowIfFailed(m_device->CreateCommandList(
-            0,
-            D3D12_COMMAND_LIST_TYPE_DIRECT,
-            m_sceneCommandAllocators[m_frameIndex].Get(),
-            m_scenePipelineState.Get(),
-            IID_PPV_ARGS(&m_sceneCommandList)));
+	// Create command lists for the scene and post-processing passes.
+	{
+		ThrowIfFailed(m_device->CreateCommandList(
+			0,
+			D3D12_COMMAND_LIST_TYPE_DIRECT,
+			m_sceneCommandAllocators[m_frameIndex].Get(),
+			m_scenePipelineState.Get(),
+			IID_PPV_ARGS(&m_sceneCommandList)));
 
-        ThrowIfFailed(m_device->CreateCommandList(
-            0,
-            D3D12_COMMAND_LIST_TYPE_DIRECT,
-            m_postCommandAllocators[m_frameIndex].Get(),
-            m_postPipelineState.Get(),
-            IID_PPV_ARGS(&m_postCommandList)));
+		ThrowIfFailed(m_device->CreateCommandList(
+			0,
+			D3D12_COMMAND_LIST_TYPE_DIRECT,
+			m_postCommandAllocators[m_frameIndex].Get(),
+			m_postPipelineState.Get(),
+			IID_PPV_ARGS(&m_postCommandList)));
 
-        // Command lists are created in the 'recording' state. We always call Reset
-        // as the first thing when populating command lists, so we need to close
-        // these here for the first frame.
-        ThrowIfFailed(m_sceneCommandList->Close());
-        ThrowIfFailed(m_postCommandList->Close());
-    }
+		// Command lists are created in the 'recording' state. We always call Reset
+		// as the first thing when populating command lists, so we need to close
+		// these here for the first frame.
+		ThrowIfFailed(m_sceneCommandList->Close());
+		ThrowIfFailed(m_postCommandList->Close());
+	}
 
-    ComPtr<CD3DX12AffinityResource> triangleVertexBufferUpload;
-    ComPtr<CD3DX12AffinityResource> quadVertexBufferUpload;
+	ComPtr<CD3DX12AffinityResource> triangleVertexBufferUpload;
+	ComPtr<CD3DX12AffinityResource> quadVertexBufferUpload;
 
-    // Create the triangle vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        SceneVertex vertices[] =
-        {
-            { { 0.0f, Settings::TriangleHalfWidth, Settings::TriangleDepth } },
-            { { Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } },
-            { { -Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } }
-        };
+	// Create the triangle vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		SceneVertex vertices[] =
+		{
+			{ { 0.0f, Settings::TriangleHalfWidth, Settings::TriangleDepth } },
+			{ { Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } },
+			{ { -Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } }
+		};
 
-        const UINT vertexBufferSize = sizeof(vertices);
+		const UINT vertexBufferSize = sizeof(vertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_sceneVertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_sceneVertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&triangleVertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&triangleVertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(vertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(vertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(commandList.Get(), m_sceneVertexBuffer.Get(), triangleVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        commandList->ResourceBarrier(1, &CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(m_sceneVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(commandList.Get(), m_sceneVertexBuffer.Get(), triangleVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		commandList->ResourceBarrier(1, &CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(m_sceneVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_sceneVertexBufferView.BufferLocation = m_sceneVertexBuffer->GetGPUVirtualAddress();
-        m_sceneVertexBufferView.StrideInBytes = sizeof(SceneVertex);
-        m_sceneVertexBufferView.SizeInBytes = sizeof(vertices);
-    }
+		// Initialize the vertex buffer view.
+		m_sceneVertexBufferView.BufferLocation = m_sceneVertexBuffer->GetGPUVirtualAddress();
+		m_sceneVertexBufferView.StrideInBytes = sizeof(SceneVertex);
+		m_sceneVertexBufferView.SizeInBytes = sizeof(vertices);
+	}
 
-    // Create the quad vertex buffer.
-    {
-        // Define the geometry for a quad.
-        PostVertex vertices[] =
-        {
-            { { -1.0f, -1.0f, 0.0f }, { 0.0f, 1.0f } },    // Bottom Left
-            { { -1.0f, 1.0f, 0.0f }, { 0.0f, 0.0f } },    // Top Left
-            { { 1.0f, -1.0f, 0.0f }, { 1.0f, 1.0f } },    // Bottom Right
-            { { 1.0f, 1.0f, 0.0f }, { 1.0f, 0.0f } },    // Top Right
-        };
+	// Create the quad vertex buffer.
+	{
+		// Define the geometry for a quad.
+		PostVertex vertices[] =
+		{
+			{ { -1.0f, -1.0f, 0.0f }, { 0.0f, 1.0f } },	// Bottom Left
+			{ { -1.0f, 1.0f, 0.0f }, { 0.0f, 0.0f } },	// Top Left
+			{ { 1.0f, -1.0f, 0.0f }, { 1.0f, 1.0f } },	// Bottom Right
+			{ { 1.0f, 1.0f, 0.0f }, { 1.0f, 0.0f } },	// Top Right
+		};
 
-        const UINT vertexBufferSize = sizeof(vertices);
+		const UINT vertexBufferSize = sizeof(vertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_postVertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_postVertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&quadVertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&quadVertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(vertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(vertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(commandList.Get(), m_postVertexBuffer.Get(), quadVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        commandList->ResourceBarrier(1, &CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(m_postVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(commandList.Get(), m_postVertexBuffer.Get(), quadVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		commandList->ResourceBarrier(1, &CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(m_postVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_postVertexBufferView.BufferLocation = m_postVertexBuffer->GetGPUVirtualAddress();
-        m_postVertexBufferView.StrideInBytes = sizeof(PostVertex);
-        m_postVertexBufferView.SizeInBytes = sizeof(vertices);
-    }
+		// Initialize the vertex buffer view.
+		m_postVertexBufferView.BufferLocation = m_postVertexBuffer->GetGPUVirtualAddress();
+		m_postVertexBufferView.StrideInBytes = sizeof(PostVertex);
+		m_postVertexBufferView.SizeInBytes = sizeof(vertices);
+	}
 
-    // Create and map the constant buffers.
-    {
-        // UPLOAD heaps are not duplicated by the Affinity layer because:
-        //   1. they live in system memory
-        //   2. they are expected to contain data that will be read by all GPUs.
-        // All of our constant buffers change each frame, so the state of any one frame
-        // is only ever read by a single GPU. Therefore, we must ensure that a large
-        // enough resource is created to persist frame data for all GPUs to read from.
-        const UINT constantBufferDataSize = Settings::TriangleCount * Settings::SceneConstantBufferFrames * sizeof(SceneConstantBuffer);
+	// Create and map the constant buffers.
+	{
+		// UPLOAD heaps are not duplicated by the Affinity layer because:
+		//   1. they live in system memory
+		//   2. they are expected to contain data that will be read by all GPUs.
+		// All of our constant buffers change each frame, so the state of any one frame
+		// is only ever read by a single GPU. Therefore, we must ensure that a large
+		// enough resource is created to persist frame data for all GPUs to read from.
+		const UINT constantBufferDataSize = Settings::TriangleCount * Settings::SceneConstantBufferFrames * sizeof(SceneConstantBuffer);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(constantBufferDataSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_sceneConstantBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(constantBufferDataSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_sceneConstantBuffer)));
 
-        // Map and initialize the constant buffer. We don't unmap this until the
-        // app closes. Keeping things mapped for the lifetime of the resource is okay.
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_sceneConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_mappedConstantBuffer)));
-        ZeroMemory(m_mappedConstantBuffer, constantBufferDataSize);
+		// Map and initialize the constant buffer. We don't unmap this until the
+		// app closes. Keeping things mapped for the lifetime of the resource is okay.
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_sceneConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_mappedConstantBuffer)));
+		ZeroMemory(m_mappedConstantBuffer, constantBufferDataSize);
 
-        // Create constant buffer views. Because the Affinity layer does not duplicate
-        // UPLOAD heaps across nodes, the CBVs on each node will all point to the same
-        // range of system memory.
-        CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_sceneCbvHeap->GetCPUDescriptorHandleForHeapStart());
-        D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
-        cbvDesc.SizeInBytes = sizeof(SceneConstantBuffer);
-        cbvDesc.BufferLocation = m_sceneConstantBuffer->GetGPUVirtualAddress();
+		// Create constant buffer views. Because the Affinity layer does not duplicate
+		// UPLOAD heaps across nodes, the CBVs on each node will all point to the same
+		// range of system memory.
+		CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_sceneCbvHeap->GetCPUDescriptorHandleForHeapStart());
+		D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
+		cbvDesc.SizeInBytes = sizeof(SceneConstantBuffer);
+		cbvDesc.BufferLocation = m_sceneConstantBuffer->GetGPUVirtualAddress();
 
-        for (UINT frame = 0; frame < Settings::SceneConstantBufferFrames; frame++)
-        {
-            for (UINT n = 0; n < Settings::TriangleCount; n++)
-            {
-                m_device->CreateConstantBufferView(&cbvDesc, cpuHandle);
+		for (UINT frame = 0; frame < Settings::SceneConstantBufferFrames; frame++)
+		{
+			for (UINT n = 0; n < Settings::TriangleCount; n++)
+			{
+				m_device->CreateConstantBufferView(&cbvDesc, cpuHandle);
 
-                cpuHandle.Offset(Settings::CbvSrvDescriptorSize);
-                cbvDesc.BufferLocation += cbvDesc.SizeInBytes;
-            }
-        }
-    }
+				cpuHandle.Offset(Settings::CbvSrvDescriptorSize);
+				cbvDesc.BufferLocation += cbvDesc.SizeInBytes;
+			}
+		}
+	}
 
-    for (UINT n = 0; n < Settings::TriangleCount; n++)
-    {
-        m_sceneData[n].velocity = XMFLOAT4(GetRandomFloat(0.005f, 0.01f), 0.0f, 0.0f, 0.0f);
-        m_sceneData[n].offset = XMFLOAT4(GetRandomFloat(-6.0f, -1.5f), GetRandomFloat(-1.0f, 1.0f), GetRandomFloat(0.0f, 2.0f), 0.0f);
-        m_sceneData[n].color = XMFLOAT4(GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), 1.0f);
-        m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
-    }
+	for (UINT n = 0; n < Settings::TriangleCount; n++)
+	{
+		m_sceneData[n].velocity = XMFLOAT4(GetRandomFloat(0.005f, 0.01f), 0.0f, 0.0f, 0.0f);
+		m_sceneData[n].offset = XMFLOAT4(GetRandomFloat(-6.0f, -1.5f), GetRandomFloat(-1.0f, 1.0f), GetRandomFloat(0.0f, 2.0f), 0.0f);
+		m_sceneData[n].color = XMFLOAT4(GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), 1.0f);
+		m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
+	}
 
-    // Describe and create a sampler.
-    {
-        D3D12_SAMPLER_DESC samplerDesc = {};
-        samplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-        samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.MinLOD = 0;
-        samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
-        samplerDesc.MipLODBias = 0.0f;
-        samplerDesc.MaxAnisotropy = 1;
-        samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
+	// Describe and create a sampler.
+	{
+		D3D12_SAMPLER_DESC samplerDesc = {};
+		samplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.MinLOD = 0;
+		samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
+		samplerDesc.MipLODBias = 0.0f;
+		samplerDesc.MaxAnisotropy = 1;
+		samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
 
-        m_device->CreateSampler(&samplerDesc, m_postSamplerHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		m_device->CreateSampler(&samplerDesc, m_postSamplerHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    m_sceneFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
-    m_postFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
+	m_sceneFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
+	m_postFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
 
-    ThrowIfFailed(commandList->Close());
+	ThrowIfFailed(commandList->Close());
 
-    // Submit the initialization work to the GPU.
-    CD3DX12AffinityCommandList* ppCommandLists[] = { commandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Submit the initialization work to the GPU.
+	CD3DX12AffinityCommandList* ppCommandLists[] = { commandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Wait for the graphics queue to finish executing the commands.
-    Fence fence(m_graphicsQueue.Get());
-    fence.FlushGpuQueue();
+	// Wait for the graphics queue to finish executing the commands.
+	Fence fence(m_graphicsQueue.Get());
+	fence.FlushGpuQueue();
 
-    LoadSizeDependentResources();
+	LoadSizeDependentResources();
 }
 
 void D3D12LinkedGpusAffinity::LoadSizeDependentResources()
 {
-    // Single-use command allocator/list for resource initialization.
-    ComPtr<CD3DX12AffinityCommandAllocator> commandAllocator;
-    ComPtr<CD3DX12AffinityGraphicsCommandList> commandList;
+	// Single-use command allocator/list for resource initialization.
+	ComPtr<CD3DX12AffinityCommandAllocator> commandAllocator;
+	ComPtr<CD3DX12AffinityGraphicsCommandList> commandList;
 
-    // Set the AffinityMask to Settings::SharedNodeMask to make the Affinity layer
-    // create n allocators and n command lists and execute the following setup commands
-    // on all GPU nodes.
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator), Settings::SharedNodeMask));
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList), Settings::SharedNodeMask));
+	// Set the AffinityMask to Settings::SharedNodeMask to make the Affinity layer
+	// create n allocators and n command lists and execute the following setup commands
+	// on all GPU nodes.
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator), Settings::SharedNodeMask));
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList), Settings::SharedNodeMask));
 
-    // Create RTVs for swap chain back buffers.
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart());
-    for (UINT n = 0; n < Settings::BackBufferCount; n++)
-    {
-        ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_postRenderTargets[n])));
+	// Create RTVs for swap chain back buffers.
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart());
+	for (UINT n = 0; n < Settings::BackBufferCount; n++)
+	{
+		ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_postRenderTargets[n])));
 
-        m_device->CreateRenderTargetView(m_postRenderTargets[n].Get(), nullptr, rtvHandle);
-        rtvHandle.Offset(Settings::RtvDescriptorSize);
-    }
+		m_device->CreateRenderTargetView(m_postRenderTargets[n].Get(), nullptr, rtvHandle);
+		rtvHandle.Offset(Settings::RtvDescriptorSize);
+	}
 
-    m_frameIndex = 0;
-    m_sceneRenderTargetIndex = 0;
-    m_nodeIndex = 0;
+	m_frameIndex = 0;
+	m_sceneRenderTargetIndex = 0;
+	m_nodeIndex = 0;
 
-    // Create the render targets used to draw the scene.
-    // These will be sampled from during the post-processing step.
-    {
-        D3D12_RESOURCE_DESC renderTargetDesc = m_postRenderTargets[0]->GetDesc();
-        D3D12_RESOURCE_ALLOCATION_INFO info = m_device->GetResourceAllocationInfo(Settings::SharedNodeMask, 1, &renderTargetDesc);
-        const UINT64 alignedRenderTargetSize = AlignResource(info.SizeInBytes, info.Alignment);
+	// Create the render targets used to draw the scene.
+	// These will be sampled from during the post-processing step.
+	{
+		D3D12_RESOURCE_DESC renderTargetDesc = m_postRenderTargets[0]->GetDesc();
+		D3D12_RESOURCE_ALLOCATION_INFO info = m_device->GetResourceAllocationInfo(Settings::SharedNodeMask, 1, &renderTargetDesc);
+		const UINT64 alignedRenderTargetSize = AlignResource(info.SizeInBytes, info.Alignment);
 
-        D3D12_HEAP_DESC heapDesc = {};
-        heapDesc.SizeInBytes = alignedRenderTargetSize * Settings::SceneHistoryCount;
-        heapDesc.Alignment = info.Alignment;
-        heapDesc.Properties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
-        heapDesc.Flags = D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES | D3D12_HEAP_FLAG_DENY_BUFFERS;
+		D3D12_HEAP_DESC heapDesc = {};
+		heapDesc.SizeInBytes = alignedRenderTargetSize * Settings::SceneHistoryCount;
+		heapDesc.Alignment = info.Alignment;
+		heapDesc.Properties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+		heapDesc.Flags = D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES | D3D12_HEAP_FLAG_DENY_BUFFERS;
 
-        ThrowIfFailed(m_device->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_sceneRenderTargetHeap)));
+		ThrowIfFailed(m_device->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_sceneRenderTargetHeap)));
 
-        CD3DX12_CLEAR_VALUE clearValue(DXGI_FORMAT_R8G8B8A8_UNORM, Settings::ClearColor);
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart());
-        CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_postSrvHeap->GetCPUDescriptorHandleForHeapStart());
+		CD3DX12_CLEAR_VALUE clearValue(DXGI_FORMAT_R8G8B8A8_UNORM, Settings::ClearColor);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart());
+		CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_postSrvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = 1;
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = 1;
 
-        D3DX12_AFFINITY_RESOURCE_BARRIER barriers[Settings::SceneHistoryCount];
+		D3DX12_AFFINITY_RESOURCE_BARRIER barriers[Settings::SceneHistoryCount];
 
-        for (UINT sceneIndex = 0; sceneIndex < Settings::SceneHistoryCount; sceneIndex++)
-        {
-            ThrowIfFailed(m_device->CreatePlacedResource(
-                m_sceneRenderTargetHeap.Get(),
-                alignedRenderTargetSize * sceneIndex,
-                &renderTargetDesc,
-                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                &clearValue,
-                IID_PPV_ARGS(&m_sceneRenderTargets[sceneIndex])));
+		for (UINT sceneIndex = 0; sceneIndex < Settings::SceneHistoryCount; sceneIndex++)
+		{
+			ThrowIfFailed(m_device->CreatePlacedResource(
+				m_sceneRenderTargetHeap.Get(),
+				alignedRenderTargetSize * sceneIndex,
+				&renderTargetDesc,
+				D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+				&clearValue,
+				IID_PPV_ARGS(&m_sceneRenderTargets[sceneIndex])));
 
-            barriers[sceneIndex] = CD3DX12_AFFINITY_RESOURCE_BARRIER::Aliasing(nullptr, m_sceneRenderTargets[sceneIndex].Get());
+			barriers[sceneIndex] = CD3DX12_AFFINITY_RESOURCE_BARRIER::Aliasing(nullptr, m_sceneRenderTargets[sceneIndex].Get());
 
-            m_device->CreateRenderTargetView(m_sceneRenderTargets[sceneIndex].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(Settings::RtvDescriptorSize);
+			m_device->CreateRenderTargetView(m_sceneRenderTargets[sceneIndex].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(Settings::RtvDescriptorSize);
 
-            m_device->CreateShaderResourceView(m_sceneRenderTargets[sceneIndex].Get(), &srvDesc, srvHandle);
-            srvHandle.Offset(Settings::CbvSrvDescriptorSize);
-        }
+			m_device->CreateShaderResourceView(m_sceneRenderTargets[sceneIndex].Get(), &srvDesc, srvHandle);
+			srvHandle.Offset(Settings::CbvSrvDescriptorSize);
+		}
 
-        commandList->ResourceBarrier(_countof(barriers), barriers);
+		commandList->ResourceBarrier(_countof(barriers), barriers);
 
-        if (m_syncSceneRenderTargets)
-        {
-            // The post-processing pass expects that a previous post-processing pass has
-            // transitioned the next frame's dependencies into the COPY_DEST state.
-            // Since these resources were created with the PIXEL_SHADER_RESOURCE state,
-            // we need to transition them to COPY_DEST.
+		if (m_syncSceneRenderTargets)
+		{
+			// The post-processing pass expects that a previous post-processing pass has
+			// transitioned the next frame's dependencies into the COPY_DEST state.
+			// Since these resources were created with the PIXEL_SHADER_RESOURCE state,
+			// we need to transition them to COPY_DEST.
 
-            for (UINT nodeIndex = 0; nodeIndex < Settings::NodeCount; nodeIndex++)
-            {
-                D3DX12_AFFINITY_RESOURCE_BARRIER copyBarriers[Settings::MaxNodeCount];
-                UINT barrierIndex = 0;
+			for (UINT nodeIndex = 0; nodeIndex < Settings::NodeCount; nodeIndex++)
+			{
+				D3DX12_AFFINITY_RESOURCE_BARRIER copyBarriers[Settings::MaxNodeCount];
+				UINT barrierIndex = 0;
 
-                // The next commands added to the command list will only apply to the
-                // node selected.
-                commandList->SetAffinity(1 << nodeIndex);
+				// The next commands added to the command list will only apply to the
+				// node selected.
+				commandList->SetAffinity(1 << nodeIndex);
 
-                for (UINT index = 0; index < Settings::NodeCount - 1; index++)
-                {
-                    UINT offset = Settings::SceneHistoryCount - (Settings::NodeCount - 1) + index;
-                    UINT renderTargetIndex = (nodeIndex + offset) % Settings::SceneHistoryCount;
+				for (UINT index = 0; index < Settings::NodeCount - 1; index++)
+				{
+					UINT offset = Settings::SceneHistoryCount - (Settings::NodeCount - 1) + index;
+					UINT renderTargetIndex = (nodeIndex + offset) % Settings::SceneHistoryCount;
 
-                    copyBarriers[index] = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
-                        m_sceneRenderTargets[renderTargetIndex].Get(),
-                        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                        D3D12_RESOURCE_STATE_COPY_DEST);
-                }
-                commandList->ResourceBarrier(Settings::NodeCount - 1, copyBarriers);
-            }
+					copyBarriers[index] = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
+						m_sceneRenderTargets[renderTargetIndex].Get(),
+						D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+						D3D12_RESOURCE_STATE_COPY_DEST);
+				}
+				commandList->ResourceBarrier(Settings::NodeCount - 1, copyBarriers);
+			}
 
-            // The next commands added to the command list will apply to all nodes.
-            commandList->SetAffinity(Settings::SharedNodeMask);
-        }
-    }
+			// The next commands added to the command list will apply to all nodes.
+			commandList->SetAffinity(Settings::SharedNodeMask);
+		}
+	}
 
-    // Create the depth stencil and its view.
-    {
-        CD3DX12_HEAP_PROPERTIES heapProps(D3D12_HEAP_TYPE_DEFAULT);
-        CD3DX12_CLEAR_VALUE depthOptimizedClearValue(DXGI_FORMAT_D32_FLOAT, 1.0f, 0);
+	// Create the depth stencil and its view.
+	{
+		CD3DX12_HEAP_PROPERTIES heapProps(D3D12_HEAP_TYPE_DEFAULT);
+		CD3DX12_CLEAR_VALUE depthOptimizedClearValue(DXGI_FORMAT_D32_FLOAT, 1.0f, 0);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &heapProps,
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, Settings::Width, Settings::Height, 1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
-            D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            &depthOptimizedClearValue,
-            IID_PPV_ARGS(&m_sceneDepthStencil)
-            ));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&heapProps,
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, Settings::Width, Settings::Height, 1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
+			D3D12_RESOURCE_STATE_DEPTH_WRITE,
+			&depthOptimizedClearValue,
+			IID_PPV_ARGS(&m_sceneDepthStencil)
+			));
 
-        D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
-        depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
-        depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+		D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
+		depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
+		depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
 
-        m_device->CreateDepthStencilView(m_sceneDepthStencil.Get(), &depthStencilDesc, m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		m_device->CreateDepthStencilView(m_sceneDepthStencil.Get(), &depthStencilDesc, m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    ThrowIfFailed(commandList->Close());
+	ThrowIfFailed(commandList->Close());
 
-    // Submit the resource barrier changes to the GPU.
-    CD3DX12AffinityCommandList* ppCommandLists[] = { commandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Submit the resource barrier changes to the GPU.
+	CD3DX12AffinityCommandList* ppCommandLists[] = { commandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Wait for the graphics queue to finish executing the commands.
-    Fence fence(m_graphicsQueue.Get());
-    fence.FlushGpuQueue();
+	// Wait for the graphics queue to finish executing the commands.
+	Fence fence(m_graphicsQueue.Get());
+	fence.FlushGpuQueue();
 }
 
 // Get a random float value between min and max.
 float D3D12LinkedGpusAffinity::GetRandomFloat(float min, float max)
 {
-    float scale = static_cast<float>(rand()) / RAND_MAX;
-    float range = max - min;
-    return scale * range + min;
+	float scale = static_cast<float>(rand()) / RAND_MAX;
+	float range = max - min;
+	return scale * range + min;
 }
 
 void D3D12LinkedGpusAffinity::UpdateWindowTitle()
 {
-    WCHAR nodeText[100];
-    if (Settings::NodeCount == 1)
-    {
-        swprintf_s(nodeText, L"Node Count = 1 | SyncInterval = %u | SimulatedLoad = %u", m_syncInterval, m_simulatedGpuLoad);
-    }
-    else
-    {
-        swprintf_s(
-            nodeText,
-            L"Node Count = %u | Cross Node Sharing Tier = %d | SyncInterval = %u | SimulatedLoad = %u",
-            Settings::NodeCount,
-            Settings::Tier2Support ? 2 : 1,
-            m_syncInterval,
-            m_simulatedGpuLoad);
-    }
-    SetCustomWindowText(nodeText);
+	WCHAR nodeText[100];
+	if (Settings::NodeCount == 1)
+	{
+		swprintf_s(nodeText, L"Node Count = 1 | SyncInterval = %u | SimulatedLoad = %u", m_syncInterval, m_simulatedGpuLoad);
+	}
+	else
+	{
+		swprintf_s(
+			nodeText,
+			L"Node Count = %u | Cross Node Sharing Tier = %d | SyncInterval = %u | SimulatedLoad = %u",
+			Settings::NodeCount,
+			Settings::Tier2Support ? 2 : 1,
+			m_syncInterval,
+			m_simulatedGpuLoad);
+	}
+	SetCustomWindowText(nodeText);
 }
 
 // Update frame-based values.
 void D3D12LinkedGpusAffinity::OnUpdate()
 {
-    for (UINT n = 0; n < Settings::TriangleCount; n++)
-    {
-        const float offsetBounds = 1.5f * m_aspectRatio;
+	for (UINT n = 0; n < Settings::TriangleCount; n++)
+	{
+		const float offsetBounds = 1.5f * m_aspectRatio;
 
-        // Animate the triangles.
-        m_sceneData[n].offset.x += m_sceneData[n].velocity.x;
-        if (m_sceneData[n].offset.x > offsetBounds)
-        {
-            m_sceneData[n].velocity.x = GetRandomFloat(0.005f, 0.01f);
-            m_sceneData[n].offset.x = -offsetBounds;
-        }
-    }
+		// Animate the triangles.
+		m_sceneData[n].offset.x += m_sceneData[n].velocity.x;
+		if (m_sceneData[n].offset.x > offsetBounds)
+		{
+			m_sceneData[n].velocity.x = GetRandomFloat(0.005f, 0.01f);
+			m_sceneData[n].offset.x = -offsetBounds;
+		}
+	}
 
-    UINT index = m_frameId % Settings::SceneConstantBufferFrames;
-    UINT offset = Settings::TriangleCount * index * sizeof(SceneConstantBuffer);
+	UINT index = m_frameId % Settings::SceneConstantBufferFrames;
+	UINT offset = Settings::TriangleCount * index * sizeof(SceneConstantBuffer);
 
-    memcpy(m_mappedConstantBuffer + offset, m_sceneData.data(), Settings::TriangleCount * sizeof(SceneConstantBuffer));
+	memcpy(m_mappedConstantBuffer + offset, m_sceneData.data(), Settings::TriangleCount * sizeof(SceneConstantBuffer));
 }
 
 // Render the scene.
 void D3D12LinkedGpusAffinity::OnRender()
 {
-    if (m_windowVisible)
-    {
-        // Render and present the current frame.
-        RenderScene();
-        RenderPost();
+	if (m_windowVisible)
+	{
+		// Render and present the current frame.
+		RenderScene();
+		RenderPost();
 
-        // When using sync interval 0, it is recommended to always pass the tearing
-        // flag when it is supported, even if not presenting to a fullscreen window.
-        // This flag cannot be used if the app is in "exclusive" fullscreen mode as
-        // a result of calling SetFullscreenState.
+		// When using sync interval 0, it is recommended to always pass the tearing
+		// flag when it is supported, even if not presenting to a fullscreen window.
+		// This flag cannot be used if the app is in "exclusive" fullscreen mode as
+		// a result of calling SetFullscreenState.
 
-        UINT presentFlags = (m_syncInterval == 0 && m_tearingSupport && m_windowedMode) ? DXGI_PRESENT_ALLOW_TEARING : 0;
-        ThrowIfFailed(m_swapChain->Present(m_syncInterval, presentFlags));
+		UINT presentFlags = (m_syncInterval == 0 && m_tearingSupport && m_windowedMode) ? DXGI_PRESENT_ALLOW_TEARING : 0;
+		ThrowIfFailed(m_swapChain->Present(m_syncInterval, presentFlags));
 
-        MoveToNextFrame();
-    }
+		MoveToNextFrame();
+	}
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12LinkedGpusAffinity::RenderScene()
 {
-    UINT cbvDescriptorTableOffset = Settings::TriangleCount * (m_frameId % Settings::SceneConstantBufferFrames);
-    CD3DX12_GPU_DESCRIPTOR_HANDLE cbvHandle(m_sceneCbvHeap->GetGPUDescriptorHandleForHeapStart(), cbvDescriptorTableOffset, Settings::CbvSrvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart(), m_sceneRenderTargetIndex, Settings::RtvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
+	UINT cbvDescriptorTableOffset = Settings::TriangleCount * (m_frameId % Settings::SceneConstantBufferFrames);
+	CD3DX12_GPU_DESCRIPTOR_HANDLE cbvHandle(m_sceneCbvHeap->GetGPUDescriptorHandleForHeapStart(), cbvDescriptorTableOffset, Settings::CbvSrvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart(), m_sceneRenderTargetIndex, Settings::RtvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
 
-    m_sceneFence->Next();
+	m_sceneFence->Next();
 
-    // Record the rendering commands.
-    ThrowIfFailed(m_sceneCommandAllocators[m_frameIndex]->Reset());
-    ThrowIfFailed(m_sceneCommandList->Reset(m_sceneCommandAllocators[m_frameIndex].Get(), m_scenePipelineState.Get()));
+	// Record the rendering commands.
+	ThrowIfFailed(m_sceneCommandAllocators[m_frameIndex]->Reset());
+	ThrowIfFailed(m_sceneCommandList->Reset(m_sceneCommandAllocators[m_frameIndex].Get(), m_scenePipelineState.Get()));
 
-    // Set necessary state.
-    m_sceneCommandList->SetGraphicsRootSignature(m_sceneRootSignature.Get());
-    m_sceneCommandList->SetGraphicsRoot32BitConstant(1, m_simulatedGpuLoad, 0);
+	// Set necessary state.
+	m_sceneCommandList->SetGraphicsRootSignature(m_sceneRootSignature.Get());
+	m_sceneCommandList->SetGraphicsRoot32BitConstant(1, m_simulatedGpuLoad, 0);
 
-    CD3DX12AffinityDescriptorHeap* ppHeaps[] = { m_sceneCbvHeap.Get() };
-    m_sceneCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	CD3DX12AffinityDescriptorHeap* ppHeaps[] = { m_sceneCbvHeap.Get() };
+	m_sceneCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_sceneCommandList->RSSetViewports(1, &Settings::Viewport);
-    m_sceneCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
-    m_sceneCommandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
+	m_sceneCommandList->RSSetViewports(1, &Settings::Viewport);
+	m_sceneCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
+	m_sceneCommandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
 
-    // Record commands.
-    D3DX12_AFFINITY_RESOURCE_BARRIER barrier = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
-        m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(),
-        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-        D3D12_RESOURCE_STATE_RENDER_TARGET);
+	// Record commands.
+	D3DX12_AFFINITY_RESOURCE_BARRIER barrier = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
+		m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(),
+		D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+		D3D12_RESOURCE_STATE_RENDER_TARGET);
 
-    m_sceneCommandList->ResourceBarrier(1, &barrier);
-    m_sceneCommandList->ClearRenderTargetView(rtvHandle, Settings::ClearColor, 0, nullptr);
-    m_sceneCommandList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+	m_sceneCommandList->ResourceBarrier(1, &barrier);
+	m_sceneCommandList->ClearRenderTargetView(rtvHandle, Settings::ClearColor, 0, nullptr);
+	m_sceneCommandList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
 
-    m_sceneCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    m_sceneCommandList->IASetVertexBuffers(0, 1, &m_sceneVertexBufferView);
+	m_sceneCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_sceneCommandList->IASetVertexBuffers(0, 1, &m_sceneVertexBufferView);
 
-    for (UINT triangle = 0; triangle < Settings::TriangleCount; triangle++)
-    {
-        m_sceneCommandList->SetGraphicsRootDescriptorTable(0, cbvHandle);
-        m_sceneCommandList->DrawInstanced(3, 1, 0, 0);
+	for (UINT triangle = 0; triangle < Settings::TriangleCount; triangle++)
+	{
+		m_sceneCommandList->SetGraphicsRootDescriptorTable(0, cbvHandle);
+		m_sceneCommandList->DrawInstanced(3, 1, 0, 0);
 
-        cbvHandle.Offset(Settings::CbvSrvDescriptorSize);
-    }
+		cbvHandle.Offset(Settings::CbvSrvDescriptorSize);
+	}
 
-    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barrier.Transition.StateAfter = m_syncSceneRenderTargets ? D3D12_RESOURCE_STATE_COPY_SOURCE : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-    m_sceneCommandList->ResourceBarrier(1, &barrier);
+	barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barrier.Transition.StateAfter = m_syncSceneRenderTargets ? D3D12_RESOURCE_STATE_COPY_SOURCE : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	m_sceneCommandList->ResourceBarrier(1, &barrier);
 
-    ThrowIfFailed(m_sceneCommandList->Close());
+	ThrowIfFailed(m_sceneCommandList->Close());
 
-    CD3DX12AffinityCommandList* ppSceneCommandLists[] = { m_sceneCommandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppSceneCommandLists), ppSceneCommandLists);
+	CD3DX12AffinityCommandList* ppSceneCommandLists[] = { m_sceneCommandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppSceneCommandLists), ppSceneCommandLists);
 
-    m_sceneFence->Signal();
+	m_sceneFence->Signal();
 }
 
 void D3D12LinkedGpusAffinity::RenderPost()
 {
-    UINT backBufferIndex = m_swapChain->GetCurrentBackBufferIndex();
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart(), backBufferIndex, Settings::RtvDescriptorSize);
+	UINT backBufferIndex = m_swapChain->GetCurrentBackBufferIndex();
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart(), backBufferIndex, Settings::RtvDescriptorSize);
 
-    m_postFence->Next();
+	m_postFence->Next();
 
-    ThrowIfFailed(m_postCommandAllocators[m_frameIndex]->Reset());
-    ThrowIfFailed(m_postCommandList->Reset(m_postCommandAllocators[m_frameIndex].Get(), m_postPipelineState.Get()));
+	ThrowIfFailed(m_postCommandAllocators[m_frameIndex]->Reset());
+	ThrowIfFailed(m_postCommandList->Reset(m_postCommandAllocators[m_frameIndex].Get(), m_postPipelineState.Get()));
 
-    if (m_syncSceneRenderTargets)
-    {
-        // If the rendered scenes need to be copied across nodes, we need to wait
-        // until the other nodes are done with their post-processing passes (which
-        // includes transitioning the state of the next render targets in the
-        // history to the COPY_DEST state).
-        if (m_frameId > 0)
-        {
-            Fence::GpuWait(m_graphicsQueue.Get(), m_postFence.get());
-        }
+	if (m_syncSceneRenderTargets)
+	{
+		// If the rendered scenes need to be copied across nodes, we need to wait
+		// until the other nodes are done with their post-processing passes (which
+		// includes transitioning the state of the next render targets in the
+		// history to the COPY_DEST state).
+		if (m_frameId > 0)
+		{
+			Fence::GpuWait(m_graphicsQueue.Get(), m_postFence.get());
+		}
 
-        // Copy the render target from the scene pass to all other nodes.
-        m_postCommandList->BroadcastResource(m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(), m_nodeIndex, Settings::SharedNodeMask);
+		// Copy the render target from the scene pass to all other nodes.
+		m_postCommandList->BroadcastResource(m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(), m_nodeIndex, Settings::SharedNodeMask);
 
-        // Transition all render target resources into the PIXEL_SHADER_RESOURCE
-        // state to prepare for rendering the motion blur effect.
-        D3DX12_AFFINITY_RESOURCE_BARRIER barriers[Settings::MaxNodeCount];
+		// Transition all render target resources into the PIXEL_SHADER_RESOURCE
+		// state to prepare for rendering the motion blur effect.
+		D3DX12_AFFINITY_RESOURCE_BARRIER barriers[Settings::MaxNodeCount];
 
-        for (UINT index = 0; index < Settings::NodeCount - 1; index++)
-        {
-            UINT offset = Settings::SceneHistoryCount - Settings::NodeCount + 1 + index;
-            UINT renderTargetIndex = (m_sceneRenderTargetIndex + offset) % Settings::SceneHistoryCount;
+		for (UINT index = 0; index < Settings::NodeCount - 1; index++)
+		{
+			UINT offset = Settings::SceneHistoryCount - Settings::NodeCount + 1 + index;
+			UINT renderTargetIndex = (m_sceneRenderTargetIndex + offset) % Settings::SceneHistoryCount;
 
-            barriers[index] = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
-                m_sceneRenderTargets[renderTargetIndex].Get(),
-                D3D12_RESOURCE_STATE_COPY_DEST,
-                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
-        }
+			barriers[index] = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
+				m_sceneRenderTargets[renderTargetIndex].Get(),
+				D3D12_RESOURCE_STATE_COPY_DEST,
+				D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+		}
 
-        barriers[Settings::NodeCount - 1] = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
-            m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(),
-            D3D12_RESOURCE_STATE_COPY_SOURCE,
-            D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+		barriers[Settings::NodeCount - 1] = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
+			m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(),
+			D3D12_RESOURCE_STATE_COPY_SOURCE,
+			D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
 
-        m_postCommandList->ResourceBarrier(Settings::NodeCount, barriers);
-    }
+		m_postCommandList->ResourceBarrier(Settings::NodeCount, barriers);
+	}
 
-    m_postCommandList->SetGraphicsRootSignature(m_postRootSignature.Get());
+	m_postCommandList->SetGraphicsRootSignature(m_postRootSignature.Get());
 
-    CD3DX12AffinityDescriptorHeap* ppPostHeaps[] = { m_postSrvHeap.Get(), m_postSamplerHeap.Get() };
-    m_postCommandList->SetDescriptorHeaps(_countof(ppPostHeaps), ppPostHeaps);
+	CD3DX12AffinityDescriptorHeap* ppPostHeaps[] = { m_postSrvHeap.Get(), m_postSamplerHeap.Get() };
+	m_postCommandList->SetDescriptorHeaps(_countof(ppPostHeaps), ppPostHeaps);
 
-    m_postCommandList->RSSetViewports(1, &Settings::Viewport);
-    m_postCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
+	m_postCommandList->RSSetViewports(1, &Settings::Viewport);
+	m_postCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
 
-    D3DX12_AFFINITY_RESOURCE_BARRIER barrier = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
-        m_postRenderTargets[backBufferIndex].Get(),
-        D3D12_RESOURCE_STATE_PRESENT,
-        D3D12_RESOURCE_STATE_RENDER_TARGET);
+	D3DX12_AFFINITY_RESOURCE_BARRIER barrier = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
+		m_postRenderTargets[backBufferIndex].Get(),
+		D3D12_RESOURCE_STATE_PRESENT,
+		D3D12_RESOURCE_STATE_RENDER_TARGET);
 
-    m_postCommandList->ResourceBarrier(1, &barrier);
+	m_postCommandList->ResourceBarrier(1, &barrier);
 
-    m_postCommandList->OMSetRenderTargets(1, &rtvHandle, false, nullptr);
+	m_postCommandList->OMSetRenderTargets(1, &rtvHandle, false, nullptr);
 
-    m_postCommandList->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-    m_postCommandList->IASetVertexBuffers(0, 1, &m_postVertexBufferView);
+	m_postCommandList->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+	m_postCommandList->IASetVertexBuffers(0, 1, &m_postVertexBufferView);
 
-    m_postCommandList->SetGraphicsRootDescriptorTable(0, m_postSrvHeap->GetGPUDescriptorHandleForHeapStart());
-    m_postCommandList->SetGraphicsRootDescriptorTable(1, m_postSamplerHeap->GetGPUDescriptorHandleForHeapStart());
-    m_postCommandList->SetGraphicsRoot32BitConstant(2, m_frameId % Settings::SceneHistoryCount, 0);
-    m_postCommandList->SetGraphicsRoot32BitConstant(2, static_cast<UINT>(min(m_frameId + 1, Settings::SceneHistoryCount)), 1);
+	m_postCommandList->SetGraphicsRootDescriptorTable(0, m_postSrvHeap->GetGPUDescriptorHandleForHeapStart());
+	m_postCommandList->SetGraphicsRootDescriptorTable(1, m_postSamplerHeap->GetGPUDescriptorHandleForHeapStart());
+	m_postCommandList->SetGraphicsRoot32BitConstant(2, m_frameId % Settings::SceneHistoryCount, 0);
+	m_postCommandList->SetGraphicsRoot32BitConstant(2, static_cast<UINT>(min(m_frameId + 1, Settings::SceneHistoryCount)), 1);
 
-    m_postCommandList->DrawInstanced(4, 1, 0, 0);
+	m_postCommandList->DrawInstanced(4, 1, 0, 0);
 
-    // Indicate that the back buffer will now be used to present.
-    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
+	// Indicate that the back buffer will now be used to present.
+	barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
 
-    D3DX12_AFFINITY_RESOURCE_BARRIER barriers[Settings::MaxNodeCount];
-    barriers[0] = barrier;
+	D3DX12_AFFINITY_RESOURCE_BARRIER barriers[Settings::MaxNodeCount];
+	barriers[0] = barrier;
 
-    if (m_syncSceneRenderTargets)
-    {
-        // Transition render target resources rendered by the next nodes into the
-        // COPY_DEST state to prepare them to be copied to during those nodes'
-        // post-process passes.
-        for (UINT offset = 1; offset < Settings::NodeCount; offset++)
-        {
-            UINT renderTargetIndex = (m_sceneRenderTargetIndex + offset) % Settings::SceneHistoryCount;
+	if (m_syncSceneRenderTargets)
+	{
+		// Transition render target resources rendered by the next nodes into the
+		// COPY_DEST state to prepare them to be copied to during those nodes'
+		// post-process passes.
+		for (UINT offset = 1; offset < Settings::NodeCount; offset++)
+		{
+			UINT renderTargetIndex = (m_sceneRenderTargetIndex + offset) % Settings::SceneHistoryCount;
 
-            barriers[offset] = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
-                m_sceneRenderTargets[renderTargetIndex].Get(),
-                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_COPY_DEST);
-        }
-    }
+			barriers[offset] = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
+				m_sceneRenderTargets[renderTargetIndex].Get(),
+				D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+				D3D12_RESOURCE_STATE_COPY_DEST);
+		}
+	}
 
-    m_postCommandList->ResourceBarrier(Settings::NodeCount, barriers);
+	m_postCommandList->ResourceBarrier(Settings::NodeCount, barriers);
 
-    ThrowIfFailed(m_postCommandList->Close());
+	ThrowIfFailed(m_postCommandList->Close());
 
-    CD3DX12AffinityCommandList* ppPostCommandLists[] = { m_postCommandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppPostCommandLists), ppPostCommandLists);
+	CD3DX12AffinityCommandList* ppPostCommandLists[] = { m_postCommandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppPostCommandLists), ppPostCommandLists);
 }
 
 void D3D12LinkedGpusAffinity::OnSizeChanged(UINT width, UINT height, bool minimized)
 {
-    // Determine if the swap buffers and other resources need to be resized or not.
-    if ((width != m_width || height != m_height) && !minimized)
-    {
-        // Flush all current GPU commands.
-        WaitForGpus();
+	// Determine if the swap buffers and other resources need to be resized or not.
+	if ((width != m_width || height != m_height) && !minimized)
+	{
+		// Flush all current GPU commands.
+		WaitForGpus();
 
-        // Release buffers tied to the swap chain and update the global Settings
-        // for the new size.
-        for (UINT n = 0; n < Settings::BackBufferCount; n++)
-        {
-            m_postRenderTargets[n].Reset();
-        }
-        Settings::OnSizeChanged(width, height);
+		// Release buffers tied to the swap chain and update the global Settings
+		// for the new size.
+		for (UINT n = 0; n < Settings::BackBufferCount; n++)
+		{
+			m_postRenderTargets[n].Reset();
+		}
+		Settings::OnSizeChanged(width, height);
 
-        // Resize the swap chain to the desired dimensions.
-        DXGI_SWAP_CHAIN_DESC1 swapChainDesc;
-        ThrowIfFailed(m_swapChain->GetDesc1(&swapChainDesc));
-        ThrowIfFailed(m_swapChain->ResizeBuffers(Settings::BackBufferCount, width, height, swapChainDesc.Format, swapChainDesc.Flags));
+		// Resize the swap chain to the desired dimensions.
+		DXGI_SWAP_CHAIN_DESC1 swapChainDesc;
+		ThrowIfFailed(m_swapChain->GetDesc1(&swapChainDesc));
+		ThrowIfFailed(m_swapChain->ResizeBuffers(Settings::BackBufferCount, width, height, swapChainDesc.Format, swapChainDesc.Flags));
 
-        BOOL fullscreenState;
-        ThrowIfFailed(m_swapChain->GetFullscreenState(&fullscreenState, nullptr));
-        m_windowedMode = !fullscreenState;
+		BOOL fullscreenState;
+		ThrowIfFailed(m_swapChain->GetFullscreenState(&fullscreenState, nullptr));
+		m_windowedMode = !fullscreenState;
 
-        // Re-create render targets.
-        LoadSizeDependentResources();
+		// Re-create render targets.
+		LoadSizeDependentResources();
 
-        // Reset the node index and align the frameId so that assumptions in post-processing hold.
-        m_nodeIndex = m_swapChain->GetCurrentBackBufferIndex() % Settings::NodeCount;
-        m_frameId += (Settings::SceneHistoryCount - (m_frameId % Settings::SceneHistoryCount));
+		// Reset the node index and align the frameId so that assumptions in post-processing hold.
+		m_nodeIndex = m_swapChain->GetCurrentBackBufferIndex() % Settings::NodeCount;
+		m_frameId += (Settings::SceneHistoryCount - (m_frameId % Settings::SceneHistoryCount));
 
-        // Update the m_width, m_height, and m_aspectRatio member variables.
-        UpdateForSizeChange(width, height);
+		// Update the m_width, m_height, and m_aspectRatio member variables.
+		UpdateForSizeChange(width, height);
 
-        // Update the scene projection matrix.
-        for (UINT n = 0; n < Settings::TriangleCount; n++)
-        {
-            m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
-        }
-    }
+		// Update the scene projection matrix.
+		for (UINT n = 0; n < Settings::TriangleCount; n++)
+		{
+			m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
+		}
+	}
 
-    m_windowVisible = !minimized;
+	m_windowVisible = !minimized;
 }
 
 void D3D12LinkedGpusAffinity::OnKeyDown(UINT8 key)
 {
-    switch (key)
-    {
-    // Instrument the Space Bar to toggle between fullscreen states.
-    // The window message loop callback will receive a WM_SIZE message once the
-    // window is in the fullscreen state. At that point, the IDXGISwapChain should
-    // be resized to match the new window size.
-    //
-    // NOTE: ALT+Enter will perform a similar operation; the code below is not
-    // required to enable that key combination.
-    case VK_SPACE:
-    {
-        if (m_tearingSupport)
-        {
-            Win32Application::ToggleFullscreenWindow();
-        }
-        else
-        {
-            BOOL fullscreenState;
+	switch (key)
+	{
+	// Instrument the Space Bar to toggle between fullscreen states.
+	// The window message loop callback will receive a WM_SIZE message once the
+	// window is in the fullscreen state. At that point, the IDXGISwapChain should
+	// be resized to match the new window size.
+	//
+	// NOTE: ALT+Enter will perform a similar operation; the code below is not
+	// required to enable that key combination.
+	case VK_SPACE:
+	{
+		if (m_tearingSupport)
+		{
+			Win32Application::ToggleFullscreenWindow();
+		}
+		else
+		{
+			BOOL fullscreenState;
 
-            ThrowIfFailed(m_swapChain->GetFullscreenState(&fullscreenState, nullptr));
-            if (FAILED(m_swapChain->SetFullscreenState(!fullscreenState, nullptr)))
-            {
-                // Transitions to fullscreen mode can fail when running apps over
-                // terminal services or for some other unexpected reason.  Consider
-                // notifying the user in some way when this happens.
-                OutputDebugString(L"Fullscreen transition failed");
-                _ASSERT(false);
-            }
-        }
-        break;
-    }
+			ThrowIfFailed(m_swapChain->GetFullscreenState(&fullscreenState, nullptr));
+			if (FAILED(m_swapChain->SetFullscreenState(!fullscreenState, nullptr)))
+			{
+				// Transitions to fullscreen mode can fail when running apps over
+				// terminal services or for some other unexpected reason.  Consider
+				// notifying the user in some way when this happens.
+				OutputDebugString(L"Fullscreen transition failed");
+				_ASSERT(false);
+			}
+		}
+		break;
+	}
 
-    case VK_LEFT:
-    case VK_RIGHT:
-        m_syncInterval = (m_syncInterval > 0) ? 0 : 1;
-        UpdateWindowTitle();
-        break;
+	case VK_LEFT:
+	case VK_RIGHT:
+		m_syncInterval = (m_syncInterval > 0) ? 0 : 1;
+		UpdateWindowTitle();
+		break;
 
-    case VK_UP:
-        if (m_simulatedGpuLoad > 0)
-        {
-            if (m_simulatedGpuLoad < 0x80000)
-            {
-                m_simulatedGpuLoad <<= 1;
-            }
-        }
-        else
-        {
-            m_simulatedGpuLoad = 1;
-        }
-        UpdateWindowTitle();
-        break;
+	case VK_UP:
+		if (m_simulatedGpuLoad > 0)
+		{
+			if (m_simulatedGpuLoad < 0x80000)
+			{
+				m_simulatedGpuLoad <<= 1;
+			}
+		}
+		else
+		{
+			m_simulatedGpuLoad = 1;
+		}
+		UpdateWindowTitle();
+		break;
 
-    case VK_DOWN:
-        if (m_simulatedGpuLoad != 0)
-        {
-            m_simulatedGpuLoad >>= 1;
-        }
-        UpdateWindowTitle();
-        break;
-    }
+	case VK_DOWN:
+		if (m_simulatedGpuLoad != 0)
+		{
+			m_simulatedGpuLoad >>= 1;
+		}
+		UpdateWindowTitle();
+		break;
+	}
 }
 
 void D3D12LinkedGpusAffinity::OnDestroy()
 {
-    // Wait for the GPUs to be done with all their resources.
-    WaitForGpus();
+	// Wait for the GPUs to be done with all their resources.
+	WaitForGpus();
 
-    if (!m_tearingSupport)
-    {
-        m_swapChain->SetFullscreenState(FALSE, nullptr);
-    }
+	if (!m_tearingSupport)
+	{
+		m_swapChain->SetFullscreenState(FALSE, nullptr);
+	}
 }
 
 // Wait for pending GPU work to complete.
 void D3D12LinkedGpusAffinity::WaitForGpus()
 {
-    m_postFence->FlushGpuQueue();
+	m_postFence->FlushGpuQueue();
 }
 
 // Prepare to render the next frame.
 void D3D12LinkedGpusAffinity::MoveToNextFrame()
 {
-    UINT nextNode = m_swapChain->GetCurrentBackBufferIndex() % Settings::NodeCount;
+	UINT nextNode = m_swapChain->GetCurrentBackBufferIndex() % Settings::NodeCount;
 
-    if (Settings::NodeCount > 1 && nextNode == m_nodeIndex)
-    {
-        // If a WM_SIZE event was processed during Present, we will already be in the
-        // correct state. Do not update any indices.
-    }
-    else
-    {
-        m_postFence->Signal();
+	if (Settings::NodeCount > 1 && nextNode == m_nodeIndex)
+	{
+		// If a WM_SIZE event was processed during Present, we will already be in the
+		// correct state. Do not update any indices.
+	}
+	else
+	{
+		m_postFence->Signal();
 
-        // Advance to the next node.
-        m_device->SwitchToNextNode();
-        m_nodeIndex = m_device->GetActiveNodeIndex();
-        if (m_nodeIndex == 0)
-        {
-            m_frameIndex = (m_frameIndex + 1) % Settings::FrameCount;
-        }
+		// Advance to the next node.
+		m_device->SwitchToNextNode();
+		m_nodeIndex = m_device->GetActiveNodeIndex();
+		if (m_nodeIndex == 0)
+		{
+			m_frameIndex = (m_frameIndex + 1) % Settings::FrameCount;
+		}
 
-        m_sceneRenderTargetIndex = (m_sceneRenderTargetIndex + 1) % Settings::SceneHistoryCount;
+		m_sceneRenderTargetIndex = (m_sceneRenderTargetIndex + 1) % Settings::SceneHistoryCount;
 
-        m_frameId++;
-    }
+		m_frameId++;
+	}
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/D3D12LinkedGpusAffinity.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/D3D12LinkedGpusAffinity.h
@@ -32,109 +32,109 @@ using Microsoft::WRL::ComPtr;
 class D3D12LinkedGpusAffinity : public DXSample
 {
 public:
-    D3D12LinkedGpusAffinity(UINT width, UINT height, std::wstring name);
+	D3D12LinkedGpusAffinity(UINT width, UINT height, std::wstring name);
 
 protected:
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
-    virtual void OnKeyDown(UINT8 key);
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
+	virtual void OnKeyDown(UINT8 key);
+	virtual void OnDestroy();
 
 private:
-    ComPtr<CD3DX12AffinityDevice> m_device;
-    ComPtr<CDXGIAffinitySwapChain> m_swapChain;
-    ComPtr<CD3DX12AffinityCommandQueue> m_graphicsQueue;
-    std::vector<ComPtr<CD3DX12AffinityCommandAllocator>> m_sceneCommandAllocators;
-    std::vector<ComPtr<CD3DX12AffinityCommandAllocator>> m_postCommandAllocators;
-    ComPtr<CD3DX12AffinityDescriptorHeap> m_sceneRtvHeap;
-    ComPtr<CD3DX12AffinityDescriptorHeap> m_sceneDsvHeap;
-    ComPtr<CD3DX12AffinityDescriptorHeap> m_sceneCbvHeap;
-    ComPtr<CD3DX12AffinityDescriptorHeap> m_postRtvHeap;
-    ComPtr<CD3DX12AffinityDescriptorHeap> m_postSrvHeap;
-    ComPtr<CD3DX12AffinityDescriptorHeap> m_postSamplerHeap;
+	ComPtr<CD3DX12AffinityDevice> m_device;
+	ComPtr<CDXGIAffinitySwapChain> m_swapChain;
+	ComPtr<CD3DX12AffinityCommandQueue> m_graphicsQueue;
+	std::vector<ComPtr<CD3DX12AffinityCommandAllocator>> m_sceneCommandAllocators;
+	std::vector<ComPtr<CD3DX12AffinityCommandAllocator>> m_postCommandAllocators;
+	ComPtr<CD3DX12AffinityDescriptorHeap> m_sceneRtvHeap;
+	ComPtr<CD3DX12AffinityDescriptorHeap> m_sceneDsvHeap;
+	ComPtr<CD3DX12AffinityDescriptorHeap> m_sceneCbvHeap;
+	ComPtr<CD3DX12AffinityDescriptorHeap> m_postRtvHeap;
+	ComPtr<CD3DX12AffinityDescriptorHeap> m_postSrvHeap;
+	ComPtr<CD3DX12AffinityDescriptorHeap> m_postSamplerHeap;
 
-    // Objects used for rendering the scene.
-    ComPtr<CD3DX12AffinityGraphicsCommandList> m_sceneCommandList;
-    ComPtr<CD3DX12AffinityRootSignature> m_sceneRootSignature;
-    ComPtr<CD3DX12AffinityPipelineState> m_scenePipelineState;
-    ComPtr<CD3DX12AffinityResource> m_sceneVertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_sceneVertexBufferView;
-    ComPtr<CD3DX12AffinityResource> m_sceneConstantBuffer;
-    UINT8* m_mappedConstantBuffer;
-    ComPtr<CD3DX12AffinityHeap> m_sceneRenderTargetHeap;
-    std::vector<ComPtr<CD3DX12AffinityResource>> m_sceneRenderTargets;
-    ComPtr<CD3DX12AffinityResource> m_sceneDepthStencil;
+	// Objects used for rendering the scene.
+	ComPtr<CD3DX12AffinityGraphicsCommandList> m_sceneCommandList;
+	ComPtr<CD3DX12AffinityRootSignature> m_sceneRootSignature;
+	ComPtr<CD3DX12AffinityPipelineState> m_scenePipelineState;
+	ComPtr<CD3DX12AffinityResource> m_sceneVertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_sceneVertexBufferView;
+	ComPtr<CD3DX12AffinityResource> m_sceneConstantBuffer;
+	UINT8* m_mappedConstantBuffer;
+	ComPtr<CD3DX12AffinityHeap> m_sceneRenderTargetHeap;
+	std::vector<ComPtr<CD3DX12AffinityResource>> m_sceneRenderTargets;
+	ComPtr<CD3DX12AffinityResource> m_sceneDepthStencil;
 
-    // Objects used for post-processing.
-    ComPtr<CD3DX12AffinityGraphicsCommandList> m_postCommandList;
-    ComPtr<CD3DX12AffinityRootSignature> m_postRootSignature;
-    ComPtr<CD3DX12AffinityPipelineState> m_postPipelineState;
-    ComPtr<CD3DX12AffinityResource> m_postVertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_postVertexBufferView;
-    std::vector<ComPtr<CD3DX12AffinityResource>> m_postRenderTargets;
+	// Objects used for post-processing.
+	ComPtr<CD3DX12AffinityGraphicsCommandList> m_postCommandList;
+	ComPtr<CD3DX12AffinityRootSignature> m_postRootSignature;
+	ComPtr<CD3DX12AffinityPipelineState> m_postPipelineState;
+	ComPtr<CD3DX12AffinityResource> m_postVertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_postVertexBufferView;
+	std::vector<ComPtr<CD3DX12AffinityResource>> m_postRenderTargets;
 
-    // A fence to indicate when the scene pass is complete.
-    std::shared_ptr<LinearFence> m_sceneFence;
+	// A fence to indicate when the scene pass is complete.
+	std::shared_ptr<LinearFence> m_sceneFence;
 
-    // A fence to regulate submission of post-processing render passes.
-    // Up to 'Settings::FrameCount' command lists can be in flight on the node at once.
-    std::shared_ptr<LinearFence> m_postFence;
+	// A fence to regulate submission of post-processing render passes.
+	// Up to 'Settings::FrameCount' command lists can be in flight on the node at once.
+	std::shared_ptr<LinearFence> m_postFence;
 
-    // Vertex definitions.
-    struct SceneVertex
-    {
-        DirectX::XMFLOAT3 position;
-    };
+	// Vertex definitions.
+	struct SceneVertex
+	{
+		DirectX::XMFLOAT3 position;
+	};
 
-    struct PostVertex
-    {
-        DirectX::XMFLOAT3 position;
-        DirectX::XMFLOAT2 uv;
-    };
+	struct PostVertex
+	{
+		DirectX::XMFLOAT3 position;
+		DirectX::XMFLOAT2 uv;
+	};
 
-    // Constant buffer definition.
-    struct SceneConstantBuffer
-    {
-        DirectX::XMFLOAT4 velocity;
-        DirectX::XMFLOAT4 offset;
-        DirectX::XMFLOAT4 color;
-        DirectX::XMMATRIX projection;
+	// Constant buffer definition.
+	struct SceneConstantBuffer
+	{
+		DirectX::XMFLOAT4 velocity;
+		DirectX::XMFLOAT4 offset;
+		DirectX::XMFLOAT4 color;
+		DirectX::XMMATRIX projection;
 
-        // Constant buffers are 256-byte aligned. Add padding in the struct to allow
-        // multiple buffers to be array-indexed.
-        float padding[36];
-    };
+		// Constant buffers are 256-byte aligned. Add padding in the struct to allow
+		// multiple buffers to be array-indexed.
+		float padding[36];
+	};
 
-    // Data about each of the triangles in the scene.
-    std::vector<SceneConstantBuffer> m_sceneData;
+	// Data about each of the triangles in the scene.
+	std::vector<SceneConstantBuffer> m_sceneData;
 
-    UINT64 m_frameId;
-    UINT m_simulatedGpuLoad;
-    UINT m_nodeIndex;
-    UINT m_frameIndex;
-    UINT m_sceneRenderTargetIndex;
-    UINT m_syncInterval;
-    bool m_windowVisible;
-    bool m_windowedMode;
+	UINT64 m_frameId;
+	UINT m_simulatedGpuLoad;
+	UINT m_nodeIndex;
+	UINT m_frameIndex;
+	UINT m_sceneRenderTargetIndex;
+	UINT m_syncInterval;
+	bool m_windowVisible;
+	bool m_windowedMode;
 
-    // Additional work must be done to synchronize dependencies in the post-processing
-    // pass when rendering with multiple nodes.
-    bool m_syncSceneRenderTargets;
+	// Additional work must be done to synchronize dependencies in the post-processing
+	// pass when rendering with multiple nodes.
+	bool m_syncSceneRenderTargets;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void LoadSizeDependentResources();
-    float GetRandomFloat(float min, float max);
-    void UpdateWindowTitle();
-    void RenderScene();
-    void RenderPost();
-    void WaitForGpus();
-    void MoveToNextFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	void LoadSizeDependentResources();
+	float GetRandomFloat(float min, float max);
+	void UpdateWindowTitle();
+	void RenderScene();
+	void RenderPost();
+	void WaitForGpus();
+	void MoveToNextFrame();
 
-    static inline UINT64 AlignResource(UINT64 size, UINT64 alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT)
-    {
-        return (size + alignment - 1) & ~(alignment - 1);
-    }
+	static inline UINT64 AlignResource(UINT64 size, UINT64 alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT)
+	{
+		return (size + alignment - 1) & ~(alignment - 1);
+	}
 };

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.cpp
@@ -52,33 +52,78 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
+
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+            }
+#if !defined(_XBOX_ONE)
+        }
+#endif
 
     *ppAdapter = adapter.Detach();
-}
+    }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.h
@@ -49,7 +49,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/Fence.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/Fence.h
@@ -20,139 +20,139 @@ using Microsoft::WRL::ComPtr;
 class Fence
 {
 public:
-    // Create a fence and associate it with the specified command queue for
-    // convenience in working with fences.
-    Fence(CD3DX12AffinityCommandQueue* pQueue) :
-        m_currentFenceValue(0)
-    {
-        ThrowIfFailed(pQueue->QueryInterface(IID_PPV_ARGS(&m_queue)));
+	// Create a fence and associate it with the specified command queue for
+	// convenience in working with fences.
+	Fence(CD3DX12AffinityCommandQueue* pQueue) :
+		m_currentFenceValue(0)
+	{
+		ThrowIfFailed(pQueue->QueryInterface(IID_PPV_ARGS(&m_queue)));
 
-        ComPtr<CD3DX12AffinityDevice> device;
-        ThrowIfFailed(m_queue->GetDevice(IID_PPV_ARGS(&device)));
+		ComPtr<CD3DX12AffinityDevice> device;
+		ThrowIfFailed(m_queue->GetDevice(IID_PPV_ARGS(&device)));
 
-        ThrowIfFailed(device->CreateFence(m_currentFenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		ThrowIfFailed(device->CreateFence(m_currentFenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
 
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
-    }
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
+	}
 
-    ~Fence()
-    {
-        if (m_fenceEvent)
-        {
-            CloseHandle(m_fenceEvent);
-            m_fenceEvent = nullptr;
-        }
-    }
+	~Fence()
+	{
+		if (m_fenceEvent)
+		{
+			CloseHandle(m_fenceEvent);
+			m_fenceEvent = nullptr;
+		}
+	}
 
-    // Drain the GPU command queue.
-    // (Blocks the calling CPU thread)
-    inline void FlushGpuQueue()
-    {
-        Signal();
-        m_queue->WaitForCompletion();
-    }
+	// Drain the GPU command queue.
+	// (Blocks the calling CPU thread)
+	inline void FlushGpuQueue()
+	{
+		Signal();
+		m_queue->WaitForCompletion();
+	}
 
-    // Issue a Signal command on the command queue.
-    // Use the current value of the fence or override it with your own value.
-    inline void Signal(UINT64 value = UnspecifiedFenceValue)
-    {
-        if (value == UnspecifiedFenceValue)
-        {
-            m_currentFenceValue++;
-        }
-        else
-        {
-            _ASSERT(value > m_currentFenceValue);
-            m_currentFenceValue = value;
-        }
+	// Issue a Signal command on the command queue.
+	// Use the current value of the fence or override it with your own value.
+	inline void Signal(UINT64 value = UnspecifiedFenceValue)
+	{
+		if (value == UnspecifiedFenceValue)
+		{
+			m_currentFenceValue++;
+		}
+		else
+		{
+			_ASSERT(value > m_currentFenceValue);
+			m_currentFenceValue = value;
+		}
 
-        ThrowIfFailed(m_queue->Signal(m_fence.Get(), m_currentFenceValue));
-    }
+		ThrowIfFailed(m_queue->Signal(m_fence.Get(), m_currentFenceValue));
+	}
 
-    // Instruct the GPU queue associated with this fence to wait for a value to be signaled.
-    // Use the current value of the fence or override it with your own value.
-    // (Does not block the calling CPU thread)
-    inline void GpuWait(UINT64 value = UnspecifiedFenceValue)
-    {
-        if (value == UnspecifiedFenceValue)
-        {
-            value = m_currentFenceValue;
-        }
+	// Instruct the GPU queue associated with this fence to wait for a value to be signaled.
+	// Use the current value of the fence or override it with your own value.
+	// (Does not block the calling CPU thread)
+	inline void GpuWait(UINT64 value = UnspecifiedFenceValue)
+	{
+		if (value == UnspecifiedFenceValue)
+		{
+			value = m_currentFenceValue;
+		}
 
-        ThrowIfFailed(m_queue->Wait(m_fence.Get(), value));
-    }
+		ThrowIfFailed(m_queue->Wait(m_fence.Get(), value));
+	}
 
-    // Instruct a GPU queue on the active node to wait for the fences on the other nodes.
-    // Use the current values of the fences or override them with your own value.
-    // (Does not block the calling CPU thread)
-    inline static void GpuWait(CD3DX12AffinityCommandQueue* pQueue, Fence* pFence, UINT64 value = UnspecifiedFenceValue)
-    {
-        if (value == UnspecifiedFenceValue)
-        {
-            value = pFence->m_currentFenceValue;
-        }
+	// Instruct a GPU queue on the active node to wait for the fences on the other nodes.
+	// Use the current values of the fences or override them with your own value.
+	// (Does not block the calling CPU thread)
+	inline static void GpuWait(CD3DX12AffinityCommandQueue* pQueue, Fence* pFence, UINT64 value = UnspecifiedFenceValue)
+	{
+		if (value == UnspecifiedFenceValue)
+		{
+			value = pFence->m_currentFenceValue;
+		}
 
-        pQueue->Wait(pFence->m_fence.Get(), value, true, Settings::SharedNodeMask);
-    }
+		pQueue->Wait(pFence->m_fence.Get(), value, true, Settings::SharedNodeMask);
+	}
 
 protected:
-    // Block the calling CPU thread until the GPU has signaled the specified fence.
-    inline void CpuWait(UINT64 fenceValue = UnspecifiedFenceValue)
-    {
-        if (fenceValue == UnspecifiedFenceValue)
-        {
-            fenceValue = m_currentFenceValue;
-        }
+	// Block the calling CPU thread until the GPU has signaled the specified fence.
+	inline void CpuWait(UINT64 fenceValue = UnspecifiedFenceValue)
+	{
+		if (fenceValue == UnspecifiedFenceValue)
+		{
+			fenceValue = m_currentFenceValue;
+		}
 
-        UINT nodeMask = 1 << m_fence->GetActiveNodeIndex();
-        if (m_fence->GetCompletedValue(nodeMask) < fenceValue)
-        {
-            ThrowIfFailed(m_fence->SetEventOnCompletion(fenceValue, m_fenceEvent));
-            WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-        }
-    }
+		UINT nodeMask = 1 << m_fence->GetActiveNodeIndex();
+		if (m_fence->GetCompletedValue(nodeMask) < fenceValue)
+		{
+			ThrowIfFailed(m_fence->SetEventOnCompletion(fenceValue, m_fenceEvent));
+			WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+		}
+	}
 
-    static const UINT64 UnspecifiedFenceValue = UINT64_MAX;
+	static const UINT64 UnspecifiedFenceValue = UINT64_MAX;
 
-    ComPtr<CD3DX12AffinityFence> m_fence;            // The D3D12 fence object.
-    ComPtr<CD3DX12AffinityCommandQueue> m_queue;    // The command queue associated with this fence.
-    UINT64 m_currentFenceValue;                        // The last value signaled by this fence.
-    HANDLE m_fenceEvent;                            // CPU-waitable event handle.
+	ComPtr<CD3DX12AffinityFence> m_fence;			// The D3D12 fence object.
+	ComPtr<CD3DX12AffinityCommandQueue> m_queue;	// The command queue associated with this fence.
+	UINT64 m_currentFenceValue;						// The last value signaled by this fence.
+	HANDLE m_fenceEvent;							// CPU-waitable event handle.
 };
 
 class LinearFence : public Fence
 {
 public:
-    // This fence implementation manages a ring buffer of issued Signal events.
-    // The "Next" API instructs the Fence to move to the next slot in the ring buffer.
-    // If the next slot represents a fence value that has not yet been signaled by
-    // the GPU, then the CPU will wait until that fence is signaled before continuing.
-    // 
-    // In this sample, LinearFences are used to guard against premature resetting
-    // of command allocators and modifying of upload heaps that might currently be
-    // in use by the GPU.
-    LinearFence(CD3DX12AffinityCommandQueue* pQueue, UINT count) :
-        Fence(pQueue),
-        m_signalIndex(0)
-    {
-        m_signalHistory.resize(count * pQueue->GetNodeCount());
-    }
+	// This fence implementation manages a ring buffer of issued Signal events.
+	// The "Next" API instructs the Fence to move to the next slot in the ring buffer.
+	// If the next slot represents a fence value that has not yet been signaled by
+	// the GPU, then the CPU will wait until that fence is signaled before continuing.
+	// 
+	// In this sample, LinearFences are used to guard against premature resetting
+	// of command allocators and modifying of upload heaps that might currently be
+	// in use by the GPU.
+	LinearFence(CD3DX12AffinityCommandQueue* pQueue, UINT count) :
+		Fence(pQueue),
+		m_signalIndex(0)
+	{
+		m_signalHistory.resize(count * pQueue->GetNodeCount());
+	}
 
-    // If the oldest Signal event in the ring buffer has not yet been processed by
-    // the GPU, block the calling CPU thread until it is.
-    inline void Next()
-    {
-        m_signalHistory[m_signalIndex] = m_currentFenceValue;
-        m_signalIndex = (m_signalIndex + 1) % m_signalHistory.size();
+	// If the oldest Signal event in the ring buffer has not yet been processed by
+	// the GPU, block the calling CPU thread until it is.
+	inline void Next()
+	{
+		m_signalHistory[m_signalIndex] = m_currentFenceValue;
+		m_signalIndex = (m_signalIndex + 1) % m_signalHistory.size();
 
-        Fence::CpuWait(m_signalHistory[m_signalIndex]);
-    }
+		Fence::CpuWait(m_signalHistory[m_signalIndex]);
+	}
 
 private:
-    std::vector<UINT64> m_signalHistory;    // The history of signal events.
-    UINT m_signalIndex;                        // The index to the next slot in the signal history ring buffer.
+	std::vector<UINT64> m_signalHistory;	// The history of signal events.
+	UINT m_signalIndex;						// The index to the next slot in the signal history ring buffer.
 };

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/Main.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12LinkedGpusAffinity sample(1280, 720, L"D3D12 Linked GPUs with the Affinity Layer Sample");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12LinkedGpusAffinity sample(1280, 720, L"D3D12 Linked GPUs with the Affinity Layer Sample");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/Post.hlsli
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/Post.hlsli
@@ -11,14 +11,14 @@
 
 struct VSInput
 {
-    float4 position : POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : POSITION;
+	float2 uv : TEXCOORD;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 Texture2D g_renderTargets[6] : register(t0);
@@ -26,6 +26,6 @@ SamplerState g_sampler : register(s0);
 
 cbuffer ShaderConstants : register(b0)
 {
-    uint currentRenderTarget;
-    uint renderTargetCount;
+	uint currentRenderTarget;
+	uint renderTargetCount;
 };

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/PostPS.hlsl
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/PostPS.hlsl
@@ -13,18 +13,18 @@
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    // This adds up to more than 1.0f, but creates a decent effect
-    // that doesn't make the triangles look too transparent.
-    float blurWeights[6] = { 0.80f, 0.25f, 0.15f, 0.075f, 0.025f, 0.0125f };
+	// This adds up to more than 1.0f, but creates a decent effect
+	// that doesn't make the triangles look too transparent.
+	float blurWeights[6] = { 0.80f, 0.25f, 0.15f, 0.075f, 0.025f, 0.0125f };
 
-    float4 result = float4(0.0f, 0.0f, 0.0f, 0.0f);
-    uint index = currentRenderTarget;
+	float4 result = float4(0.0f, 0.0f, 0.0f, 0.0f);
+	uint index = currentRenderTarget;
 
-    for (uint n = 0; n < renderTargetCount; n++)
-    {
-        result += blurWeights[n] * g_renderTargets[index].Sample(g_sampler, input.uv);
-        index = (index == 0) ? renderTargetCount - 1 : index - 1;
-    }
+	for (uint n = 0; n < renderTargetCount; n++)
+	{
+		result += blurWeights[n] * g_renderTargets[index].Sample(g_sampler, input.uv);
+		index = (index == 0) ? renderTargetCount - 1 : index - 1;
+	}
 
-    return saturate(result);
+	return saturate(result);
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/PostVS.hlsl
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/PostVS.hlsl
@@ -13,10 +13,10 @@
 
 PSInput VSMain(VSInput input)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = input.position;
-    result.uv = input.uv;
+	result.position = input.position;
+	result.uv = input.uv;
 
-    return result;
+	return result;
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/Scene.hlsli
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/Scene.hlsli
@@ -11,19 +11,19 @@
 
 cbuffer SceneConstantBuffer : register(b0)
 {
-    float4 velocity;
-    float4 offset;
-    float4 color;
-    float4x4 projection;
+	float4 velocity;
+	float4 offset;
+	float4 color;
+	float4x4 projection;
 };
 
 cbuffer SceneRootConstants : register(b1)
 {
-    uint simulatedGpuLoad;
+	uint simulatedGpuLoad;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/ScenePS.hlsl
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/ScenePS.hlsl
@@ -13,5 +13,5 @@
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/SceneVS.hlsl
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/SceneVS.hlsl
@@ -13,29 +13,29 @@
 
 PSInput VSMain(float4 position : POSITION)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = mul(position + offset, projection);
+	result.position = mul(position + offset, projection);
 
-    float intensity = saturate((4.0f - result.position.z) / 2.0f);
-    float4 c = float4(color.xyz * intensity, 1.0f);
+	float intensity = saturate((4.0f - result.position.z) / 2.0f);
+	float4 c = float4(color.xyz * intensity, 1.0f);
 
-    if (simulatedGpuLoad > 0)
-    {
-        float4 total = float4(0.0f, 0.0f, 0.0f, 0.0f);
+	if (simulatedGpuLoad > 0)
+	{
+		float4 total = float4(0.0f, 0.0f, 0.0f, 0.0f);
 
-        // Simulate additional workload on the GPU.
-        for (uint x = 0; x < simulatedGpuLoad; x++)
-        {
-            total += c;
-        }
+		// Simulate additional workload on the GPU.
+		for (uint x = 0; x < simulatedGpuLoad; x++)
+		{
+			total += c;
+		}
 
-        result.color = total / simulatedGpuLoad;
-    }
-    else
-    {
-        result.color = c;
-    }
+		result.color = total / simulatedGpuLoad;
+	}
+	else
+	{
+		result.color = c;
+	}
 
-    return result;
+	return result;
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/Settings.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/Settings.cpp
@@ -15,8 +15,8 @@
 
 using Microsoft::WRL::ComPtr;
 
-const float Settings::TriangleHalfWidth = 0.05f;    // The x and y offsets used by the triangle vertices.
-const float Settings::TriangleDepth = 1.0f;            // The z offset used by the triangle vertices.
+const float Settings::TriangleHalfWidth = 0.05f;	// The x and y offsets used by the triangle vertices.
+const float Settings::TriangleDepth = 1.0f;			// The z offset used by the triangle vertices.
 const float Settings::ClearColor[4] = { 0.0f, 0.2f, 0.4f, 1.0f };
 
 UINT Settings::NodeCount;
@@ -35,33 +35,33 @@ D3D12_RECT Settings::ScissorRect;
 
 void Settings::Initialize(CD3DX12AffinityDevice* pDevice, UINT width, UINT height)
 {
-    NodeCount = pDevice->GetNodeCount();
-    _ASSERT(NodeCount <= MaxNodeCount);
+	NodeCount = pDevice->GetNodeCount();
+	_ASSERT(NodeCount <= MaxNodeCount);
 
-    BackBuffersPerNode = (NodeCount > 1) ? 1 : 2;
-    FrameCount = (NodeCount > 1) ? 1 : 2;
-    _ASSERT(FrameCount * NodeCount <= SceneConstantBufferFrames);
+	BackBuffersPerNode = (NodeCount > 1) ? 1 : 2;
+	FrameCount = (NodeCount > 1) ? 1 : 2;
+	_ASSERT(FrameCount * NodeCount <= SceneConstantBufferFrames);
 
-    D3D12_FEATURE_DATA_D3D12_OPTIONS featureOptions;
-    ThrowIfFailed(pDevice->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &featureOptions, sizeof(featureOptions)));
-    Tier2Support = (featureOptions.CrossNodeSharingTier == D3D12_CROSS_NODE_SHARING_TIER_2);
+	D3D12_FEATURE_DATA_D3D12_OPTIONS featureOptions;
+	ThrowIfFailed(pDevice->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &featureOptions, sizeof(featureOptions)));
+	Tier2Support = (featureOptions.CrossNodeSharingTier == D3D12_CROSS_NODE_SHARING_TIER_2);
 
-    RtvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    CbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	RtvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	CbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 
-    SharedNodeMask = (1 << NodeCount) - 1;
-    BackBufferCount = NodeCount * BackBuffersPerNode;
+	SharedNodeMask = (1 << NodeCount) - 1;
+	BackBufferCount = NodeCount * BackBuffersPerNode;
 
-    // We assume that each node will be assigned the same number of render targets.
-    _ASSERT(SceneHistoryCount % NodeCount == 0);
+	// We assume that each node will be assigned the same number of render targets.
+	_ASSERT(SceneHistoryCount % NodeCount == 0);
 
-    OnSizeChanged(width, height);
+	OnSizeChanged(width, height);
 }
 
 void Settings::OnSizeChanged(UINT width, UINT height)
 {
-    Width = width;
-    Height = height;
-    Viewport = CD3DX12_VIEWPORT(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 0.0f, 1.0f);
-    ScissorRect = CD3DX12_RECT(0, 0, static_cast<LONG>(width), static_cast<LONG>(height));
+	Width = width;
+	Height = height;
+	Viewport = CD3DX12_VIEWPORT(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 0.0f, 1.0f);
+	ScissorRect = CD3DX12_RECT(0, 0, static_cast<LONG>(width), static_cast<LONG>(height));
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/Settings.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/Settings.h
@@ -15,29 +15,29 @@
 // for the lifetime of the sample.
 struct Settings
 {
-    static void Initialize(CD3DX12AffinityDevice* pDevice, UINT width, UINT height);
-    static void OnSizeChanged(UINT width, UINT height);
+	static void Initialize(CD3DX12AffinityDevice* pDevice, UINT width, UINT height);
+	static void OnSizeChanged(UINT width, UINT height);
 
-    static const UINT MaxNodeCount = 2;
-    static UINT BackBuffersPerNode;
-    static UINT FrameCount;                                // The maximum number of frames that will be buffered on each node.
+	static const UINT MaxNodeCount = 2;
+	static UINT BackBuffersPerNode;
+	static UINT FrameCount;								// The maximum number of frames that will be buffered on each node.
 
-    static const UINT SceneHistoryCount = 6;            // The number of frames used in the motion blur effect.
-    static const UINT SceneConstantBufferFrames = 10;    // The number of frames that can be buffered in the constant buffer heap.
-    static const UINT TriangleCount = 1024;                // The number of triangles drawn per frame.
-    static const float TriangleHalfWidth;                // The x and y offsets used by the triangle vertices.
-    static const float TriangleDepth;                    // The z offset used by the triangle vertices.
-    static const float ClearColor[4];
+	static const UINT SceneHistoryCount = 6;			// The number of frames used in the motion blur effect.
+	static const UINT SceneConstantBufferFrames = 10;	// The number of frames that can be buffered in the constant buffer heap.
+	static const UINT TriangleCount = 1024;				// The number of triangles drawn per frame.
+	static const float TriangleHalfWidth;				// The x and y offsets used by the triangle vertices.
+	static const float TriangleDepth;					// The z offset used by the triangle vertices.
+	static const float ClearColor[4];
 
-    static UINT NodeCount;                                // The number of linked GPUs on the system.
-    static UINT SharedNodeMask;                            // The mask representing all GPUs on the system.
-    static bool Tier2Support;
-    static UINT RtvDescriptorSize;
-    static UINT CbvSrvDescriptorSize;
-    static UINT BackBufferCount;
+	static UINT NodeCount;								// The number of linked GPUs on the system.
+	static UINT SharedNodeMask;							// The mask representing all GPUs on the system.
+	static bool Tier2Support;
+	static UINT RtvDescriptorSize;
+	static UINT CbvSrvDescriptorSize;
+	static UINT BackBufferCount;
 
-    static UINT Width;
-    static UINT Height;
-    static D3D12_VIEWPORT Viewport;
-    static D3D12_RECT ScissorRect;
+	static UINT Width;
+	static UINT Height;
+	static D3D12_VIEWPORT Viewport;
+	static D3D12_RECT ScissorRect;
 };

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/d3dx12.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/D3D12SingleGpu.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/D3D12SingleGpu.cpp
@@ -21,886 +21,886 @@
 using namespace DirectX;
 
 D3D12SingleGpu::D3D12SingleGpu(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_frameId(0),
-    m_simulatedGpuLoad(0x1000),
-    m_syncInterval(0),
-    m_windowVisible(true),
-    m_windowedMode(true)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_frameId(0),
+	m_simulatedGpuLoad(0x1000),
+	m_syncInterval(0),
+	m_windowVisible(true),
+	m_windowedMode(true)
 {
-    m_sceneData.resize(Settings::TriangleCount);
+	m_sceneData.resize(Settings::TriangleCount);
 }
 
 void D3D12SingleGpu::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 
-    UpdateWindowTitle();
+	UpdateWindowTitle();
 }
 
 void D3D12SingleGpu::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Query capabilities of the device to configure the sample.
-    Settings::Initialize(m_device.Get(), m_width, m_height);
+	// Query capabilities of the device to configure the sample.
+	Settings::Initialize(m_device.Get(), m_width, m_height);
 
-    // Initialize member variables dependent on the Settings.
-    m_sceneRenderTargets.resize(Settings::SceneHistoryCount);
-    m_postRenderTargets.resize(Settings::BackBufferCount);
-    m_sceneCommandAllocators.resize(Settings::FrameCount);
-    m_postCommandAllocators.resize(Settings::FrameCount);
+	// Initialize member variables dependent on the Settings.
+	m_sceneRenderTargets.resize(Settings::SceneHistoryCount);
+	m_postRenderTargets.resize(Settings::BackBufferCount);
+	m_sceneCommandAllocators.resize(Settings::FrameCount);
+	m_postCommandAllocators.resize(Settings::FrameCount);
 
-    // Describe and create the command queues.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queues.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_graphicsQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_graphicsQueue)));
 
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = Settings::BackBufferCount;
-    swapChainDesc.Width = Settings::Width;
-    swapChainDesc.Height = Settings::Height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
-    swapChainDesc.Flags = m_tearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = Settings::BackBufferCount;
+	swapChainDesc.Width = Settings::Width;
+	swapChainDesc.Height = Settings::Height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
+	swapChainDesc.Flags = m_tearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_graphicsQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_graphicsQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    if (m_tearingSupport)
-    {
-        factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER);
-    }
+	if (m_tearingSupport)
+	{
+		factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER);
+	}
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
+	ThrowIfFailed(swapChain.As(&m_swapChain));
 
-    // Scene descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_sceneRtvHeap)));
+	// Scene descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_sceneRtvHeap)));
 
-        // Describe and create a depth stencil view (DSV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
-        dsvHeapDesc.NumDescriptors = 1;
-        dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-        dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_sceneDsvHeap)));
+		// Describe and create a depth stencil view (DSV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
+		dsvHeapDesc.NumDescriptors = 1;
+		dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+		dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_sceneDsvHeap)));
 
-        // Describe and create a constant buffer view (CBV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
-        cbvHeapDesc.NumDescriptors = Settings::TriangleCount * Settings::SceneConstantBufferFrames;
-        cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_sceneCbvHeap)));
-    }
+		// Describe and create a constant buffer view (CBV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
+		cbvHeapDesc.NumDescriptors = Settings::TriangleCount * Settings::SceneConstantBufferFrames;
+		cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_sceneCbvHeap)));
+	}
 
-    // Post-process descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap for 
-        // the final output.
-        D3D12_DESCRIPTOR_HEAP_DESC postRtvHeapDesc = {};
-        postRtvHeapDesc.NumDescriptors = Settings::BackBufferCount;
-        postRtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        postRtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&postRtvHeapDesc, IID_PPV_ARGS(&m_postRtvHeap)));
+	// Post-process descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap for 
+		// the final output.
+		D3D12_DESCRIPTOR_HEAP_DESC postRtvHeapDesc = {};
+		postRtvHeapDesc.NumDescriptors = Settings::BackBufferCount;
+		postRtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		postRtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&postRtvHeapDesc, IID_PPV_ARGS(&m_postRtvHeap)));
 
-        // Describe and create a shader resource view (SRV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
-        srvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
-        srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_postSrvHeap)));
+		// Describe and create a shader resource view (SRV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
+		srvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
+		srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_postSrvHeap)));
 
-        // Describe and create a sampler descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
-        samplerHeapDesc.NumDescriptors = 1;
-        samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
-        samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_postSamplerHeap)));
-    }
+		// Describe and create a sampler descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
+		samplerHeapDesc.NumDescriptors = 1;
+		samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
+		samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_postSamplerHeap)));
+	}
 
-    // Create command allocators for each buffered frame.
-    for (UINT n = 0; n < Settings::FrameCount; n++)
-    {
-        ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[n])));
-        ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_postCommandAllocators[n])));
-    }
+	// Create command allocators for each buffered frame.
+	for (UINT n = 0; n < Settings::FrameCount; n++)
+	{
+		ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[n])));
+		ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_postCommandAllocators[n])));
+	}
 }
 
 // Generate data for the scene triangles.
 void D3D12SingleGpu::LoadAssets()
 {
-    // Create the root signatures.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signatures.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        // Create a root signature for rendering the triangle scene.
-        {
-            CD3DX12_DESCRIPTOR_RANGE1 sceneRanges[1];
-            sceneRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		// Create a root signature for rendering the triangle scene.
+		{
+			CD3DX12_DESCRIPTOR_RANGE1 sceneRanges[1];
+			sceneRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
 
-            CD3DX12_ROOT_PARAMETER1 sceneRootParameters[2];
-            sceneRootParameters[0].InitAsDescriptorTable(1, &sceneRanges[0], D3D12_SHADER_VISIBILITY_VERTEX);
-            sceneRootParameters[1].InitAsConstants(1, 1, 0, D3D12_SHADER_VISIBILITY_VERTEX);
+			CD3DX12_ROOT_PARAMETER1 sceneRootParameters[2];
+			sceneRootParameters[0].InitAsDescriptorTable(1, &sceneRanges[0], D3D12_SHADER_VISIBILITY_VERTEX);
+			sceneRootParameters[1].InitAsConstants(1, 1, 0, D3D12_SHADER_VISIBILITY_VERTEX);
 
-            CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC sceneRootSignatureDesc;
-            sceneRootSignatureDesc.Init_1_1(_countof(sceneRootParameters), sceneRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+			CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC sceneRootSignatureDesc;
+			sceneRootSignatureDesc.Init_1_1(_countof(sceneRootParameters), sceneRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-            ComPtr<ID3DBlob> signature;
-            ComPtr<ID3DBlob> error;
-            ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&sceneRootSignatureDesc, featureData.HighestVersion, &signature, &error));
-            ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_sceneRootSignature)));
-        }
+			ComPtr<ID3DBlob> signature;
+			ComPtr<ID3DBlob> error;
+			ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&sceneRootSignatureDesc, featureData.HighestVersion, &signature, &error));
+			ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_sceneRootSignature)));
+		}
 
-        // Create a root signature for the post-process pass.
-        {
-            // We don't modify the SRV in the post-processing command list after
-            // SetGraphicsRootDescriptorTable is executed on the GPU so we can use the default
-            // range behavior: D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
-            CD3DX12_DESCRIPTOR_RANGE1 postRanges[2];
-            postRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, Settings::SceneHistoryCount, 0);
-            postRanges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
+		// Create a root signature for the post-process pass.
+		{
+			// We don't modify the SRV in the post-processing command list after
+			// SetGraphicsRootDescriptorTable is executed on the GPU so we can use the default
+			// range behavior: D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
+			CD3DX12_DESCRIPTOR_RANGE1 postRanges[2];
+			postRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, Settings::SceneHistoryCount, 0);
+			postRanges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
 
-            CD3DX12_ROOT_PARAMETER1 postRootParameters[3];
-            postRootParameters[0].InitAsDescriptorTable(1, &postRanges[0], D3D12_SHADER_VISIBILITY_PIXEL);
-            postRootParameters[1].InitAsDescriptorTable(1, &postRanges[1], D3D12_SHADER_VISIBILITY_PIXEL);
-            postRootParameters[2].InitAsConstants(2, 0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
+			CD3DX12_ROOT_PARAMETER1 postRootParameters[3];
+			postRootParameters[0].InitAsDescriptorTable(1, &postRanges[0], D3D12_SHADER_VISIBILITY_PIXEL);
+			postRootParameters[1].InitAsDescriptorTable(1, &postRanges[1], D3D12_SHADER_VISIBILITY_PIXEL);
+			postRootParameters[2].InitAsConstants(2, 0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
 
-            CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC postRootSignatureDesc;
-            postRootSignatureDesc.Init_1_1(_countof(postRootParameters), postRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+			CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC postRootSignatureDesc;
+			postRootSignatureDesc.Init_1_1(_countof(postRootParameters), postRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-            ComPtr<ID3DBlob> signature;
-            ComPtr<ID3DBlob> error;
-            ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&postRootSignatureDesc, featureData.HighestVersion, &signature, &error));
-            ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_postRootSignature)));
-        }
-    }
+			ComPtr<ID3DBlob> signature;
+			ComPtr<ID3DBlob> error;
+			ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&postRootSignatureDesc, featureData.HighestVersion, &signature, &error));
+			ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_postRootSignature)));
+		}
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        // Define the vertex input layout for the triangle scene.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		// Define the vertex input layout for the triangle scene.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        // Describe and create the graphics pipeline state objects (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_sceneRootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_SceneVS, sizeof(g_SceneVS));
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_ScenePS, sizeof(g_ScenePS));
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state objects (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_sceneRootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_SceneVS, sizeof(g_SceneVS));
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_ScenePS, sizeof(g_ScenePS));
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_scenePipelineState)));
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_scenePipelineState)));
 
-        // Define the vertex input layout for the post-process fullscreen quad.
-        D3D12_INPUT_ELEMENT_DESC postInputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+		// Define the vertex input layout for the post-process fullscreen quad.
+		D3D12_INPUT_ELEMENT_DESC postInputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        // Describe and create the PSO for the post-process pass.
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC postPsoDesc = {};
-        postPsoDesc.InputLayout = { postInputElementDescs, _countof(postInputElementDescs) };
-        postPsoDesc.pRootSignature = m_postRootSignature.Get();
-        postPsoDesc.VS = CD3DX12_SHADER_BYTECODE(g_PostVS, sizeof(g_PostVS));
-        postPsoDesc.PS = CD3DX12_SHADER_BYTECODE(g_PostPS, sizeof(g_PostPS));
-        postPsoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        postPsoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        postPsoDesc.DepthStencilState.DepthEnable = FALSE;
-        postPsoDesc.DepthStencilState.StencilEnable = FALSE;
-        postPsoDesc.SampleMask = UINT_MAX;
-        postPsoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        postPsoDesc.NumRenderTargets = 1;
-        postPsoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        postPsoDesc.SampleDesc.Count = 1;
+		// Describe and create the PSO for the post-process pass.
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC postPsoDesc = {};
+		postPsoDesc.InputLayout = { postInputElementDescs, _countof(postInputElementDescs) };
+		postPsoDesc.pRootSignature = m_postRootSignature.Get();
+		postPsoDesc.VS = CD3DX12_SHADER_BYTECODE(g_PostVS, sizeof(g_PostVS));
+		postPsoDesc.PS = CD3DX12_SHADER_BYTECODE(g_PostPS, sizeof(g_PostPS));
+		postPsoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		postPsoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		postPsoDesc.DepthStencilState.DepthEnable = FALSE;
+		postPsoDesc.DepthStencilState.StencilEnable = FALSE;
+		postPsoDesc.SampleMask = UINT_MAX;
+		postPsoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		postPsoDesc.NumRenderTargets = 1;
+		postPsoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		postPsoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&postPsoDesc, IID_PPV_ARGS(&m_postPipelineState)));
-    }
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&postPsoDesc, IID_PPV_ARGS(&m_postPipelineState)));
+	}
 
-    // Single-use command allocator/list for resource initialization.
-    ComPtr<ID3D12CommandAllocator> commandAllocator;
-    ComPtr<ID3D12GraphicsCommandList> commandList;
+	// Single-use command allocator/list for resource initialization.
+	ComPtr<ID3D12CommandAllocator> commandAllocator;
+	ComPtr<ID3D12GraphicsCommandList> commandList;
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator)));
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
 
-    // Create command lists for the scene and post-processing passes.
-    {
-        ThrowIfFailed(m_device->CreateCommandList(
-            0,
-            D3D12_COMMAND_LIST_TYPE_DIRECT,
-            m_sceneCommandAllocators[m_frameIndex].Get(),
-            m_scenePipelineState.Get(),
-            IID_PPV_ARGS(&m_sceneCommandList)));
+	// Create command lists for the scene and post-processing passes.
+	{
+		ThrowIfFailed(m_device->CreateCommandList(
+			0,
+			D3D12_COMMAND_LIST_TYPE_DIRECT,
+			m_sceneCommandAllocators[m_frameIndex].Get(),
+			m_scenePipelineState.Get(),
+			IID_PPV_ARGS(&m_sceneCommandList)));
 
-        ThrowIfFailed(m_device->CreateCommandList(
-            0,
-            D3D12_COMMAND_LIST_TYPE_DIRECT,
-            m_postCommandAllocators[m_frameIndex].Get(),
-            m_postPipelineState.Get(),
-            IID_PPV_ARGS(&m_postCommandList)));
+		ThrowIfFailed(m_device->CreateCommandList(
+			0,
+			D3D12_COMMAND_LIST_TYPE_DIRECT,
+			m_postCommandAllocators[m_frameIndex].Get(),
+			m_postPipelineState.Get(),
+			IID_PPV_ARGS(&m_postCommandList)));
 
-        // Command lists are created in the 'recording' state. We always call Reset
-        // as the first thing when populating command lists, so we need to close
-        // these here for the first frame.
-        ThrowIfFailed(m_sceneCommandList->Close());
-        ThrowIfFailed(m_postCommandList->Close());
-    }
+		// Command lists are created in the 'recording' state. We always call Reset
+		// as the first thing when populating command lists, so we need to close
+		// these here for the first frame.
+		ThrowIfFailed(m_sceneCommandList->Close());
+		ThrowIfFailed(m_postCommandList->Close());
+	}
 
-    ComPtr<ID3D12Resource> triangleVertexBufferUpload;
-    ComPtr<ID3D12Resource> quadVertexBufferUpload;
+	ComPtr<ID3D12Resource> triangleVertexBufferUpload;
+	ComPtr<ID3D12Resource> quadVertexBufferUpload;
 
-    // Create the triangle vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        SceneVertex vertices[] =
-        {
-            { { 0.0f, Settings::TriangleHalfWidth, Settings::TriangleDepth } },
-            { { Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } },
-            { { -Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } }
-        };
+	// Create the triangle vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		SceneVertex vertices[] =
+		{
+			{ { 0.0f, Settings::TriangleHalfWidth, Settings::TriangleDepth } },
+			{ { Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } },
+			{ { -Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } }
+		};
 
-        const UINT vertexBufferSize = sizeof(vertices);
+		const UINT vertexBufferSize = sizeof(vertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_sceneVertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_sceneVertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&triangleVertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&triangleVertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(vertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(vertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(commandList.Get(), m_sceneVertexBuffer.Get(), triangleVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_sceneVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(commandList.Get(), m_sceneVertexBuffer.Get(), triangleVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_sceneVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_sceneVertexBufferView.BufferLocation = m_sceneVertexBuffer->GetGPUVirtualAddress();
-        m_sceneVertexBufferView.StrideInBytes = sizeof(SceneVertex);
-        m_sceneVertexBufferView.SizeInBytes = sizeof(vertices);
-    }
+		// Initialize the vertex buffer view.
+		m_sceneVertexBufferView.BufferLocation = m_sceneVertexBuffer->GetGPUVirtualAddress();
+		m_sceneVertexBufferView.StrideInBytes = sizeof(SceneVertex);
+		m_sceneVertexBufferView.SizeInBytes = sizeof(vertices);
+	}
 
-    // Create the quad vertex buffer.
-    {
-        // Define the geometry for a quad.
-        PostVertex vertices[] =
-        {
-            { { -1.0f, -1.0f, 0.0f }, { 0.0f, 1.0f } },    // Bottom Left
-            { { -1.0f, 1.0f, 0.0f }, { 0.0f, 0.0f } },    // Top Left
-            { { 1.0f, -1.0f, 0.0f }, { 1.0f, 1.0f } },    // Bottom Right
-            { { 1.0f, 1.0f, 0.0f }, { 1.0f, 0.0f } },    // Top Right
-        };
+	// Create the quad vertex buffer.
+	{
+		// Define the geometry for a quad.
+		PostVertex vertices[] =
+		{
+			{ { -1.0f, -1.0f, 0.0f }, { 0.0f, 1.0f } },	// Bottom Left
+			{ { -1.0f, 1.0f, 0.0f }, { 0.0f, 0.0f } },	// Top Left
+			{ { 1.0f, -1.0f, 0.0f }, { 1.0f, 1.0f } },	// Bottom Right
+			{ { 1.0f, 1.0f, 0.0f }, { 1.0f, 0.0f } },	// Top Right
+		};
 
-        const UINT vertexBufferSize = sizeof(vertices);
+		const UINT vertexBufferSize = sizeof(vertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_postVertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_postVertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&quadVertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&quadVertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(vertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(vertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(commandList.Get(), m_postVertexBuffer.Get(), quadVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_postVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(commandList.Get(), m_postVertexBuffer.Get(), quadVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_postVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_postVertexBufferView.BufferLocation = m_postVertexBuffer->GetGPUVirtualAddress();
-        m_postVertexBufferView.StrideInBytes = sizeof(PostVertex);
-        m_postVertexBufferView.SizeInBytes = sizeof(vertices);
-    }
+		// Initialize the vertex buffer view.
+		m_postVertexBufferView.BufferLocation = m_postVertexBuffer->GetGPUVirtualAddress();
+		m_postVertexBufferView.StrideInBytes = sizeof(PostVertex);
+		m_postVertexBufferView.SizeInBytes = sizeof(vertices);
+	}
 
-    // Create and map the constant buffers.
-    {
-        // UPLOAD heaps are not duplicated by the Affinity layer because:
-        //   1. they live in system memory
-        //   2. they are expected to contain data that will be read by all GPUs.
-        // All of our constant buffers change each frame, so the state of any one frame
-        // is only ever read by a single GPU. Therefore, we must ensure that a large
-        // enough resource is created to persist frame data for all GPUs to read from.
-        const UINT constantBufferDataSize = Settings::TriangleCount * Settings::SceneConstantBufferFrames * sizeof(SceneConstantBuffer);
+	// Create and map the constant buffers.
+	{
+		// UPLOAD heaps are not duplicated by the Affinity layer because:
+		//   1. they live in system memory
+		//   2. they are expected to contain data that will be read by all GPUs.
+		// All of our constant buffers change each frame, so the state of any one frame
+		// is only ever read by a single GPU. Therefore, we must ensure that a large
+		// enough resource is created to persist frame data for all GPUs to read from.
+		const UINT constantBufferDataSize = Settings::TriangleCount * Settings::SceneConstantBufferFrames * sizeof(SceneConstantBuffer);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(constantBufferDataSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_sceneConstantBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(constantBufferDataSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_sceneConstantBuffer)));
 
-        // Map and initialize the constant buffer. We don't unmap this until the
-        // app closes. Keeping things mapped for the lifetime of the resource is okay.
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_sceneConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_mappedConstantBuffer)));
-        ZeroMemory(m_mappedConstantBuffer, constantBufferDataSize);
+		// Map and initialize the constant buffer. We don't unmap this until the
+		// app closes. Keeping things mapped for the lifetime of the resource is okay.
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_sceneConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_mappedConstantBuffer)));
+		ZeroMemory(m_mappedConstantBuffer, constantBufferDataSize);
 
-        // Create constant buffer views.
-        CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_sceneCbvHeap->GetCPUDescriptorHandleForHeapStart());
-        D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
-        cbvDesc.SizeInBytes = sizeof(SceneConstantBuffer);
-        cbvDesc.BufferLocation = m_sceneConstantBuffer->GetGPUVirtualAddress();
+		// Create constant buffer views.
+		CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_sceneCbvHeap->GetCPUDescriptorHandleForHeapStart());
+		D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
+		cbvDesc.SizeInBytes = sizeof(SceneConstantBuffer);
+		cbvDesc.BufferLocation = m_sceneConstantBuffer->GetGPUVirtualAddress();
 
-        for (UINT frame = 0; frame < Settings::SceneConstantBufferFrames; frame++)
-        {
-            for (UINT n = 0; n < Settings::TriangleCount; n++)
-            {
-                m_device->CreateConstantBufferView(&cbvDesc, cpuHandle);
+		for (UINT frame = 0; frame < Settings::SceneConstantBufferFrames; frame++)
+		{
+			for (UINT n = 0; n < Settings::TriangleCount; n++)
+			{
+				m_device->CreateConstantBufferView(&cbvDesc, cpuHandle);
 
-                cpuHandle.Offset(Settings::CbvSrvDescriptorSize);
-                cbvDesc.BufferLocation += cbvDesc.SizeInBytes;
-            }
-        }
-    }
+				cpuHandle.Offset(Settings::CbvSrvDescriptorSize);
+				cbvDesc.BufferLocation += cbvDesc.SizeInBytes;
+			}
+		}
+	}
 
-    for (UINT n = 0; n < Settings::TriangleCount; n++)
-    {
-        m_sceneData[n].velocity = XMFLOAT4(GetRandomFloat(0.005f, 0.01f), 0.0f, 0.0f, 0.0f);
-        m_sceneData[n].offset = XMFLOAT4(GetRandomFloat(-6.0f, -1.5f), GetRandomFloat(-1.0f, 1.0f), GetRandomFloat(0.0f, 2.0f), 0.0f);
-        m_sceneData[n].color = XMFLOAT4(GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), 1.0f);
-        m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
-    }
+	for (UINT n = 0; n < Settings::TriangleCount; n++)
+	{
+		m_sceneData[n].velocity = XMFLOAT4(GetRandomFloat(0.005f, 0.01f), 0.0f, 0.0f, 0.0f);
+		m_sceneData[n].offset = XMFLOAT4(GetRandomFloat(-6.0f, -1.5f), GetRandomFloat(-1.0f, 1.0f), GetRandomFloat(0.0f, 2.0f), 0.0f);
+		m_sceneData[n].color = XMFLOAT4(GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), 1.0f);
+		m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
+	}
 
-    // Describe and create a sampler.
-    {
-        D3D12_SAMPLER_DESC samplerDesc = {};
-        samplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-        samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.MinLOD = 0;
-        samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
-        samplerDesc.MipLODBias = 0.0f;
-        samplerDesc.MaxAnisotropy = 1;
-        samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
+	// Describe and create a sampler.
+	{
+		D3D12_SAMPLER_DESC samplerDesc = {};
+		samplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.MinLOD = 0;
+		samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
+		samplerDesc.MipLODBias = 0.0f;
+		samplerDesc.MaxAnisotropy = 1;
+		samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
 
-        m_device->CreateSampler(&samplerDesc, m_postSamplerHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		m_device->CreateSampler(&samplerDesc, m_postSamplerHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    m_sceneFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
-    m_postFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
+	m_sceneFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
+	m_postFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
 
-    ThrowIfFailed(commandList->Close());
+	ThrowIfFailed(commandList->Close());
 
-    // Submit the initialization work to the GPU.
-    ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Submit the initialization work to the GPU.
+	ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Wait for the graphics queue to finish executing the commands.
-    Fence fence(m_graphicsQueue.Get());
-    fence.FlushGpuQueue();
+	// Wait for the graphics queue to finish executing the commands.
+	Fence fence(m_graphicsQueue.Get());
+	fence.FlushGpuQueue();
 
-    LoadSizeDependentResources();
+	LoadSizeDependentResources();
 }
 
 void D3D12SingleGpu::LoadSizeDependentResources()
 {
-    // Single-use command allocator/list for resource initialization.
-    ComPtr<ID3D12CommandAllocator> commandAllocator;
-    ComPtr<ID3D12GraphicsCommandList> commandList;
+	// Single-use command allocator/list for resource initialization.
+	ComPtr<ID3D12CommandAllocator> commandAllocator;
+	ComPtr<ID3D12GraphicsCommandList> commandList;
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator)));
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
 
-    // Create RTVs for swap chain back buffers.
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart());
-    for (UINT n = 0; n < Settings::BackBufferCount; n++)
-    {
-        ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_postRenderTargets[n])));
+	// Create RTVs for swap chain back buffers.
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart());
+	for (UINT n = 0; n < Settings::BackBufferCount; n++)
+	{
+		ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_postRenderTargets[n])));
 
-        m_device->CreateRenderTargetView(m_postRenderTargets[n].Get(), nullptr, rtvHandle);
-        rtvHandle.Offset(Settings::RtvDescriptorSize);
-    }
+		m_device->CreateRenderTargetView(m_postRenderTargets[n].Get(), nullptr, rtvHandle);
+		rtvHandle.Offset(Settings::RtvDescriptorSize);
+	}
 
-    m_frameIndex = 0;
-    m_sceneRenderTargetIndex = 0;
+	m_frameIndex = 0;
+	m_sceneRenderTargetIndex = 0;
 
-    // Create the render targets used to draw the scene.
-    // These will be sampled from during the post-processing step.
-    {
-        D3D12_RESOURCE_DESC renderTargetDesc = m_postRenderTargets[0]->GetDesc();
-        D3D12_RESOURCE_ALLOCATION_INFO info = m_device->GetResourceAllocationInfo(0, 1, &renderTargetDesc);
-        const UINT64 alignedRenderTargetSize = AlignResource(info.SizeInBytes, info.Alignment);
+	// Create the render targets used to draw the scene.
+	// These will be sampled from during the post-processing step.
+	{
+		D3D12_RESOURCE_DESC renderTargetDesc = m_postRenderTargets[0]->GetDesc();
+		D3D12_RESOURCE_ALLOCATION_INFO info = m_device->GetResourceAllocationInfo(0, 1, &renderTargetDesc);
+		const UINT64 alignedRenderTargetSize = AlignResource(info.SizeInBytes, info.Alignment);
 
-        D3D12_HEAP_DESC heapDesc = {};
-        heapDesc.SizeInBytes = alignedRenderTargetSize * Settings::SceneHistoryCount;
-        heapDesc.Alignment = info.Alignment;
-        heapDesc.Properties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
-        heapDesc.Flags = D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES | D3D12_HEAP_FLAG_DENY_BUFFERS;
+		D3D12_HEAP_DESC heapDesc = {};
+		heapDesc.SizeInBytes = alignedRenderTargetSize * Settings::SceneHistoryCount;
+		heapDesc.Alignment = info.Alignment;
+		heapDesc.Properties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+		heapDesc.Flags = D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES | D3D12_HEAP_FLAG_DENY_BUFFERS;
 
-        ThrowIfFailed(m_device->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_sceneRenderTargetHeap)));
+		ThrowIfFailed(m_device->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_sceneRenderTargetHeap)));
 
-        CD3DX12_CLEAR_VALUE clearValue(DXGI_FORMAT_R8G8B8A8_UNORM, Settings::ClearColor);
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart());
-        CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_postSrvHeap->GetCPUDescriptorHandleForHeapStart());
+		CD3DX12_CLEAR_VALUE clearValue(DXGI_FORMAT_R8G8B8A8_UNORM, Settings::ClearColor);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart());
+		CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_postSrvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = 1;
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = 1;
 
-        D3D12_RESOURCE_BARRIER barriers[Settings::SceneHistoryCount];
+		D3D12_RESOURCE_BARRIER barriers[Settings::SceneHistoryCount];
 
-        for (UINT sceneIndex = 0; sceneIndex < Settings::SceneHistoryCount; sceneIndex++)
-        {
-            ThrowIfFailed(m_device->CreatePlacedResource(
-                m_sceneRenderTargetHeap.Get(),
-                alignedRenderTargetSize * sceneIndex,
-                &renderTargetDesc,
-                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                &clearValue,
-                IID_PPV_ARGS(&m_sceneRenderTargets[sceneIndex])));
+		for (UINT sceneIndex = 0; sceneIndex < Settings::SceneHistoryCount; sceneIndex++)
+		{
+			ThrowIfFailed(m_device->CreatePlacedResource(
+				m_sceneRenderTargetHeap.Get(),
+				alignedRenderTargetSize * sceneIndex,
+				&renderTargetDesc,
+				D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+				&clearValue,
+				IID_PPV_ARGS(&m_sceneRenderTargets[sceneIndex])));
 
-            barriers[sceneIndex] = CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, m_sceneRenderTargets[sceneIndex].Get());
+			barriers[sceneIndex] = CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, m_sceneRenderTargets[sceneIndex].Get());
 
-            m_device->CreateRenderTargetView(m_sceneRenderTargets[sceneIndex].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(Settings::RtvDescriptorSize);
+			m_device->CreateRenderTargetView(m_sceneRenderTargets[sceneIndex].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(Settings::RtvDescriptorSize);
 
-            m_device->CreateShaderResourceView(m_sceneRenderTargets[sceneIndex].Get(), &srvDesc, srvHandle);
-            srvHandle.Offset(Settings::CbvSrvDescriptorSize);
-        }
+			m_device->CreateShaderResourceView(m_sceneRenderTargets[sceneIndex].Get(), &srvDesc, srvHandle);
+			srvHandle.Offset(Settings::CbvSrvDescriptorSize);
+		}
 
-        commandList->ResourceBarrier(_countof(barriers), barriers);
-    }
+		commandList->ResourceBarrier(_countof(barriers), barriers);
+	}
 
-    // Create the depth stencil and its view.
-    {
-        CD3DX12_HEAP_PROPERTIES heapProps(D3D12_HEAP_TYPE_DEFAULT);
-        CD3DX12_CLEAR_VALUE depthOptimizedClearValue(DXGI_FORMAT_D32_FLOAT, 1.0f, 0);
+	// Create the depth stencil and its view.
+	{
+		CD3DX12_HEAP_PROPERTIES heapProps(D3D12_HEAP_TYPE_DEFAULT);
+		CD3DX12_CLEAR_VALUE depthOptimizedClearValue(DXGI_FORMAT_D32_FLOAT, 1.0f, 0);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &heapProps,
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, Settings::Width, Settings::Height, 1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
-            D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            &depthOptimizedClearValue,
-            IID_PPV_ARGS(&m_sceneDepthStencil)
-            ));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&heapProps,
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, Settings::Width, Settings::Height, 1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
+			D3D12_RESOURCE_STATE_DEPTH_WRITE,
+			&depthOptimizedClearValue,
+			IID_PPV_ARGS(&m_sceneDepthStencil)
+			));
 
-        D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
-        depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
-        depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+		D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
+		depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
+		depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
 
-        m_device->CreateDepthStencilView(m_sceneDepthStencil.Get(), &depthStencilDesc, m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		m_device->CreateDepthStencilView(m_sceneDepthStencil.Get(), &depthStencilDesc, m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    ThrowIfFailed(commandList->Close());
+	ThrowIfFailed(commandList->Close());
 
-    // Submit the resource barrier changes to the GPU.
-    ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Submit the resource barrier changes to the GPU.
+	ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Wait for the graphics queue to finish executing the commands.
-    Fence fence(m_graphicsQueue.Get());
-    fence.FlushGpuQueue();
+	// Wait for the graphics queue to finish executing the commands.
+	Fence fence(m_graphicsQueue.Get());
+	fence.FlushGpuQueue();
 }
 
 // Get a random float value between min and max.
 float D3D12SingleGpu::GetRandomFloat(float min, float max)
 {
-    float scale = static_cast<float>(rand()) / RAND_MAX;
-    float range = max - min;
-    return scale * range + min;
+	float scale = static_cast<float>(rand()) / RAND_MAX;
+	float range = max - min;
+	return scale * range + min;
 }
 
 void D3D12SingleGpu::UpdateWindowTitle()
 {
-    WCHAR nodeText[100];
-    swprintf_s(nodeText, L"Node Count = 1 | SyncInterval = %u | SimulatedLoad = %u", m_syncInterval, m_simulatedGpuLoad);
-    SetCustomWindowText(nodeText);
+	WCHAR nodeText[100];
+	swprintf_s(nodeText, L"Node Count = 1 | SyncInterval = %u | SimulatedLoad = %u", m_syncInterval, m_simulatedGpuLoad);
+	SetCustomWindowText(nodeText);
 }
 
 // Update frame-based values.
 void D3D12SingleGpu::OnUpdate()
 {
-    for (UINT n = 0; n < Settings::TriangleCount; n++)
-    {
-        const float offsetBounds = 1.5f * m_aspectRatio;
+	for (UINT n = 0; n < Settings::TriangleCount; n++)
+	{
+		const float offsetBounds = 1.5f * m_aspectRatio;
 
-        // Animate the triangles.
-        m_sceneData[n].offset.x += m_sceneData[n].velocity.x;
-        if (m_sceneData[n].offset.x > offsetBounds)
-        {
-            m_sceneData[n].velocity.x = GetRandomFloat(0.005f, 0.01f);
-            m_sceneData[n].offset.x = -offsetBounds;
-        }
-    }
+		// Animate the triangles.
+		m_sceneData[n].offset.x += m_sceneData[n].velocity.x;
+		if (m_sceneData[n].offset.x > offsetBounds)
+		{
+			m_sceneData[n].velocity.x = GetRandomFloat(0.005f, 0.01f);
+			m_sceneData[n].offset.x = -offsetBounds;
+		}
+	}
 
-    UINT index = m_frameId % Settings::SceneConstantBufferFrames;
-    UINT offset = Settings::TriangleCount * index * sizeof(SceneConstantBuffer);
+	UINT index = m_frameId % Settings::SceneConstantBufferFrames;
+	UINT offset = Settings::TriangleCount * index * sizeof(SceneConstantBuffer);
 
-    memcpy(m_mappedConstantBuffer + offset, m_sceneData.data(), Settings::TriangleCount * sizeof(SceneConstantBuffer));
+	memcpy(m_mappedConstantBuffer + offset, m_sceneData.data(), Settings::TriangleCount * sizeof(SceneConstantBuffer));
 }
 
 // Render the scene.
 void D3D12SingleGpu::OnRender()
 {
-    if (m_windowVisible)
-    {
-        // Render and present the current frame.
-        RenderScene();
-        RenderPost();
+	if (m_windowVisible)
+	{
+		// Render and present the current frame.
+		RenderScene();
+		RenderPost();
 
-        // When using sync interval 0, it is recommended to always pass the tearing
-        // flag when it is supported, even if not presenting to a fullscreen window.
-        // This flag cannot be used if the app is in "exclusive" fullscreen mode as
-        // a result of calling SetFullscreenState.
+		// When using sync interval 0, it is recommended to always pass the tearing
+		// flag when it is supported, even if not presenting to a fullscreen window.
+		// This flag cannot be used if the app is in "exclusive" fullscreen mode as
+		// a result of calling SetFullscreenState.
 
-        UINT presentFlags = (m_syncInterval == 0 && m_tearingSupport && m_windowedMode) ? DXGI_PRESENT_ALLOW_TEARING : 0;
-        ThrowIfFailed(m_swapChain->Present(m_syncInterval, presentFlags));
+		UINT presentFlags = (m_syncInterval == 0 && m_tearingSupport && m_windowedMode) ? DXGI_PRESENT_ALLOW_TEARING : 0;
+		ThrowIfFailed(m_swapChain->Present(m_syncInterval, presentFlags));
 
-        MoveToNextFrame();
-    }
+		MoveToNextFrame();
+	}
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12SingleGpu::RenderScene()
 {
-    UINT cbvDescriptorTableOffset = Settings::TriangleCount * (m_frameId % Settings::SceneConstantBufferFrames);
-    CD3DX12_GPU_DESCRIPTOR_HANDLE cbvHandle(m_sceneCbvHeap->GetGPUDescriptorHandleForHeapStart(), cbvDescriptorTableOffset, Settings::CbvSrvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart(), m_sceneRenderTargetIndex, Settings::RtvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
+	UINT cbvDescriptorTableOffset = Settings::TriangleCount * (m_frameId % Settings::SceneConstantBufferFrames);
+	CD3DX12_GPU_DESCRIPTOR_HANDLE cbvHandle(m_sceneCbvHeap->GetGPUDescriptorHandleForHeapStart(), cbvDescriptorTableOffset, Settings::CbvSrvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart(), m_sceneRenderTargetIndex, Settings::RtvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
 
-    m_sceneFence->Next();
+	m_sceneFence->Next();
 
-    // Record the rendering commands.
-    ThrowIfFailed(m_sceneCommandAllocators[m_frameIndex]->Reset());
-    ThrowIfFailed(m_sceneCommandList->Reset(m_sceneCommandAllocators[m_frameIndex].Get(), m_scenePipelineState.Get()));
+	// Record the rendering commands.
+	ThrowIfFailed(m_sceneCommandAllocators[m_frameIndex]->Reset());
+	ThrowIfFailed(m_sceneCommandList->Reset(m_sceneCommandAllocators[m_frameIndex].Get(), m_scenePipelineState.Get()));
 
-    // Set necessary state.
-    m_sceneCommandList->SetGraphicsRootSignature(m_sceneRootSignature.Get());
-    m_sceneCommandList->SetGraphicsRoot32BitConstant(1, m_simulatedGpuLoad, 0);
+	// Set necessary state.
+	m_sceneCommandList->SetGraphicsRootSignature(m_sceneRootSignature.Get());
+	m_sceneCommandList->SetGraphicsRoot32BitConstant(1, m_simulatedGpuLoad, 0);
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_sceneCbvHeap.Get() };
-    m_sceneCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_sceneCbvHeap.Get() };
+	m_sceneCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_sceneCommandList->RSSetViewports(1, &Settings::Viewport);
-    m_sceneCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
-    m_sceneCommandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
+	m_sceneCommandList->RSSetViewports(1, &Settings::Viewport);
+	m_sceneCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
+	m_sceneCommandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
 
-    // Record commands.
-    D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(
-        m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(),
-        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-        D3D12_RESOURCE_STATE_RENDER_TARGET);
+	// Record commands.
+	D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(
+		m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(),
+		D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+		D3D12_RESOURCE_STATE_RENDER_TARGET);
 
-    m_sceneCommandList->ResourceBarrier(1, &barrier);
-    m_sceneCommandList->ClearRenderTargetView(rtvHandle, Settings::ClearColor, 0, nullptr);
-    m_sceneCommandList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+	m_sceneCommandList->ResourceBarrier(1, &barrier);
+	m_sceneCommandList->ClearRenderTargetView(rtvHandle, Settings::ClearColor, 0, nullptr);
+	m_sceneCommandList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
 
-    m_sceneCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    m_sceneCommandList->IASetVertexBuffers(0, 1, &m_sceneVertexBufferView);
+	m_sceneCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_sceneCommandList->IASetVertexBuffers(0, 1, &m_sceneVertexBufferView);
 
-    for (UINT triangle = 0; triangle < Settings::TriangleCount; triangle++)
-    {
-        m_sceneCommandList->SetGraphicsRootDescriptorTable(0, cbvHandle);
-        m_sceneCommandList->DrawInstanced(3, 1, 0, 0);
+	for (UINT triangle = 0; triangle < Settings::TriangleCount; triangle++)
+	{
+		m_sceneCommandList->SetGraphicsRootDescriptorTable(0, cbvHandle);
+		m_sceneCommandList->DrawInstanced(3, 1, 0, 0);
 
-        cbvHandle.Offset(Settings::CbvSrvDescriptorSize);
-    }
+		cbvHandle.Offset(Settings::CbvSrvDescriptorSize);
+	}
 
-    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-    m_sceneCommandList->ResourceBarrier(1, &barrier);
+	barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	m_sceneCommandList->ResourceBarrier(1, &barrier);
 
-    ThrowIfFailed(m_sceneCommandList->Close());
+	ThrowIfFailed(m_sceneCommandList->Close());
 
-    ID3D12CommandList* ppSceneCommandLists[] = { m_sceneCommandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppSceneCommandLists), ppSceneCommandLists);
+	ID3D12CommandList* ppSceneCommandLists[] = { m_sceneCommandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppSceneCommandLists), ppSceneCommandLists);
 
-    m_sceneFence->Signal();
+	m_sceneFence->Signal();
 }
 
 void D3D12SingleGpu::RenderPost()
 {
-    UINT backBufferIndex = m_swapChain->GetCurrentBackBufferIndex();
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart(), backBufferIndex, Settings::RtvDescriptorSize);
+	UINT backBufferIndex = m_swapChain->GetCurrentBackBufferIndex();
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart(), backBufferIndex, Settings::RtvDescriptorSize);
 
-    m_postFence->Next();
+	m_postFence->Next();
 
-    ThrowIfFailed(m_postCommandAllocators[m_frameIndex]->Reset());
-    ThrowIfFailed(m_postCommandList->Reset(m_postCommandAllocators[m_frameIndex].Get(), m_postPipelineState.Get()));
+	ThrowIfFailed(m_postCommandAllocators[m_frameIndex]->Reset());
+	ThrowIfFailed(m_postCommandList->Reset(m_postCommandAllocators[m_frameIndex].Get(), m_postPipelineState.Get()));
 
-    m_postCommandList->SetGraphicsRootSignature(m_postRootSignature.Get());
+	m_postCommandList->SetGraphicsRootSignature(m_postRootSignature.Get());
 
-    ID3D12DescriptorHeap* ppPostHeaps[] = { m_postSrvHeap.Get(), m_postSamplerHeap.Get() };
-    m_postCommandList->SetDescriptorHeaps(_countof(ppPostHeaps), ppPostHeaps);
+	ID3D12DescriptorHeap* ppPostHeaps[] = { m_postSrvHeap.Get(), m_postSamplerHeap.Get() };
+	m_postCommandList->SetDescriptorHeaps(_countof(ppPostHeaps), ppPostHeaps);
 
-    m_postCommandList->RSSetViewports(1, &Settings::Viewport);
-    m_postCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
+	m_postCommandList->RSSetViewports(1, &Settings::Viewport);
+	m_postCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
 
-    D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(
-        m_postRenderTargets[backBufferIndex].Get(),
-        D3D12_RESOURCE_STATE_PRESENT,
-        D3D12_RESOURCE_STATE_RENDER_TARGET);
+	D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(
+		m_postRenderTargets[backBufferIndex].Get(),
+		D3D12_RESOURCE_STATE_PRESENT,
+		D3D12_RESOURCE_STATE_RENDER_TARGET);
 
-    m_postCommandList->ResourceBarrier(1, &barrier);
+	m_postCommandList->ResourceBarrier(1, &barrier);
 
-    m_postCommandList->OMSetRenderTargets(1, &rtvHandle, false, nullptr);
+	m_postCommandList->OMSetRenderTargets(1, &rtvHandle, false, nullptr);
 
-    m_postCommandList->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-    m_postCommandList->IASetVertexBuffers(0, 1, &m_postVertexBufferView);
+	m_postCommandList->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+	m_postCommandList->IASetVertexBuffers(0, 1, &m_postVertexBufferView);
 
-    m_postCommandList->SetGraphicsRootDescriptorTable(0, m_postSrvHeap->GetGPUDescriptorHandleForHeapStart());
-    m_postCommandList->SetGraphicsRootDescriptorTable(1, m_postSamplerHeap->GetGPUDescriptorHandleForHeapStart());
-    m_postCommandList->SetGraphicsRoot32BitConstant(2, m_frameId % Settings::SceneHistoryCount, 0);
-    m_postCommandList->SetGraphicsRoot32BitConstant(2, static_cast<UINT>(min(m_frameId + 1, Settings::SceneHistoryCount)), 1);
+	m_postCommandList->SetGraphicsRootDescriptorTable(0, m_postSrvHeap->GetGPUDescriptorHandleForHeapStart());
+	m_postCommandList->SetGraphicsRootDescriptorTable(1, m_postSamplerHeap->GetGPUDescriptorHandleForHeapStart());
+	m_postCommandList->SetGraphicsRoot32BitConstant(2, m_frameId % Settings::SceneHistoryCount, 0);
+	m_postCommandList->SetGraphicsRoot32BitConstant(2, static_cast<UINT>(min(m_frameId + 1, Settings::SceneHistoryCount)), 1);
 
-    m_postCommandList->DrawInstanced(4, 1, 0, 0);
+	m_postCommandList->DrawInstanced(4, 1, 0, 0);
 
-    // Indicate that the back buffer will now be used to present.
-    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
+	// Indicate that the back buffer will now be used to present.
+	barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
 
-    m_postCommandList->ResourceBarrier(1, &barrier);
+	m_postCommandList->ResourceBarrier(1, &barrier);
 
-    ThrowIfFailed(m_postCommandList->Close());
+	ThrowIfFailed(m_postCommandList->Close());
 
-    ID3D12CommandList* ppPostCommandLists[] = { m_postCommandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppPostCommandLists), ppPostCommandLists);
+	ID3D12CommandList* ppPostCommandLists[] = { m_postCommandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppPostCommandLists), ppPostCommandLists);
 }
 
 void D3D12SingleGpu::OnSizeChanged(UINT width, UINT height, bool minimized)
 {
-    // Determine if the swap buffers and other resources need to be resized or not.
-    if ((width != m_width || height != m_height) && !minimized)
-    {
-        // Flush all current GPU commands.
-        WaitForGpu();
+	// Determine if the swap buffers and other resources need to be resized or not.
+	if ((width != m_width || height != m_height) && !minimized)
+	{
+		// Flush all current GPU commands.
+		WaitForGpu();
 
-        // Release buffers tied to the swap chain and update the global Settings
-        // for the new size.
-        for (UINT n = 0; n < Settings::BackBufferCount; n++)
-        {
-            m_postRenderTargets[n].Reset();
-        }
-        Settings::OnSizeChanged(width, height);
+		// Release buffers tied to the swap chain and update the global Settings
+		// for the new size.
+		for (UINT n = 0; n < Settings::BackBufferCount; n++)
+		{
+			m_postRenderTargets[n].Reset();
+		}
+		Settings::OnSizeChanged(width, height);
 
-        // Resize the swap chain to the desired dimensions.
-        DXGI_SWAP_CHAIN_DESC1 swapChainDesc;
-        ThrowIfFailed(m_swapChain->GetDesc1(&swapChainDesc));
-        ThrowIfFailed(m_swapChain->ResizeBuffers(Settings::BackBufferCount, width, height, swapChainDesc.Format, swapChainDesc.Flags));
+		// Resize the swap chain to the desired dimensions.
+		DXGI_SWAP_CHAIN_DESC1 swapChainDesc;
+		ThrowIfFailed(m_swapChain->GetDesc1(&swapChainDesc));
+		ThrowIfFailed(m_swapChain->ResizeBuffers(Settings::BackBufferCount, width, height, swapChainDesc.Format, swapChainDesc.Flags));
 
-        BOOL fullscreenState;
-        ThrowIfFailed(m_swapChain->GetFullscreenState(&fullscreenState, nullptr));
-        m_windowedMode = !fullscreenState;
+		BOOL fullscreenState;
+		ThrowIfFailed(m_swapChain->GetFullscreenState(&fullscreenState, nullptr));
+		m_windowedMode = !fullscreenState;
 
-        // Re-create render targets.
-        LoadSizeDependentResources();
+		// Re-create render targets.
+		LoadSizeDependentResources();
 
-        // Align the frameId so that assumptions in post-processing hold.
-        m_frameId += (Settings::SceneHistoryCount - (m_frameId % Settings::SceneHistoryCount));
+		// Align the frameId so that assumptions in post-processing hold.
+		m_frameId += (Settings::SceneHistoryCount - (m_frameId % Settings::SceneHistoryCount));
 
-        // Update the m_width, m_height, and m_aspectRatio member variables.
-        UpdateForSizeChange(width, height);
+		// Update the m_width, m_height, and m_aspectRatio member variables.
+		UpdateForSizeChange(width, height);
 
-        // Update the scene projection matrix.
-        for (UINT n = 0; n < Settings::TriangleCount; n++)
-        {
-            m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
-        }
-    }
+		// Update the scene projection matrix.
+		for (UINT n = 0; n < Settings::TriangleCount; n++)
+		{
+			m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
+		}
+	}
 
-    m_windowVisible = !minimized;
+	m_windowVisible = !minimized;
 }
 
 void D3D12SingleGpu::OnKeyDown(UINT8 key)
 {
-    switch (key)
-    {
-    // Instrument the Space Bar to toggle between fullscreen states.
-    // The window message loop callback will receive a WM_SIZE message once the
-    // window is in the fullscreen state. At that point, the IDXGISwapChain should
-    // be resized to match the new window size.
-    //
-    // NOTE: ALT+Enter will perform a similar operation; the code below is not
-    // required to enable that key combination.
-    case VK_SPACE:
-    {
-        if (m_tearingSupport)
-        {
-            Win32Application::ToggleFullscreenWindow();
-        }
-        else
-        {
-            BOOL fullscreenState;
+	switch (key)
+	{
+	// Instrument the Space Bar to toggle between fullscreen states.
+	// The window message loop callback will receive a WM_SIZE message once the
+	// window is in the fullscreen state. At that point, the IDXGISwapChain should
+	// be resized to match the new window size.
+	//
+	// NOTE: ALT+Enter will perform a similar operation; the code below is not
+	// required to enable that key combination.
+	case VK_SPACE:
+	{
+		if (m_tearingSupport)
+		{
+			Win32Application::ToggleFullscreenWindow();
+		}
+		else
+		{
+			BOOL fullscreenState;
 
-            ThrowIfFailed(m_swapChain->GetFullscreenState(&fullscreenState, nullptr));
-            if (FAILED(m_swapChain->SetFullscreenState(!fullscreenState, nullptr)))
-            {
-                // Transitions to fullscreen mode can fail when running apps over
-                // terminal services or for some other unexpected reason.  Consider
-                // notifying the user in some way when this happens.
-                OutputDebugString(L"Fullscreen transition failed");
-                _ASSERT(false);
-            }
-        }
-        break;
-    }
+			ThrowIfFailed(m_swapChain->GetFullscreenState(&fullscreenState, nullptr));
+			if (FAILED(m_swapChain->SetFullscreenState(!fullscreenState, nullptr)))
+			{
+				// Transitions to fullscreen mode can fail when running apps over
+				// terminal services or for some other unexpected reason.  Consider
+				// notifying the user in some way when this happens.
+				OutputDebugString(L"Fullscreen transition failed");
+				_ASSERT(false);
+			}
+		}
+		break;
+	}
 
-    case VK_LEFT:
-    case VK_RIGHT:
-        m_syncInterval = (m_syncInterval > 0) ? 0 : 1;
-        UpdateWindowTitle();
-        break;
+	case VK_LEFT:
+	case VK_RIGHT:
+		m_syncInterval = (m_syncInterval > 0) ? 0 : 1;
+		UpdateWindowTitle();
+		break;
 
-    case VK_UP:
-        if (m_simulatedGpuLoad > 0)
-        {
-            if (m_simulatedGpuLoad < 0x80000)
-            {
-                m_simulatedGpuLoad <<= 1;
-            }
-        }
-        else
-        {
-            m_simulatedGpuLoad = 1;
-        }
-        UpdateWindowTitle();
-        break;
+	case VK_UP:
+		if (m_simulatedGpuLoad > 0)
+		{
+			if (m_simulatedGpuLoad < 0x80000)
+			{
+				m_simulatedGpuLoad <<= 1;
+			}
+		}
+		else
+		{
+			m_simulatedGpuLoad = 1;
+		}
+		UpdateWindowTitle();
+		break;
 
-    case VK_DOWN:
-        if (m_simulatedGpuLoad != 0)
-        {
-            m_simulatedGpuLoad >>= 1;
-        }
-        UpdateWindowTitle();
-        break;
-    }
+	case VK_DOWN:
+		if (m_simulatedGpuLoad != 0)
+		{
+			m_simulatedGpuLoad >>= 1;
+		}
+		UpdateWindowTitle();
+		break;
+	}
 }
 
 void D3D12SingleGpu::OnDestroy()
 {
-    // Wait for the GPUs to be done with all their resources.
-    WaitForGpu();
+	// Wait for the GPUs to be done with all their resources.
+	WaitForGpu();
 
-    if (!m_tearingSupport)
-    {
-        m_swapChain->SetFullscreenState(FALSE, nullptr);
-    }
+	if (!m_tearingSupport)
+	{
+		m_swapChain->SetFullscreenState(FALSE, nullptr);
+	}
 }
 
 // Wait for pending GPU work to complete.
 void D3D12SingleGpu::WaitForGpu()
 {
-    m_postFence->FlushGpuQueue();
+	m_postFence->FlushGpuQueue();
 }
 
 // Prepare to render the next frame.
 void D3D12SingleGpu::MoveToNextFrame()
 {
-    m_postFence->Signal();
+	m_postFence->Signal();
 
-    // Advance to the next frame.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Advance to the next frame.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    m_sceneRenderTargetIndex = (m_sceneRenderTargetIndex + 1) % Settings::SceneHistoryCount;
+	m_sceneRenderTargetIndex = (m_sceneRenderTargetIndex + 1) % Settings::SceneHistoryCount;
 
-    m_frameId++;
+	m_frameId++;
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/D3D12SingleGpu.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/D3D12SingleGpu.h
@@ -22,104 +22,104 @@ using Microsoft::WRL::ComPtr;
 class D3D12SingleGpu : public DXSample
 {
 public:
-    D3D12SingleGpu(UINT width, UINT height, std::wstring name);
+	D3D12SingleGpu(UINT width, UINT height, std::wstring name);
 
 protected:
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
-    virtual void OnKeyDown(UINT8 key);
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
+	virtual void OnKeyDown(UINT8 key);
+	virtual void OnDestroy();
 
 private:
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12CommandQueue> m_graphicsQueue;
-    std::vector<ComPtr<ID3D12CommandAllocator>> m_sceneCommandAllocators;
-    std::vector<ComPtr<ID3D12CommandAllocator>> m_postCommandAllocators;
-    ComPtr<ID3D12DescriptorHeap> m_sceneRtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_sceneDsvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_sceneCbvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_postRtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_postSrvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_postSamplerHeap;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12CommandQueue> m_graphicsQueue;
+	std::vector<ComPtr<ID3D12CommandAllocator>> m_sceneCommandAllocators;
+	std::vector<ComPtr<ID3D12CommandAllocator>> m_postCommandAllocators;
+	ComPtr<ID3D12DescriptorHeap> m_sceneRtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_sceneDsvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_sceneCbvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_postRtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_postSrvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_postSamplerHeap;
 
-    // Objects used for rendering the scene.
-    ComPtr<ID3D12GraphicsCommandList> m_sceneCommandList;
-    ComPtr<ID3D12RootSignature> m_sceneRootSignature;
-    ComPtr<ID3D12PipelineState> m_scenePipelineState;
-    ComPtr<ID3D12Resource> m_sceneVertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_sceneVertexBufferView;
-    ComPtr<ID3D12Resource> m_sceneConstantBuffer;
-    UINT8* m_mappedConstantBuffer;
-    ComPtr<ID3D12Heap> m_sceneRenderTargetHeap;
-    std::vector<ComPtr<ID3D12Resource>> m_sceneRenderTargets;
-    ComPtr<ID3D12Resource> m_sceneDepthStencil;
+	// Objects used for rendering the scene.
+	ComPtr<ID3D12GraphicsCommandList> m_sceneCommandList;
+	ComPtr<ID3D12RootSignature> m_sceneRootSignature;
+	ComPtr<ID3D12PipelineState> m_scenePipelineState;
+	ComPtr<ID3D12Resource> m_sceneVertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_sceneVertexBufferView;
+	ComPtr<ID3D12Resource> m_sceneConstantBuffer;
+	UINT8* m_mappedConstantBuffer;
+	ComPtr<ID3D12Heap> m_sceneRenderTargetHeap;
+	std::vector<ComPtr<ID3D12Resource>> m_sceneRenderTargets;
+	ComPtr<ID3D12Resource> m_sceneDepthStencil;
 
-    // Objects used for post-processing.
-    ComPtr<ID3D12GraphicsCommandList> m_postCommandList;
-    ComPtr<ID3D12RootSignature> m_postRootSignature;
-    ComPtr<ID3D12PipelineState> m_postPipelineState;
-    ComPtr<ID3D12Resource> m_postVertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_postVertexBufferView;
-    std::vector<ComPtr<ID3D12Resource>> m_postRenderTargets;
+	// Objects used for post-processing.
+	ComPtr<ID3D12GraphicsCommandList> m_postCommandList;
+	ComPtr<ID3D12RootSignature> m_postRootSignature;
+	ComPtr<ID3D12PipelineState> m_postPipelineState;
+	ComPtr<ID3D12Resource> m_postVertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_postVertexBufferView;
+	std::vector<ComPtr<ID3D12Resource>> m_postRenderTargets;
 
-    // A fence to indicate when the scene pass is complete.
-    std::shared_ptr<LinearFence> m_sceneFence;
+	// A fence to indicate when the scene pass is complete.
+	std::shared_ptr<LinearFence> m_sceneFence;
 
-    // A fence to regulate submission of post-processing render passes.
-    // Up to 'Settings::FrameCount' command lists can be in flight on the node at once.
-    std::shared_ptr<LinearFence> m_postFence;
+	// A fence to regulate submission of post-processing render passes.
+	// Up to 'Settings::FrameCount' command lists can be in flight on the node at once.
+	std::shared_ptr<LinearFence> m_postFence;
 
-    // Vertex definitions.
-    struct SceneVertex
-    {
-        DirectX::XMFLOAT3 position;
-    };
+	// Vertex definitions.
+	struct SceneVertex
+	{
+		DirectX::XMFLOAT3 position;
+	};
 
-    struct PostVertex
-    {
-        DirectX::XMFLOAT3 position;
-        DirectX::XMFLOAT2 uv;
-    };
+	struct PostVertex
+	{
+		DirectX::XMFLOAT3 position;
+		DirectX::XMFLOAT2 uv;
+	};
 
-    // Constant buffer definition.
-    struct SceneConstantBuffer
-    {
-        DirectX::XMFLOAT4 velocity;
-        DirectX::XMFLOAT4 offset;
-        DirectX::XMFLOAT4 color;
-        DirectX::XMMATRIX projection;
+	// Constant buffer definition.
+	struct SceneConstantBuffer
+	{
+		DirectX::XMFLOAT4 velocity;
+		DirectX::XMFLOAT4 offset;
+		DirectX::XMFLOAT4 color;
+		DirectX::XMMATRIX projection;
 
-        // Constant buffers are 256-byte aligned. Add padding in the struct to allow
-        // multiple buffers to be array-indexed.
-        float padding[36];
-    };
+		// Constant buffers are 256-byte aligned. Add padding in the struct to allow
+		// multiple buffers to be array-indexed.
+		float padding[36];
+	};
 
-    // Data about each of the triangles in the scene.
-    std::vector<SceneConstantBuffer> m_sceneData;
+	// Data about each of the triangles in the scene.
+	std::vector<SceneConstantBuffer> m_sceneData;
 
-    UINT64 m_frameId;
-    UINT m_simulatedGpuLoad;
-    UINT m_frameIndex;
-    UINT m_sceneRenderTargetIndex;
-    UINT m_syncInterval;
-    bool m_windowVisible;
-    bool m_windowedMode;
+	UINT64 m_frameId;
+	UINT m_simulatedGpuLoad;
+	UINT m_frameIndex;
+	UINT m_sceneRenderTargetIndex;
+	UINT m_syncInterval;
+	bool m_windowVisible;
+	bool m_windowedMode;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void LoadSizeDependentResources();
-    float GetRandomFloat(float min, float max);
-    void UpdateWindowTitle();
-    void RenderScene();
-    void RenderPost();
-    void WaitForGpu();
-    void MoveToNextFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	void LoadSizeDependentResources();
+	float GetRandomFloat(float min, float max);
+	void UpdateWindowTitle();
+	void RenderScene();
+	void RenderPost();
+	void WaitForGpu();
+	void MoveToNextFrame();
 
-    static inline UINT64 AlignResource(UINT64 size, UINT64 alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT)
-    {
-        return (size + alignment - 1) & ~(alignment - 1);
-    }
+	static inline UINT64 AlignResource(UINT64 size, UINT64 alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT)
+	{
+		return (size + alignment - 1) & ~(alignment - 1);
+	}
 };

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/DXSample.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/DXSample.cpp
@@ -52,33 +52,78 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
+
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+            }
+#if !defined(_XBOX_ONE)
+        }
+#endif
 
     *ppAdapter = adapter.Detach();
-}
+    }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/DXSample.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/DXSample.h
@@ -49,7 +49,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/Fence.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/Fence.h
@@ -20,138 +20,138 @@ using Microsoft::WRL::ComPtr;
 class Fence
 {
 public:
-    // Create a fence and associate it with the specified command queue for
-    // convenience in working with fences.
-    Fence(ID3D12CommandQueue* pQueue) :
-        m_currentFenceValue(0)
-    {
-        ThrowIfFailed(pQueue->QueryInterface(IID_PPV_ARGS(&m_queue)));
+	// Create a fence and associate it with the specified command queue for
+	// convenience in working with fences.
+	Fence(ID3D12CommandQueue* pQueue) :
+		m_currentFenceValue(0)
+	{
+		ThrowIfFailed(pQueue->QueryInterface(IID_PPV_ARGS(&m_queue)));
 
-        ComPtr<ID3D12Device> device;
-        ThrowIfFailed(m_queue->GetDevice(IID_PPV_ARGS(&device)));
+		ComPtr<ID3D12Device> device;
+		ThrowIfFailed(m_queue->GetDevice(IID_PPV_ARGS(&device)));
 
-        ThrowIfFailed(device->CreateFence(m_currentFenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		ThrowIfFailed(device->CreateFence(m_currentFenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
 
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
-    }
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
+	}
 
-    ~Fence()
-    {
-        if (m_fenceEvent)
-        {
-            CloseHandle(m_fenceEvent);
-            m_fenceEvent = nullptr;
-        }
-    }
+	~Fence()
+	{
+		if (m_fenceEvent)
+		{
+			CloseHandle(m_fenceEvent);
+			m_fenceEvent = nullptr;
+		}
+	}
 
-    // Drain the GPU command queue.
-    // (Blocks the calling CPU thread)
-    inline void FlushGpuQueue()
-    {
-        Signal();
-        CpuWait(m_currentFenceValue);
-    }
+	// Drain the GPU command queue.
+	// (Blocks the calling CPU thread)
+	inline void FlushGpuQueue()
+	{
+		Signal();
+		CpuWait(m_currentFenceValue);
+	}
 
-    // Issue a Signal command on the command queue.
-    // Use the current value of the fence or override it with your own value.
-    inline void Signal(UINT64 value = UnspecifiedFenceValue)
-    {
-        if (value == UnspecifiedFenceValue)
-        {
-            m_currentFenceValue++;
-        }
-        else
-        {
-            _ASSERT(value > m_currentFenceValue);
-            m_currentFenceValue = value;
-        }
+	// Issue a Signal command on the command queue.
+	// Use the current value of the fence or override it with your own value.
+	inline void Signal(UINT64 value = UnspecifiedFenceValue)
+	{
+		if (value == UnspecifiedFenceValue)
+		{
+			m_currentFenceValue++;
+		}
+		else
+		{
+			_ASSERT(value > m_currentFenceValue);
+			m_currentFenceValue = value;
+		}
 
-        ThrowIfFailed(m_queue->Signal(m_fence.Get(), m_currentFenceValue));
-    }
+		ThrowIfFailed(m_queue->Signal(m_fence.Get(), m_currentFenceValue));
+	}
 
-    // Instruct the GPU queue associated with this fence to wait for a value to be signaled.
-    // Use the current value of the fence or override it with your own value.
-    // (Does not block the calling CPU thread)
-    inline void GpuWait(UINT64 value = UnspecifiedFenceValue)
-    {
-        if (value == UnspecifiedFenceValue)
-        {
-            value = m_currentFenceValue;
-        }
+	// Instruct the GPU queue associated with this fence to wait for a value to be signaled.
+	// Use the current value of the fence or override it with your own value.
+	// (Does not block the calling CPU thread)
+	inline void GpuWait(UINT64 value = UnspecifiedFenceValue)
+	{
+		if (value == UnspecifiedFenceValue)
+		{
+			value = m_currentFenceValue;
+		}
 
-        ThrowIfFailed(m_queue->Wait(m_fence.Get(), value));
-    }
+		ThrowIfFailed(m_queue->Wait(m_fence.Get(), value));
+	}
 
-    // Instruct a GPU queue on the active node to wait for the fences on the other nodes.
-    // Use the current values of the fences or override them with your own value.
-    // (Does not block the calling CPU thread)
-    inline static void GpuWait(ID3D12CommandQueue* pQueue, Fence* pFence, UINT64 value = UnspecifiedFenceValue)
-    {
-        if (value == UnspecifiedFenceValue)
-        {
-            value = pFence->m_currentFenceValue;
-        }
+	// Instruct a GPU queue on the active node to wait for the fences on the other nodes.
+	// Use the current values of the fences or override them with your own value.
+	// (Does not block the calling CPU thread)
+	inline static void GpuWait(ID3D12CommandQueue* pQueue, Fence* pFence, UINT64 value = UnspecifiedFenceValue)
+	{
+		if (value == UnspecifiedFenceValue)
+		{
+			value = pFence->m_currentFenceValue;
+		}
 
-        pQueue->Wait(pFence->m_fence.Get(), value);
-    }
+		pQueue->Wait(pFence->m_fence.Get(), value);
+	}
 
 protected:
-    // Block the calling CPU thread until the GPU has signaled the specified fence.
-    inline void CpuWait(UINT64 fenceValue = UnspecifiedFenceValue)
-    {
-        if (fenceValue == UnspecifiedFenceValue)
-        {
-            fenceValue = m_currentFenceValue;
-        }
+	// Block the calling CPU thread until the GPU has signaled the specified fence.
+	inline void CpuWait(UINT64 fenceValue = UnspecifiedFenceValue)
+	{
+		if (fenceValue == UnspecifiedFenceValue)
+		{
+			fenceValue = m_currentFenceValue;
+		}
 
-        if (m_fence->GetCompletedValue() < fenceValue)
-        {
-            ThrowIfFailed(m_fence->SetEventOnCompletion(fenceValue, m_fenceEvent));
-            WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-        }
-    }
+		if (m_fence->GetCompletedValue() < fenceValue)
+		{
+			ThrowIfFailed(m_fence->SetEventOnCompletion(fenceValue, m_fenceEvent));
+			WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+		}
+	}
 
-    static const UINT64 UnspecifiedFenceValue = UINT64_MAX;
+	static const UINT64 UnspecifiedFenceValue = UINT64_MAX;
 
-    ComPtr<ID3D12Fence> m_fence;            // The D3D12 fence object.
-    ComPtr<ID3D12CommandQueue> m_queue;    // The command queue associated with this fence.
-    UINT64 m_currentFenceValue;                        // The last value signaled by this fence.
-    HANDLE m_fenceEvent;                            // CPU-waitable event handle.
+	ComPtr<ID3D12Fence> m_fence;			// The D3D12 fence object.
+	ComPtr<ID3D12CommandQueue> m_queue;	// The command queue associated with this fence.
+	UINT64 m_currentFenceValue;						// The last value signaled by this fence.
+	HANDLE m_fenceEvent;							// CPU-waitable event handle.
 };
 
 class LinearFence : public Fence
 {
 public:
-    // This fence implementation manages a ring buffer of issued Signal events.
-    // The "Next" API instructs the Fence to move to the next slot in the ring buffer.
-    // If the next slot represents a fence value that has not yet been signaled by
-    // the GPU, then the CPU will wait until that fence is signaled before continuing.
-    // 
-    // In this sample, LinearFences are used to guard against premature resetting
-    // of command allocators and modifying of upload heaps that might currently be
-    // in use by the GPU.
-    LinearFence(ID3D12CommandQueue* pQueue, UINT count) :
-        Fence(pQueue),
-        m_signalIndex(0)
-    {
-        m_signalHistory.resize(count);
-    }
+	// This fence implementation manages a ring buffer of issued Signal events.
+	// The "Next" API instructs the Fence to move to the next slot in the ring buffer.
+	// If the next slot represents a fence value that has not yet been signaled by
+	// the GPU, then the CPU will wait until that fence is signaled before continuing.
+	// 
+	// In this sample, LinearFences are used to guard against premature resetting
+	// of command allocators and modifying of upload heaps that might currently be
+	// in use by the GPU.
+	LinearFence(ID3D12CommandQueue* pQueue, UINT count) :
+		Fence(pQueue),
+		m_signalIndex(0)
+	{
+		m_signalHistory.resize(count);
+	}
 
-    // If the oldest Signal event in the ring buffer has not yet been processed by
-    // the GPU, block the calling CPU thread until it is.
-    inline void Next()
-    {
-        m_signalHistory[m_signalIndex] = m_currentFenceValue;
-        m_signalIndex = (m_signalIndex + 1) % m_signalHistory.size();
+	// If the oldest Signal event in the ring buffer has not yet been processed by
+	// the GPU, block the calling CPU thread until it is.
+	inline void Next()
+	{
+		m_signalHistory[m_signalIndex] = m_currentFenceValue;
+		m_signalIndex = (m_signalIndex + 1) % m_signalHistory.size();
 
-        Fence::CpuWait(m_signalHistory[m_signalIndex]);
-    }
+		Fence::CpuWait(m_signalHistory[m_signalIndex]);
+	}
 
 private:
-    std::vector<UINT64> m_signalHistory;    // The history of signal events.
-    UINT m_signalIndex;                        // The index to the next slot in the signal history ring buffer.
+	std::vector<UINT64> m_signalHistory;	// The history of signal events.
+	UINT m_signalIndex;						// The index to the next slot in the signal history ring buffer.
 };

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/Main.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12SingleGpu sample(1280, 720, L"D3D12 Single GPU reference project for the Affinity Layer");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12SingleGpu sample(1280, 720, L"D3D12 Single GPU reference project for the Affinity Layer");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/Post.hlsli
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/Post.hlsli
@@ -11,14 +11,14 @@
 
 struct VSInput
 {
-    float4 position : POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : POSITION;
+	float2 uv : TEXCOORD;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 Texture2D g_renderTargets[6] : register(t0);
@@ -26,6 +26,6 @@ SamplerState g_sampler : register(s0);
 
 cbuffer ShaderConstants : register(b0)
 {
-    uint currentRenderTarget;
-    uint renderTargetCount;
+	uint currentRenderTarget;
+	uint renderTargetCount;
 };

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/PostPS.hlsl
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/PostPS.hlsl
@@ -13,18 +13,18 @@
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    // This adds up to more than 1.0f, but creates a decent effect
-    // that doesn't make the triangles look too transparent.
-    float blurWeights[6] = { 0.80f, 0.25f, 0.15f, 0.075f, 0.025f, 0.0125f };
+	// This adds up to more than 1.0f, but creates a decent effect
+	// that doesn't make the triangles look too transparent.
+	float blurWeights[6] = { 0.80f, 0.25f, 0.15f, 0.075f, 0.025f, 0.0125f };
 
-    float4 result = float4(0.0f, 0.0f, 0.0f, 0.0f);
-    uint index = currentRenderTarget;
+	float4 result = float4(0.0f, 0.0f, 0.0f, 0.0f);
+	uint index = currentRenderTarget;
 
-    for (uint n = 0; n < renderTargetCount; n++)
-    {
-        result += blurWeights[n] * g_renderTargets[index].Sample(g_sampler, input.uv);
-        index = (index == 0) ? renderTargetCount - 1 : index - 1;
-    }
+	for (uint n = 0; n < renderTargetCount; n++)
+	{
+		result += blurWeights[n] * g_renderTargets[index].Sample(g_sampler, input.uv);
+		index = (index == 0) ? renderTargetCount - 1 : index - 1;
+	}
 
-    return saturate(result);
+	return saturate(result);
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/PostVS.hlsl
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/PostVS.hlsl
@@ -13,10 +13,10 @@
 
 PSInput VSMain(VSInput input)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = input.position;
-    result.uv = input.uv;
+	result.position = input.position;
+	result.uv = input.uv;
 
-    return result;
+	return result;
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/Scene.hlsli
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/Scene.hlsli
@@ -11,19 +11,19 @@
 
 cbuffer SceneConstantBuffer : register(b0)
 {
-    float4 velocity;
-    float4 offset;
-    float4 color;
-    float4x4 projection;
+	float4 velocity;
+	float4 offset;
+	float4 color;
+	float4x4 projection;
 };
 
 cbuffer SceneRootConstants : register(b1)
 {
-    uint simulatedGpuLoad;
+	uint simulatedGpuLoad;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/ScenePS.hlsl
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/ScenePS.hlsl
@@ -13,5 +13,5 @@
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/SceneVS.hlsl
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/SceneVS.hlsl
@@ -13,29 +13,29 @@
 
 PSInput VSMain(float4 position : POSITION)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = mul(position + offset, projection);
+	result.position = mul(position + offset, projection);
 
-    float intensity = saturate((4.0f - result.position.z) / 2.0f);
-    float4 c = float4(color.xyz * intensity, 1.0f);
+	float intensity = saturate((4.0f - result.position.z) / 2.0f);
+	float4 c = float4(color.xyz * intensity, 1.0f);
 
-    if (simulatedGpuLoad > 0)
-    {
-        float4 total = float4(0.0f, 0.0f, 0.0f, 0.0f);
+	if (simulatedGpuLoad > 0)
+	{
+		float4 total = float4(0.0f, 0.0f, 0.0f, 0.0f);
 
-        // Simulate additional workload on the GPU.
-        for (uint x = 0; x < simulatedGpuLoad; x++)
-        {
-            total += c;
-        }
+		// Simulate additional workload on the GPU.
+		for (uint x = 0; x < simulatedGpuLoad; x++)
+		{
+			total += c;
+		}
 
-        result.color = total / simulatedGpuLoad;
-    }
-    else
-    {
-        result.color = c;
-    }
+		result.color = total / simulatedGpuLoad;
+	}
+	else
+	{
+		result.color = c;
+	}
 
-    return result;
+	return result;
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/Settings.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/Settings.cpp
@@ -15,8 +15,8 @@
 
 using Microsoft::WRL::ComPtr;
 
-const float Settings::TriangleHalfWidth = 0.05f;    // The x and y offsets used by the triangle vertices.
-const float Settings::TriangleDepth = 1.0f;            // The z offset used by the triangle vertices.
+const float Settings::TriangleHalfWidth = 0.05f;	// The x and y offsets used by the triangle vertices.
+const float Settings::TriangleDepth = 1.0f;			// The z offset used by the triangle vertices.
 const float Settings::ClearColor[4] = { 0.0f, 0.2f, 0.4f, 1.0f };
 
 UINT Settings::FrameCount;
@@ -31,20 +31,20 @@ D3D12_RECT Settings::ScissorRect;
 
 void Settings::Initialize(ID3D12Device* pDevice, UINT width, UINT height)
 {
-    FrameCount = 2;
+	FrameCount = 2;
 
-    RtvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    CbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	RtvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	CbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 
-    BackBufferCount = 2;
+	BackBufferCount = 2;
 
-    OnSizeChanged(width, height);
+	OnSizeChanged(width, height);
 }
 
 void Settings::OnSizeChanged(UINT width, UINT height)
 {
-    Width = width;
-    Height = height;
-    Viewport = CD3DX12_VIEWPORT(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 0.0f, 1.0f);
-    ScissorRect = CD3DX12_RECT(0, 0, static_cast<LONG>(width), static_cast<LONG>(height));
+	Width = width;
+	Height = height;
+	Viewport = CD3DX12_VIEWPORT(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 0.0f, 1.0f);
+	ScissorRect = CD3DX12_RECT(0, 0, static_cast<LONG>(width), static_cast<LONG>(height));
 }

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/Settings.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/Settings.h
@@ -15,24 +15,24 @@
 // for the lifetime of the sample.
 struct Settings
 {
-    static void Initialize(ID3D12Device* pDevice, UINT width, UINT height);
-    static void OnSizeChanged(UINT width, UINT height);
+	static void Initialize(ID3D12Device* pDevice, UINT width, UINT height);
+	static void OnSizeChanged(UINT width, UINT height);
 
-    static UINT FrameCount;                                // The maximum number of frames that will be buffered on each node.
+	static UINT FrameCount;								// The maximum number of frames that will be buffered on each node.
 
-    static const UINT SceneHistoryCount = 6;            // The number of frames used in the motion blur effect.
-    static const UINT SceneConstantBufferFrames = 10;    // The number of frames that can be buffered in the constant buffer heap.
-    static const UINT TriangleCount = 1024;                // The number of triangles drawn per frame.
-    static const float TriangleHalfWidth;                // The x and y offsets used by the triangle vertices.
-    static const float TriangleDepth;                    // The z offset used by the triangle vertices.
-    static const float ClearColor[4];
+	static const UINT SceneHistoryCount = 6;			// The number of frames used in the motion blur effect.
+	static const UINT SceneConstantBufferFrames = 10;	// The number of frames that can be buffered in the constant buffer heap.
+	static const UINT TriangleCount = 1024;				// The number of triangles drawn per frame.
+	static const float TriangleHalfWidth;				// The x and y offsets used by the triangle vertices.
+	static const float TriangleDepth;					// The z offset used by the triangle vertices.
+	static const float ClearColor[4];
 
-    static UINT RtvDescriptorSize;
-    static UINT CbvSrvDescriptorSize;
-    static UINT BackBufferCount;
+	static UINT RtvDescriptorSize;
+	static UINT CbvSrvDescriptorSize;
+	static UINT BackBufferCount;
 
-    static UINT Width;
-    static UINT Height;
-    static D3D12_VIEWPORT Viewport;
-    static D3D12_RECT ScissorRect;
+	static UINT Width;
+	static UINT Height;
+	static D3D12_VIEWPORT Viewport;
+	static D3D12_RECT ScissorRect;
 };

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/d3dx12.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12Multithreading/src/Camera.cpp
+++ b/Samples/Desktop/D3D12Multithreading/src/Camera.cpp
@@ -16,65 +16,65 @@ Camera* Camera::mCamera = nullptr;
 
 Camera::Camera()
 {
-    Reset();
-    mCamera = this;
+	Reset();
+	mCamera = this;
 }
 
 Camera::~Camera()
 {
-    mCamera = nullptr;
+	mCamera = nullptr;
 }
 
 Camera* Camera::get()
 {
-    return mCamera;
+	return mCamera;
 }
 
 void Camera::Get3DViewProjMatrices(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float fovInDegrees, float screenWidth, float screenHeight)
 {
-    
-    float aspectRatio = (float)screenWidth / (float)screenHeight;
-    float fovAngleY = fovInDegrees * XM_PI / 180.0f;
+	
+	float aspectRatio = (float)screenWidth / (float)screenHeight;
+	float fovAngleY = fovInDegrees * XM_PI / 180.0f;
 
-    if (aspectRatio < 1.0f)
-    {
-        fovAngleY /= aspectRatio;
-    }
+	if (aspectRatio < 1.0f)
+	{
+		fovAngleY /= aspectRatio;
+	}
 
-    XMStoreFloat4x4(view, XMMatrixTranspose(XMMatrixLookAtRH(mEye, mAt, mUp)));
-    XMStoreFloat4x4(proj, XMMatrixTranspose(XMMatrixPerspectiveFovRH(fovAngleY, aspectRatio, 0.01f, 125.0f)));
+	XMStoreFloat4x4(view, XMMatrixTranspose(XMMatrixLookAtRH(mEye, mAt, mUp)));
+	XMStoreFloat4x4(proj, XMMatrixTranspose(XMMatrixPerspectiveFovRH(fovAngleY, aspectRatio, 0.01f, 125.0f)));
 }
 
 void Camera::GetOrthoProjMatrices(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float width, float height)
 {
-    XMStoreFloat4x4(view, XMMatrixTranspose(XMMatrixLookAtRH(mEye, mAt, mUp)));
-    XMStoreFloat4x4(proj, XMMatrixTranspose(XMMatrixOrthographicRH(width, height, 0.01f, 125.0f)));
+	XMStoreFloat4x4(view, XMMatrixTranspose(XMMatrixLookAtRH(mEye, mAt, mUp)));
+	XMStoreFloat4x4(proj, XMMatrixTranspose(XMMatrixOrthographicRH(width, height, 0.01f, 125.0f)));
 }
 void Camera::RotateYaw(float deg)
 {
-    XMMATRIX rotation = XMMatrixRotationAxis(mUp, deg);
+	XMMATRIX rotation = XMMatrixRotationAxis(mUp, deg);
 
-    mEye = XMVector3TransformCoord(mEye, rotation);
+	mEye = XMVector3TransformCoord(mEye, rotation);
 }
 
 void Camera::RotatePitch(float deg)
 {
-    XMVECTOR right = XMVector3Normalize(XMVector3Cross(mEye, mUp));
-    XMMATRIX rotation = XMMatrixRotationAxis(right, deg);
+	XMVECTOR right = XMVector3Normalize(XMVector3Cross(mEye, mUp));
+	XMMATRIX rotation = XMMatrixRotationAxis(right, deg);
 
-    mEye = XMVector3TransformCoord(mEye, rotation);
+	mEye = XMVector3TransformCoord(mEye, rotation);
 }
 
 void Camera::Reset()
 {
-    mEye = XMVectorSet(0.0f, 15.0f, -30.0f, 0.0f);
-    mAt = XMVectorSet(0.0f, 8.0f, 0.0f, 0.0f);
-    mUp = XMVectorSet(0.0f, 1.0f, 0.0f, 0.0f);
+	mEye = XMVectorSet(0.0f, 15.0f, -30.0f, 0.0f);
+	mAt = XMVectorSet(0.0f, 8.0f, 0.0f, 0.0f);
+	mUp = XMVectorSet(0.0f, 1.0f, 0.0f, 0.0f);
 }
 
 void Camera::Set(XMVECTOR eye, XMVECTOR at, XMVECTOR up)
 {
-    mEye = eye;
-    mAt = at;
-    mUp = up;
+	mEye = eye;
+	mAt = at;
+	mUp = up;
 }

--- a/Samples/Desktop/D3D12Multithreading/src/Camera.h
+++ b/Samples/Desktop/D3D12Multithreading/src/Camera.h
@@ -17,19 +17,19 @@ using namespace DirectX;
 class Camera
 {
 public:
-    Camera();
-    ~Camera();
+	Camera();
+	~Camera();
 
-    void Get3DViewProjMatrices(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float fovInDegrees, float screenWidth, float screenHeight);
-    void Reset();
-    void Set(XMVECTOR eye, XMVECTOR at, XMVECTOR up);
-    static Camera *get();
-    void RotateYaw(float deg);
-    void RotatePitch(float deg);
-    void GetOrthoProjMatrices(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float width, float height);
-    XMVECTOR mEye; // Where the camera is in world space. Z increases into of the screen when using LH coord system (which we are and DX uses)
-    XMVECTOR mAt; // What the camera is looking at (world origin)
-    XMVECTOR mUp; // Which way is up
+	void Get3DViewProjMatrices(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float fovInDegrees, float screenWidth, float screenHeight);
+	void Reset();
+	void Set(XMVECTOR eye, XMVECTOR at, XMVECTOR up);
+	static Camera *get();
+	void RotateYaw(float deg);
+	void RotatePitch(float deg);
+	void GetOrthoProjMatrices(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float width, float height);
+	XMVECTOR mEye; // Where the camera is in world space. Z increases into of the screen when using LH coord system (which we are and DX uses)
+	XMVECTOR mAt; // What the camera is looking at (world origin)
+	XMVECTOR mUp; // Which way is up
 private:
-    static Camera* mCamera;
+	static Camera* mCamera;
 };

--- a/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.cpp
+++ b/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.cpp
@@ -16,988 +16,1041 @@
 D3D12Multithreading* D3D12Multithreading::s_app = nullptr;
 
 D3D12Multithreading::D3D12Multithreading(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_keyboardInput(),
-    m_titleCount(0),
-    m_cpuTime(0),
-    m_fenceValue(0),
-    m_rtvDescriptorSize(0),
-    m_currentFrameResourceIndex(0),
-    m_pCurrentFrameResource(nullptr)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_keyboardInput(),
+	m_titleCount(0),
+	m_cpuTime(0),
+	m_fenceValue(0),
+	m_rtvDescriptorSize(0),
+	m_currentFrameResourceIndex(0),
+	m_pCurrentFrameResource(nullptr)
 {
-    s_app = this;
+	s_app = this;
 
-    m_keyboardInput.animate = true;
+	m_keyboardInput.animate = true;
+
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
 }
 
 D3D12Multithreading::~D3D12Multithreading()
 {
-    s_app = nullptr;
+	s_app = nullptr;
 }
 
 void D3D12Multithreading::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
-    LoadContexts();
+	LoadPipeline();
+	LoadAssets();
+	LoadContexts();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12Multithreading::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter, true);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
-    NAME_D3D12_OBJECT(m_commandQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	NAME_D3D12_OBJECT(m_commandQueue);
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    // This sample does not support fullscreen transitions.
-    ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
+	// This sample does not support fullscreen transitions.
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a depth stencil view (DSV) descriptor heap.
-        // Each frame has its own depth stencils (to write shadows onto) 
-        // and then there is one for the scene itself.
-        D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
-        dsvHeapDesc.NumDescriptors = 1 + FrameCount * 1;
-        dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-        dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
+		// Describe and create a depth stencil view (DSV) descriptor heap.
+		// Each frame has its own depth stencils (to write shadows onto) 
+		// and then there is one for the scene itself.
+		D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
+		dsvHeapDesc.NumDescriptors = 1 + FrameCount * 1;
+		dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+		dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
 
-        // Describe and create a shader resource view (SRV) and constant 
-        // buffer view (CBV) descriptor heap.  Heap layout: null views, 
-        // object diffuse + normal textures views, frame 1's shadow buffer, 
-        // frame 1's 2x constant buffer, frame 2's shadow buffer, frame 2's 
-        // 2x constant buffers, etc...
-        const UINT nullSrvCount = 2;        // Null descriptors are needed for out of bounds behavior reads.
-        const UINT cbvCount = FrameCount * 2;
-        const UINT srvCount = _countof(SampleAssets::Textures) + (FrameCount * 1);
-        D3D12_DESCRIPTOR_HEAP_DESC cbvSrvHeapDesc = {};
-        cbvSrvHeapDesc.NumDescriptors = nullSrvCount + cbvCount + srvCount;
-        cbvSrvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        cbvSrvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvSrvHeapDesc, IID_PPV_ARGS(&m_cbvSrvHeap)));
-        NAME_D3D12_OBJECT(m_cbvSrvHeap);
+		// Describe and create a shader resource view (SRV) and constant 
+		// buffer view (CBV) descriptor heap.  Heap layout: null views, 
+		// object diffuse + normal textures views, frame 1's shadow buffer, 
+		// frame 1's 2x constant buffer, frame 2's shadow buffer, frame 2's 
+		// 2x constant buffers, etc...
+		const UINT nullSrvCount = 2;		// Null descriptors are needed for out of bounds behavior reads.
+		const UINT cbvCount = FrameCount * 2;
+		const UINT srvCount = _countof(SampleAssets::Textures) + (FrameCount * 1);
+		D3D12_DESCRIPTOR_HEAP_DESC cbvSrvHeapDesc = {};
+		cbvSrvHeapDesc.NumDescriptors = nullSrvCount + cbvCount + srvCount;
+		cbvSrvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		cbvSrvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvSrvHeapDesc, IID_PPV_ARGS(&m_cbvSrvHeap)));
+		NAME_D3D12_OBJECT(m_cbvSrvHeap);
 
-        // Describe and create a sampler descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
-        samplerHeapDesc.NumDescriptors = 2;        // One clamp and one wrap sampler.
-        samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
-        samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_samplerHeap)));
-        NAME_D3D12_OBJECT(m_samplerHeap);
+		// Describe and create a sampler descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
+		samplerHeapDesc.NumDescriptors = 2;		// One clamp and one wrap sampler.
+		samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
+		samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_samplerHeap)));
+		NAME_D3D12_OBJECT(m_samplerHeap);
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	}
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
 }
 
 // Load the sample assets.
 void D3D12Multithreading::LoadAssets()
 {
-    // Create the root signature.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signature.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[4]; // Perfomance TIP: Order from most frequent to least frequent.
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 1, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);    // 2 frequently changed diffuse + normal textures - using registers t1 and t2.
-        ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);    // 1 frequently changed constant buffer.
-        ranges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);                                                // 1 infrequently changed shadow texture - starting in register t0.
-        ranges[3].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 2, 0);                                            // 2 static samplers.
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[4]; // Perfomance TIP: Order from most frequent to least frequent.
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 1, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);	// 2 frequently changed diffuse + normal textures - using registers t1 and t2.
+		ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);	// 1 frequently changed constant buffer.
+		ranges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);												// 1 infrequently changed shadow texture - starting in register t0.
+		ranges[3].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 2, 0);											// 2 static samplers.
 
-        CD3DX12_ROOT_PARAMETER1 rootParameters[4];
-        rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
-        rootParameters[1].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_ALL);
-        rootParameters[2].InitAsDescriptorTable(1, &ranges[2], D3D12_SHADER_VISIBILITY_PIXEL);
-        rootParameters[3].InitAsDescriptorTable(1, &ranges[3], D3D12_SHADER_VISIBILITY_PIXEL);
+		CD3DX12_ROOT_PARAMETER1 rootParameters[4];
+		rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
+		rootParameters[1].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_ALL);
+		rootParameters[2].InitAsDescriptorTable(1, &ranges[2], D3D12_SHADER_VISIBILITY_PIXEL);
+		rootParameters[3].InitAsDescriptorTable(1, &ranges[3], D3D12_SHADER_VISIBILITY_PIXEL);
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-        NAME_D3D12_OBJECT(m_rootSignature);
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+		NAME_D3D12_OBJECT(m_rootSignature);
+	}
 
-    // Create the pipeline state, which includes loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
+	// Create the pipeline state, which includes loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = D3DCOMPILE_OPTIMIZATION_LEVEL3;
+		UINT compileFlags = D3DCOMPILE_OPTIMIZATION_LEVEL3;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
-        D3D12_INPUT_LAYOUT_DESC inputLayoutDesc;
-        inputLayoutDesc.pInputElementDescs = SampleAssets::StandardVertexDescription;
-        inputLayoutDesc.NumElements = _countof(SampleAssets::StandardVertexDescription);
+		D3D12_INPUT_LAYOUT_DESC inputLayoutDesc;
+		inputLayoutDesc.pInputElementDescs = SampleAssets::StandardVertexDescription;
+		inputLayoutDesc.NumElements = _countof(SampleAssets::StandardVertexDescription);
 
-        CD3DX12_DEPTH_STENCIL_DESC depthStencilDesc(D3D12_DEFAULT);
-        depthStencilDesc.DepthEnable = true;
-        depthStencilDesc.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
-        depthStencilDesc.DepthFunc = D3D12_COMPARISON_FUNC_LESS_EQUAL;
-        depthStencilDesc.StencilEnable = FALSE;
+		CD3DX12_DEPTH_STENCIL_DESC depthStencilDesc(D3D12_DEFAULT);
+		depthStencilDesc.DepthEnable = true;
+		depthStencilDesc.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
+		depthStencilDesc.DepthFunc = D3D12_COMPARISON_FUNC_LESS_EQUAL;
+		depthStencilDesc.StencilEnable = FALSE;
 
-        // Describe and create the PSO for rendering the scene.
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = inputLayoutDesc;
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState = depthStencilDesc;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the PSO for rendering the scene.
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = inputLayoutDesc;
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState = depthStencilDesc;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-        NAME_D3D12_OBJECT(m_pipelineState);
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+		NAME_D3D12_OBJECT(m_pipelineState);
 
-        // Alter the description and create the PSO for rendering
-        // the shadow map.  The shadow map does not use a pixel
-        // shader or render targets.
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(0, 0);
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_UNKNOWN;
-        psoDesc.NumRenderTargets = 0;
+		// Alter the description and create the PSO for rendering
+		// the shadow map.  The shadow map does not use a pixel
+		// shader or render targets.
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(0, 0);
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_UNKNOWN;
+		psoDesc.NumRenderTargets = 0;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStateShadowMap)));
-        NAME_D3D12_OBJECT(m_pipelineStateShadowMap);
-    }
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStateShadowMap)));
+		NAME_D3D12_OBJECT(m_pipelineStateShadowMap);
+	}
 
-    // Create temporary command list for initial GPU setup.
-    ComPtr<ID3D12GraphicsCommandList> commandList;
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&commandList)));
+	// Create temporary command list for initial GPU setup.
+	ComPtr<ID3D12GraphicsCommandList> commandList;
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&commandList)));
 
-    // Create render target views (RTVs).
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
-    for (UINT i = 0; i < FrameCount; i++)
-    {
-        ThrowIfFailed(m_swapChain->GetBuffer(i, IID_PPV_ARGS(&m_renderTargets[i])));
-        m_device->CreateRenderTargetView(m_renderTargets[i].Get(), nullptr, rtvHandle);
-        rtvHandle.Offset(1, m_rtvDescriptorSize);
+	// Create render target views (RTVs).
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	for (UINT i = 0; i < FrameCount; i++)
+	{
+		ThrowIfFailed(m_swapChain->GetBuffer(i, IID_PPV_ARGS(&m_renderTargets[i])));
+		m_device->CreateRenderTargetView(m_renderTargets[i].Get(), nullptr, rtvHandle);
+		rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-        NAME_D3D12_OBJECT_INDEXED(m_renderTargets, i);
-    }
+		NAME_D3D12_OBJECT_INDEXED(m_renderTargets, i);
+	}
 
-    // Create the depth stencil.
-    {
-        CD3DX12_RESOURCE_DESC shadowTextureDesc(
-            D3D12_RESOURCE_DIMENSION_TEXTURE2D,
-            0,
-            static_cast<UINT>(m_viewport.Width), 
-            static_cast<UINT>(m_viewport.Height), 
-            1,
-            1,
-            DXGI_FORMAT_D32_FLOAT,
-            1, 
-            0,
-            D3D12_TEXTURE_LAYOUT_UNKNOWN,
-            D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL | D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE);
+	// Create the depth stencil.
+	{
+		CD3DX12_RESOURCE_DESC shadowTextureDesc(
+			D3D12_RESOURCE_DIMENSION_TEXTURE2D,
+			0,
+			static_cast<UINT>(m_viewport.Width), 
+			static_cast<UINT>(m_viewport.Height), 
+			1,
+			1,
+			DXGI_FORMAT_D32_FLOAT,
+			1, 
+			0,
+			D3D12_TEXTURE_LAYOUT_UNKNOWN,
+			D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL | D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE);
 
-        D3D12_CLEAR_VALUE clearValue;    // Performance tip: Tell the runtime at resource creation the desired clear value.
-        clearValue.Format = DXGI_FORMAT_D32_FLOAT;
-        clearValue.DepthStencil.Depth = 1.0f;
-        clearValue.DepthStencil.Stencil = 0;
+		D3D12_CLEAR_VALUE clearValue;	// Performance tip: Tell the runtime at resource creation the desired clear value.
+		clearValue.Format = DXGI_FORMAT_D32_FLOAT;
+		clearValue.DepthStencil.Depth = 1.0f;
+		clearValue.DepthStencil.Stencil = 0;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &shadowTextureDesc,
-            D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            &clearValue,
-            IID_PPV_ARGS(&m_depthStencil)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&shadowTextureDesc,
+			D3D12_RESOURCE_STATE_DEPTH_WRITE,
+			&clearValue,
+			IID_PPV_ARGS(&m_depthStencil)));
 
-        NAME_D3D12_OBJECT(m_depthStencil);
+		NAME_D3D12_OBJECT(m_depthStencil);
 
-        // Create the depth stencil view.
-        m_device->CreateDepthStencilView(m_depthStencil.Get(), nullptr, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		// Create the depth stencil view.
+		m_device->CreateDepthStencilView(m_depthStencil.Get(), nullptr, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    // Load scene assets.
-    UINT fileSize = 0;
-    UINT8* pAssetData;
-    ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(SampleAssets::DataFileName).c_str(), &pAssetData, &fileSize));
+	// Load scene assets.
+	UINT fileSize = 0;
+	UINT8* pAssetData;
+	ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(SampleAssets::DataFileName).c_str(), &pAssetData, &fileSize));
 
-    // Create the vertex buffer.
-    {
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+	// Create the vertex buffer.
+	{
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        NAME_D3D12_OBJECT(m_vertexBuffer);
+		NAME_D3D12_OBJECT(m_vertexBuffer);
 
-        {
-            ThrowIfFailed(m_device->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-                D3D12_HEAP_FLAG_NONE,
-                &CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize),
-                D3D12_RESOURCE_STATE_GENERIC_READ,
-                nullptr,
-                IID_PPV_ARGS(&m_vertexBufferUpload)));
+		{
+			ThrowIfFailed(m_device->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+				D3D12_HEAP_FLAG_NONE,
+				&CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize),
+				D3D12_RESOURCE_STATE_GENERIC_READ,
+				nullptr,
+				IID_PPV_ARGS(&m_vertexBufferUpload)));
 
-            // Copy data to the upload heap and then schedule a copy 
-            // from the upload heap to the vertex buffer.
-            D3D12_SUBRESOURCE_DATA vertexData = {};
-            vertexData.pData = pAssetData + SampleAssets::VertexDataOffset;
-            vertexData.RowPitch = SampleAssets::VertexDataSize;
-            vertexData.SlicePitch = vertexData.RowPitch;
+			// Copy data to the upload heap and then schedule a copy 
+			// from the upload heap to the vertex buffer.
+			D3D12_SUBRESOURCE_DATA vertexData = {};
+			vertexData.pData = pAssetData + SampleAssets::VertexDataOffset;
+			vertexData.RowPitch = SampleAssets::VertexDataSize;
+			vertexData.SlicePitch = vertexData.RowPitch;
 
-            PIXBeginEvent(commandList.Get(), 0, L"Copy vertex buffer data to default resource...");
+			PIXBeginEvent(commandList.Get(), 0, L"Copy vertex buffer data to default resource...");
 
-            UpdateSubresources<1>(commandList.Get(), m_vertexBuffer.Get(), m_vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-            commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+			UpdateSubresources<1>(commandList.Get(), m_vertexBuffer.Get(), m_vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+			commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-            PIXEndEvent(commandList.Get());
-        }
+			PIXEndEvent(commandList.Get());
+		}
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.SizeInBytes = SampleAssets::VertexDataSize;
-        m_vertexBufferView.StrideInBytes = SampleAssets::StandardVertexStride;
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.SizeInBytes = SampleAssets::VertexDataSize;
+		m_vertexBufferView.StrideInBytes = SampleAssets::StandardVertexStride;
+	}
 
-    // Create the index buffer.
-    {
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::IndexDataSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_indexBuffer)));
+	// Create the index buffer.
+	{
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::IndexDataSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_indexBuffer)));
 
-        NAME_D3D12_OBJECT(m_indexBuffer);
+		NAME_D3D12_OBJECT(m_indexBuffer);
 
-        {
-            ThrowIfFailed(m_device->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-                D3D12_HEAP_FLAG_NONE,
-                &CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::IndexDataSize),
-                D3D12_RESOURCE_STATE_GENERIC_READ,
-                nullptr,
-                IID_PPV_ARGS(&m_indexBufferUpload)));
+		{
+			ThrowIfFailed(m_device->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+				D3D12_HEAP_FLAG_NONE,
+				&CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::IndexDataSize),
+				D3D12_RESOURCE_STATE_GENERIC_READ,
+				nullptr,
+				IID_PPV_ARGS(&m_indexBufferUpload)));
 
-            // Copy data to the upload heap and then schedule a copy 
-            // from the upload heap to the index buffer.
-            D3D12_SUBRESOURCE_DATA indexData = {};
-            indexData.pData = pAssetData + SampleAssets::IndexDataOffset;
-            indexData.RowPitch = SampleAssets::IndexDataSize;
-            indexData.SlicePitch = indexData.RowPitch;
+			// Copy data to the upload heap and then schedule a copy 
+			// from the upload heap to the index buffer.
+			D3D12_SUBRESOURCE_DATA indexData = {};
+			indexData.pData = pAssetData + SampleAssets::IndexDataOffset;
+			indexData.RowPitch = SampleAssets::IndexDataSize;
+			indexData.SlicePitch = indexData.RowPitch;
 
-            PIXBeginEvent(commandList.Get(), 0, L"Copy index buffer data to default resource...");
+			PIXBeginEvent(commandList.Get(), 0, L"Copy index buffer data to default resource...");
 
-            UpdateSubresources<1>(commandList.Get(), m_indexBuffer.Get(), m_indexBufferUpload.Get(), 0, 0, 1, &indexData);
-            commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_indexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_INDEX_BUFFER));
+			UpdateSubresources<1>(commandList.Get(), m_indexBuffer.Get(), m_indexBufferUpload.Get(), 0, 0, 1, &indexData);
+			commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_indexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_INDEX_BUFFER));
 
-            PIXEndEvent(commandList.Get());
-        }
+			PIXEndEvent(commandList.Get());
+		}
 
-        // Initialize the index buffer view.
-        m_indexBufferView.BufferLocation = m_indexBuffer->GetGPUVirtualAddress();
-        m_indexBufferView.SizeInBytes = SampleAssets::IndexDataSize;
-        m_indexBufferView.Format = SampleAssets::StandardIndexFormat;
-    }
+		// Initialize the index buffer view.
+		m_indexBufferView.BufferLocation = m_indexBuffer->GetGPUVirtualAddress();
+		m_indexBufferView.SizeInBytes = SampleAssets::IndexDataSize;
+		m_indexBufferView.Format = SampleAssets::StandardIndexFormat;
+	}
 
-    // Create shader resources.
-    {
-        // Get the CBV SRV descriptor size for the current device.
-        const UINT cbvSrvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	// Create shader resources.
+	{
+		// Get the CBV SRV descriptor size for the current device.
+		const UINT cbvSrvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 
-        // Get a handle to the start of the descriptor heap.
-        CD3DX12_CPU_DESCRIPTOR_HANDLE cbvSrvHandle(m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart());
+		// Get a handle to the start of the descriptor heap.
+		CD3DX12_CPU_DESCRIPTOR_HANDLE cbvSrvHandle(m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        {
-            // Describe and create 2 null SRVs. Null descriptors are needed in order 
-            // to achieve the effect of an "unbound" resource.
-            D3D12_SHADER_RESOURCE_VIEW_DESC nullSrvDesc = {};
-            nullSrvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-            nullSrvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-            nullSrvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-            nullSrvDesc.Texture2D.MipLevels = 1;
-            nullSrvDesc.Texture2D.MostDetailedMip = 0;
-            nullSrvDesc.Texture2D.ResourceMinLODClamp = 0.0f;
+		{
+			// Describe and create 2 null SRVs. Null descriptors are needed in order 
+			// to achieve the effect of an "unbound" resource.
+			D3D12_SHADER_RESOURCE_VIEW_DESC nullSrvDesc = {};
+			nullSrvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+			nullSrvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+			nullSrvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+			nullSrvDesc.Texture2D.MipLevels = 1;
+			nullSrvDesc.Texture2D.MostDetailedMip = 0;
+			nullSrvDesc.Texture2D.ResourceMinLODClamp = 0.0f;
 
-            m_device->CreateShaderResourceView(nullptr, &nullSrvDesc, cbvSrvHandle);
-            cbvSrvHandle.Offset(cbvSrvDescriptorSize);
+			m_device->CreateShaderResourceView(nullptr, &nullSrvDesc, cbvSrvHandle);
+			cbvSrvHandle.Offset(cbvSrvDescriptorSize);
 
-            m_device->CreateShaderResourceView(nullptr, &nullSrvDesc, cbvSrvHandle);
-            cbvSrvHandle.Offset(cbvSrvDescriptorSize);
-        }
+			m_device->CreateShaderResourceView(nullptr, &nullSrvDesc, cbvSrvHandle);
+			cbvSrvHandle.Offset(cbvSrvDescriptorSize);
+		}
 
-        // Create each texture and SRV descriptor.
-        const UINT srvCount = _countof(SampleAssets::Textures);
-        PIXBeginEvent(commandList.Get(), 0, L"Copy diffuse and normal texture data to default resources...");
-        for (UINT i = 0; i < srvCount; i++)
-        {
-            // Describe and create a Texture2D.
-            const SampleAssets::TextureResource &tex = SampleAssets::Textures[i];
-            CD3DX12_RESOURCE_DESC texDesc(
-                D3D12_RESOURCE_DIMENSION_TEXTURE2D,
-                0,
-                tex.Width, 
-                tex.Height, 
-                1,
-                static_cast<UINT16>(tex.MipLevels),
-                tex.Format,
-                1, 
-                0,
-                D3D12_TEXTURE_LAYOUT_UNKNOWN,
-                D3D12_RESOURCE_FLAG_NONE);
+		// Create each texture and SRV descriptor.
+		const UINT srvCount = _countof(SampleAssets::Textures);
+		PIXBeginEvent(commandList.Get(), 0, L"Copy diffuse and normal texture data to default resources...");
+		for (UINT i = 0; i < srvCount; i++)
+		{
+			// Describe and create a Texture2D.
+			const SampleAssets::TextureResource &tex = SampleAssets::Textures[i];
+			CD3DX12_RESOURCE_DESC texDesc(
+				D3D12_RESOURCE_DIMENSION_TEXTURE2D,
+				0,
+				tex.Width, 
+				tex.Height, 
+				1,
+				static_cast<UINT16>(tex.MipLevels),
+				tex.Format,
+				1, 
+				0,
+				D3D12_TEXTURE_LAYOUT_UNKNOWN,
+				D3D12_RESOURCE_FLAG_NONE);
 
-            ThrowIfFailed(m_device->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-                D3D12_HEAP_FLAG_NONE,
-                &texDesc,
-                D3D12_RESOURCE_STATE_COPY_DEST,
-                nullptr,
-                IID_PPV_ARGS(&m_textures[i])));
+			ThrowIfFailed(m_device->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+				D3D12_HEAP_FLAG_NONE,
+				&texDesc,
+				D3D12_RESOURCE_STATE_COPY_DEST,
+				nullptr,
+				IID_PPV_ARGS(&m_textures[i])));
 
-            NAME_D3D12_OBJECT_INDEXED(m_textures, i);
+			NAME_D3D12_OBJECT_INDEXED(m_textures, i);
 
-            {
-                const UINT subresourceCount = texDesc.DepthOrArraySize * texDesc.MipLevels;
-                UINT64 uploadBufferSize = GetRequiredIntermediateSize(m_textures[i].Get(), 0, subresourceCount);
-                ThrowIfFailed(m_device->CreateCommittedResource(
-                    &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-                    D3D12_HEAP_FLAG_NONE,
-                    &CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
-                    D3D12_RESOURCE_STATE_GENERIC_READ,
-                    nullptr,
-                    IID_PPV_ARGS(&m_textureUploads[i])));
+			{
+				const UINT subresourceCount = texDesc.DepthOrArraySize * texDesc.MipLevels;
+				UINT64 uploadBufferSize = GetRequiredIntermediateSize(m_textures[i].Get(), 0, subresourceCount);
+				ThrowIfFailed(m_device->CreateCommittedResource(
+					&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+					D3D12_HEAP_FLAG_NONE,
+					&CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
+					D3D12_RESOURCE_STATE_GENERIC_READ,
+					nullptr,
+					IID_PPV_ARGS(&m_textureUploads[i])));
 
-                // Copy data to the intermediate upload heap and then schedule a copy
-                // from the upload heap to the Texture2D.
-                D3D12_SUBRESOURCE_DATA textureData = {};
-                textureData.pData = pAssetData + tex.Data->Offset;
-                textureData.RowPitch = tex.Data->Pitch;
-                textureData.SlicePitch = tex.Data->Size;
+				// Copy data to the intermediate upload heap and then schedule a copy
+				// from the upload heap to the Texture2D.
+				D3D12_SUBRESOURCE_DATA textureData = {};
+				textureData.pData = pAssetData + tex.Data->Offset;
+				textureData.RowPitch = tex.Data->Pitch;
+				textureData.SlicePitch = tex.Data->Size;
 
-                UpdateSubresources(commandList.Get(), m_textures[i].Get(), m_textureUploads[i].Get(), 0, 0, subresourceCount, &textureData);
-                commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_textures[i].Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
-            }
+				UpdateSubresources(commandList.Get(), m_textures[i].Get(), m_textureUploads[i].Get(), 0, 0, subresourceCount, &textureData);
+				commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_textures[i].Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
+			}
 
-            // Describe and create an SRV.
-            D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-            srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-            srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-            srvDesc.Format = tex.Format;
-            srvDesc.Texture2D.MipLevels = tex.MipLevels;
-            srvDesc.Texture2D.MostDetailedMip = 0;
-            srvDesc.Texture2D.ResourceMinLODClamp = 0.0f;
-            m_device->CreateShaderResourceView(m_textures[i].Get(), &srvDesc, cbvSrvHandle);
+			// Describe and create an SRV.
+			D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+			srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+			srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+			srvDesc.Format = tex.Format;
+			srvDesc.Texture2D.MipLevels = tex.MipLevels;
+			srvDesc.Texture2D.MostDetailedMip = 0;
+			srvDesc.Texture2D.ResourceMinLODClamp = 0.0f;
+			m_device->CreateShaderResourceView(m_textures[i].Get(), &srvDesc, cbvSrvHandle);
 
-            // Move to the next descriptor slot.
-            cbvSrvHandle.Offset(cbvSrvDescriptorSize);
-        }
-        PIXEndEvent(commandList.Get());
-    }
+			// Move to the next descriptor slot.
+			cbvSrvHandle.Offset(cbvSrvDescriptorSize);
+		}
+		PIXEndEvent(commandList.Get());
+	}
 
-    free(pAssetData);
+	free(pAssetData);
 
-    // Create the samplers.
-    {
-        // Get the sampler descriptor size for the current device.
-        const UINT samplerDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
+	// Create the samplers.
+	{
+		// Get the sampler descriptor size for the current device.
+		const UINT samplerDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
 
-        // Get a handle to the start of the descriptor heap.
-        CD3DX12_CPU_DESCRIPTOR_HANDLE samplerHandle(m_samplerHeap->GetCPUDescriptorHandleForHeapStart());
+		// Get a handle to the start of the descriptor heap.
+		CD3DX12_CPU_DESCRIPTOR_HANDLE samplerHandle(m_samplerHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Describe and create the wrapping sampler, which is used for 
-        // sampling diffuse/normal maps.
-        D3D12_SAMPLER_DESC wrapSamplerDesc = {};
-        wrapSamplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-        wrapSamplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        wrapSamplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        wrapSamplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        wrapSamplerDesc.MinLOD = 0;
-        wrapSamplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
-        wrapSamplerDesc.MipLODBias = 0.0f;
-        wrapSamplerDesc.MaxAnisotropy = 1;
-        wrapSamplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
-        wrapSamplerDesc.BorderColor[0] = wrapSamplerDesc.BorderColor[1] = wrapSamplerDesc.BorderColor[2] = wrapSamplerDesc.BorderColor[3] = 0;
-        m_device->CreateSampler(&wrapSamplerDesc, samplerHandle);
+		// Describe and create the wrapping sampler, which is used for 
+		// sampling diffuse/normal maps.
+		D3D12_SAMPLER_DESC wrapSamplerDesc = {};
+		wrapSamplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		wrapSamplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		wrapSamplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		wrapSamplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		wrapSamplerDesc.MinLOD = 0;
+		wrapSamplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
+		wrapSamplerDesc.MipLODBias = 0.0f;
+		wrapSamplerDesc.MaxAnisotropy = 1;
+		wrapSamplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
+		wrapSamplerDesc.BorderColor[0] = wrapSamplerDesc.BorderColor[1] = wrapSamplerDesc.BorderColor[2] = wrapSamplerDesc.BorderColor[3] = 0;
+		m_device->CreateSampler(&wrapSamplerDesc, samplerHandle);
 
-        // Move the handle to the next slot in the descriptor heap.
-        samplerHandle.Offset(samplerDescriptorSize);
+		// Move the handle to the next slot in the descriptor heap.
+		samplerHandle.Offset(samplerDescriptorSize);
 
-        // Describe and create the point clamping sampler, which is 
-        // used for the shadow map.
-        D3D12_SAMPLER_DESC clampSamplerDesc = {};
-        clampSamplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
-        clampSamplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-        clampSamplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-        clampSamplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-        clampSamplerDesc.MipLODBias = 0.0f;
-        clampSamplerDesc.MaxAnisotropy = 1;
-        clampSamplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
-        clampSamplerDesc.BorderColor[0] = clampSamplerDesc.BorderColor[1] = clampSamplerDesc.BorderColor[2] = clampSamplerDesc.BorderColor[3] = 0;
-        clampSamplerDesc.MinLOD = 0;
-        clampSamplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
-        m_device->CreateSampler(&clampSamplerDesc, samplerHandle);
-    }
+		// Describe and create the point clamping sampler, which is 
+		// used for the shadow map.
+		D3D12_SAMPLER_DESC clampSamplerDesc = {};
+		clampSamplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
+		clampSamplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+		clampSamplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+		clampSamplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+		clampSamplerDesc.MipLODBias = 0.0f;
+		clampSamplerDesc.MaxAnisotropy = 1;
+		clampSamplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
+		clampSamplerDesc.BorderColor[0] = clampSamplerDesc.BorderColor[1] = clampSamplerDesc.BorderColor[2] = clampSamplerDesc.BorderColor[3] = 0;
+		clampSamplerDesc.MinLOD = 0;
+		clampSamplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
+		m_device->CreateSampler(&clampSamplerDesc, samplerHandle);
+	}
 
-    // Create lights.
-    for (int i = 0; i < NumLights; i++)
-    {
-        // Set up each of the light positions and directions (they all start 
-        // in the same place).
-        m_lights[i].position = { 0.0f, 15.0f, -30.0f, 1.0f };
-        m_lights[i].direction = { 0.0, 0.0f, 1.0f, 0.0f };
-        m_lights[i].falloff = { 800.0f, 1.0f, 0.0f, 1.0f };
-        m_lights[i].color = { 0.7f, 0.7f, 0.7f, 1.0f };
+	// Create lights.
+	for (int i = 0; i < NumLights; i++)
+	{
+		// Set up each of the light positions and directions (they all start 
+		// in the same place).
+		m_lights[i].position = { 0.0f, 15.0f, -30.0f, 1.0f };
+		m_lights[i].direction = { 0.0, 0.0f, 1.0f, 0.0f };
+		m_lights[i].falloff = { 800.0f, 1.0f, 0.0f, 1.0f };
+		m_lights[i].color = { 0.7f, 0.7f, 0.7f, 1.0f };
 
-        XMVECTOR eye = XMLoadFloat4(&m_lights[i].position);
-        XMVECTOR at = XMVectorAdd(eye, XMLoadFloat4(&m_lights[i].direction));
-        XMVECTOR up = { 0, 1, 0 };
+		XMVECTOR eye = XMLoadFloat4(&m_lights[i].position);
+		XMVECTOR at = XMVectorAdd(eye, XMLoadFloat4(&m_lights[i].direction));
+		XMVECTOR up = XMVectorSet(0.0f, 1.0f, 0.0f, 0.0f);
 
-        m_lightCameras[i].Set(eye, at, up);
-    }
+		m_lightCameras[i].Set(eye, at, up);
+	}
 
-    // Close the command list and use it to execute the initial GPU setup.
-    ThrowIfFailed(commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and use it to execute the initial GPU setup.
+	ThrowIfFailed(commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create frame resources.
-    for (int i = 0; i < FrameCount; i++)
-    {
-        m_frameResources[i] = new FrameResource(m_device.Get(), m_pipelineState.Get(), m_pipelineStateShadowMap.Get(), m_dsvHeap.Get(), m_cbvSrvHeap.Get(), &m_viewport, i);
-        m_frameResources[i]->WriteConstantBuffers(&m_viewport, &m_camera, m_lightCameras, m_lights);
-    }
-    m_currentFrameResourceIndex = 0;
-    m_pCurrentFrameResource = m_frameResources[m_currentFrameResourceIndex];
+	// Create frame resources.
+	for (int i = 0; i < FrameCount; i++)
+	{
+		m_frameResources[i] = new FrameResource(m_device.Get(), m_pipelineState.Get(), m_pipelineStateShadowMap.Get(), m_dsvHeap.Get(), m_cbvSrvHeap.Get(), &m_viewport, i);
+		m_frameResources[i]->WriteConstantBuffers(&m_viewport, &m_camera, m_lightCameras, m_lights);
+	}
+	m_currentFrameResourceIndex = 0;
+	m_pCurrentFrameResource = m_frameResources[m_currentFrameResourceIndex];
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_fenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValue++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_fenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValue++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
 
-        // Signal and increment the fence value.
-        const UINT64 fenceToWaitFor = m_fenceValue;
-        ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fenceToWaitFor));
-        m_fenceValue++;
+		// Signal and increment the fence value.
+		const UINT64 fenceToWaitFor = m_fenceValue;
+		ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fenceToWaitFor));
+		m_fenceValue++;
 
-        // Wait until the fence is completed.
-        ThrowIfFailed(m_fence->SetEventOnCompletion(fenceToWaitFor, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+		// Wait until the fence is completed.
+		ThrowIfFailed(m_fence->SetEventOnCompletion(fenceToWaitFor, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 }
 
 // Initialize threads and events.
 void D3D12Multithreading::LoadContexts()
 {
 #if !SINGLETHREADED
-    struct threadwrapper
-    {
-        static unsigned int WINAPI thunk(LPVOID lpParameter)
-        {
-            ThreadParameter* parameter = reinterpret_cast<ThreadParameter*>(lpParameter);
-            D3D12Multithreading::Get()->WorkerThread(parameter->threadIndex);
-            return 0;
-        }
-    };
+	struct threadwrapper
+	{
+		static unsigned int WINAPI thunk(LPVOID lpParameter)
+		{
+			ThreadParameter* parameter = reinterpret_cast<ThreadParameter*>(lpParameter);
+			D3D12Multithreading::Get()->WorkerThread(parameter->threadIndex);
+			return 0;
+		}
+	};
 
-    for (int i = 0; i < NumContexts; i++)
-    {
-        m_workerBeginRenderFrame[i] = CreateEvent(
-            NULL,
-            FALSE,
-            FALSE,
-            NULL);
+	for (int i = 0; i < NumContexts; i++)
+	{
+		m_workerBeginRenderFrame[i] = CreateEvent(
+			NULL,
+			FALSE,
+			FALSE,
+			NULL);
 
-        m_workerFinishedRenderFrame[i] = CreateEvent(
-            NULL,
-            FALSE,
-            FALSE,
-            NULL);
+		m_workerFinishedRenderFrame[i] = CreateEvent(
+			NULL,
+			FALSE,
+			FALSE,
+			NULL);
 
-        m_workerFinishShadowPass[i] = CreateEvent(
-            NULL,
-            FALSE,
-            FALSE,
-            NULL);
+		m_workerFinishShadowPass[i] = CreateEvent(
+			NULL,
+			FALSE,
+			FALSE,
+			NULL);
 
-        m_threadParameters[i].threadIndex = i;
+		m_threadParameters[i].threadIndex = i;
 
-        m_threadHandles[i] = reinterpret_cast<HANDLE>(_beginthreadex(
-            nullptr,
-            0,
-            threadwrapper::thunk,
-            reinterpret_cast<LPVOID>(&m_threadParameters[i]),
-            0,
-            nullptr));
+		m_threadHandles[i] = reinterpret_cast<HANDLE>(_beginthreadex(
+			nullptr,
+			0,
+			threadwrapper::thunk,
+			reinterpret_cast<LPVOID>(&m_threadParameters[i]),
+			0,
+			nullptr));
 
-        assert(m_workerBeginRenderFrame[i] != NULL);
-        assert(m_workerFinishedRenderFrame[i] != NULL);
-        assert(m_threadHandles[i] != NULL);
+		assert(m_workerBeginRenderFrame[i] != NULL);
+		assert(m_workerFinishedRenderFrame[i] != NULL);
+		assert(m_threadHandles[i] != NULL);
 
-    }
+	}
 #endif
 }
 
 // Update frame-based values.
 void D3D12Multithreading::OnUpdate()
 {
-    m_timer.Tick(NULL);
+	m_timer.Tick(NULL);
 
-    PIXSetMarker(m_commandQueue.Get(), 0, L"Getting last completed fence.");
+	PIXSetMarker(m_commandQueue.Get(), 0, L"Getting last completed fence.");
 
-    // Get current GPU progress against submitted workload. Resources still scheduled 
-    // for GPU execution cannot be modified or else undefined behavior will result.
-    const UINT64 lastCompletedFence = m_fence->GetCompletedValue();
+	// Get current GPU progress against submitted workload. Resources still scheduled 
+	// for GPU execution cannot be modified or else undefined behavior will result.
+	const UINT64 lastCompletedFence = m_fence->GetCompletedValue();
 
-    // Move to the next frame resource.
-    m_currentFrameResourceIndex = (m_currentFrameResourceIndex + 1) % FrameCount;
-    m_pCurrentFrameResource = m_frameResources[m_currentFrameResourceIndex];
+	// Move to the next frame resource.
+	m_currentFrameResourceIndex = (m_currentFrameResourceIndex + 1) % FrameCount;
+	m_pCurrentFrameResource = m_frameResources[m_currentFrameResourceIndex];
 
-    // Make sure that this frame resource isn't still in use by the GPU.
-    // If it is, wait for it to complete.
-    if (m_pCurrentFrameResource->m_fenceValue > lastCompletedFence)
-    {
-        HANDLE eventHandle = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (eventHandle == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_pCurrentFrameResource->m_fenceValue, eventHandle));
-        WaitForSingleObject(eventHandle, INFINITE);
-        CloseHandle(eventHandle);
-    }
+	// Make sure that this frame resource isn't still in use by the GPU.
+	// If it is, wait for it to complete.
+	if (m_pCurrentFrameResource->m_fenceValue > lastCompletedFence)
+	{
+		HANDLE eventHandle = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (eventHandle == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_pCurrentFrameResource->m_fenceValue, eventHandle));
+		WaitForSingleObject(eventHandle, INFINITE);
+		CloseHandle(eventHandle);
+	}
 
-    m_cpuTimer.Tick(NULL);
-    float frameTime = static_cast<float>(m_timer.GetElapsedSeconds());
-    float frameChange = 2.0f * frameTime;
+	m_cpuTimer.Tick(NULL);
+	float frameTime = static_cast<float>(m_timer.GetElapsedSeconds());
+	float frameChange = 2.0f * frameTime;
 
-    if (m_keyboardInput.leftArrowPressed)
-        m_camera.RotateYaw(-frameChange);
-    if (m_keyboardInput.rightArrowPressed)
-        m_camera.RotateYaw(frameChange);
-    if (m_keyboardInput.upArrowPressed)
-        m_camera.RotatePitch(frameChange);
-    if (m_keyboardInput.downArrowPressed)
-        m_camera.RotatePitch(-frameChange);
+	if (m_keyboardInput.leftArrowPressed)
+		m_camera.RotateYaw(-frameChange);
+	if (m_keyboardInput.rightArrowPressed)
+		m_camera.RotateYaw(frameChange);
+	if (m_keyboardInput.upArrowPressed)
+		m_camera.RotatePitch(frameChange);
+	if (m_keyboardInput.downArrowPressed)
+		m_camera.RotatePitch(-frameChange);
 
-    if (m_keyboardInput.animate)
-    {
-        for (int i = 0; i < NumLights; i++)
-        {
-            float direction = frameChange * pow(-1.0f, i);
-            XMStoreFloat4(&m_lights[i].position, XMVector4Transform(XMLoadFloat4(&m_lights[i].position), XMMatrixRotationY(direction)));
+	if (m_keyboardInput.animate)
+	{
+		for (int i = 0; i < NumLights; i++)
+		{
+			float direction = frameChange * pow(-1.0f, i);
+			XMStoreFloat4(&m_lights[i].position, XMVector4Transform(XMLoadFloat4(&m_lights[i].position), XMMatrixRotationY(direction)));
 
-            XMVECTOR eye = XMLoadFloat4(&m_lights[i].position);
-            XMVECTOR at = { 0.0f, 8.0f, 0.0f };
-            XMStoreFloat4(&m_lights[i].direction, XMVector3Normalize(XMVectorSubtract(at, eye)));
-            XMVECTOR up = { 0.0f, 1.0f, 0.0f };
-            m_lightCameras[i].Set(eye, at, up);
+			XMVECTOR eye = XMLoadFloat4(&m_lights[i].position);
+			XMVECTOR at = XMVectorSet(0.0f, 8.0f, 0.0f, 0.0f);
+			XMStoreFloat4(&m_lights[i].direction, XMVector3Normalize(XMVectorSubtract(at, eye)));
+			XMVECTOR up = XMVectorSet(0.0f, 1.0f, 0.0f, 0.0f);
+			m_lightCameras[i].Set(eye, at, up);
 
-            m_lightCameras[i].Get3DViewProjMatrices(&m_lights[i].view, &m_lights[i].projection, 90.0f, static_cast<float>(m_width), static_cast<float>(m_height));
-        }
-    }
+			m_lightCameras[i].Get3DViewProjMatrices(&m_lights[i].view, &m_lights[i].projection, 90.0f, static_cast<float>(m_width), static_cast<float>(m_height));
+		}
+	}
 
-    m_pCurrentFrameResource->WriteConstantBuffers(&m_viewport, &m_camera, m_lightCameras, m_lights);
+	m_pCurrentFrameResource->WriteConstantBuffers(&m_viewport, &m_camera, m_lightCameras, m_lights);
 }
 
 // Render the scene.
 void D3D12Multithreading::OnRender()
 {
-    BeginFrame();
+    try
+    {
+        BeginFrame();
 
 #if SINGLETHREADED
-    for (int i = 0; i < NumContexts; i++)
-    {
-        WorkerThread(i);
-    }
-    MidFrame();
-    EndFrame();
-    m_commandQueue->ExecuteCommandLists(_countof(m_pCurrentFrameResource->m_batchSubmit), m_pCurrentFrameResource->m_batchSubmit);
+        for (int i = 0; i < NumContexts; i++)
+        {
+            WorkerThread(i);
+        }
+        MidFrame();
+        EndFrame();
+        m_commandQueue->ExecuteCommandLists(_countof(m_pCurrentFrameResource->m_batchSubmit), m_pCurrentFrameResource->m_batchSubmit);
 #else
-    for (int i = 0; i < NumContexts; i++)
-    {
-        SetEvent(m_workerBeginRenderFrame[i]); // Tell each worker to start drawing.
-    }
+        for (int i = 0; i < NumContexts; i++)
+        {
+            SetEvent(m_workerBeginRenderFrame[i]); // Tell each worker to start drawing.
+        }
 
-    MidFrame();
-    EndFrame();
+        MidFrame();
+        EndFrame();
 
-    WaitForMultipleObjects(NumContexts, m_workerFinishShadowPass, TRUE, INFINITE);
+        WaitForMultipleObjects(NumContexts, m_workerFinishShadowPass, TRUE, INFINITE);
 
-    // You can execute command lists on any thread. Depending on the work 
-    // load, apps can choose between using ExecuteCommandLists on one thread 
-    // vs ExecuteCommandList from multiple threads.
-    m_commandQueue->ExecuteCommandLists(NumContexts + 2, m_pCurrentFrameResource->m_batchSubmit); // Submit PRE, MID and shadows.
+        // You can execute command lists on any thread. Depending on the work 
+        // load, apps can choose between using ExecuteCommandLists on one thread 
+        // vs ExecuteCommandList from multiple threads.
+        m_commandQueue->ExecuteCommandLists(NumContexts + 2, m_pCurrentFrameResource->m_batchSubmit); // Submit PRE, MID and shadows.
 
-    WaitForMultipleObjects(NumContexts, m_workerFinishedRenderFrame, TRUE, INFINITE);
+        WaitForMultipleObjects(NumContexts, m_workerFinishedRenderFrame, TRUE, INFINITE);
 
-    // Submit remaining command lists.
-    m_commandQueue->ExecuteCommandLists(_countof(m_pCurrentFrameResource->m_batchSubmit) - NumContexts - 2, m_pCurrentFrameResource->m_batchSubmit + NumContexts + 2);
+        // Submit remaining command lists.
+        m_commandQueue->ExecuteCommandLists(_countof(m_pCurrentFrameResource->m_batchSubmit) - NumContexts - 2, m_pCurrentFrameResource->m_batchSubmit + NumContexts + 2);
 #endif
 
-    m_cpuTimer.Tick(NULL);
-    if (m_titleCount == TitleThrottle)
-    {
-        WCHAR cpu[64];
-        swprintf_s(cpu, L"%.4f CPU", m_cpuTime / m_titleCount);
-        SetCustomWindowText(cpu);
+        m_cpuTimer.Tick(NULL);
+        if (m_titleCount == TitleThrottle)
+        {
+            WCHAR cpu[64];
+            swprintf_s(cpu, L"%.4f CPU", m_cpuTime / m_titleCount);
+            SetCustomWindowText(cpu);
 
-        m_titleCount = 0;
-        m_cpuTime = 0;
+            m_titleCount = 0;
+            m_cpuTime = 0;
+        }
+        else
+        {
+            m_titleCount++;
+            m_cpuTime += m_cpuTimer.GetElapsedSeconds() * 1000;
+            m_cpuTimer.ResetElapsedTime();
+        }
+
+        // Present and update the frame index for the next frame.
+        PIXBeginEvent(m_commandQueue.Get(), 0, L"Presenting to screen");
+        ThrowIfFailed(m_swapChain->Present(1, 0));
+        PIXEndEvent(m_commandQueue.Get());
+        m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+
+        // Signal and increment the fence value.
+        m_pCurrentFrameResource->m_fenceValue = m_fenceValue;
+        ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValue));
+        m_fenceValue++;
     }
-    else
+    catch (HrException& e)
     {
-        m_titleCount++;
-        m_cpuTime += m_cpuTimer.GetElapsedSeconds() * 1000;
-        m_cpuTimer.ResetElapsedTime();
+        if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
+        {
+            RestoreD3DResources();
+        }
+        else
+        {
+            throw;
+        }
     }
+}
 
-    // Present and update the frame index for the next frame.
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Presenting to screen");
-    ThrowIfFailed(m_swapChain->Present(1, 0));
-    PIXEndEvent(m_commandQueue.Get());
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+// Release sample's D3D objects.
+void D3D12Multithreading::ReleaseD3DResources()
+{
+    m_fence.Reset();
+    ResetComPtrArray(&m_renderTargets);
+    m_commandQueue.Reset();
+    m_swapChain.Reset();
+    m_device.Reset();
+}
 
-    // Signal and increment the fence value.
-    m_pCurrentFrameResource->m_fenceValue = m_fenceValue;
+// Tears down D3D resources and reinitializes them.
+void D3D12Multithreading::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
+    {
+        WaitForGpu();
+    }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
+}
+
+// Wait for pending GPU work to complete.
+void D3D12Multithreading::WaitForGpu()
+{
+    // Schedule a Signal command in the queue.
     ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValue));
-    m_fenceValue++;
+
+    // Wait until the fence has been processed.
+    ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValue, m_fenceEvent));
+    WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
 }
 
 void D3D12Multithreading::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    {
-        const UINT64 fence = m_fenceValue;
-        const UINT64 lastCompletedFence = m_fence->GetCompletedValue();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	{
+		const UINT64 fence = m_fenceValue;
+		const UINT64 lastCompletedFence = m_fence->GetCompletedValue();
 
-        // Signal and increment the fence value.
-        ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValue));
-        m_fenceValue++;
+		// Signal and increment the fence value.
+		ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValue));
+		m_fenceValue++;
 
-        // Wait until the previous frame is finished.
-        if (lastCompletedFence < fence)
-        {
-            ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
-            WaitForSingleObject(m_fenceEvent, INFINITE);
-        }
-        CloseHandle(m_fenceEvent);
-    }
+		// Wait until the previous frame is finished.
+		if (lastCompletedFence < fence)
+		{
+			ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
+			WaitForSingleObject(m_fenceEvent, INFINITE);
+		}
+		CloseHandle(m_fenceEvent);
+	}
 
-    // Close thread events and thread handles.
-    for (int i = 0; i < NumContexts; i++)
-    {
-        CloseHandle(m_workerBeginRenderFrame[i]);
-        CloseHandle(m_workerFinishShadowPass[i]);
-        CloseHandle(m_workerFinishedRenderFrame[i]);
-        CloseHandle(m_threadHandles[i]);
-    }
+	// Close thread events and thread handles.
+	for (int i = 0; i < NumContexts; i++)
+	{
+		CloseHandle(m_workerBeginRenderFrame[i]);
+		CloseHandle(m_workerFinishShadowPass[i]);
+		CloseHandle(m_workerFinishedRenderFrame[i]);
+		CloseHandle(m_threadHandles[i]);
+	}
 
-    for (int i = 0; i < _countof(m_frameResources); i++)
-    {
-        delete m_frameResources[i];
-    }
+	for (int i = 0; i < _countof(m_frameResources); i++)
+	{
+		delete m_frameResources[i];
+	}
 }
 
 void D3D12Multithreading::OnKeyDown(UINT8 key)
 {
-    switch (key)
-    {
-    case VK_LEFT:
-        m_keyboardInput.leftArrowPressed = true;
-        break;
-    case VK_RIGHT:
-        m_keyboardInput.rightArrowPressed = true;
-        break;
-    case VK_UP:
-        m_keyboardInput.upArrowPressed = true;
-        break;
-    case VK_DOWN:
-        m_keyboardInput.downArrowPressed = true;
-        break;
-    case VK_SPACE:
-        m_keyboardInput.animate = !m_keyboardInput.animate;
-        break;
-    }
+	switch (key)
+	{
+	case VK_LEFT:
+		m_keyboardInput.leftArrowPressed = true;
+		break;
+	case VK_RIGHT:
+		m_keyboardInput.rightArrowPressed = true;
+		break;
+	case VK_UP:
+		m_keyboardInput.upArrowPressed = true;
+		break;
+	case VK_DOWN:
+		m_keyboardInput.downArrowPressed = true;
+		break;
+	case VK_SPACE:
+		m_keyboardInput.animate = !m_keyboardInput.animate;
+		break;
+	}
 }
 
 void D3D12Multithreading::OnKeyUp(UINT8 key)
 {
-    switch (key)
-    {
-    case VK_LEFT:
-        m_keyboardInput.leftArrowPressed = false;
-        break;
-    case VK_RIGHT:
-        m_keyboardInput.rightArrowPressed = false;
-        break;
-    case VK_UP:
-        m_keyboardInput.upArrowPressed = false;
-        break;
-    case VK_DOWN:
-        m_keyboardInput.downArrowPressed = false;
-        break;
-    }
+	switch (key)
+	{
+	case VK_LEFT:
+		m_keyboardInput.leftArrowPressed = false;
+		break;
+	case VK_RIGHT:
+		m_keyboardInput.rightArrowPressed = false;
+		break;
+	case VK_UP:
+		m_keyboardInput.upArrowPressed = false;
+		break;
+	case VK_DOWN:
+		m_keyboardInput.downArrowPressed = false;
+		break;
+	}
 }
 
 // Assemble the CommandListPre command list.
 void D3D12Multithreading::BeginFrame()
 {
-    m_pCurrentFrameResource->Init();
+	m_pCurrentFrameResource->Init();
 
-    // Indicate that the back buffer will be used as a render target.
-    m_pCurrentFrameResource->m_commandLists[CommandListPre]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_pCurrentFrameResource->m_commandLists[CommandListPre]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    // Clear the render target and depth stencil.
-    const float clearColor[] = { 0.0f, 0.0f, 0.0f, 1.0f };
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    m_pCurrentFrameResource->m_commandLists[CommandListPre]->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    m_pCurrentFrameResource->m_commandLists[CommandListPre]->ClearDepthStencilView(m_dsvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+	// Clear the render target and depth stencil.
+	const float clearColor[] = { 0.0f, 0.0f, 0.0f, 1.0f };
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	m_pCurrentFrameResource->m_commandLists[CommandListPre]->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	m_pCurrentFrameResource->m_commandLists[CommandListPre]->ClearDepthStencilView(m_dsvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
 
-    ThrowIfFailed(m_pCurrentFrameResource->m_commandLists[CommandListPre]->Close());
+	ThrowIfFailed(m_pCurrentFrameResource->m_commandLists[CommandListPre]->Close());
 }
 
 // Assemble the CommandListMid command list.
 void D3D12Multithreading::MidFrame()
 {
-    // Transition our shadow map from the shadow pass to readable in the scene pass.
-    m_pCurrentFrameResource->SwapBarriers();
+	// Transition our shadow map from the shadow pass to readable in the scene pass.
+	m_pCurrentFrameResource->SwapBarriers();
 
-    ThrowIfFailed(m_pCurrentFrameResource->m_commandLists[CommandListMid]->Close());
+	ThrowIfFailed(m_pCurrentFrameResource->m_commandLists[CommandListMid]->Close());
 }
 
 // Assemble the CommandListPost command list.
 void D3D12Multithreading::EndFrame()
 {
-    m_pCurrentFrameResource->Finish();
+	m_pCurrentFrameResource->Finish();
 
-    // Indicate that the back buffer will now be used to present.
-    m_pCurrentFrameResource->m_commandLists[CommandListPost]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_pCurrentFrameResource->m_commandLists[CommandListPost]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_pCurrentFrameResource->m_commandLists[CommandListPost]->Close());
+	ThrowIfFailed(m_pCurrentFrameResource->m_commandLists[CommandListPost]->Close());
 }
 
 // Worker thread body. workerIndex is an integer from 0 to NumContexts 
 // describing the worker's thread index.
 void D3D12Multithreading::WorkerThread(int threadIndex)
 {
-    assert(threadIndex >= 0);
-    assert(threadIndex < NumContexts);
+	assert(threadIndex >= 0);
+	assert(threadIndex < NumContexts);
 #if !SINGLETHREADED
 
-    while (threadIndex >= 0 && threadIndex < NumContexts)
-    {
-        // Wait for main thread to tell us to draw.
+	while (threadIndex >= 0 && threadIndex < NumContexts)
+	{
+		// Wait for main thread to tell us to draw.
 
-        WaitForSingleObject(m_workerBeginRenderFrame[threadIndex], INFINITE);
+		WaitForSingleObject(m_workerBeginRenderFrame[threadIndex], INFINITE);
 
 #endif
-        ID3D12GraphicsCommandList* pShadowCommandList = m_pCurrentFrameResource->m_shadowCommandLists[threadIndex].Get();
-        ID3D12GraphicsCommandList* pSceneCommandList = m_pCurrentFrameResource->m_sceneCommandLists[threadIndex].Get();
+		ID3D12GraphicsCommandList* pShadowCommandList = m_pCurrentFrameResource->m_shadowCommandLists[threadIndex].Get();
+		ID3D12GraphicsCommandList* pSceneCommandList = m_pCurrentFrameResource->m_sceneCommandLists[threadIndex].Get();
 
-        //
-        // Shadow pass
-        //
+		//
+		// Shadow pass
+		//
 
-        // Populate the command list.
-        SetCommonPipelineState(pShadowCommandList);
-        m_pCurrentFrameResource->Bind(pShadowCommandList, FALSE, nullptr, nullptr);    // No need to pass RTV or DSV descriptor heap.
+		// Populate the command list.
+		SetCommonPipelineState(pShadowCommandList);
+		m_pCurrentFrameResource->Bind(pShadowCommandList, FALSE, nullptr, nullptr);	// No need to pass RTV or DSV descriptor heap.
 
-        // Set null SRVs for the diffuse/normal textures.
-        pShadowCommandList->SetGraphicsRootDescriptorTable(0, m_cbvSrvHeap->GetGPUDescriptorHandleForHeapStart());
+		// Set null SRVs for the diffuse/normal textures.
+		pShadowCommandList->SetGraphicsRootDescriptorTable(0, m_cbvSrvHeap->GetGPUDescriptorHandleForHeapStart());
 
-        // Distribute objects over threads by drawing only 1/NumContexts 
-        // objects per worker (i.e. every object such that objectnum % 
-        // NumContexts == threadIndex).
-        PIXBeginEvent(pShadowCommandList, 0, L"Worker drawing shadow pass...");
+		// Distribute objects over threads by drawing only 1/NumContexts 
+		// objects per worker (i.e. every object such that objectnum % 
+		// NumContexts == threadIndex).
+		PIXBeginEvent(pShadowCommandList, 0, L"Worker drawing shadow pass...");
 
-        for (int j = threadIndex; j < _countof(SampleAssets::Draws); j += NumContexts)
-        {
-            SampleAssets::DrawParameters drawArgs = SampleAssets::Draws[j];
+		for (int j = threadIndex; j < _countof(SampleAssets::Draws); j += NumContexts)
+		{
+			SampleAssets::DrawParameters drawArgs = SampleAssets::Draws[j];
 
-            pShadowCommandList->DrawIndexedInstanced(drawArgs.IndexCount, 1, drawArgs.IndexStart, drawArgs.VertexBase, 0);
-        }
+			pShadowCommandList->DrawIndexedInstanced(drawArgs.IndexCount, 1, drawArgs.IndexStart, drawArgs.VertexBase, 0);
+		}
 
-        PIXEndEvent(pShadowCommandList);
+		PIXEndEvent(pShadowCommandList);
 
-        ThrowIfFailed(pShadowCommandList->Close());
+		ThrowIfFailed(pShadowCommandList->Close());
 
 #if !SINGLETHREADED
-        // Submit shadow pass.
-        SetEvent(m_workerFinishShadowPass[threadIndex]);
+		// Submit shadow pass.
+		SetEvent(m_workerFinishShadowPass[threadIndex]);
 #endif
 
-        //
-        // Scene pass
-        // 
+		//
+		// Scene pass
+		// 
 
-        // Populate the command list.  These can only be sent after the shadow 
-        // passes for this frame have been submitted.
-        SetCommonPipelineState(pSceneCommandList);
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-        CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-        m_pCurrentFrameResource->Bind(pSceneCommandList, TRUE, &rtvHandle, &dsvHandle);
+		// Populate the command list.  These can only be sent after the shadow 
+		// passes for this frame have been submitted.
+		SetCommonPipelineState(pSceneCommandList);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+		m_pCurrentFrameResource->Bind(pSceneCommandList, TRUE, &rtvHandle, &dsvHandle);
 
-        PIXBeginEvent(pSceneCommandList, 0, L"Worker drawing scene pass...");
+		PIXBeginEvent(pSceneCommandList, 0, L"Worker drawing scene pass...");
 
-        D3D12_GPU_DESCRIPTOR_HANDLE cbvSrvHeapStart = m_cbvSrvHeap->GetGPUDescriptorHandleForHeapStart();
-        const UINT cbvSrvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-        const UINT nullSrvCount = 2;
-        for (int j = threadIndex; j < _countof(SampleAssets::Draws); j += NumContexts)
-        {
-            SampleAssets::DrawParameters drawArgs = SampleAssets::Draws[j];
+		D3D12_GPU_DESCRIPTOR_HANDLE cbvSrvHeapStart = m_cbvSrvHeap->GetGPUDescriptorHandleForHeapStart();
+		const UINT cbvSrvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+		const UINT nullSrvCount = 2;
+		for (int j = threadIndex; j < _countof(SampleAssets::Draws); j += NumContexts)
+		{
+			SampleAssets::DrawParameters drawArgs = SampleAssets::Draws[j];
 
-            // Set the diffuse and normal textures for the current object.
-            CD3DX12_GPU_DESCRIPTOR_HANDLE cbvSrvHandle(cbvSrvHeapStart, nullSrvCount + drawArgs.DiffuseTextureIndex, cbvSrvDescriptorSize);
-            pSceneCommandList->SetGraphicsRootDescriptorTable(0, cbvSrvHandle);
+			// Set the diffuse and normal textures for the current object.
+			CD3DX12_GPU_DESCRIPTOR_HANDLE cbvSrvHandle(cbvSrvHeapStart, nullSrvCount + drawArgs.DiffuseTextureIndex, cbvSrvDescriptorSize);
+			pSceneCommandList->SetGraphicsRootDescriptorTable(0, cbvSrvHandle);
 
-            pSceneCommandList->DrawIndexedInstanced(drawArgs.IndexCount, 1, drawArgs.IndexStart, drawArgs.VertexBase, 0);
-        }
+			pSceneCommandList->DrawIndexedInstanced(drawArgs.IndexCount, 1, drawArgs.IndexStart, drawArgs.VertexBase, 0);
+		}
 
-        PIXEndEvent(pSceneCommandList);
-        ThrowIfFailed(pSceneCommandList->Close());
+		PIXEndEvent(pSceneCommandList);
+		ThrowIfFailed(pSceneCommandList->Close());
 
 #if !SINGLETHREADED
-        // Tell main thread that we are done.
-        SetEvent(m_workerFinishedRenderFrame[threadIndex]); 
-    }
+		// Tell main thread that we are done.
+		SetEvent(m_workerFinishedRenderFrame[threadIndex]); 
+	}
 #endif
 }
 
 void D3D12Multithreading::SetCommonPipelineState(ID3D12GraphicsCommandList* pCommandList)
 {
-    pCommandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	pCommandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvHeap.Get(), m_samplerHeap.Get() };
-    pCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvHeap.Get(), m_samplerHeap.Get() };
+	pCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    pCommandList->RSSetViewports(1, &m_viewport);
-    pCommandList->RSSetScissorRects(1, &m_scissorRect);
-    pCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    pCommandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
-    pCommandList->IASetIndexBuffer(&m_indexBufferView);
-    pCommandList->SetGraphicsRootDescriptorTable(3, m_samplerHeap->GetGPUDescriptorHandleForHeapStart());
-    pCommandList->OMSetStencilRef(0);
+	pCommandList->RSSetViewports(1, &m_viewport);
+	pCommandList->RSSetScissorRects(1, &m_scissorRect);
+	pCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	pCommandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+	pCommandList->IASetIndexBuffer(&m_indexBufferView);
+	pCommandList->SetGraphicsRootDescriptorTable(3, m_samplerHeap->GetGPUDescriptorHandleForHeapStart());
+	pCommandList->OMSetStencilRef(0);
 
-    // Render targets and depth stencil are set elsewhere because the 
-    // depth stencil depends on the frame resource being used.
+	// Render targets and depth stencil are set elsewhere because the 
+	// depth stencil depends on the frame resource being used.
 
-    // Constant buffers are set elsewhere because they depend on the 
-    // frame resource being used.
+	// Constant buffers are set elsewhere because they depend on the 
+	// frame resource being used.
 
-    // SRVs are set elsewhere because they change based on the object 
-    // being drawn.
+	// SRVs are set elsewhere because they change based on the object 
+	// being drawn.
 }

--- a/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.h
+++ b/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.h
@@ -29,118 +29,121 @@ class FrameResource;
 
 struct LightState
 {
-    XMFLOAT4 position;
-    XMFLOAT4 direction;
-    XMFLOAT4 color;
-    XMFLOAT4 falloff;
+	XMFLOAT4 position;
+	XMFLOAT4 direction;
+	XMFLOAT4 color;
+	XMFLOAT4 falloff;
 
-    XMFLOAT4X4 view;
-    XMFLOAT4X4 projection;
+	XMFLOAT4X4 view;
+	XMFLOAT4X4 projection;
 };
 
 struct SceneConstantBuffer
 {
-    XMFLOAT4X4 model;
-    XMFLOAT4X4 view;
-    XMFLOAT4X4 projection;
-    XMFLOAT4 ambientColor;
-    BOOL sampleShadowMap;
-    BOOL padding[3];        // Must be aligned to be made up of N float4s.
-    LightState lights[NumLights];
+	XMFLOAT4X4 model;
+	XMFLOAT4X4 view;
+	XMFLOAT4X4 projection;
+	XMFLOAT4 ambientColor;
+	BOOL sampleShadowMap;
+	BOOL padding[3];		// Must be aligned to be made up of N float4s.
+	LightState lights[NumLights];
 };
 
 class D3D12Multithreading : public DXSample
 {
 public:
-    D3D12Multithreading(UINT width, UINT height, std::wstring name);
-    virtual ~D3D12Multithreading();
+	D3D12Multithreading(UINT width, UINT height, std::wstring name);
+	virtual ~D3D12Multithreading();
 
-    static D3D12Multithreading* Get() { return s_app; }
+	static D3D12Multithreading* Get() { return s_app; }
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
-    virtual void OnKeyDown(UINT8 key);
-    virtual void OnKeyUp(UINT8 key);
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
+	virtual void OnKeyDown(UINT8 key);
+	virtual void OnKeyUp(UINT8 key);
 
 private:
-    struct InputState
-    {
-        bool rightArrowPressed;
-        bool leftArrowPressed;
-        bool upArrowPressed;
-        bool downArrowPressed;
-        bool animate;
-    };
+	struct InputState
+	{
+		bool rightArrowPressed;
+		bool leftArrowPressed;
+		bool upArrowPressed;
+		bool downArrowPressed;
+		bool animate;
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12Resource> m_depthStencil;
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_cbvSrvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_samplerHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12PipelineState> m_pipelineStateShadowMap;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12Resource> m_depthStencil;
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_cbvSrvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_samplerHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12PipelineState> m_pipelineStateShadowMap;
 
-    // App resources.
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
-    D3D12_INDEX_BUFFER_VIEW m_indexBufferView;
-    ComPtr<ID3D12Resource> m_textures[_countof(SampleAssets::Textures)];
-    ComPtr<ID3D12Resource> m_textureUploads[_countof(SampleAssets::Textures)];
-    ComPtr<ID3D12Resource> m_indexBuffer;
-    ComPtr<ID3D12Resource> m_indexBufferUpload;
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    ComPtr<ID3D12Resource> m_vertexBufferUpload;
-    UINT m_rtvDescriptorSize;
-    InputState m_keyboardInput;
-    LightState m_lights[NumLights];
-    Camera m_lightCameras[NumLights];
-    Camera m_camera;
-    StepTimer m_timer;
-    StepTimer m_cpuTimer;
-    int m_titleCount;
-    double m_cpuTime;
+	// App resources.
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	D3D12_INDEX_BUFFER_VIEW m_indexBufferView;
+	ComPtr<ID3D12Resource> m_textures[_countof(SampleAssets::Textures)];
+	ComPtr<ID3D12Resource> m_textureUploads[_countof(SampleAssets::Textures)];
+	ComPtr<ID3D12Resource> m_indexBuffer;
+	ComPtr<ID3D12Resource> m_indexBufferUpload;
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	ComPtr<ID3D12Resource> m_vertexBufferUpload;
+	UINT m_rtvDescriptorSize;
+	InputState m_keyboardInput;
+	LightState m_lights[NumLights];
+	Camera m_lightCameras[NumLights];
+	Camera m_camera;
+	StepTimer m_timer;
+	StepTimer m_cpuTimer;
+	int m_titleCount;
+	double m_cpuTime;
 
-    // Synchronization objects.
-    HANDLE m_workerBeginRenderFrame[NumContexts];
-    HANDLE m_workerFinishShadowPass[NumContexts];
-    HANDLE m_workerFinishedRenderFrame[NumContexts];
-    HANDLE m_threadHandles[NumContexts];
-    UINT m_frameIndex;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValue;
+	// Synchronization objects.
+	HANDLE m_workerBeginRenderFrame[NumContexts];
+	HANDLE m_workerFinishShadowPass[NumContexts];
+	HANDLE m_workerFinishedRenderFrame[NumContexts];
+	HANDLE m_threadHandles[NumContexts];
+	UINT m_frameIndex;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValue;
 
-    // Singleton object so that worker threads can share members.
-    static D3D12Multithreading* s_app; 
+	// Singleton object so that worker threads can share members.
+	static D3D12Multithreading* s_app; 
 
-    // Frame resources.
-    FrameResource* m_frameResources[FrameCount];
-    FrameResource* m_pCurrentFrameResource;
-    int m_currentFrameResourceIndex;
+	// Frame resources.
+	FrameResource* m_frameResources[FrameCount];
+	FrameResource* m_pCurrentFrameResource;
+	int m_currentFrameResourceIndex;
 
-    struct ThreadParameter
-    {
-        int threadIndex;
-    };
-    ThreadParameter m_threadParameters[NumContexts];
+	struct ThreadParameter
+	{
+		int threadIndex;
+	};
+	ThreadParameter m_threadParameters[NumContexts];
 
-    void WorkerThread(int threadIndex);
-    void SetCommonPipelineState(ID3D12GraphicsCommandList* pCommandList);
+	void WorkerThread(int threadIndex);
+	void SetCommonPipelineState(ID3D12GraphicsCommandList* pCommandList);
 
-    void LoadPipeline();
-    void LoadAssets();
-    void LoadContexts();
-    void BeginFrame();
-    void MidFrame();
-    void EndFrame();
+	void LoadPipeline();
+	void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
+    void WaitForGpu();
+	void LoadContexts();
+	void BeginFrame();
+	void MidFrame();
+	void EndFrame();
 };

--- a/Samples/Desktop/D3D12Multithreading/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12Multithreading/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,58 +34,103 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title + L": " + text;
-    SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
+	std::wstring windowText = m_title + L": " + text;
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/Desktop/D3D12Multithreading/src/DXSample.h
+++ b/Samples/Desktop/D3D12Multithreading/src/DXSample.h
@@ -17,42 +17,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/Desktop/D3D12Multithreading/src/FrameResource.cpp
+++ b/Samples/Desktop/D3D12Multithreading/src/FrameResource.cpp
@@ -14,278 +14,278 @@
 #include "SquidRoom.h"
 
 FrameResource::FrameResource(ID3D12Device* pDevice, ID3D12PipelineState* pPso, ID3D12PipelineState* pShadowMapPso, ID3D12DescriptorHeap* pDsvHeap, ID3D12DescriptorHeap* pCbvSrvHeap, D3D12_VIEWPORT* pViewport, UINT frameResourceIndex) :
-    m_fenceValue(0),
-    m_pipelineState(pPso),
-    m_pipelineStateShadowMap(pShadowMapPso)
+	m_fenceValue(0),
+	m_pipelineState(pPso),
+	m_pipelineStateShadowMap(pShadowMapPso)
 {
-    for (UINT i = 0; i < CommandListCount; i++)
-    {
-        ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[i])));
-        ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[i].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandLists[i])));
+	for (UINT i = 0; i < CommandListCount; i++)
+	{
+		ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[i])));
+		ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[i].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandLists[i])));
 
-        NAME_D3D12_OBJECT_INDEXED(m_commandLists, i);
+		NAME_D3D12_OBJECT_INDEXED(m_commandLists, i);
 
-        // Close these command lists; don't record into them for now.
-        ThrowIfFailed(m_commandLists[i]->Close());
-    }
+		// Close these command lists; don't record into them for now.
+		ThrowIfFailed(m_commandLists[i]->Close());
+	}
 
-    for (UINT i = 0; i < NumContexts; i++)
-    {
-        // Create command list allocators for worker threads. One alloc is 
-        // for the shadow pass command list, and one is for the scene pass.
-        ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_shadowCommandAllocators[i])));
-        ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[i])));
+	for (UINT i = 0; i < NumContexts; i++)
+	{
+		// Create command list allocators for worker threads. One alloc is 
+		// for the shadow pass command list, and one is for the scene pass.
+		ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_shadowCommandAllocators[i])));
+		ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[i])));
 
-        ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_shadowCommandAllocators[i].Get(), m_pipelineStateShadowMap.Get(), IID_PPV_ARGS(&m_shadowCommandLists[i])));
-        ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_sceneCommandAllocators[i].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_sceneCommandLists[i])));
+		ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_shadowCommandAllocators[i].Get(), m_pipelineStateShadowMap.Get(), IID_PPV_ARGS(&m_shadowCommandLists[i])));
+		ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_sceneCommandAllocators[i].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_sceneCommandLists[i])));
 
-        NAME_D3D12_OBJECT_INDEXED(m_shadowCommandLists, i);
-        NAME_D3D12_OBJECT_INDEXED(m_sceneCommandLists, i);
+		NAME_D3D12_OBJECT_INDEXED(m_shadowCommandLists, i);
+		NAME_D3D12_OBJECT_INDEXED(m_sceneCommandLists, i);
 
-        // Close these command lists; don't record into them for now. We will 
-        // reset them to a recording state when we start the render loop.
-        ThrowIfFailed(m_shadowCommandLists[i]->Close());
-        ThrowIfFailed(m_sceneCommandLists[i]->Close());
-    }
+		// Close these command lists; don't record into them for now. We will 
+		// reset them to a recording state when we start the render loop.
+		ThrowIfFailed(m_shadowCommandLists[i]->Close());
+		ThrowIfFailed(m_sceneCommandLists[i]->Close());
+	}
 
-    // Describe and create the shadow map texture.
-    CD3DX12_RESOURCE_DESC shadowTexDesc(
-        D3D12_RESOURCE_DIMENSION_TEXTURE2D,
-        0,
-        static_cast<UINT>(pViewport->Width), 
-        static_cast<UINT>(pViewport->Height), 
-        1,
-        1,
-        DXGI_FORMAT_R32_TYPELESS,
-        1, 
-        0,
-        D3D12_TEXTURE_LAYOUT_UNKNOWN,
-        D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
+	// Describe and create the shadow map texture.
+	CD3DX12_RESOURCE_DESC shadowTexDesc(
+		D3D12_RESOURCE_DIMENSION_TEXTURE2D,
+		0,
+		static_cast<UINT>(pViewport->Width), 
+		static_cast<UINT>(pViewport->Height), 
+		1,
+		1,
+		DXGI_FORMAT_R32_TYPELESS,
+		1, 
+		0,
+		D3D12_TEXTURE_LAYOUT_UNKNOWN,
+		D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
 
-    D3D12_CLEAR_VALUE clearValue;        // Performance tip: Tell the runtime at resource creation the desired clear value.
-    clearValue.Format = DXGI_FORMAT_D32_FLOAT;
-    clearValue.DepthStencil.Depth = 1.0f;
-    clearValue.DepthStencil.Stencil = 0;
+	D3D12_CLEAR_VALUE clearValue;		// Performance tip: Tell the runtime at resource creation the desired clear value.
+	clearValue.Format = DXGI_FORMAT_D32_FLOAT;
+	clearValue.DepthStencil.Depth = 1.0f;
+	clearValue.DepthStencil.Stencil = 0;
 
-    ThrowIfFailed(pDevice->CreateCommittedResource(
-        &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-        D3D12_HEAP_FLAG_NONE,
-        &shadowTexDesc,
-        D3D12_RESOURCE_STATE_DEPTH_WRITE,
-        &clearValue,
-        IID_PPV_ARGS(&m_shadowTexture)));
+	ThrowIfFailed(pDevice->CreateCommittedResource(
+		&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+		D3D12_HEAP_FLAG_NONE,
+		&shadowTexDesc,
+		D3D12_RESOURCE_STATE_DEPTH_WRITE,
+		&clearValue,
+		IID_PPV_ARGS(&m_shadowTexture)));
 
-    NAME_D3D12_OBJECT(m_shadowTexture);
+	NAME_D3D12_OBJECT(m_shadowTexture);
 
-    // Get a handle to the start of the descriptor heap then offset 
-    // it based on the frame resource index.
-    const UINT dsvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_DSV);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE depthHandle(pDsvHeap->GetCPUDescriptorHandleForHeapStart(), 1 + frameResourceIndex, dsvDescriptorSize); // + 1 for the shadow map.
+	// Get a handle to the start of the descriptor heap then offset 
+	// it based on the frame resource index.
+	const UINT dsvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_DSV);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE depthHandle(pDsvHeap->GetCPUDescriptorHandleForHeapStart(), 1 + frameResourceIndex, dsvDescriptorSize); // + 1 for the shadow map.
 
-    // Describe and create the shadow depth view and cache the CPU 
-    // descriptor handle.
-    D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilViewDesc = {};
-    depthStencilViewDesc.Format = DXGI_FORMAT_D32_FLOAT;
-    depthStencilViewDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
-    depthStencilViewDesc.Texture2D.MipSlice = 0;
-    pDevice->CreateDepthStencilView(m_shadowTexture.Get(), &depthStencilViewDesc, depthHandle);
-    m_shadowDepthView = depthHandle;
+	// Describe and create the shadow depth view and cache the CPU 
+	// descriptor handle.
+	D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilViewDesc = {};
+	depthStencilViewDesc.Format = DXGI_FORMAT_D32_FLOAT;
+	depthStencilViewDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+	depthStencilViewDesc.Texture2D.MipSlice = 0;
+	pDevice->CreateDepthStencilView(m_shadowTexture.Get(), &depthStencilViewDesc, depthHandle);
+	m_shadowDepthView = depthHandle;
 
-    // Get a handle to the start of the descriptor heap then offset it 
-    // based on the existing textures and the frame resource index. Each 
-    // frame has 1 SRV (shadow tex) and 2 CBVs.
-    const UINT nullSrvCount = 2;                                // Null descriptors at the start of the heap.
-    const UINT textureCount = _countof(SampleAssets::Textures);    // Diffuse + normal textures near the start of the heap.  Ideally, track descriptor heap contents/offsets at a higher level.
-    const UINT cbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE cbvSrvCpuHandle(pCbvSrvHeap->GetCPUDescriptorHandleForHeapStart());
-    CD3DX12_GPU_DESCRIPTOR_HANDLE cbvSrvGpuHandle(pCbvSrvHeap->GetGPUDescriptorHandleForHeapStart());
-    m_nullSrvHandle = cbvSrvGpuHandle;
-    cbvSrvCpuHandle.Offset(nullSrvCount + textureCount + (frameResourceIndex * FrameCount), cbvSrvDescriptorSize);
-    cbvSrvGpuHandle.Offset(nullSrvCount + textureCount + (frameResourceIndex * FrameCount), cbvSrvDescriptorSize);
+	// Get a handle to the start of the descriptor heap then offset it 
+	// based on the existing textures and the frame resource index. Each 
+	// frame has 1 SRV (shadow tex) and 2 CBVs.
+	const UINT nullSrvCount = 2;								// Null descriptors at the start of the heap.
+	const UINT textureCount = _countof(SampleAssets::Textures);	// Diffuse + normal textures near the start of the heap.  Ideally, track descriptor heap contents/offsets at a higher level.
+	const UINT cbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE cbvSrvCpuHandle(pCbvSrvHeap->GetCPUDescriptorHandleForHeapStart());
+	CD3DX12_GPU_DESCRIPTOR_HANDLE cbvSrvGpuHandle(pCbvSrvHeap->GetGPUDescriptorHandleForHeapStart());
+	m_nullSrvHandle = cbvSrvGpuHandle;
+	cbvSrvCpuHandle.Offset(nullSrvCount + textureCount + (frameResourceIndex * FrameCount), cbvSrvDescriptorSize);
+	cbvSrvGpuHandle.Offset(nullSrvCount + textureCount + (frameResourceIndex * FrameCount), cbvSrvDescriptorSize);
 
-    // Describe and create a shader resource view (SRV) for the shadow depth 
-    // texture and cache the GPU descriptor handle. This SRV is for sampling 
-    // the shadow map from our shader. It uses the same texture that we use 
-    // as a depth-stencil during the shadow pass.
-    D3D12_SHADER_RESOURCE_VIEW_DESC shadowSrvDesc = {};
-    shadowSrvDesc.Format = DXGI_FORMAT_R32_FLOAT;
-    shadowSrvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-    shadowSrvDesc.Texture2D.MipLevels = 1;
-    shadowSrvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-    pDevice->CreateShaderResourceView(m_shadowTexture.Get(), &shadowSrvDesc, cbvSrvCpuHandle);
-    m_shadowDepthHandle = cbvSrvGpuHandle;
+	// Describe and create a shader resource view (SRV) for the shadow depth 
+	// texture and cache the GPU descriptor handle. This SRV is for sampling 
+	// the shadow map from our shader. It uses the same texture that we use 
+	// as a depth-stencil during the shadow pass.
+	D3D12_SHADER_RESOURCE_VIEW_DESC shadowSrvDesc = {};
+	shadowSrvDesc.Format = DXGI_FORMAT_R32_FLOAT;
+	shadowSrvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+	shadowSrvDesc.Texture2D.MipLevels = 1;
+	shadowSrvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+	pDevice->CreateShaderResourceView(m_shadowTexture.Get(), &shadowSrvDesc, cbvSrvCpuHandle);
+	m_shadowDepthHandle = cbvSrvGpuHandle;
 
-    // Increment the descriptor handles.
-    cbvSrvCpuHandle.Offset(cbvSrvDescriptorSize);
-    cbvSrvGpuHandle.Offset(cbvSrvDescriptorSize);
+	// Increment the descriptor handles.
+	cbvSrvCpuHandle.Offset(cbvSrvDescriptorSize);
+	cbvSrvGpuHandle.Offset(cbvSrvDescriptorSize);
 
-    // Create the constant buffers.
-    const UINT constantBufferSize = (sizeof(SceneConstantBuffer) + (D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1)) & ~(D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1); // must be a multiple 256 bytes
-    ThrowIfFailed(pDevice->CreateCommittedResource(
-        &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-        D3D12_HEAP_FLAG_NONE,
-        &CD3DX12_RESOURCE_DESC::Buffer(constantBufferSize),
-        D3D12_RESOURCE_STATE_GENERIC_READ,
-        nullptr,
-        IID_PPV_ARGS(&m_shadowConstantBuffer)));
-    ThrowIfFailed(pDevice->CreateCommittedResource(
-        &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-        D3D12_HEAP_FLAG_NONE,
-        &CD3DX12_RESOURCE_DESC::Buffer(constantBufferSize),
-        D3D12_RESOURCE_STATE_GENERIC_READ,
-        nullptr,
-        IID_PPV_ARGS(&m_sceneConstantBuffer)));
+	// Create the constant buffers.
+	const UINT constantBufferSize = (sizeof(SceneConstantBuffer) + (D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1)) & ~(D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1); // must be a multiple 256 bytes
+	ThrowIfFailed(pDevice->CreateCommittedResource(
+		&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+		D3D12_HEAP_FLAG_NONE,
+		&CD3DX12_RESOURCE_DESC::Buffer(constantBufferSize),
+		D3D12_RESOURCE_STATE_GENERIC_READ,
+		nullptr,
+		IID_PPV_ARGS(&m_shadowConstantBuffer)));
+	ThrowIfFailed(pDevice->CreateCommittedResource(
+		&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+		D3D12_HEAP_FLAG_NONE,
+		&CD3DX12_RESOURCE_DESC::Buffer(constantBufferSize),
+		D3D12_RESOURCE_STATE_GENERIC_READ,
+		nullptr,
+		IID_PPV_ARGS(&m_sceneConstantBuffer)));
 
-    // Map the constant buffers and cache their heap pointers.
-    CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-    ThrowIfFailed(m_shadowConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&mp_shadowConstantBufferWO)));
-    ThrowIfFailed(m_sceneConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&mp_sceneConstantBufferWO)));
+	// Map the constant buffers and cache their heap pointers.
+	CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+	ThrowIfFailed(m_shadowConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&mp_shadowConstantBufferWO)));
+	ThrowIfFailed(m_sceneConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&mp_sceneConstantBufferWO)));
 
-    // Create the constant buffer views: one for the shadow pass and
-    // another for the scene pass.
-    D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
-    cbvDesc.SizeInBytes = constantBufferSize;
+	// Create the constant buffer views: one for the shadow pass and
+	// another for the scene pass.
+	D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
+	cbvDesc.SizeInBytes = constantBufferSize;
 
-    // Describe and create the shadow constant buffer view (CBV) and 
-    // cache the GPU descriptor handle.
-    cbvDesc.BufferLocation = m_shadowConstantBuffer->GetGPUVirtualAddress();
-    pDevice->CreateConstantBufferView(&cbvDesc, cbvSrvCpuHandle);
-    m_shadowCbvHandle = cbvSrvGpuHandle;
+	// Describe and create the shadow constant buffer view (CBV) and 
+	// cache the GPU descriptor handle.
+	cbvDesc.BufferLocation = m_shadowConstantBuffer->GetGPUVirtualAddress();
+	pDevice->CreateConstantBufferView(&cbvDesc, cbvSrvCpuHandle);
+	m_shadowCbvHandle = cbvSrvGpuHandle;
 
-    // Increment the descriptor handles.
-    cbvSrvCpuHandle.Offset(cbvSrvDescriptorSize);
-    cbvSrvGpuHandle.Offset(cbvSrvDescriptorSize);
+	// Increment the descriptor handles.
+	cbvSrvCpuHandle.Offset(cbvSrvDescriptorSize);
+	cbvSrvGpuHandle.Offset(cbvSrvDescriptorSize);
 
-    // Describe and create the scene constant buffer view (CBV) and 
-    // cache the GPU descriptor handle.
-    cbvDesc.BufferLocation = m_sceneConstantBuffer->GetGPUVirtualAddress();
-    pDevice->CreateConstantBufferView(&cbvDesc, cbvSrvCpuHandle);
-    m_sceneCbvHandle = cbvSrvGpuHandle;
+	// Describe and create the scene constant buffer view (CBV) and 
+	// cache the GPU descriptor handle.
+	cbvDesc.BufferLocation = m_sceneConstantBuffer->GetGPUVirtualAddress();
+	pDevice->CreateConstantBufferView(&cbvDesc, cbvSrvCpuHandle);
+	m_sceneCbvHandle = cbvSrvGpuHandle;
 
-    // Batch up command lists for execution later.
-    const UINT batchSize = _countof(m_sceneCommandLists) + _countof(m_shadowCommandLists) + 3;
-    m_batchSubmit[0] = m_commandLists[CommandListPre].Get();
-    memcpy(m_batchSubmit + 1, m_shadowCommandLists, _countof(m_shadowCommandLists) * sizeof(ID3D12CommandList*));
-    m_batchSubmit[_countof(m_shadowCommandLists) + 1] = m_commandLists[CommandListMid].Get();
-    memcpy(m_batchSubmit + _countof(m_shadowCommandLists) + 2, m_sceneCommandLists, _countof(m_sceneCommandLists) * sizeof(ID3D12CommandList*));
-    m_batchSubmit[batchSize - 1] = m_commandLists[CommandListPost].Get();
+	// Batch up command lists for execution later.
+	const UINT batchSize = _countof(m_sceneCommandLists) + _countof(m_shadowCommandLists) + 3;
+	m_batchSubmit[0] = m_commandLists[CommandListPre].Get();
+	memcpy(m_batchSubmit + 1, m_shadowCommandLists, _countof(m_shadowCommandLists) * sizeof(ID3D12CommandList*));
+	m_batchSubmit[_countof(m_shadowCommandLists) + 1] = m_commandLists[CommandListMid].Get();
+	memcpy(m_batchSubmit + _countof(m_shadowCommandLists) + 2, m_sceneCommandLists, _countof(m_sceneCommandLists) * sizeof(ID3D12CommandList*));
+	m_batchSubmit[batchSize - 1] = m_commandLists[CommandListPost].Get();
 }
 
 FrameResource::~FrameResource()
 {
-    for (int i = 0; i < CommandListCount; i++)
-    {
-        m_commandAllocators[i] = nullptr;
-        m_commandLists[i] = nullptr;
-    }
+	for (int i = 0; i < CommandListCount; i++)
+	{
+		m_commandAllocators[i] = nullptr;
+		m_commandLists[i] = nullptr;
+	}
 
-    m_shadowConstantBuffer = nullptr;
-    m_sceneConstantBuffer = nullptr;
+	m_shadowConstantBuffer = nullptr;
+	m_sceneConstantBuffer = nullptr;
 
-    for (int i = 0; i < NumContexts; i++)
-    {
-        m_shadowCommandLists[i] = nullptr;
-        m_shadowCommandAllocators[i] = nullptr;
+	for (int i = 0; i < NumContexts; i++)
+	{
+		m_shadowCommandLists[i] = nullptr;
+		m_shadowCommandAllocators[i] = nullptr;
 
-        m_sceneCommandLists[i] = nullptr;
-        m_sceneCommandAllocators[i] = nullptr;
-    }
+		m_sceneCommandLists[i] = nullptr;
+		m_sceneCommandAllocators[i] = nullptr;
+	}
 
-    m_shadowTexture = nullptr;
+	m_shadowTexture = nullptr;
 }
 
 // Builds and writes constant buffers from scratch to the proper slots for 
 // this frame resource.
 void FrameResource::WriteConstantBuffers(D3D12_VIEWPORT* pViewport, Camera* pSceneCamera, Camera lightCams[NumLights], LightState lights[NumLights])
 {
-    SceneConstantBuffer sceneConsts = {}; 
-    SceneConstantBuffer shadowConsts = {};
-    
-    // Scale down the world a bit.
-    ::XMStoreFloat4x4(&sceneConsts.model, XMMatrixScaling(0.1f, 0.1f, 0.1f));
-    ::XMStoreFloat4x4(&shadowConsts.model, XMMatrixScaling(0.1f, 0.1f, 0.1f));
+	SceneConstantBuffer sceneConsts = {}; 
+	SceneConstantBuffer shadowConsts = {};
+	
+	// Scale down the world a bit.
+	::XMStoreFloat4x4(&sceneConsts.model, XMMatrixScaling(0.1f, 0.1f, 0.1f));
+	::XMStoreFloat4x4(&shadowConsts.model, XMMatrixScaling(0.1f, 0.1f, 0.1f));
 
-    // The scene pass is drawn from the camera.
-    pSceneCamera->Get3DViewProjMatrices(&sceneConsts.view, &sceneConsts.projection, 90.0f, pViewport->Width, pViewport->Height);
+	// The scene pass is drawn from the camera.
+	pSceneCamera->Get3DViewProjMatrices(&sceneConsts.view, &sceneConsts.projection, 90.0f, pViewport->Width, pViewport->Height);
 
-    // The light pass is drawn from the first light.
-    lightCams[0].Get3DViewProjMatrices(&shadowConsts.view, &shadowConsts.projection, 90.0f, pViewport->Width, pViewport->Height);
+	// The light pass is drawn from the first light.
+	lightCams[0].Get3DViewProjMatrices(&shadowConsts.view, &shadowConsts.projection, 90.0f, pViewport->Width, pViewport->Height);
 
-    for (int i = 0; i < NumLights; i++)
-    {
-        memcpy(&sceneConsts.lights[i], &lights[i], sizeof(LightState));
-        memcpy(&shadowConsts.lights[i], &lights[i], sizeof(LightState));
-    }
+	for (int i = 0; i < NumLights; i++)
+	{
+		memcpy(&sceneConsts.lights[i], &lights[i], sizeof(LightState));
+		memcpy(&shadowConsts.lights[i], &lights[i], sizeof(LightState));
+	}
 
-    // The shadow pass won't sample the shadow map, but rather write to it.
-    shadowConsts.sampleShadowMap = FALSE;
+	// The shadow pass won't sample the shadow map, but rather write to it.
+	shadowConsts.sampleShadowMap = FALSE;
 
-    // The scene pass samples the shadow map.
-    sceneConsts.sampleShadowMap = TRUE;
+	// The scene pass samples the shadow map.
+	sceneConsts.sampleShadowMap = TRUE;
 
-    shadowConsts.ambientColor = sceneConsts.ambientColor = { 0.1f, 0.2f, 0.3f, 1.0f };
+	shadowConsts.ambientColor = sceneConsts.ambientColor = { 0.1f, 0.2f, 0.3f, 1.0f };
 
-    memcpy(mp_sceneConstantBufferWO, &sceneConsts, sizeof(SceneConstantBuffer));
-    memcpy(mp_shadowConstantBufferWO, &shadowConsts, sizeof(SceneConstantBuffer));
+	memcpy(mp_sceneConstantBufferWO, &sceneConsts, sizeof(SceneConstantBuffer));
+	memcpy(mp_shadowConstantBufferWO, &shadowConsts, sizeof(SceneConstantBuffer));
 }
 
 void FrameResource::Init()
 {
-    // Reset the command allocators and lists for the main thread.
-    for (int i = 0; i < CommandListCount; i++)
-    {
-        ThrowIfFailed(m_commandAllocators[i]->Reset());
-        ThrowIfFailed(m_commandLists[i]->Reset(m_commandAllocators[i].Get(), m_pipelineState.Get()));
-    }
+	// Reset the command allocators and lists for the main thread.
+	for (int i = 0; i < CommandListCount; i++)
+	{
+		ThrowIfFailed(m_commandAllocators[i]->Reset());
+		ThrowIfFailed(m_commandLists[i]->Reset(m_commandAllocators[i].Get(), m_pipelineState.Get()));
+	}
 
-    // Clear the depth stencil buffer in preparation for rendering the shadow map.
-    m_commandLists[CommandListPre]->ClearDepthStencilView(m_shadowDepthView, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+	// Clear the depth stencil buffer in preparation for rendering the shadow map.
+	m_commandLists[CommandListPre]->ClearDepthStencilView(m_shadowDepthView, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
 
-    // Reset the worker command allocators and lists.
-    for (int i = 0; i < NumContexts; i++)
-    {
-        ThrowIfFailed(m_shadowCommandAllocators[i]->Reset());
-        ThrowIfFailed(m_shadowCommandLists[i]->Reset(m_shadowCommandAllocators[i].Get(), m_pipelineStateShadowMap.Get()));
+	// Reset the worker command allocators and lists.
+	for (int i = 0; i < NumContexts; i++)
+	{
+		ThrowIfFailed(m_shadowCommandAllocators[i]->Reset());
+		ThrowIfFailed(m_shadowCommandLists[i]->Reset(m_shadowCommandAllocators[i].Get(), m_pipelineStateShadowMap.Get()));
 
-        ThrowIfFailed(m_sceneCommandAllocators[i]->Reset());
-        ThrowIfFailed(m_sceneCommandLists[i]->Reset(m_sceneCommandAllocators[i].Get(), m_pipelineState.Get()));
-    }
+		ThrowIfFailed(m_sceneCommandAllocators[i]->Reset());
+		ThrowIfFailed(m_sceneCommandLists[i]->Reset(m_sceneCommandAllocators[i].Get(), m_pipelineState.Get()));
+	}
 }
 
 void FrameResource::SwapBarriers()
 {
-    // Transition the shadow map from writeable to readable.
-    m_commandLists[CommandListMid]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_shadowTexture.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
+	// Transition the shadow map from writeable to readable.
+	m_commandLists[CommandListMid]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_shadowTexture.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
 }
 
 void FrameResource::Finish()
 {
-    m_commandLists[CommandListPost]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_shadowTexture.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE));
+	m_commandLists[CommandListPost]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_shadowTexture.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE));
 }
 
 // Sets up the descriptor tables for the worker command list to use 
 // resources provided by frame resource.
 void FrameResource::Bind(ID3D12GraphicsCommandList* pCommandList, BOOL scenePass, D3D12_CPU_DESCRIPTOR_HANDLE* pRtvHandle, D3D12_CPU_DESCRIPTOR_HANDLE* pDsvHandle)
 {
-    if (scenePass)
-    {
-        // Scene pass. We use constant buf #2 and depth stencil #2
-        // with rendering to the render target enabled.
-        pCommandList->SetGraphicsRootDescriptorTable(2, m_shadowDepthHandle);        // Set the shadow texture as an SRV.
-        pCommandList->SetGraphicsRootDescriptorTable(1, m_sceneCbvHandle);
-        
-        assert(pRtvHandle != nullptr);
-        assert(pDsvHandle != nullptr);
+	if (scenePass)
+	{
+		// Scene pass. We use constant buf #2 and depth stencil #2
+		// with rendering to the render target enabled.
+		pCommandList->SetGraphicsRootDescriptorTable(2, m_shadowDepthHandle);		// Set the shadow texture as an SRV.
+		pCommandList->SetGraphicsRootDescriptorTable(1, m_sceneCbvHandle);
+		
+		assert(pRtvHandle != nullptr);
+		assert(pDsvHandle != nullptr);
 
-        pCommandList->OMSetRenderTargets(1, pRtvHandle, FALSE, pDsvHandle);
-    }
-    else
-    {
-        // Shadow pass. We use constant buf #1 and depth stencil #1
-        // with rendering to the render target disabled.
-        pCommandList->SetGraphicsRootDescriptorTable(2, m_nullSrvHandle);            // Set a null SRV for the shadow texture.
-        pCommandList->SetGraphicsRootDescriptorTable(1, m_shadowCbvHandle);
+		pCommandList->OMSetRenderTargets(1, pRtvHandle, FALSE, pDsvHandle);
+	}
+	else
+	{
+		// Shadow pass. We use constant buf #1 and depth stencil #1
+		// with rendering to the render target disabled.
+		pCommandList->SetGraphicsRootDescriptorTable(2, m_nullSrvHandle);			// Set a null SRV for the shadow texture.
+		pCommandList->SetGraphicsRootDescriptorTable(1, m_shadowCbvHandle);
 
-        pCommandList->OMSetRenderTargets(0, nullptr, FALSE, &m_shadowDepthView);    // No render target needed for the shadow pass.
-    }
+		pCommandList->OMSetRenderTargets(0, nullptr, FALSE, &m_shadowDepthView);	// No render target needed for the shadow pass.
+	}
 }

--- a/Samples/Desktop/D3D12Multithreading/src/FrameResource.h
+++ b/Samples/Desktop/D3D12Multithreading/src/FrameResource.h
@@ -22,40 +22,40 @@ using namespace Microsoft::WRL;
 class FrameResource
 {
 public:
-    ID3D12CommandList* m_batchSubmit[NumContexts * 2 + CommandListCount];
+	ID3D12CommandList* m_batchSubmit[NumContexts * 2 + CommandListCount];
 
-    ComPtr<ID3D12CommandAllocator> m_commandAllocators[CommandListCount];
-    ComPtr<ID3D12GraphicsCommandList> m_commandLists[CommandListCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocators[CommandListCount];
+	ComPtr<ID3D12GraphicsCommandList> m_commandLists[CommandListCount];
 
-    ComPtr<ID3D12CommandAllocator> m_shadowCommandAllocators[NumContexts];
-    ComPtr<ID3D12GraphicsCommandList> m_shadowCommandLists[NumContexts];
+	ComPtr<ID3D12CommandAllocator> m_shadowCommandAllocators[NumContexts];
+	ComPtr<ID3D12GraphicsCommandList> m_shadowCommandLists[NumContexts];
 
-    ComPtr<ID3D12CommandAllocator> m_sceneCommandAllocators[NumContexts];
-    ComPtr<ID3D12GraphicsCommandList> m_sceneCommandLists[NumContexts];
+	ComPtr<ID3D12CommandAllocator> m_sceneCommandAllocators[NumContexts];
+	ComPtr<ID3D12GraphicsCommandList> m_sceneCommandLists[NumContexts];
 
-    UINT64 m_fenceValue;
+	UINT64 m_fenceValue;
 
 private:
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12PipelineState> m_pipelineStateShadowMap;
-    ComPtr<ID3D12Resource> m_shadowTexture;
-    D3D12_CPU_DESCRIPTOR_HANDLE m_shadowDepthView;
-    ComPtr<ID3D12Resource> m_shadowConstantBuffer;
-    ComPtr<ID3D12Resource> m_sceneConstantBuffer;
-    SceneConstantBuffer* mp_shadowConstantBufferWO;        // WRITE-ONLY pointer to the shadow pass constant buffer.
-    SceneConstantBuffer* mp_sceneConstantBufferWO;        // WRITE-ONLY pointer to the scene pass constant buffer.
-    D3D12_GPU_DESCRIPTOR_HANDLE m_nullSrvHandle;    // Null SRV for out of bounds behavior.
-    D3D12_GPU_DESCRIPTOR_HANDLE m_shadowDepthHandle;
-    D3D12_GPU_DESCRIPTOR_HANDLE m_shadowCbvHandle;
-    D3D12_GPU_DESCRIPTOR_HANDLE m_sceneCbvHandle;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12PipelineState> m_pipelineStateShadowMap;
+	ComPtr<ID3D12Resource> m_shadowTexture;
+	D3D12_CPU_DESCRIPTOR_HANDLE m_shadowDepthView;
+	ComPtr<ID3D12Resource> m_shadowConstantBuffer;
+	ComPtr<ID3D12Resource> m_sceneConstantBuffer;
+	SceneConstantBuffer* mp_shadowConstantBufferWO;		// WRITE-ONLY pointer to the shadow pass constant buffer.
+	SceneConstantBuffer* mp_sceneConstantBufferWO;		// WRITE-ONLY pointer to the scene pass constant buffer.
+	D3D12_GPU_DESCRIPTOR_HANDLE m_nullSrvHandle;	// Null SRV for out of bounds behavior.
+	D3D12_GPU_DESCRIPTOR_HANDLE m_shadowDepthHandle;
+	D3D12_GPU_DESCRIPTOR_HANDLE m_shadowCbvHandle;
+	D3D12_GPU_DESCRIPTOR_HANDLE m_sceneCbvHandle;
 
 public:
-    FrameResource(ID3D12Device* pDevice, ID3D12PipelineState* pPso, ID3D12PipelineState* pShadowMapPso, ID3D12DescriptorHeap* pDsvHeap, ID3D12DescriptorHeap* pCbvSrvHeap, D3D12_VIEWPORT* pViewport, UINT frameResourceIndex);
-    ~FrameResource();
+	FrameResource(ID3D12Device* pDevice, ID3D12PipelineState* pPso, ID3D12PipelineState* pShadowMapPso, ID3D12DescriptorHeap* pDsvHeap, ID3D12DescriptorHeap* pCbvSrvHeap, D3D12_VIEWPORT* pViewport, UINT frameResourceIndex);
+	~FrameResource();
 
-    void Bind(ID3D12GraphicsCommandList* pCommandList, BOOL scenePass, D3D12_CPU_DESCRIPTOR_HANDLE* pRtvHandle, D3D12_CPU_DESCRIPTOR_HANDLE* pDsvHandle);
-    void Init();
-    void SwapBarriers();
-    void Finish();
-    void WriteConstantBuffers(D3D12_VIEWPORT* pViewport, Camera* pSceneCamera, Camera lightCams[NumLights], LightState lights[NumLights]);
+	void Bind(ID3D12GraphicsCommandList* pCommandList, BOOL scenePass, D3D12_CPU_DESCRIPTOR_HANDLE* pRtvHandle, D3D12_CPU_DESCRIPTOR_HANDLE* pDsvHandle);
+	void Init();
+	void SwapBarriers();
+	void Finish();
+	void WriteConstantBuffers(D3D12_VIEWPORT* pViewport, Camera* pSceneCamera, Camera lightCams[NumLights], LightState lights[NumLights]);
 };

--- a/Samples/Desktop/D3D12Multithreading/src/Main.cpp
+++ b/Samples/Desktop/D3D12Multithreading/src/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12Multithreading sample(1280, 720, L"D3D12 Multithreading Sample");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12Multithreading sample(1280, 720, L"D3D12 Multithreading Sample");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12Multithreading/src/SquidRoom.h
+++ b/Samples/Desktop/D3D12Multithreading/src/SquidRoom.h
@@ -15,1153 +15,1153 @@
 
 namespace SampleAssets
 {
-    const wchar_t DataFileName[] = L"SquidRoom.bin";
+	const wchar_t DataFileName[] = L"SquidRoom.bin";
 
-    const D3D12_INPUT_ELEMENT_DESC StandardVertexDescription[] =
-    {
-        { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,  D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "NORMAL",   0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,    0, 24, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "TANGENT",  0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 32, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-    };
+	const D3D12_INPUT_ELEMENT_DESC StandardVertexDescription[] =
+	{
+		{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,  D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		{ "NORMAL",   0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,    0, 24, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		{ "TANGENT",  0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 32, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+	};
 
-    const UINT StandardVertexStride = 44;
+	const UINT StandardVertexStride = 44;
 
-    const DXGI_FORMAT StandardIndexFormat = DXGI_FORMAT_R32_UINT;
+	const DXGI_FORMAT StandardIndexFormat = DXGI_FORMAT_R32_UINT;
 
-    struct TextureResource
-    {
-        UINT Width;
-        UINT Height;
-        UINT MipLevels;
-        DXGI_FORMAT Format;
-        struct DataProperties
-        {
-            UINT Offset;
-            UINT Size;
-            UINT Pitch;
-        } Data[D3D12_REQ_MIP_LEVELS];
-    };
+	struct TextureResource
+	{
+		UINT Width;
+		UINT Height;
+		UINT MipLevels;
+		DXGI_FORMAT Format;
+		struct DataProperties
+		{
+			UINT Offset;
+			UINT Size;
+			UINT Pitch;
+		} Data[D3D12_REQ_MIP_LEVELS];
+	};
 
-    struct DrawParameters
-    {
-        INT DiffuseTextureIndex;
-        INT NormalTextureIndex;
-        INT SpecularTextureIndex;
-        UINT IndexStart;
-        UINT IndexCount;
-        UINT VertexBase;
-    };
+	struct DrawParameters
+	{
+		INT DiffuseTextureIndex;
+		INT NormalTextureIndex;
+		INT SpecularTextureIndex;
+		UINT IndexStart;
+		UINT IndexCount;
+		UINT VertexBase;
+	};
 
-    const UINT VertexDataOffset = 30277640;
-    const UINT VertexDataSize = 9685808;
-    const UINT IndexDataOffset = 39963448;
-    const UINT IndexDataSize = 3056844;
+	const UINT VertexDataOffset = 30277640;
+	const UINT VertexDataSize = 9685808;
+	const UINT IndexDataOffset = 39963448;
+	const UINT IndexDataSize = 3056844;
 
-    const TextureResource Textures[] =
-    {
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 0, 131072, 1024 }, } }, // squard room platform_3_diff_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 131072, 131072, 1024 }, } }, // squard room platform_3_norm_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 262144, 524288, 2048 }, } }, // squard room platform_2_diff_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 786432, 524288, 2048 }, } }, // squard room platform_2_norm_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 1310720, 524288, 2048 }, } }, // squard room platform_1_diff_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 1835008, 524288, 2048 }, } }, // squard room platform_1_norm_1024.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 2359296, 131072, 1024 }, } }, // shelves2_diff1_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 2490368, 131072, 1024 }, } }, // shelves2_nm1_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 2621440, 524288, 2048 }, } }, // Misc_Boss_2 1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 3145728, 524288, 2048 }, } }, // Misc_Boss_2_normal1024.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 3670016, 131072, 1024 }, } }, // Hanging_bundle_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 3801088, 131072, 1024 }, } }, // Catwalk_03_Normal_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 3932160, 524288, 2048 }, } }, // Stack_ Boxes_Diff02_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 4456448, 524288, 2048 }, } }, // Stack_ Boxes_Nm02_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 4980736, 524288, 2048 }, } }, // Stack_ Boxes_Diff03_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 5505024, 524288, 2048 }, } }, // Stack_ Boxes_Nm03_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 6029312, 524288, 2048 }, } }, // Stack_ Boxes_Diff01_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 6553600, 524288, 2048 }, } }, // Stack_ Boxes_Nm01_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 7077888, 524288, 2048 }, } }, // Back_Alley_box_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 7602176, 524288, 2048 }, } }, // Back_Alley_box _norm_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 8126464, 524288, 2048 }, } }, // gameCrates_01_Diff_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 8650752, 524288, 2048 }, } }, // gameCrates_01_Nor_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 9175040, 524288, 2048 }, } }, // RaceCar_Strorage_Diff512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 9699328, 524288, 2048 }, } }, // RaceCar_Strorage_Norm512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10223616, 131072, 1024 }, } }, // hats_02_diff_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10354688, 131072, 1024 }, } }, // hats_02_norm_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10485760, 131072, 1024 }, } }, // hats_01_diff_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10616832, 131072, 1024 }, } }, // hats_01_norm_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 10747904, 524288, 2048 }, } }, // Misc_Boss_1_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 11272192, 524288, 2048 }, } }, // Misc_Boss_1_normal_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 11796480, 524288, 2048 }, } }, // gameCrates_03_Diff_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 12320768, 524288, 2048 }, } }, // gameCrates_03_Nor_1024.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 12845056, 131072, 1024 }, } }, // gameCrates_02_Diff_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 12976128, 524288, 2048 }, } }, // Back_Alley_Drum.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13500416, 131072, 1024 }, } }, // Back_Alley_Drum _norm_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13631488, 131072, 1024 }, } }, // shelves2_diff_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13762560, 131072, 1024 }, } }, // shelves2_nor_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13893632, 131072, 1024 }, } }, // shelves2_diff2_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 14024704, 131072, 1024 }, } }, // shelves2_nm2_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 14155776, 524288, 2048 }, } }, // marbel drum texture_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 14680064, 524288, 2048 }, } }, // marbel drum texture _Nrml_1024.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15204352, 131072, 1024 }, } }, // Catwalk_02_Diffuse512.dds
-        {     1,     1,   1,  DXGI_FORMAT_R8G8B8A8_UNORM, { { 15335424, 4, 4 }, } }, // default-normalmap.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15335428, 131072, 1024 }, } }, // Catwalk_03_Diffuse_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15466500, 131072, 1024 }, } }, // shelves3_diff_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15597572, 131072, 1024 }, } }, // shelves3_nor_512.dds
-        {  2048,  2048,   1,       DXGI_FORMAT_BC1_UNORM, { { 15728644, 2097152, 4096 }, } }, // Misc_Boss_3_2048.dds
-        {  2048,  2048,   1,       DXGI_FORMAT_BC1_UNORM, { { 17825796, 2097152, 4096 }, } }, // Misc_Boss_3_normal2048R.dds
-        {     1,     1,   1,  DXGI_FORMAT_R8G8B8A8_UNORM, { { 19922948, 4, 4 }, } }, // default.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 19922952, 131072, 1024 }, } }, // Hanghing Light_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20054024, 131072, 1024 }, } }, // Hanghing Light_normal_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20185096, 131072, 1024 }, } }, // Hanging_bundle_normal_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20316168, 131072, 1024 }, } }, // Hanging_bundle_marble_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20447240, 131072, 1024 }, } }, // Hanging_bundle_marble_normal_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20578312, 131072, 1024 }, } }, // window_Diff512.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 20709384, 262144, 1024 }, } }, // Sliding Steel Door_Diff_512.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 20971528, 262144, 1024 }, } }, // Sliding Steel Door_Norm_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 21233672, 131072, 1024 }, } }, // window_Norm512.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 21364744, 262144, 1024 }, } }, // Door_Diff_512.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 21626888, 262144, 1024 }, } }, // Door_Norm_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 21889032, 524288, 2048 }, } }, // floor_Diff_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 22413320, 524288, 2048 }, } }, // floor_Normal_1024.dds
-        {  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 22937608, 1048576, 4096 }, } }, // wall03_Diff_2048.dds
-        {  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 23986184, 1048576, 4096 }, } }, // wall03_Normal_2048.dds
-        {  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 25034760, 1048576, 4096 }, } }, // wall01_Diff_2048.dds
-        {  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 26083336, 1048576, 4096 }, } }, // wall01_Normal_2048.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 27131912, 524288, 2048 }, } }, // Roof_Diff1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 27656200, 524288, 2048 }, } }, // Roof_Normal1024.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28180488, 262144, 1024 }, } }, // pillar_Diff_512.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28442632, 262144, 1024 }, } }, // pillar_Norm_512.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28704776, 262144, 1024 }, } }, // Broken_Pillar_Diff_512.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28966920, 262144, 1024 }, } }, // Broken_Pillar_Norm_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 29229064, 524288, 2048 }, } }, // Golfclub_dm_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 29753352, 524288, 2048 }, } }, // Golfclub_nm_1024.dds
-    };
+	const TextureResource Textures[] =
+	{
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 0, 131072, 1024 }, } }, // squard room platform_3_diff_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 131072, 131072, 1024 }, } }, // squard room platform_3_norm_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 262144, 524288, 2048 }, } }, // squard room platform_2_diff_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 786432, 524288, 2048 }, } }, // squard room platform_2_norm_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 1310720, 524288, 2048 }, } }, // squard room platform_1_diff_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 1835008, 524288, 2048 }, } }, // squard room platform_1_norm_1024.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 2359296, 131072, 1024 }, } }, // shelves2_diff1_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 2490368, 131072, 1024 }, } }, // shelves2_nm1_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 2621440, 524288, 2048 }, } }, // Misc_Boss_2 1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 3145728, 524288, 2048 }, } }, // Misc_Boss_2_normal1024.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 3670016, 131072, 1024 }, } }, // Hanging_bundle_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 3801088, 131072, 1024 }, } }, // Catwalk_03_Normal_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 3932160, 524288, 2048 }, } }, // Stack_ Boxes_Diff02_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 4456448, 524288, 2048 }, } }, // Stack_ Boxes_Nm02_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 4980736, 524288, 2048 }, } }, // Stack_ Boxes_Diff03_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 5505024, 524288, 2048 }, } }, // Stack_ Boxes_Nm03_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 6029312, 524288, 2048 }, } }, // Stack_ Boxes_Diff01_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 6553600, 524288, 2048 }, } }, // Stack_ Boxes_Nm01_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 7077888, 524288, 2048 }, } }, // Back_Alley_box_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 7602176, 524288, 2048 }, } }, // Back_Alley_box _norm_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 8126464, 524288, 2048 }, } }, // gameCrates_01_Diff_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 8650752, 524288, 2048 }, } }, // gameCrates_01_Nor_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 9175040, 524288, 2048 }, } }, // RaceCar_Strorage_Diff512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 9699328, 524288, 2048 }, } }, // RaceCar_Strorage_Norm512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10223616, 131072, 1024 }, } }, // hats_02_diff_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10354688, 131072, 1024 }, } }, // hats_02_norm_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10485760, 131072, 1024 }, } }, // hats_01_diff_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10616832, 131072, 1024 }, } }, // hats_01_norm_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 10747904, 524288, 2048 }, } }, // Misc_Boss_1_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 11272192, 524288, 2048 }, } }, // Misc_Boss_1_normal_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 11796480, 524288, 2048 }, } }, // gameCrates_03_Diff_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 12320768, 524288, 2048 }, } }, // gameCrates_03_Nor_1024.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 12845056, 131072, 1024 }, } }, // gameCrates_02_Diff_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 12976128, 524288, 2048 }, } }, // Back_Alley_Drum.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13500416, 131072, 1024 }, } }, // Back_Alley_Drum _norm_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13631488, 131072, 1024 }, } }, // shelves2_diff_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13762560, 131072, 1024 }, } }, // shelves2_nor_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13893632, 131072, 1024 }, } }, // shelves2_diff2_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 14024704, 131072, 1024 }, } }, // shelves2_nm2_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 14155776, 524288, 2048 }, } }, // marbel drum texture_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 14680064, 524288, 2048 }, } }, // marbel drum texture _Nrml_1024.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15204352, 131072, 1024 }, } }, // Catwalk_02_Diffuse512.dds
+		{     1,     1,   1,  DXGI_FORMAT_R8G8B8A8_UNORM, { { 15335424, 4, 4 }, } }, // default-normalmap.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15335428, 131072, 1024 }, } }, // Catwalk_03_Diffuse_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15466500, 131072, 1024 }, } }, // shelves3_diff_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15597572, 131072, 1024 }, } }, // shelves3_nor_512.dds
+		{  2048,  2048,   1,       DXGI_FORMAT_BC1_UNORM, { { 15728644, 2097152, 4096 }, } }, // Misc_Boss_3_2048.dds
+		{  2048,  2048,   1,       DXGI_FORMAT_BC1_UNORM, { { 17825796, 2097152, 4096 }, } }, // Misc_Boss_3_normal2048R.dds
+		{     1,     1,   1,  DXGI_FORMAT_R8G8B8A8_UNORM, { { 19922948, 4, 4 }, } }, // default.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 19922952, 131072, 1024 }, } }, // Hanghing Light_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20054024, 131072, 1024 }, } }, // Hanghing Light_normal_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20185096, 131072, 1024 }, } }, // Hanging_bundle_normal_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20316168, 131072, 1024 }, } }, // Hanging_bundle_marble_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20447240, 131072, 1024 }, } }, // Hanging_bundle_marble_normal_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20578312, 131072, 1024 }, } }, // window_Diff512.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 20709384, 262144, 1024 }, } }, // Sliding Steel Door_Diff_512.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 20971528, 262144, 1024 }, } }, // Sliding Steel Door_Norm_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 21233672, 131072, 1024 }, } }, // window_Norm512.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 21364744, 262144, 1024 }, } }, // Door_Diff_512.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 21626888, 262144, 1024 }, } }, // Door_Norm_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 21889032, 524288, 2048 }, } }, // floor_Diff_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 22413320, 524288, 2048 }, } }, // floor_Normal_1024.dds
+		{  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 22937608, 1048576, 4096 }, } }, // wall03_Diff_2048.dds
+		{  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 23986184, 1048576, 4096 }, } }, // wall03_Normal_2048.dds
+		{  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 25034760, 1048576, 4096 }, } }, // wall01_Diff_2048.dds
+		{  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 26083336, 1048576, 4096 }, } }, // wall01_Normal_2048.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 27131912, 524288, 2048 }, } }, // Roof_Diff1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 27656200, 524288, 2048 }, } }, // Roof_Normal1024.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28180488, 262144, 1024 }, } }, // pillar_Diff_512.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28442632, 262144, 1024 }, } }, // pillar_Norm_512.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28704776, 262144, 1024 }, } }, // Broken_Pillar_Diff_512.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28966920, 262144, 1024 }, } }, // Broken_Pillar_Norm_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 29229064, 524288, 2048 }, } }, // Golfclub_dm_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 29753352, 524288, 2048 }, } }, // Golfclub_nm_1024.dds
+	};
 
-    const DrawParameters Draws[] =
-    {
-        {   0,   1,  -1,        0,    15198,        0 }, // subset0_squard_room_platform_3_dif1
-        {   2,   3,  -1,    15198,      438,     6051 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    15636,      300,     6164 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    15936,      300,     6225 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    16236,      438,     6286 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    16674,      300,     6399 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    16974,      438,     6460 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    17412,      300,     6573 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    17712,      450,     6634 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    18162,      300,     6756 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    18462,      438,     6817 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    18900,      300,     6930 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    19200,      300,     6991 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    19500,      438,     7052 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    19938,      300,     7165 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    20238,      438,     7226 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    20676,      300,     7339 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    20976,      300,     7400 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    21276,      438,     7461 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    21714,      300,     7574 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    22014,      438,     7635 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    22452,      300,     7748 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    22752,      450,     7809 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    23202,      300,     7931 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    23502,      438,     7992 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    23940,      300,     8105 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    24240,      300,     8166 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    24540,      438,     8227 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    24978,      300,     8340 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    25278,      438,     8401 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    25716,      300,     8514 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    26016,      300,     8575 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    26316,      438,     8636 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    26754,      300,     8749 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    27054,      438,     8810 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    27492,      300,     8923 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    27792,      300,     8984 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    28092,      438,     9045 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    28530,      300,     9158 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    28830,      438,     9219 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    29268,      300,     9332 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    29568,      450,     9393 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    30018,      300,     9515 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    30318,      438,     9576 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    30756,      300,     9689 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    31056,      300,     9750 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    31356,      438,     9811 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    31794,      300,     9924 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    32094,      438,     9985 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    32532,      300,    10098 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    32832,      450,    10159 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    33282,      300,    10281 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    33582,      438,    10342 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    34020,      300,    10455 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    34320,      300,    10516 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    34620,      438,    10577 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    35058,      300,    10690 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    35358,      900,    10751 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    36258,      282,    11016 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    36540,      282,    11142 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    36822,      222,    11228 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    37044,      282,    11304 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    37326,      282,    11396 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    37608,      282,    11485 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    37890,      243,    11577 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    38133,      222,    11665 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    38355,      282,    11743 }, // subset0_squard_room_platform_2_dif
-        {   4,   5,  -1,    38637,     2700,    11834 }, // subset0_squard_room_platform_1_diff
-        {   6,   7,  -1,    41337,     1788,    12560 }, // subset0_shelves1_diff
-        {   8,   9,  -1,    43125,      180,    13101 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43305,      180,    13138 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43485,       96,    13175 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43581,       96,    13202 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43677,       96,    13229 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43773,       96,    13256 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43869,       96,    13283 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43965,       30,    13310 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43995,       24,    13322 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44019,       24,    13332 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44043,       24,    13342 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44067,       24,    13351 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44091,       54,    13360 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44145,       12,    13380 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44157,       72,    13386 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44229,       84,    13424 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44313,       30,    13448 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44343,        6,    13460 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44349,       36,    13464 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44385,       60,    13478 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44445,       72,    13496 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44517,       48,    13534 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44565,       24,    13549 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44589,       24,    13559 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44613,       24,    13569 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44637,       42,    13579 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44679,       12,    13595 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44691,       48,    13603 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44739,        6,    13625 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44745,       48,    13629 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44793,        6,    13644 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44799,       60,    13648 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44859,        6,    13666 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44865,       60,    13670 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44925,       72,    13688 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44997,       48,    13709 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45045,       36,    13727 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45081,       72,    13741 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45153,       12,    13779 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45165,       12,    13785 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45177,       30,    13791 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45207,       36,    13803 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45243,        6,    13817 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45249,        6,    13821 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45255,       24,    13825 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45279,       24,    13835 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45303,       24,    13845 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45327,       96,    13855 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45423,       30,    13882 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45453,       96,    13894 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45549,       96,    13921 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45645,       72,    13948 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45717,       72,    13969 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45789,       42,    13990 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45831,       42,    14006 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45873,       54,    14022 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45927,       54,    14042 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45981,       60,    14062 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46041,       60,    14080 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46101,       36,    14098 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46137,       12,    14112 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46149,       12,    14118 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46161,       12,    14124 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46173,       24,    14130 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46197,       24,    14140 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46221,       24,    14150 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46245,       24,    14160 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46269,       24,    14170 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46293,       48,    14180 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46341,       48,    14195 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46389,       48,    14210 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46437,       48,    14225 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46485,       48,    14240 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46533,       36,    14255 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46569,       36,    14269 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46605,       36,    14283 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46641,       36,    14297 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46677,       36,    14311 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46713,       72,    14325 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46785,       72,    14363 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46857,        6,    14401 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46863,        6,    14405 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46869,        6,    14409 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46875,       24,    14413 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46899,       24,    14422 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46923,       48,    14431 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46971,       48,    14449 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47019,       12,    14464 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47031,       12,    14470 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47043,       12,    14476 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47055,       12,    14482 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47067,       12,    14488 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47079,       12,    14494 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47091,       12,    14500 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47103,       12,    14506 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47115,       24,    14512 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47139,       24,    14521 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47163,       60,    14530 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47223,       60,    14548 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47283,       60,    14566 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47343,       60,    14584 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47403,       60,    14602 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47463,       48,    14620 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47511,       48,    14642 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47559,       36,    14664 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47595,       36,    14678 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47631,       24,    14692 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47655,       12,    14701 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47667,       12,    14707 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47679,       12,    14713 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47691,       12,    14719 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47703,       12,    14725 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47715,       12,    14731 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47727,       12,    14737 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47739,        6,    14743 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47745,        6,    14747 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47751,        6,    14751 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47757,        6,    14755 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47763,       12,    14759 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47775,       12,    14765 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47787,       12,    14771 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47799,       12,    14777 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47811,       60,    14783 }, // subset0_blinnMisc_Boss_2
-        {  10,  11,  -1,    47871,      762,    14801 }, // subset0_lambert1
-        {   8,   9,  -1,    48633,       66,    14801 }, // subset1_blinnMisc_Boss_2_0
-        {   8,   9,  -1,    48699,      144,    15136 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    48843,      144,    15171 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    48987,      144,    15206 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    49131,      144,    15241 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    49275,      180,    15276 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    49455,      144,    15318 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    49599,      144,    15353 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    49743,      144,    15388 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    49887,      180,    15423 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    50067,      180,    15465 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    50247,      144,    15507 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    50391,      180,    15542 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    50571,      144,    15584 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    50715,      108,    15619 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    50823,     4416,    15647 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    55239,      273,    16657 }, // subset0_blinnMisc_Boss_2
-        {  12,  13,  -1,    55512,     4143,    16754 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    59655,      360,    19212 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    60015,      300,    19293 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    60315,      360,    19359 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    60675,      240,    19436 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    60915,     1566,    19491 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62481,       48,    19889 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62529,       48,    19907 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62577,       48,    19925 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62625,       48,    19943 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62673,       48,    19961 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62721,       48,    19979 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62769,       96,    19997 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62865,       36,    20024 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62901,       36,    20038 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62937,       36,    20052 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62973,       36,    20066 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63009,       36,    20080 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63045,       36,    20094 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63081,       36,    20108 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63117,       36,    20122 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63153,       36,    20136 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63189,       36,    20150 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63225,       36,    20164 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63261,      108,    20178 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63369,       36,    20206 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63405,       36,    20220 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63441,       36,    20234 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63477,       36,    20248 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63513,       36,    20262 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63549,       36,    20276 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63585,       36,    20290 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63621,       72,    20304 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63693,       72,    20325 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63765,      144,    20346 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63909,       72,    20381 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63981,       36,    20402 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64017,       36,    20416 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64053,      144,    20430 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64197,      144,    20465 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64341,       36,    20500 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64377,       36,    20514 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64413,       36,    20528 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64449,       36,    20542 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64485,       36,    20556 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64521,       36,    20570 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64557,       36,    20584 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64593,       36,    20598 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64629,       36,    20612 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64665,       36,    20626 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64701,      252,    20640 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64953,      276,    20816 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    65229,      276,    21014 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    65505,      276,    21200 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    65781,      294,    21394 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    66075,      279,    21582 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    66354,      264,    21732 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    66618,      288,    21898 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    66906,      468,    22065 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    67374,     1296,    22222 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    68670,       18,    22988 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    68688,       36,    22996 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    68724,       42,    23022 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    68766,       36,    23054 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    68802,       42,    23076 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    68844,      336,    23104 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    69180,      144,    23104 }, // subset1_lambert1_0
-        {  12,  13,  -1,    69324,      240,    23250 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    69564,      240,    23334 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    69804,      246,    23427 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    70050,      120,    23543 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    70170,      630,    23600 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    70800,     1080,    23743 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    71880,      720,    23991 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    72600,      204,    24154 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    72804,      336,    24198 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    73140,      144,    24198 }, // subset1_lambert1_0
-        {  12,  13,  -1,    73284,      225,    24344 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    73509,       15,    24344 }, // subset1_lambert1_0
-        {  12,  13,  -1,    73524,      225,    24458 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    73749,       15,    24458 }, // subset1_lambert1_0
-        {  12,  13,  -1,    73764,      225,    24572 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    73989,       15,    24572 }, // subset1_lambert1_0
-        {  12,  13,  -1,    74004,      225,    24686 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    74229,       15,    24686 }, // subset1_lambert1_0
-        {  12,  13,  -1,    74244,      225,    24800 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    74469,       15,    24800 }, // subset1_lambert1_0
-        {  12,  13,  -1,    74484,      225,    24914 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    74709,       15,    24914 }, // subset1_lambert1_0
-        {  14,  15,  -1,    74724,     2208,    25028 }, // subset0_Stack__Boxes_Diff03
-        {  16,  17,  -1,    76932,     9381,    25553 }, // subset0_Stack__Boxes_Diff01
-        {  18,  19,  -1,    86313,      948,    29643 }, // subset0_Back_Alley_box
-        {  20,  21,  -1,    87261,     1488,    29946 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,    88749,     1998,    30265 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,    90747,     1872,    30649 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,    92619,     1692,    31034 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,    94311,     1638,    31387 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,    95949,     1872,    31702 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,    97821,     1662,    32056 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,    99483,     1902,    32409 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   101385,      720,    32807 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   102105,     1296,    32957 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   103401,      432,    33232 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   103833,     1152,    33332 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   104985,     1152,    33557 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   106137,     1380,    33782 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   107517,     1470,    34080 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   108987,     1308,    34364 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   110295,     1662,    34622 }, // subset0_gameCrates_01_Diff
-        {  22,  23,  -1,   111957,      636,    34941 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   112593,     1728,    35137 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   114321,      336,    35500 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   114657,     2304,    35577 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   116961,      246,    36138 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   117207,     1260,    36270 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   118467,     1866,    36512 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   120333,     2070,    36976 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   122403,     1050,    37421 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   123453,      450,    37624 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   123903,      450,    37760 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   124353,      390,    37896 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   124743,      390,    38021 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   125133,      390,    38148 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   125523,      330,    38273 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   125853,      390,    38387 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   126243,      330,    38512 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   126573,      420,    38626 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   126993,      390,    38763 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   127383,      300,    38888 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   127683,      300,    38961 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   127983,      300,    39045 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   128283,      300,    39131 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   128583,      300,    39215 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   128883,      300,    39286 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   129183,      300,    39410 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   129483,      300,    39483 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   129783,      300,    39567 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   130083,      300,    39653 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   130383,      300,    39737 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   130683,      300,    39808 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   130983,      300,    39968 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   131283,      300,    40041 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   131583,      300,    40125 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   131883,      300,    40211 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   132183,      300,    40295 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   132483,      300,    40366 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   132783,      300,    40490 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   133083,      300,    40561 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   133383,      300,    40721 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   133683,      300,    40794 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   133983,      300,    40878 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   134283,      300,    40964 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   134583,      300,    41048 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   134883,      300,    41119 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   135183,      300,    41243 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   135483,      300,    41314 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   135783,      300,    41474 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   136083,      300,    41547 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   136383,      300,    41631 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   136683,      300,    41717 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   136983,      300,    41801 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   137283,      300,    41872 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   137583,      300,    41996 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   137883,      300,    42069 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   138183,      300,    42153 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   138483,      300,    42239 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   138783,      300,    42323 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   139083,      300,    42394 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   139383,      300,    42554 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   139683,      300,    42627 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   139983,      300,    42711 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   140283,      300,    42797 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   140583,      300,    42881 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   140883,      300,    42952 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   141183,      300,    43076 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   141483,      300,    43149 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   141783,      300,    43349 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   142083,      300,    43551 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   142383,      300,    43751 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   142683,      300,    43951 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   142983,      300,    44151 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   143283,      300,    44351 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   143583,      300,    44551 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   143883,      300,    44751 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   144183,      300,    44951 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   144483,      300,    45153 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   144783,      300,    45353 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   145083,      300,    45553 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   145383,      300,    45753 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   145683,      300,    45953 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   145983,      300,    46153 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   146283,      300,    46353 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   146583,      300,    46553 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   146883,      300,    46755 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   147183,      300,    46955 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   147483,      300,    47155 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   147783,      300,    47355 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   148083,      300,    47555 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   148383,      300,    47755 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   148683,      300,    47955 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   148983,      300,    48155 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   149283,      300,    48355 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   149583,      300,    48557 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   149883,      300,    48757 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   150183,      300,    48957 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   150483,      300,    49157 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   150783,      216,    49357 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   150999,      216,    49455 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   151215,      216,    49553 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   151431,     1014,    49651 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   152445,      216,    49929 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   152661,     1014,    50029 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   153675,     1014,    50324 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   154689,     1014,    50614 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   155703,      588,    50894 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   156291,     5574,    51104 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   161865,      588,    52700 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   162453,      588,    52910 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   163041,      588,    53120 }, // subset0_RaceCar_Strorage_Diff
-        {  24,  25,  -1,   163629,       48,    53330 }, // subset0_hats_2
-        {  24,  25,  -1,   163677,      501,    53362 }, // subset0_hats_2
-        {  24,  25,  -1,   164178,      252,    53471 }, // subset0_hats_2
-        {  24,  25,  -1,   164430,       48,    53520 }, // subset0_hats_2
-        {  24,  25,  -1,   164478,     1620,    53552 }, // subset0_hats_2
-        {  24,  25,  -1,   166098,     3978,    53850 }, // subset0_hats_2
-        {  24,  25,  -1,   170076,      765,    54754 }, // subset0_hats_2
-        {  24,  25,  -1,   170841,      900,    54906 }, // subset0_hats_2
-        {  24,  25,  -1,   171741,     1260,    55154 }, // subset0_hats_2
-        {  24,  25,  -1,   173001,      408,    55431 }, // subset0_hats_2
-        {  24,  25,  -1,   173409,      765,    55546 }, // subset0_hats_2
-        {  24,  25,  -1,   174174,      720,    55694 }, // subset0_hats_2
-        {  24,  25,  -1,   174894,      252,    55894 }, // subset0_hats_2
-        {  24,  25,  -1,   175146,      252,    55943 }, // subset0_hats_2
-        {  24,  25,  -1,   175398,      252,    55992 }, // subset0_hats_2
-        {  24,  25,  -1,   175650,      252,    56041 }, // subset0_hats_2
-        {  24,  25,  -1,   175902,      252,    56090 }, // subset0_hats_2
-        {  24,  25,  -1,   176154,      252,    56139 }, // subset0_hats_2
-        {  24,  25,  -1,   176406,      252,    56188 }, // subset0_hats_2
-        {  24,  25,  -1,   176658,      252,    56237 }, // subset0_hats_2
-        {  26,  27,  -1,   176910,       48,    56286 }, // subset0_Hats_1
-        {  24,  25,  -1,   176958,     6792,    56318 }, // subset0_hats_2
-        {  24,  25,  -1,   183750,     2124,    57790 }, // subset0_hats_2
-        {  24,  25,  -1,   185874,     2268,    58361 }, // subset0_hats_2
-        {  24,  25,  -1,   188142,       66,    58938 }, // subset0_hats_2
-        {  24,  25,  -1,   188208,      270,    58973 }, // subset0_hats_2
-        {  24,  25,  -1,   188478,       48,    59080 }, // subset0_hats_2
-        {  24,  25,  -1,   188526,       66,    59111 }, // subset0_hats_2
-        {  24,  25,  -1,   188592,       60,    59148 }, // subset0_hats_2
-        {  24,  25,  -1,   188652,       66,    59178 }, // subset0_hats_2
-        {  24,  25,  -1,   188718,      168,    59215 }, // subset0_hats_2
-        {  24,  25,  -1,   188886,      168,    59275 }, // subset0_hats_2
-        {  24,  25,  -1,   189054,      174,    59333 }, // subset0_hats_2
-        {  24,  25,  -1,   189228,     1650,    59418 }, // subset0_hats_2
-        {  24,  25,  -1,   190878,      918,    59867 }, // subset0_hats_2
-        {  24,  25,  -1,   191796,      426,    60089 }, // subset0_hats_2
-        {  26,  27,  -1,   192222,     1209,    60211 }, // subset0_Hats_1
-        {  24,  25,  -1,   193431,      180,    60506 }, // subset0_hats_2
-        {  26,  27,  -1,   193611,      714,    60571 }, // subset0_Hats_1
-        {  26,  27,  -1,   194325,      426,    60759 }, // subset0_Hats_1
-        {  26,  27,  -1,   194751,      426,    60888 }, // subset0_Hats_1
-        {  26,  27,  -1,   195177,      432,    61010 }, // subset0_Hats_1
-        {  26,  27,  -1,   195609,      432,    61147 }, // subset0_Hats_1
-        {  26,  27,  -1,   196041,     1608,    61268 }, // subset0_Hats_1
-        {  28,  29,  -1,   197649,    18219,    61783 }, // subset0_Misc_Boss_1
-        {  16,  17,  -1,   215868,     2484,    69708 }, // subset0_Stack__Boxes_Diff01
-        {  16,  17,  -1,   218352,     2409,    71274 }, // subset0_Stack__Boxes_Diff01
-        {  16,  17,  -1,   220761,     2409,    72652 }, // subset0_Stack__Boxes_Diff01
-        {  16,  17,  -1,   223170,     2409,    74026 }, // subset0_Stack__Boxes_Diff01
-        {  16,  17,  -1,   225579,     1833,    75404 }, // subset0_Stack__Boxes_Diff01
-        {  30,  31,  -1,   227412,     3867,    76541 }, // subset0_gameCrates_03_Diff
-        {  30,  31,  -1,   231279,     3750,    78113 }, // subset0_gameCrates_03_Diff
-        {  16,  17,  -1,   235029,     2409,    79856 }, // subset0_Stack__Boxes_Diff01
-        {  16,  17,  -1,   237438,     2409,    81222 }, // subset0_Stack__Boxes_Diff01
-        {  30,  31,  -1,   239847,    12468,    82594 }, // subset0_gameCrates_03_Diff
-        {  30,  31,  -1,   252315,     3441,    88547 }, // subset0_gameCrates_03_Diff
-        {  32,  32,  -1,   255756,     1932,    89479 }, // subset0_gameCrates_02_Diff
-        {  14,  15,  -1,   257688,      984,    89905 }, // subset0_Stack__Boxes_Diff03
-        {  14,  15,  -1,   258672,      741,    90403 }, // subset0_Stack__Boxes_Diff03
-        {  14,  15,  -1,   259413,      426,    90727 }, // subset0_Stack__Boxes_Diff03
-        {  32,  32,  -1,   259839,     1419,    90932 }, // subset0_gameCrates_02_Diff
-        {  18,  19,  -1,   261258,     3090,    91251 }, // subset0_Back_Alley_box
-        {  14,  15,  -1,   264348,      573,    92286 }, // subset0_Stack__Boxes_Diff03
-        {  32,  32,  -1,   264921,     1176,    92524 }, // subset0_gameCrates_02_Diff
-        {  32,  32,  -1,   266097,      792,    92809 }, // subset0_gameCrates_02_Diff
-        {  14,  15,  -1,   266889,      573,    93047 }, // subset0_Stack__Boxes_Diff03
-        {  14,  15,  -1,   267462,      741,    93285 }, // subset0_Stack__Boxes_Diff03
-        {  18,  19,  -1,   268203,     1620,    93609 }, // subset0_Back_Alley_box
-        {  14,  15,  -1,   269823,      396,    94126 }, // subset0_Stack__Boxes_Diff03
-        {  14,  15,  -1,   270219,      396,    94281 }, // subset0_Stack__Boxes_Diff03
-        {  14,  15,  -1,   270615,      396,    94436 }, // subset0_Stack__Boxes_Diff03
-        {  32,  32,  -1,   271011,     1008,    94591 }, // subset0_gameCrates_02_Diff
-        {  32,  32,  -1,   272019,     2040,    94830 }, // subset0_gameCrates_02_Diff
-        {  14,  15,  -1,   274059,      468,    95269 }, // subset0_Stack__Boxes_Diff03
-        {  32,  32,  -1,   274527,     1236,    95437 }, // subset0_gameCrates_02_Diff
-        {  32,  32,  -1,   275763,      903,    95726 }, // subset0_gameCrates_02_Diff
-        {  32,  32,  -1,   276666,     1884,    95942 }, // subset0_gameCrates_02_Diff
-        {  32,  32,  -1,   278550,     2088,    96353 }, // subset0_gameCrates_02_Diff
-        {  32,  32,  -1,   280638,     1008,    96827 }, // subset0_gameCrates_02_Diff
-        {  33,  34,  -1,   281646,     1920,    97063 }, // subset0_Back_Alley_Drum
-        {  35,  36,  -1,   283566,     7809,    97728 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   291375,     8172,    99390 }, // subset0_shelves2_diff
-        {  37,  38,  -1,   299547,       12,   101144 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   299559,      132,   101150 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   299691,      132,   101218 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   299823,      228,   101286 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   300051,      228,   101382 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   300279,      228,   101485 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   300507,      228,   101581 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   300735,      228,   101689 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   300963,      228,   101785 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   301191,      852,   101881 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   302043,      702,   102217 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   302745,      372,   102461 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   303117,      564,   102637 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   303681,      324,   102857 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   304005,      324,   102977 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   304329,      588,   103097 }, // subset0_shelves2_diff1
-        {   6,   7,  -1,   304917,     1122,   103337 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   306039,      888,   103622 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   306927,       96,   103854 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   307023,       96,   103902 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   307119,      102,   103947 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   307221,       96,   103987 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   307317,       96,   104032 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   307413,      576,   104078 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   307989,       78,   104208 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   308067,      102,   104240 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   308169,       72,   104284 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   308241,      336,   104315 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   308577,      144,   104450 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   308721,      120,   104490 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   308841,      144,   104518 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   308985,      120,   104558 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   309105,      126,   104586 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   309231,      120,   104624 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   309351,      144,   104652 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   309495,      117,   104692 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   309612,     1572,   104720 }, // subset0_shelves1_diff2
-        {  39,  40,  -1,   311184,      540,   105150 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   311724,     2136,   105282 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   313860,       24,   105899 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   313884,       24,   105911 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   313908,       27,   105923 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   313935,     2964,   105936 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   316899,     2964,   106458 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   319863,      702,   106980 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   320565,      702,   107117 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   321267,      702,   107249 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   321969,      702,   107379 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   322671,     2964,   107511 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   325635,        6,   108033 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   325641,      432,   108037 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   326073,      429,   108130 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   326502,     2964,   108216 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   329466,     2106,   108738 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   331572,     2106,   109129 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   333678,      429,   109515 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   334107,     1794,   109614 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   335901,     2262,   109948 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   338163,     2964,   110365 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   341127,     2964,   110880 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   344091,     2964,   111402 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   347055,     2730,   111919 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   349785,     2964,   112407 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   352749,     2964,   112929 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   355713,     2964,   113444 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   358677,     3276,   113961 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   361953,      780,   114605 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   362733,      936,   114773 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   363669,      936,   114969 }, // subset0_marbel_drum_blinn
-        {  41,  42,  -1,   364605,      108,   115165 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   364713,       81,   115185 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   364794,       81,   115225 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   364875,       81,   115255 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   364956,       81,   115287 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365037,      108,   115328 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365145,       81,   115348 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365226,       81,   115388 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365307,       81,   115418 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365388,      108,   115450 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365496,       81,   115470 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365577,      108,   115510 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365685,       81,   115530 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365766,       81,   115570 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365847,       81,   115602 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365928,      108,   115641 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366036,       81,   115669 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366117,       81,   115709 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366198,       81,   115741 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366279,      108,   115780 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366387,       81,   115808 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366468,       81,   115847 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366549,       81,   115879 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366630,       81,   115909 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366711,      108,   115948 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366819,       81,   115976 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366900,       81,   116006 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366981,      108,   116038 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367089,       81,   116066 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367170,       81,   116105 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367251,      108,   116137 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367359,       81,   116165 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367440,       81,   116204 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367521,      237,   116234 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367758,      216,   116293 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367974,      216,   116348 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   368190,      240,   116398 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   368430,      216,   116453 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   368646,      216,   116503 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   368862,      324,   116558 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   369186,      108,   116650 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   369294,      324,   116688 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   369618,      108,   116780 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   369726,      324,   116818 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   370050,      108,   116910 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   370158,      324,   116948 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   370482,      108,   117040 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   370590,      324,   117078 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   370914,      108,   117170 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371022,      324,   117208 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371346,      108,   117300 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371454,       54,   117338 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371508,       54,   117357 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371562,       54,   117376 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371616,       54,   117395 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371670,       54,   117414 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371724,       54,   117433 }, // subset0_blinnCatwalk
-        {  43,  11,  -1,   371778,      120,   117452 }, // subset0_Catwalk_03_Diffuse
-        {  43,  11,  -1,   371898,     3078,   117532 }, // subset0_Catwalk_03_Diffuse
-        {  43,  11,  -1,   374976,     4356,   118172 }, // subset0_Catwalk_03_Diffuse
-        {  43,  11,  -1,   379332,     4356,   119043 }, // subset0_Catwalk_03_Diffuse
-        {  43,  11,  -1,   383688,     4356,   119896 }, // subset0_Catwalk_03_Diffuse
-        {  43,  11,  -1,   388044,     3636,   120749 }, // subset0_Catwalk_03_Diffuse
-        {  41,  42,  -1,   391680,       72,   121481 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   391752,      162,   121513 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   391914,      324,   121553 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   392238,      144,   121630 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   392382,      144,   121665 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   392526,      162,   121705 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   392688,      324,   121745 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   393012,      144,   121822 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   393156,      144,   121857 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   393300,      162,   121897 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   393462,      360,   121937 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   393822,      144,   122014 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   393966,      144,   122049 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   394110,      162,   122084 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   394272,      324,   122124 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   394596,      153,   122194 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   394749,      144,   122234 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   394893,      162,   122269 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   395055,      324,   122309 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   395379,      144,   122379 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   395523,      144,   122419 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   395667,      162,   122459 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   395829,      324,   122503 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   396153,      150,   122573 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   396303,      144,   122621 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   396447,      162,   122661 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   396609,      324,   122701 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   396933,      144,   122778 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   397077,      144,   122818 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   397221,      162,   122853 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   397383,      324,   122897 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   397707,      141,   122967 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   397848,      144,   123006 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   397992,      162,   123041 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   398154,    19506,   123085 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   417660,    19506,   129867 }, // subset0_blinnCatwalk
-        {  43,  11,  -1,   437166,      120,   136640 }, // subset0_Catwalk_03_Diffuse
-        {  41,  42,  -1,   437286,       72,   136720 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437358,       24,   136752 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437382,       24,   136768 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437406,       24,   136784 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437430,       24,   136800 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437454,       24,   136816 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437478,       24,   136832 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437502,       24,   136848 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437526,       24,   136864 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437550,       24,   136880 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437574,       24,   136896 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437598,       24,   136912 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437622,       24,   136928 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437646,       24,   136944 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437670,       24,   136960 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437694,       24,   136976 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437718,       24,   136992 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437742,       24,   137008 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437766,       24,   137024 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437790,       24,   137040 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437814,       24,   137056 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437838,       24,   137072 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437862,       24,   137088 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437886,       24,   137104 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437910,       24,   137120 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437934,       24,   137136 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437958,       24,   137152 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437982,       24,   137168 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438006,       24,   137184 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438030,       24,   137200 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438054,       24,   137216 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438078,       24,   137232 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438102,       24,   137248 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438126,       24,   137264 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438150,       24,   137280 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438174,       24,   137296 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438198,       24,   137312 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438222,       24,   137328 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438246,       24,   137344 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438270,       24,   137360 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438294,       24,   137376 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438318,       24,   137392 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438342,       24,   137408 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438366,       24,   137424 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438390,       24,   137440 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438414,       24,   137456 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438438,       24,   137472 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438462,       24,   137488 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438486,       24,   137504 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438510,       24,   137520 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438534,       24,   137536 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438558,       24,   137552 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438582,       24,   137568 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438606,       24,   137584 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438630,       24,   137600 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438654,       24,   137616 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438678,       24,   137632 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438702,       24,   137648 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438726,       24,   137664 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438750,       24,   137680 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438774,       24,   137696 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438798,       24,   137712 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438822,       24,   137728 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438846,       24,   137744 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438870,       24,   137760 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438894,       24,   137776 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438918,       24,   137792 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438942,       24,   137808 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438966,       24,   137824 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438990,       24,   137840 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439014,       24,   137856 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439038,       24,   137872 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439062,       24,   137888 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439086,       24,   137904 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439110,       24,   137920 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439134,       24,   137936 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439158,       24,   137952 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439182,       24,   137968 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439206,       24,   137984 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439230,       24,   138000 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439254,       24,   138016 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439278,       24,   138032 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439302,       24,   138048 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439326,       24,   138064 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439350,       24,   138080 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439374,       24,   138096 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439398,       24,   138112 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439422,       24,   138128 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439446,       24,   138144 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439470,       24,   138160 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439494,       24,   138176 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439518,       24,   138192 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439542,       24,   138208 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439566,       24,   138224 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439590,       24,   138240 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439614,       24,   138256 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439638,       24,   138272 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439662,       24,   138288 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439686,       24,   138304 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439710,       24,   138320 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439734,       24,   138336 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439758,       24,   138352 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439782,       24,   138368 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439806,       24,   138384 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439830,       24,   138400 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439854,       24,   138416 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439878,       24,   138432 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439902,       24,   138448 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439926,       24,   138464 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439950,       24,   138480 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439974,       24,   138496 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439998,       24,   138512 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440022,       24,   138528 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440046,       24,   138544 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440070,       24,   138560 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440094,       24,   138576 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440118,       24,   138592 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440142,       24,   138608 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440166,       24,   138624 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440190,       24,   138640 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440214,       24,   138656 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440238,       24,   138672 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440262,       24,   138688 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440286,       24,   138704 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440310,       24,   138720 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440334,       24,   138736 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440358,       24,   138752 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440382,       24,   138768 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440406,       24,   138784 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440430,       24,   138800 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440454,       24,   138816 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440478,       24,   138832 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440502,       24,   138848 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440526,       24,   138864 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440550,       24,   138880 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440574,       24,   138896 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440598,       24,   138912 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440622,       24,   138928 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440646,       24,   138944 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440670,       24,   138960 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440694,       24,   138976 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440718,       24,   138992 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440742,       24,   139008 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440766,       24,   139024 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440790,       24,   139040 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440814,       24,   139056 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440838,       24,   139072 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440862,       24,   139088 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440886,       24,   139104 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440910,       24,   139120 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440934,       24,   139136 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440958,       24,   139152 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440982,       24,   139168 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441006,       24,   139184 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441030,       24,   139200 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441054,       24,   139216 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441078,       24,   139232 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441102,       24,   139248 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441126,       24,   139264 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441150,       24,   139280 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441174,       24,   139296 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441198,       24,   139312 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441222,       24,   139328 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441246,       24,   139344 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441270,       24,   139360 }, // subset0_blinnCatwalk
-        {  44,  45,  -1,   441294,     2826,   139376 }, // subset0_shelves3_diff
-        {  35,  36,  -1,   444120,     2637,   139376 }, // subset1_shelves2_diff_0
-        {  14,  15,  -1,   446757,      636,   139376 }, // subset2_Stack__Boxes_Diff03_0
-        {  46,  47,  -1,   447393,       24,   141190 }, // subset0_blinn46
-        {  46,  47,  -1,   447417,      306,   141206 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   447723,      306,   141325 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   448029,      306,   141443 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   448335,      306,   141561 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   448641,      216,   141677 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   448857,     1812,   141759 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   450669,      306,   142479 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   450975,      222,   142604 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   451197,      132,   142704 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   451329,      222,   142754 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   451551,      306,   142854 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   451857,      132,   142975 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   451989,      222,   143025 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   452211,      306,   143125 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   452517,      306,   143247 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   452823,      132,   143370 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   452955,      222,   143420 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   453177,      132,   143520 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   453309,     1368,   143570 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   454677,     2484,   143914 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   457161,     5790,   144731 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   462951,     1836,   147045 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   464787,     3816,   147679 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   468603,    54240,   149038 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   522843,      792,   158991 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   523635,      792,   159136 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   524427,      216,   159281 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   524643,      216,   159363 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   524859,      216,   159445 }, // subset0_phongMisc_Boss_3_2048
-        {  48,  42,  -1,   525075,     1050,   159527 }, // subset0_LightBulbsColor
-        {  49,  50,  -1,   526125,     1128,   159773 }, // subset0_Hanghing_Light
-        {  10,  11,  -1,   527253,      540,   160003 }, // subset0_lambert1
-        {  10,  11,  -1,   527793,      225,   160123 }, // subset0_lambert1
-        {  49,  50,  -1,   528018,     2160,   160202 }, // subset0_Hanghing_Light
-        {  48,  42,  -1,   530178,     1050,   160707 }, // subset0_LightBulbsColor
-        {  49,  50,  -1,   531228,     1128,   160966 }, // subset0_Hanghing_Light
-        {  10,  11,  -1,   532356,      540,   161197 }, // subset0_lambert1
-        {  10,  11,  -1,   532896,      225,   161317 }, // subset0_lambert1
-        {  49,  50,  -1,   533121,     2160,   161391 }, // subset0_Hanghing_Light
-        {  48,  42,  -1,   535281,     1134,   161896 }, // subset0_LightBulbsColor
-        {  49,  50,  -1,   536415,     1128,   162168 }, // subset0_Hanghing_Light
-        {  49,  50,  -1,   537543,      600,   162399 }, // subset0_Hanghing_Light
-        {  49,  50,  -1,   538143,      225,   162531 }, // subset0_Hanghing_Light
-        {  49,  50,  -1,   538368,     2160,   162610 }, // subset0_Hanghing_Light
-        {  10,  51,  -1,   540528,      498,   163115 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   541026,      300,   163321 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   541326,      300,   163400 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   541626,      600,   163479 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   542226,      681,   163604 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   542907,      300,   163755 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   543207,      300,   163834 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   543507,      144,   163913 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   543651,      780,   163949 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   544431,      168,   164135 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   544599,      156,   164197 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   544755,      390,   164255 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   545145,     3702,   164393 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   548847,      468,   165239 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   549315,     1128,   165324 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   550443,      810,   165562 }, // subset0_Hanging_bundle
-        {  52,  53,  -1,   551253,      714,   165819 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   551967,      540,   165949 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   552507,     1080,   166048 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   553587,     1080,   166242 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   554667,      540,   166436 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   555207,      540,   166535 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   555747,     1080,   166642 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   556827,      540,   166836 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   557367,     1080,   166935 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   558447,     1080,   167129 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   559527,      540,   167323 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   560067,     1080,   167422 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   561147,     1080,   167616 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   562227,     1080,   167810 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   563307,     1080,   168001 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   564387,      714,   168195 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   565101,     1080,   168325 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   566181,      540,   168519 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   566721,      540,   168618 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   567261,      540,   168719 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   567801,     1080,   168818 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   568881,      540,   169012 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   569421,     1080,   169111 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   570501,      540,   169305 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   571041,      714,   169404 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   571755,     1080,   169534 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   572835,     1080,   169728 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   573915,      540,   169922 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   574455,      540,   170021 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   574995,     1080,   170120 }, // subset0_Hanging_bundle_marble
-        {  10,  51,  -1,   576075,    17184,   170314 }, // subset0_Rope
-        {  10,  51,  -1,   593259,      576,   176140 }, // subset0_Rope
-        {  10,  51,  -1,   593835,     2556,   176293 }, // subset0_Rope
-        {  10,  51,  -1,   596391,     4032,   176950 }, // subset0_Rope
-        {  10,  51,  -1,   600423,     4284,   177857 }, // subset0_Rope
-        {  10,  51,  -1,   604707,     4536,   178939 }, // subset0_Rope
-        {  10,  51,  -1,   609243,     4536,   179837 }, // subset0_Rope
-        {  10,  51,  -1,   613779,      612,   180733 }, // subset0_Rope
-        {  44,  45,  -1,   614391,      396,   180879 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   614787,      600,   181009 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   615387,      600,   181216 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   615987,      744,   181423 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   616731,      729,   181680 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   617460,     1920,   181932 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   619380,      324,   182343 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   619704,     2274,   182475 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   621978,     1860,   182902 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   623838,     2376,   183256 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   626214,     2190,   183705 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   628404,     2280,   184118 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   630684,      840,   184550 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   631524,      840,   184754 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   632364,      840,   184958 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   633204,      840,   185162 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   634044,     1008,   185366 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   635052,     1332,   185608 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   636384,     1617,   185890 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   638001,     1410,   186290 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   639411,      948,   186589 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   640359,       90,   187035 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   640449,      504,   187055 }, // subset0_shelves3_diff
-        {  35,  36,  -1,   640953,      378,   187197 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   641331,      432,   187284 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   641763,      378,   187378 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   642141,     3120,   187462 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   645261,      402,   188387 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   645663,     2580,   188525 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   648243,     3180,   189008 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   651423,     2100,   189678 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   653523,     3180,   190158 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   656703,      180,   190828 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   656883,      276,   190872 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   657159,      180,   190970 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   657339,      180,   191014 }, // subset0_shelves2_diff
-        {  44,  45,  -1,   657519,      228,   191068 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   657747,      108,   191162 }, // subset0_shelves3_diff
-        {  35,  36,  -1,   657855,      192,   191197 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   658047,      192,   191271 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   658239,      192,   191345 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   658431,      168,   191419 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   658599,      168,   191485 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   658767,      168,   191551 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   658935,      192,   191617 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   659127,      192,   191691 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   659319,      168,   191765 }, // subset0_shelves2_diff
-        {  44,  45,  -1,   659487,     1617,   191831 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   661104,     1617,   192226 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   662721,     1617,   192605 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   664338,       90,   192995 }, // subset0_shelves3_diff
-        {  54,  42,  -1,   664428,     1248,   193015 }, // subset0_Window
-        {  55,  56,  -1,   665676,     3312,   193319 }, // subset0_Sliding_Steel_Door
-        {  54,  57,  -1,   668988,      930,   194197 }, // subset0_window_Diff
-        {  58,  59,  -1,   669918,    12912,   194433 }, // subset0_Door2
-        {  60,  61,  -1,   682830,      969,   197161 }, // subset0_Floor
-        {  62,  63,  -1,   683799,     2037,   197482 }, // subset0_wall_4
-        {  62,  63,  -1,   685836,     3000,   198168 }, // subset0_wall_3
-        {  64,  65,  -1,   688836,     2205,   199986 }, // subset0_wall_1
-        {  64,  65,  -1,   691041,     1656,   200663 }, // subset0_wall_2
-        {  66,  67,  -1,   692697,     5424,   201041 }, // subset0_roof
-        {  68,  69,  -1,   698121,      939,   203677 }, // subset0_Pillar
-        {  66,  67,  -1,   699060,     1536,   203892 }, // subset0_roof
-        {  70,  71,  -1,   700596,      609,   204339 }, // subset0_Broken_Pillar_Diff
-        {  33,  34,  -1,   701205,     1920,   204469 }, // subset0_Back_Alley_Drum
-        {  33,  34,  -1,   703125,     1920,   205134 }, // subset0_Back_Alley_Drum
-        {  33,  34,  -1,   705045,     1920,   205799 }, // subset0_Back_Alley_Drum
-        {  35,  36,  -1,   706965,     7809,   206464 }, // subset0_shelves2_diff
-        {  14,  15,  -1,   714774,     1920,   208128 }, // subset0_Stack__Boxes_Diff03
-        {  33,  34,  -1,   716694,     1920,   208629 }, // subset0_Back_Alley_Drum
-        {  33,  34,  -1,   718614,     1920,   209294 }, // subset0_Back_Alley_Drum
-        {  33,  34,  -1,   720534,     1920,   209959 }, // subset0_Back_Alley_Drum
-        {  35,  36,  -1,   722454,     7809,   210624 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   730263,     7809,   212294 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   738072,     7809,   213953 }, // subset0_shelves2_diff
-        {  32,  32,  -1,   745881,      783,   215619 }, // subset0_gameCrates_02_Diff
-        {  72,  73,  -1,   746664,    14451,   215808 }, // subset0_GolfBag:Golfclub
-        {  18,  19,  -1,   761115,     3096,   219093 }, // subset0_Back_Alley_box
-    };
+	const DrawParameters Draws[] =
+	{
+		{   0,   1,  -1,        0,    15198,        0 }, // subset0_squard_room_platform_3_dif1
+		{   2,   3,  -1,    15198,      438,     6051 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    15636,      300,     6164 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    15936,      300,     6225 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    16236,      438,     6286 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    16674,      300,     6399 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    16974,      438,     6460 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    17412,      300,     6573 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    17712,      450,     6634 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    18162,      300,     6756 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    18462,      438,     6817 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    18900,      300,     6930 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    19200,      300,     6991 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    19500,      438,     7052 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    19938,      300,     7165 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    20238,      438,     7226 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    20676,      300,     7339 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    20976,      300,     7400 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    21276,      438,     7461 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    21714,      300,     7574 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    22014,      438,     7635 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    22452,      300,     7748 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    22752,      450,     7809 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    23202,      300,     7931 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    23502,      438,     7992 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    23940,      300,     8105 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    24240,      300,     8166 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    24540,      438,     8227 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    24978,      300,     8340 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    25278,      438,     8401 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    25716,      300,     8514 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    26016,      300,     8575 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    26316,      438,     8636 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    26754,      300,     8749 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    27054,      438,     8810 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    27492,      300,     8923 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    27792,      300,     8984 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    28092,      438,     9045 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    28530,      300,     9158 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    28830,      438,     9219 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    29268,      300,     9332 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    29568,      450,     9393 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    30018,      300,     9515 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    30318,      438,     9576 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    30756,      300,     9689 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    31056,      300,     9750 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    31356,      438,     9811 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    31794,      300,     9924 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    32094,      438,     9985 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    32532,      300,    10098 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    32832,      450,    10159 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    33282,      300,    10281 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    33582,      438,    10342 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    34020,      300,    10455 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    34320,      300,    10516 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    34620,      438,    10577 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    35058,      300,    10690 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    35358,      900,    10751 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    36258,      282,    11016 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    36540,      282,    11142 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    36822,      222,    11228 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    37044,      282,    11304 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    37326,      282,    11396 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    37608,      282,    11485 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    37890,      243,    11577 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    38133,      222,    11665 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    38355,      282,    11743 }, // subset0_squard_room_platform_2_dif
+		{   4,   5,  -1,    38637,     2700,    11834 }, // subset0_squard_room_platform_1_diff
+		{   6,   7,  -1,    41337,     1788,    12560 }, // subset0_shelves1_diff
+		{   8,   9,  -1,    43125,      180,    13101 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43305,      180,    13138 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43485,       96,    13175 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43581,       96,    13202 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43677,       96,    13229 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43773,       96,    13256 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43869,       96,    13283 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43965,       30,    13310 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43995,       24,    13322 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44019,       24,    13332 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44043,       24,    13342 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44067,       24,    13351 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44091,       54,    13360 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44145,       12,    13380 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44157,       72,    13386 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44229,       84,    13424 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44313,       30,    13448 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44343,        6,    13460 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44349,       36,    13464 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44385,       60,    13478 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44445,       72,    13496 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44517,       48,    13534 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44565,       24,    13549 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44589,       24,    13559 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44613,       24,    13569 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44637,       42,    13579 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44679,       12,    13595 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44691,       48,    13603 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44739,        6,    13625 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44745,       48,    13629 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44793,        6,    13644 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44799,       60,    13648 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44859,        6,    13666 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44865,       60,    13670 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44925,       72,    13688 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44997,       48,    13709 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45045,       36,    13727 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45081,       72,    13741 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45153,       12,    13779 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45165,       12,    13785 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45177,       30,    13791 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45207,       36,    13803 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45243,        6,    13817 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45249,        6,    13821 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45255,       24,    13825 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45279,       24,    13835 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45303,       24,    13845 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45327,       96,    13855 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45423,       30,    13882 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45453,       96,    13894 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45549,       96,    13921 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45645,       72,    13948 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45717,       72,    13969 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45789,       42,    13990 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45831,       42,    14006 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45873,       54,    14022 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45927,       54,    14042 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45981,       60,    14062 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46041,       60,    14080 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46101,       36,    14098 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46137,       12,    14112 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46149,       12,    14118 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46161,       12,    14124 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46173,       24,    14130 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46197,       24,    14140 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46221,       24,    14150 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46245,       24,    14160 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46269,       24,    14170 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46293,       48,    14180 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46341,       48,    14195 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46389,       48,    14210 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46437,       48,    14225 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46485,       48,    14240 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46533,       36,    14255 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46569,       36,    14269 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46605,       36,    14283 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46641,       36,    14297 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46677,       36,    14311 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46713,       72,    14325 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46785,       72,    14363 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46857,        6,    14401 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46863,        6,    14405 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46869,        6,    14409 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46875,       24,    14413 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46899,       24,    14422 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46923,       48,    14431 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46971,       48,    14449 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47019,       12,    14464 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47031,       12,    14470 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47043,       12,    14476 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47055,       12,    14482 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47067,       12,    14488 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47079,       12,    14494 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47091,       12,    14500 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47103,       12,    14506 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47115,       24,    14512 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47139,       24,    14521 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47163,       60,    14530 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47223,       60,    14548 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47283,       60,    14566 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47343,       60,    14584 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47403,       60,    14602 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47463,       48,    14620 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47511,       48,    14642 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47559,       36,    14664 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47595,       36,    14678 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47631,       24,    14692 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47655,       12,    14701 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47667,       12,    14707 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47679,       12,    14713 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47691,       12,    14719 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47703,       12,    14725 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47715,       12,    14731 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47727,       12,    14737 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47739,        6,    14743 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47745,        6,    14747 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47751,        6,    14751 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47757,        6,    14755 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47763,       12,    14759 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47775,       12,    14765 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47787,       12,    14771 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47799,       12,    14777 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47811,       60,    14783 }, // subset0_blinnMisc_Boss_2
+		{  10,  11,  -1,    47871,      762,    14801 }, // subset0_lambert1
+		{   8,   9,  -1,    48633,       66,    14801 }, // subset1_blinnMisc_Boss_2_0
+		{   8,   9,  -1,    48699,      144,    15136 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    48843,      144,    15171 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    48987,      144,    15206 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    49131,      144,    15241 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    49275,      180,    15276 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    49455,      144,    15318 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    49599,      144,    15353 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    49743,      144,    15388 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    49887,      180,    15423 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    50067,      180,    15465 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    50247,      144,    15507 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    50391,      180,    15542 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    50571,      144,    15584 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    50715,      108,    15619 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    50823,     4416,    15647 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    55239,      273,    16657 }, // subset0_blinnMisc_Boss_2
+		{  12,  13,  -1,    55512,     4143,    16754 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    59655,      360,    19212 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    60015,      300,    19293 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    60315,      360,    19359 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    60675,      240,    19436 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    60915,     1566,    19491 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62481,       48,    19889 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62529,       48,    19907 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62577,       48,    19925 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62625,       48,    19943 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62673,       48,    19961 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62721,       48,    19979 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62769,       96,    19997 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62865,       36,    20024 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62901,       36,    20038 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62937,       36,    20052 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62973,       36,    20066 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63009,       36,    20080 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63045,       36,    20094 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63081,       36,    20108 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63117,       36,    20122 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63153,       36,    20136 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63189,       36,    20150 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63225,       36,    20164 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63261,      108,    20178 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63369,       36,    20206 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63405,       36,    20220 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63441,       36,    20234 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63477,       36,    20248 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63513,       36,    20262 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63549,       36,    20276 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63585,       36,    20290 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63621,       72,    20304 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63693,       72,    20325 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63765,      144,    20346 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63909,       72,    20381 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63981,       36,    20402 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64017,       36,    20416 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64053,      144,    20430 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64197,      144,    20465 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64341,       36,    20500 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64377,       36,    20514 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64413,       36,    20528 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64449,       36,    20542 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64485,       36,    20556 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64521,       36,    20570 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64557,       36,    20584 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64593,       36,    20598 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64629,       36,    20612 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64665,       36,    20626 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64701,      252,    20640 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64953,      276,    20816 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    65229,      276,    21014 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    65505,      276,    21200 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    65781,      294,    21394 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    66075,      279,    21582 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    66354,      264,    21732 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    66618,      288,    21898 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    66906,      468,    22065 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    67374,     1296,    22222 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    68670,       18,    22988 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    68688,       36,    22996 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    68724,       42,    23022 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    68766,       36,    23054 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    68802,       42,    23076 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    68844,      336,    23104 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    69180,      144,    23104 }, // subset1_lambert1_0
+		{  12,  13,  -1,    69324,      240,    23250 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    69564,      240,    23334 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    69804,      246,    23427 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    70050,      120,    23543 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    70170,      630,    23600 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    70800,     1080,    23743 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    71880,      720,    23991 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    72600,      204,    24154 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    72804,      336,    24198 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    73140,      144,    24198 }, // subset1_lambert1_0
+		{  12,  13,  -1,    73284,      225,    24344 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    73509,       15,    24344 }, // subset1_lambert1_0
+		{  12,  13,  -1,    73524,      225,    24458 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    73749,       15,    24458 }, // subset1_lambert1_0
+		{  12,  13,  -1,    73764,      225,    24572 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    73989,       15,    24572 }, // subset1_lambert1_0
+		{  12,  13,  -1,    74004,      225,    24686 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    74229,       15,    24686 }, // subset1_lambert1_0
+		{  12,  13,  -1,    74244,      225,    24800 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    74469,       15,    24800 }, // subset1_lambert1_0
+		{  12,  13,  -1,    74484,      225,    24914 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    74709,       15,    24914 }, // subset1_lambert1_0
+		{  14,  15,  -1,    74724,     2208,    25028 }, // subset0_Stack__Boxes_Diff03
+		{  16,  17,  -1,    76932,     9381,    25553 }, // subset0_Stack__Boxes_Diff01
+		{  18,  19,  -1,    86313,      948,    29643 }, // subset0_Back_Alley_box
+		{  20,  21,  -1,    87261,     1488,    29946 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,    88749,     1998,    30265 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,    90747,     1872,    30649 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,    92619,     1692,    31034 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,    94311,     1638,    31387 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,    95949,     1872,    31702 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,    97821,     1662,    32056 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,    99483,     1902,    32409 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   101385,      720,    32807 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   102105,     1296,    32957 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   103401,      432,    33232 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   103833,     1152,    33332 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   104985,     1152,    33557 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   106137,     1380,    33782 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   107517,     1470,    34080 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   108987,     1308,    34364 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   110295,     1662,    34622 }, // subset0_gameCrates_01_Diff
+		{  22,  23,  -1,   111957,      636,    34941 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   112593,     1728,    35137 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   114321,      336,    35500 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   114657,     2304,    35577 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   116961,      246,    36138 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   117207,     1260,    36270 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   118467,     1866,    36512 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   120333,     2070,    36976 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   122403,     1050,    37421 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   123453,      450,    37624 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   123903,      450,    37760 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   124353,      390,    37896 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   124743,      390,    38021 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   125133,      390,    38148 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   125523,      330,    38273 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   125853,      390,    38387 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   126243,      330,    38512 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   126573,      420,    38626 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   126993,      390,    38763 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   127383,      300,    38888 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   127683,      300,    38961 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   127983,      300,    39045 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   128283,      300,    39131 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   128583,      300,    39215 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   128883,      300,    39286 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   129183,      300,    39410 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   129483,      300,    39483 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   129783,      300,    39567 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   130083,      300,    39653 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   130383,      300,    39737 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   130683,      300,    39808 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   130983,      300,    39968 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   131283,      300,    40041 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   131583,      300,    40125 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   131883,      300,    40211 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   132183,      300,    40295 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   132483,      300,    40366 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   132783,      300,    40490 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   133083,      300,    40561 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   133383,      300,    40721 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   133683,      300,    40794 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   133983,      300,    40878 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   134283,      300,    40964 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   134583,      300,    41048 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   134883,      300,    41119 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   135183,      300,    41243 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   135483,      300,    41314 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   135783,      300,    41474 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   136083,      300,    41547 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   136383,      300,    41631 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   136683,      300,    41717 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   136983,      300,    41801 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   137283,      300,    41872 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   137583,      300,    41996 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   137883,      300,    42069 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   138183,      300,    42153 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   138483,      300,    42239 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   138783,      300,    42323 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   139083,      300,    42394 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   139383,      300,    42554 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   139683,      300,    42627 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   139983,      300,    42711 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   140283,      300,    42797 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   140583,      300,    42881 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   140883,      300,    42952 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   141183,      300,    43076 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   141483,      300,    43149 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   141783,      300,    43349 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   142083,      300,    43551 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   142383,      300,    43751 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   142683,      300,    43951 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   142983,      300,    44151 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   143283,      300,    44351 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   143583,      300,    44551 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   143883,      300,    44751 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   144183,      300,    44951 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   144483,      300,    45153 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   144783,      300,    45353 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   145083,      300,    45553 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   145383,      300,    45753 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   145683,      300,    45953 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   145983,      300,    46153 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   146283,      300,    46353 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   146583,      300,    46553 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   146883,      300,    46755 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   147183,      300,    46955 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   147483,      300,    47155 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   147783,      300,    47355 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   148083,      300,    47555 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   148383,      300,    47755 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   148683,      300,    47955 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   148983,      300,    48155 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   149283,      300,    48355 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   149583,      300,    48557 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   149883,      300,    48757 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   150183,      300,    48957 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   150483,      300,    49157 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   150783,      216,    49357 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   150999,      216,    49455 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   151215,      216,    49553 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   151431,     1014,    49651 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   152445,      216,    49929 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   152661,     1014,    50029 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   153675,     1014,    50324 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   154689,     1014,    50614 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   155703,      588,    50894 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   156291,     5574,    51104 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   161865,      588,    52700 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   162453,      588,    52910 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   163041,      588,    53120 }, // subset0_RaceCar_Strorage_Diff
+		{  24,  25,  -1,   163629,       48,    53330 }, // subset0_hats_2
+		{  24,  25,  -1,   163677,      501,    53362 }, // subset0_hats_2
+		{  24,  25,  -1,   164178,      252,    53471 }, // subset0_hats_2
+		{  24,  25,  -1,   164430,       48,    53520 }, // subset0_hats_2
+		{  24,  25,  -1,   164478,     1620,    53552 }, // subset0_hats_2
+		{  24,  25,  -1,   166098,     3978,    53850 }, // subset0_hats_2
+		{  24,  25,  -1,   170076,      765,    54754 }, // subset0_hats_2
+		{  24,  25,  -1,   170841,      900,    54906 }, // subset0_hats_2
+		{  24,  25,  -1,   171741,     1260,    55154 }, // subset0_hats_2
+		{  24,  25,  -1,   173001,      408,    55431 }, // subset0_hats_2
+		{  24,  25,  -1,   173409,      765,    55546 }, // subset0_hats_2
+		{  24,  25,  -1,   174174,      720,    55694 }, // subset0_hats_2
+		{  24,  25,  -1,   174894,      252,    55894 }, // subset0_hats_2
+		{  24,  25,  -1,   175146,      252,    55943 }, // subset0_hats_2
+		{  24,  25,  -1,   175398,      252,    55992 }, // subset0_hats_2
+		{  24,  25,  -1,   175650,      252,    56041 }, // subset0_hats_2
+		{  24,  25,  -1,   175902,      252,    56090 }, // subset0_hats_2
+		{  24,  25,  -1,   176154,      252,    56139 }, // subset0_hats_2
+		{  24,  25,  -1,   176406,      252,    56188 }, // subset0_hats_2
+		{  24,  25,  -1,   176658,      252,    56237 }, // subset0_hats_2
+		{  26,  27,  -1,   176910,       48,    56286 }, // subset0_Hats_1
+		{  24,  25,  -1,   176958,     6792,    56318 }, // subset0_hats_2
+		{  24,  25,  -1,   183750,     2124,    57790 }, // subset0_hats_2
+		{  24,  25,  -1,   185874,     2268,    58361 }, // subset0_hats_2
+		{  24,  25,  -1,   188142,       66,    58938 }, // subset0_hats_2
+		{  24,  25,  -1,   188208,      270,    58973 }, // subset0_hats_2
+		{  24,  25,  -1,   188478,       48,    59080 }, // subset0_hats_2
+		{  24,  25,  -1,   188526,       66,    59111 }, // subset0_hats_2
+		{  24,  25,  -1,   188592,       60,    59148 }, // subset0_hats_2
+		{  24,  25,  -1,   188652,       66,    59178 }, // subset0_hats_2
+		{  24,  25,  -1,   188718,      168,    59215 }, // subset0_hats_2
+		{  24,  25,  -1,   188886,      168,    59275 }, // subset0_hats_2
+		{  24,  25,  -1,   189054,      174,    59333 }, // subset0_hats_2
+		{  24,  25,  -1,   189228,     1650,    59418 }, // subset0_hats_2
+		{  24,  25,  -1,   190878,      918,    59867 }, // subset0_hats_2
+		{  24,  25,  -1,   191796,      426,    60089 }, // subset0_hats_2
+		{  26,  27,  -1,   192222,     1209,    60211 }, // subset0_Hats_1
+		{  24,  25,  -1,   193431,      180,    60506 }, // subset0_hats_2
+		{  26,  27,  -1,   193611,      714,    60571 }, // subset0_Hats_1
+		{  26,  27,  -1,   194325,      426,    60759 }, // subset0_Hats_1
+		{  26,  27,  -1,   194751,      426,    60888 }, // subset0_Hats_1
+		{  26,  27,  -1,   195177,      432,    61010 }, // subset0_Hats_1
+		{  26,  27,  -1,   195609,      432,    61147 }, // subset0_Hats_1
+		{  26,  27,  -1,   196041,     1608,    61268 }, // subset0_Hats_1
+		{  28,  29,  -1,   197649,    18219,    61783 }, // subset0_Misc_Boss_1
+		{  16,  17,  -1,   215868,     2484,    69708 }, // subset0_Stack__Boxes_Diff01
+		{  16,  17,  -1,   218352,     2409,    71274 }, // subset0_Stack__Boxes_Diff01
+		{  16,  17,  -1,   220761,     2409,    72652 }, // subset0_Stack__Boxes_Diff01
+		{  16,  17,  -1,   223170,     2409,    74026 }, // subset0_Stack__Boxes_Diff01
+		{  16,  17,  -1,   225579,     1833,    75404 }, // subset0_Stack__Boxes_Diff01
+		{  30,  31,  -1,   227412,     3867,    76541 }, // subset0_gameCrates_03_Diff
+		{  30,  31,  -1,   231279,     3750,    78113 }, // subset0_gameCrates_03_Diff
+		{  16,  17,  -1,   235029,     2409,    79856 }, // subset0_Stack__Boxes_Diff01
+		{  16,  17,  -1,   237438,     2409,    81222 }, // subset0_Stack__Boxes_Diff01
+		{  30,  31,  -1,   239847,    12468,    82594 }, // subset0_gameCrates_03_Diff
+		{  30,  31,  -1,   252315,     3441,    88547 }, // subset0_gameCrates_03_Diff
+		{  32,  32,  -1,   255756,     1932,    89479 }, // subset0_gameCrates_02_Diff
+		{  14,  15,  -1,   257688,      984,    89905 }, // subset0_Stack__Boxes_Diff03
+		{  14,  15,  -1,   258672,      741,    90403 }, // subset0_Stack__Boxes_Diff03
+		{  14,  15,  -1,   259413,      426,    90727 }, // subset0_Stack__Boxes_Diff03
+		{  32,  32,  -1,   259839,     1419,    90932 }, // subset0_gameCrates_02_Diff
+		{  18,  19,  -1,   261258,     3090,    91251 }, // subset0_Back_Alley_box
+		{  14,  15,  -1,   264348,      573,    92286 }, // subset0_Stack__Boxes_Diff03
+		{  32,  32,  -1,   264921,     1176,    92524 }, // subset0_gameCrates_02_Diff
+		{  32,  32,  -1,   266097,      792,    92809 }, // subset0_gameCrates_02_Diff
+		{  14,  15,  -1,   266889,      573,    93047 }, // subset0_Stack__Boxes_Diff03
+		{  14,  15,  -1,   267462,      741,    93285 }, // subset0_Stack__Boxes_Diff03
+		{  18,  19,  -1,   268203,     1620,    93609 }, // subset0_Back_Alley_box
+		{  14,  15,  -1,   269823,      396,    94126 }, // subset0_Stack__Boxes_Diff03
+		{  14,  15,  -1,   270219,      396,    94281 }, // subset0_Stack__Boxes_Diff03
+		{  14,  15,  -1,   270615,      396,    94436 }, // subset0_Stack__Boxes_Diff03
+		{  32,  32,  -1,   271011,     1008,    94591 }, // subset0_gameCrates_02_Diff
+		{  32,  32,  -1,   272019,     2040,    94830 }, // subset0_gameCrates_02_Diff
+		{  14,  15,  -1,   274059,      468,    95269 }, // subset0_Stack__Boxes_Diff03
+		{  32,  32,  -1,   274527,     1236,    95437 }, // subset0_gameCrates_02_Diff
+		{  32,  32,  -1,   275763,      903,    95726 }, // subset0_gameCrates_02_Diff
+		{  32,  32,  -1,   276666,     1884,    95942 }, // subset0_gameCrates_02_Diff
+		{  32,  32,  -1,   278550,     2088,    96353 }, // subset0_gameCrates_02_Diff
+		{  32,  32,  -1,   280638,     1008,    96827 }, // subset0_gameCrates_02_Diff
+		{  33,  34,  -1,   281646,     1920,    97063 }, // subset0_Back_Alley_Drum
+		{  35,  36,  -1,   283566,     7809,    97728 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   291375,     8172,    99390 }, // subset0_shelves2_diff
+		{  37,  38,  -1,   299547,       12,   101144 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   299559,      132,   101150 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   299691,      132,   101218 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   299823,      228,   101286 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   300051,      228,   101382 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   300279,      228,   101485 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   300507,      228,   101581 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   300735,      228,   101689 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   300963,      228,   101785 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   301191,      852,   101881 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   302043,      702,   102217 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   302745,      372,   102461 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   303117,      564,   102637 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   303681,      324,   102857 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   304005,      324,   102977 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   304329,      588,   103097 }, // subset0_shelves2_diff1
+		{   6,   7,  -1,   304917,     1122,   103337 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   306039,      888,   103622 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   306927,       96,   103854 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   307023,       96,   103902 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   307119,      102,   103947 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   307221,       96,   103987 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   307317,       96,   104032 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   307413,      576,   104078 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   307989,       78,   104208 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   308067,      102,   104240 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   308169,       72,   104284 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   308241,      336,   104315 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   308577,      144,   104450 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   308721,      120,   104490 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   308841,      144,   104518 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   308985,      120,   104558 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   309105,      126,   104586 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   309231,      120,   104624 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   309351,      144,   104652 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   309495,      117,   104692 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   309612,     1572,   104720 }, // subset0_shelves1_diff2
+		{  39,  40,  -1,   311184,      540,   105150 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   311724,     2136,   105282 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   313860,       24,   105899 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   313884,       24,   105911 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   313908,       27,   105923 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   313935,     2964,   105936 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   316899,     2964,   106458 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   319863,      702,   106980 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   320565,      702,   107117 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   321267,      702,   107249 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   321969,      702,   107379 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   322671,     2964,   107511 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   325635,        6,   108033 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   325641,      432,   108037 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   326073,      429,   108130 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   326502,     2964,   108216 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   329466,     2106,   108738 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   331572,     2106,   109129 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   333678,      429,   109515 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   334107,     1794,   109614 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   335901,     2262,   109948 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   338163,     2964,   110365 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   341127,     2964,   110880 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   344091,     2964,   111402 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   347055,     2730,   111919 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   349785,     2964,   112407 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   352749,     2964,   112929 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   355713,     2964,   113444 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   358677,     3276,   113961 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   361953,      780,   114605 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   362733,      936,   114773 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   363669,      936,   114969 }, // subset0_marbel_drum_blinn
+		{  41,  42,  -1,   364605,      108,   115165 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   364713,       81,   115185 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   364794,       81,   115225 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   364875,       81,   115255 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   364956,       81,   115287 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365037,      108,   115328 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365145,       81,   115348 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365226,       81,   115388 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365307,       81,   115418 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365388,      108,   115450 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365496,       81,   115470 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365577,      108,   115510 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365685,       81,   115530 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365766,       81,   115570 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365847,       81,   115602 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365928,      108,   115641 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366036,       81,   115669 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366117,       81,   115709 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366198,       81,   115741 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366279,      108,   115780 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366387,       81,   115808 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366468,       81,   115847 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366549,       81,   115879 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366630,       81,   115909 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366711,      108,   115948 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366819,       81,   115976 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366900,       81,   116006 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366981,      108,   116038 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367089,       81,   116066 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367170,       81,   116105 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367251,      108,   116137 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367359,       81,   116165 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367440,       81,   116204 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367521,      237,   116234 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367758,      216,   116293 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367974,      216,   116348 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   368190,      240,   116398 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   368430,      216,   116453 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   368646,      216,   116503 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   368862,      324,   116558 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   369186,      108,   116650 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   369294,      324,   116688 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   369618,      108,   116780 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   369726,      324,   116818 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   370050,      108,   116910 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   370158,      324,   116948 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   370482,      108,   117040 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   370590,      324,   117078 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   370914,      108,   117170 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371022,      324,   117208 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371346,      108,   117300 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371454,       54,   117338 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371508,       54,   117357 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371562,       54,   117376 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371616,       54,   117395 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371670,       54,   117414 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371724,       54,   117433 }, // subset0_blinnCatwalk
+		{  43,  11,  -1,   371778,      120,   117452 }, // subset0_Catwalk_03_Diffuse
+		{  43,  11,  -1,   371898,     3078,   117532 }, // subset0_Catwalk_03_Diffuse
+		{  43,  11,  -1,   374976,     4356,   118172 }, // subset0_Catwalk_03_Diffuse
+		{  43,  11,  -1,   379332,     4356,   119043 }, // subset0_Catwalk_03_Diffuse
+		{  43,  11,  -1,   383688,     4356,   119896 }, // subset0_Catwalk_03_Diffuse
+		{  43,  11,  -1,   388044,     3636,   120749 }, // subset0_Catwalk_03_Diffuse
+		{  41,  42,  -1,   391680,       72,   121481 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   391752,      162,   121513 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   391914,      324,   121553 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   392238,      144,   121630 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   392382,      144,   121665 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   392526,      162,   121705 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   392688,      324,   121745 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   393012,      144,   121822 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   393156,      144,   121857 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   393300,      162,   121897 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   393462,      360,   121937 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   393822,      144,   122014 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   393966,      144,   122049 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   394110,      162,   122084 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   394272,      324,   122124 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   394596,      153,   122194 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   394749,      144,   122234 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   394893,      162,   122269 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   395055,      324,   122309 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   395379,      144,   122379 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   395523,      144,   122419 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   395667,      162,   122459 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   395829,      324,   122503 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   396153,      150,   122573 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   396303,      144,   122621 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   396447,      162,   122661 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   396609,      324,   122701 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   396933,      144,   122778 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   397077,      144,   122818 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   397221,      162,   122853 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   397383,      324,   122897 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   397707,      141,   122967 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   397848,      144,   123006 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   397992,      162,   123041 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   398154,    19506,   123085 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   417660,    19506,   129867 }, // subset0_blinnCatwalk
+		{  43,  11,  -1,   437166,      120,   136640 }, // subset0_Catwalk_03_Diffuse
+		{  41,  42,  -1,   437286,       72,   136720 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437358,       24,   136752 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437382,       24,   136768 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437406,       24,   136784 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437430,       24,   136800 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437454,       24,   136816 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437478,       24,   136832 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437502,       24,   136848 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437526,       24,   136864 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437550,       24,   136880 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437574,       24,   136896 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437598,       24,   136912 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437622,       24,   136928 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437646,       24,   136944 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437670,       24,   136960 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437694,       24,   136976 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437718,       24,   136992 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437742,       24,   137008 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437766,       24,   137024 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437790,       24,   137040 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437814,       24,   137056 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437838,       24,   137072 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437862,       24,   137088 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437886,       24,   137104 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437910,       24,   137120 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437934,       24,   137136 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437958,       24,   137152 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437982,       24,   137168 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438006,       24,   137184 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438030,       24,   137200 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438054,       24,   137216 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438078,       24,   137232 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438102,       24,   137248 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438126,       24,   137264 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438150,       24,   137280 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438174,       24,   137296 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438198,       24,   137312 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438222,       24,   137328 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438246,       24,   137344 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438270,       24,   137360 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438294,       24,   137376 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438318,       24,   137392 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438342,       24,   137408 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438366,       24,   137424 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438390,       24,   137440 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438414,       24,   137456 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438438,       24,   137472 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438462,       24,   137488 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438486,       24,   137504 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438510,       24,   137520 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438534,       24,   137536 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438558,       24,   137552 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438582,       24,   137568 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438606,       24,   137584 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438630,       24,   137600 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438654,       24,   137616 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438678,       24,   137632 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438702,       24,   137648 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438726,       24,   137664 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438750,       24,   137680 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438774,       24,   137696 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438798,       24,   137712 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438822,       24,   137728 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438846,       24,   137744 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438870,       24,   137760 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438894,       24,   137776 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438918,       24,   137792 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438942,       24,   137808 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438966,       24,   137824 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438990,       24,   137840 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439014,       24,   137856 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439038,       24,   137872 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439062,       24,   137888 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439086,       24,   137904 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439110,       24,   137920 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439134,       24,   137936 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439158,       24,   137952 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439182,       24,   137968 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439206,       24,   137984 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439230,       24,   138000 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439254,       24,   138016 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439278,       24,   138032 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439302,       24,   138048 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439326,       24,   138064 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439350,       24,   138080 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439374,       24,   138096 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439398,       24,   138112 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439422,       24,   138128 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439446,       24,   138144 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439470,       24,   138160 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439494,       24,   138176 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439518,       24,   138192 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439542,       24,   138208 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439566,       24,   138224 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439590,       24,   138240 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439614,       24,   138256 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439638,       24,   138272 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439662,       24,   138288 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439686,       24,   138304 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439710,       24,   138320 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439734,       24,   138336 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439758,       24,   138352 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439782,       24,   138368 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439806,       24,   138384 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439830,       24,   138400 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439854,       24,   138416 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439878,       24,   138432 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439902,       24,   138448 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439926,       24,   138464 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439950,       24,   138480 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439974,       24,   138496 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439998,       24,   138512 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440022,       24,   138528 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440046,       24,   138544 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440070,       24,   138560 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440094,       24,   138576 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440118,       24,   138592 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440142,       24,   138608 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440166,       24,   138624 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440190,       24,   138640 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440214,       24,   138656 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440238,       24,   138672 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440262,       24,   138688 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440286,       24,   138704 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440310,       24,   138720 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440334,       24,   138736 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440358,       24,   138752 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440382,       24,   138768 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440406,       24,   138784 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440430,       24,   138800 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440454,       24,   138816 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440478,       24,   138832 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440502,       24,   138848 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440526,       24,   138864 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440550,       24,   138880 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440574,       24,   138896 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440598,       24,   138912 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440622,       24,   138928 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440646,       24,   138944 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440670,       24,   138960 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440694,       24,   138976 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440718,       24,   138992 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440742,       24,   139008 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440766,       24,   139024 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440790,       24,   139040 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440814,       24,   139056 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440838,       24,   139072 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440862,       24,   139088 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440886,       24,   139104 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440910,       24,   139120 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440934,       24,   139136 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440958,       24,   139152 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440982,       24,   139168 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441006,       24,   139184 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441030,       24,   139200 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441054,       24,   139216 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441078,       24,   139232 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441102,       24,   139248 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441126,       24,   139264 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441150,       24,   139280 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441174,       24,   139296 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441198,       24,   139312 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441222,       24,   139328 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441246,       24,   139344 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441270,       24,   139360 }, // subset0_blinnCatwalk
+		{  44,  45,  -1,   441294,     2826,   139376 }, // subset0_shelves3_diff
+		{  35,  36,  -1,   444120,     2637,   139376 }, // subset1_shelves2_diff_0
+		{  14,  15,  -1,   446757,      636,   139376 }, // subset2_Stack__Boxes_Diff03_0
+		{  46,  47,  -1,   447393,       24,   141190 }, // subset0_blinn46
+		{  46,  47,  -1,   447417,      306,   141206 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   447723,      306,   141325 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   448029,      306,   141443 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   448335,      306,   141561 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   448641,      216,   141677 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   448857,     1812,   141759 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   450669,      306,   142479 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   450975,      222,   142604 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   451197,      132,   142704 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   451329,      222,   142754 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   451551,      306,   142854 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   451857,      132,   142975 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   451989,      222,   143025 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   452211,      306,   143125 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   452517,      306,   143247 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   452823,      132,   143370 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   452955,      222,   143420 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   453177,      132,   143520 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   453309,     1368,   143570 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   454677,     2484,   143914 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   457161,     5790,   144731 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   462951,     1836,   147045 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   464787,     3816,   147679 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   468603,    54240,   149038 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   522843,      792,   158991 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   523635,      792,   159136 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   524427,      216,   159281 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   524643,      216,   159363 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   524859,      216,   159445 }, // subset0_phongMisc_Boss_3_2048
+		{  48,  42,  -1,   525075,     1050,   159527 }, // subset0_LightBulbsColor
+		{  49,  50,  -1,   526125,     1128,   159773 }, // subset0_Hanghing_Light
+		{  10,  11,  -1,   527253,      540,   160003 }, // subset0_lambert1
+		{  10,  11,  -1,   527793,      225,   160123 }, // subset0_lambert1
+		{  49,  50,  -1,   528018,     2160,   160202 }, // subset0_Hanghing_Light
+		{  48,  42,  -1,   530178,     1050,   160707 }, // subset0_LightBulbsColor
+		{  49,  50,  -1,   531228,     1128,   160966 }, // subset0_Hanghing_Light
+		{  10,  11,  -1,   532356,      540,   161197 }, // subset0_lambert1
+		{  10,  11,  -1,   532896,      225,   161317 }, // subset0_lambert1
+		{  49,  50,  -1,   533121,     2160,   161391 }, // subset0_Hanghing_Light
+		{  48,  42,  -1,   535281,     1134,   161896 }, // subset0_LightBulbsColor
+		{  49,  50,  -1,   536415,     1128,   162168 }, // subset0_Hanghing_Light
+		{  49,  50,  -1,   537543,      600,   162399 }, // subset0_Hanghing_Light
+		{  49,  50,  -1,   538143,      225,   162531 }, // subset0_Hanghing_Light
+		{  49,  50,  -1,   538368,     2160,   162610 }, // subset0_Hanghing_Light
+		{  10,  51,  -1,   540528,      498,   163115 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   541026,      300,   163321 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   541326,      300,   163400 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   541626,      600,   163479 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   542226,      681,   163604 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   542907,      300,   163755 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   543207,      300,   163834 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   543507,      144,   163913 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   543651,      780,   163949 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   544431,      168,   164135 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   544599,      156,   164197 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   544755,      390,   164255 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   545145,     3702,   164393 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   548847,      468,   165239 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   549315,     1128,   165324 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   550443,      810,   165562 }, // subset0_Hanging_bundle
+		{  52,  53,  -1,   551253,      714,   165819 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   551967,      540,   165949 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   552507,     1080,   166048 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   553587,     1080,   166242 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   554667,      540,   166436 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   555207,      540,   166535 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   555747,     1080,   166642 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   556827,      540,   166836 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   557367,     1080,   166935 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   558447,     1080,   167129 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   559527,      540,   167323 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   560067,     1080,   167422 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   561147,     1080,   167616 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   562227,     1080,   167810 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   563307,     1080,   168001 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   564387,      714,   168195 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   565101,     1080,   168325 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   566181,      540,   168519 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   566721,      540,   168618 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   567261,      540,   168719 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   567801,     1080,   168818 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   568881,      540,   169012 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   569421,     1080,   169111 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   570501,      540,   169305 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   571041,      714,   169404 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   571755,     1080,   169534 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   572835,     1080,   169728 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   573915,      540,   169922 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   574455,      540,   170021 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   574995,     1080,   170120 }, // subset0_Hanging_bundle_marble
+		{  10,  51,  -1,   576075,    17184,   170314 }, // subset0_Rope
+		{  10,  51,  -1,   593259,      576,   176140 }, // subset0_Rope
+		{  10,  51,  -1,   593835,     2556,   176293 }, // subset0_Rope
+		{  10,  51,  -1,   596391,     4032,   176950 }, // subset0_Rope
+		{  10,  51,  -1,   600423,     4284,   177857 }, // subset0_Rope
+		{  10,  51,  -1,   604707,     4536,   178939 }, // subset0_Rope
+		{  10,  51,  -1,   609243,     4536,   179837 }, // subset0_Rope
+		{  10,  51,  -1,   613779,      612,   180733 }, // subset0_Rope
+		{  44,  45,  -1,   614391,      396,   180879 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   614787,      600,   181009 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   615387,      600,   181216 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   615987,      744,   181423 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   616731,      729,   181680 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   617460,     1920,   181932 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   619380,      324,   182343 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   619704,     2274,   182475 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   621978,     1860,   182902 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   623838,     2376,   183256 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   626214,     2190,   183705 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   628404,     2280,   184118 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   630684,      840,   184550 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   631524,      840,   184754 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   632364,      840,   184958 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   633204,      840,   185162 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   634044,     1008,   185366 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   635052,     1332,   185608 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   636384,     1617,   185890 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   638001,     1410,   186290 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   639411,      948,   186589 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   640359,       90,   187035 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   640449,      504,   187055 }, // subset0_shelves3_diff
+		{  35,  36,  -1,   640953,      378,   187197 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   641331,      432,   187284 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   641763,      378,   187378 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   642141,     3120,   187462 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   645261,      402,   188387 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   645663,     2580,   188525 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   648243,     3180,   189008 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   651423,     2100,   189678 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   653523,     3180,   190158 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   656703,      180,   190828 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   656883,      276,   190872 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   657159,      180,   190970 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   657339,      180,   191014 }, // subset0_shelves2_diff
+		{  44,  45,  -1,   657519,      228,   191068 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   657747,      108,   191162 }, // subset0_shelves3_diff
+		{  35,  36,  -1,   657855,      192,   191197 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   658047,      192,   191271 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   658239,      192,   191345 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   658431,      168,   191419 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   658599,      168,   191485 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   658767,      168,   191551 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   658935,      192,   191617 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   659127,      192,   191691 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   659319,      168,   191765 }, // subset0_shelves2_diff
+		{  44,  45,  -1,   659487,     1617,   191831 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   661104,     1617,   192226 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   662721,     1617,   192605 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   664338,       90,   192995 }, // subset0_shelves3_diff
+		{  54,  42,  -1,   664428,     1248,   193015 }, // subset0_Window
+		{  55,  56,  -1,   665676,     3312,   193319 }, // subset0_Sliding_Steel_Door
+		{  54,  57,  -1,   668988,      930,   194197 }, // subset0_window_Diff
+		{  58,  59,  -1,   669918,    12912,   194433 }, // subset0_Door2
+		{  60,  61,  -1,   682830,      969,   197161 }, // subset0_Floor
+		{  62,  63,  -1,   683799,     2037,   197482 }, // subset0_wall_4
+		{  62,  63,  -1,   685836,     3000,   198168 }, // subset0_wall_3
+		{  64,  65,  -1,   688836,     2205,   199986 }, // subset0_wall_1
+		{  64,  65,  -1,   691041,     1656,   200663 }, // subset0_wall_2
+		{  66,  67,  -1,   692697,     5424,   201041 }, // subset0_roof
+		{  68,  69,  -1,   698121,      939,   203677 }, // subset0_Pillar
+		{  66,  67,  -1,   699060,     1536,   203892 }, // subset0_roof
+		{  70,  71,  -1,   700596,      609,   204339 }, // subset0_Broken_Pillar_Diff
+		{  33,  34,  -1,   701205,     1920,   204469 }, // subset0_Back_Alley_Drum
+		{  33,  34,  -1,   703125,     1920,   205134 }, // subset0_Back_Alley_Drum
+		{  33,  34,  -1,   705045,     1920,   205799 }, // subset0_Back_Alley_Drum
+		{  35,  36,  -1,   706965,     7809,   206464 }, // subset0_shelves2_diff
+		{  14,  15,  -1,   714774,     1920,   208128 }, // subset0_Stack__Boxes_Diff03
+		{  33,  34,  -1,   716694,     1920,   208629 }, // subset0_Back_Alley_Drum
+		{  33,  34,  -1,   718614,     1920,   209294 }, // subset0_Back_Alley_Drum
+		{  33,  34,  -1,   720534,     1920,   209959 }, // subset0_Back_Alley_Drum
+		{  35,  36,  -1,   722454,     7809,   210624 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   730263,     7809,   212294 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   738072,     7809,   213953 }, // subset0_shelves2_diff
+		{  32,  32,  -1,   745881,      783,   215619 }, // subset0_gameCrates_02_Diff
+		{  72,  73,  -1,   746664,    14451,   215808 }, // subset0_GolfBag:Golfclub
+		{  18,  19,  -1,   761115,     3096,   219093 }, // subset0_Back_Alley_box
+	};
 }

--- a/Samples/Desktop/D3D12Multithreading/src/Win32Application.cpp
+++ b/Samples/Desktop/D3D12Multithreading/src/Win32Application.cpp
@@ -16,104 +16,104 @@ HWND Win32Application::m_hwnd = nullptr;
 
 int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
 {
-    // Parse the command line parameters
-    int argc;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    pSample->ParseCommandLineArgs(argv, argc);
-    LocalFree(argv);
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
 
-    // Initialize the window class.
-    WNDCLASSEX windowClass = { 0 };
-    windowClass.cbSize = sizeof(WNDCLASSEX);
-    windowClass.style = CS_HREDRAW | CS_VREDRAW;
-    windowClass.lpfnWndProc = WindowProc;
-    windowClass.hInstance = hInstance;
-    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-    windowClass.lpszClassName = L"DXSampleClass";
-    RegisterClassEx(&windowClass);
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
 
-    RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
-    AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
 
-    // Create the window and store a handle to it.
-    m_hwnd = CreateWindow(
-        windowClass.lpszClassName,
-        pSample->GetTitle(),
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        windowRect.right - windowRect.left,
-        windowRect.bottom - windowRect.top,
-        nullptr,        // We have no parent window.
-        nullptr,        // We aren't using menus.
-        hInstance,
-        pSample);
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
 
-    // Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-    pSample->OnInit();
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
 
-    ShowWindow(m_hwnd, nCmdShow);
+	ShowWindow(m_hwnd, nCmdShow);
 
-    // Main sample loop.
-    MSG msg = {};
-    while (msg.message != WM_QUIT)
-    {
-        // Process any messages in the queue.
-        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
-    }
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
 
-    pSample->OnDestroy();
+	pSample->OnDestroy();
 
-    // Return this part of the WM_QUIT message to Windows.
-    return static_cast<char>(msg.wParam);
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
 }
 
 // Main message handler for the sample.
 LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
-    switch (message)
-    {
-    case WM_CREATE:
-        {
-            // Save the DXSample* passed in to CreateWindow.
-            LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
-            SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
-        }
-        return 0;
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
 
-    case WM_KEYDOWN:
-        if (pSample)
-        {
-            pSample->OnKeyDown(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_KEYUP:
-        if (pSample)
-        {
-            pSample->OnKeyUp(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_PAINT:
-        if (pSample)
-        {
-            pSample->OnUpdate();
-            pSample->OnRender();
-        }
-        return 0;
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
 
-    case WM_DESTROY:
-        PostQuitMessage(0);
-        return 0;
-    }
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
 
-    // Handle any messages the switch statement didn't.
-    return DefWindowProc(hWnd, message, wParam, lParam);
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/Desktop/D3D12Multithreading/src/Win32Application.h
+++ b/Samples/Desktop/D3D12Multithreading/src/Win32Application.h
@@ -18,12 +18,12 @@ class DXSample;
 class Win32Application
 {
 public:
-    static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
-    static HWND GetHwnd() { return m_hwnd; }
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
 
 protected:
-    static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
-    static HWND m_hwnd;
+	static HWND m_hwnd;
 };

--- a/Samples/Desktop/D3D12Multithreading/src/d3dx12.h
+++ b/Samples/Desktop/D3D12Multithreading/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12Multithreading/src/shaders.hlsl
+++ b/Samples/Desktop/D3D12Multithreading/src/shaders.hlsl
@@ -21,31 +21,31 @@ SamplerState sampleClamp : register(s1);
 
 struct LightState
 {
-    float3 position;
-    float3 direction;
-    float4 color;
-    float4 falloff;
-    float4x4 view;
-    float4x4 projection;
+	float3 position;
+	float3 direction;
+	float4 color;
+	float4 falloff;
+	float4x4 view;
+	float4x4 projection;
 };
 
 cbuffer SceneConstantBuffer : register(b0)
 {
-    float4x4 model;
-    float4x4 view;
-    float4x4 projection;
-    float4 ambientColor;
-    bool sampleShadowMap;
-    LightState lights[NUM_LIGHTS];
+	float4x4 model;
+	float4x4 view;
+	float4x4 projection;
+	float4 ambientColor;
+	bool sampleShadowMap;
+	LightState lights[NUM_LIGHTS];
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 worldpos : POSITION;
-    float2 uv : TEXCOORD0;
-    float3 normal : NORMAL;
-    float3 tangent : TANGENT;
+	float4 position : SV_POSITION;
+	float4 worldpos : POSITION;
+	float2 uv : TEXCOORD0;
+	float3 normal : NORMAL;
+	float3 tangent : TANGENT;
 };
 
 
@@ -54,18 +54,18 @@ struct PSInput
 //--------------------------------------------------------------------------------------
 float3 CalcPerPixelNormal(float2 vTexcoord, float3 vVertNormal, float3 vVertTangent)
 {
-    // Compute tangent frame.
-    vVertNormal = normalize(vVertNormal);
-    vVertTangent = normalize(vVertTangent);
+	// Compute tangent frame.
+	vVertNormal = normalize(vVertNormal);
+	vVertTangent = normalize(vVertTangent);
 
-    float3 vVertBinormal = normalize(cross(vVertTangent, vVertNormal));
-    float3x3 mTangentSpaceToWorldSpace = float3x3(vVertTangent, vVertBinormal, vVertNormal);
+	float3 vVertBinormal = normalize(cross(vVertTangent, vVertNormal));
+	float3x3 mTangentSpaceToWorldSpace = float3x3(vVertTangent, vVertBinormal, vVertNormal);
 
-    // Compute per-pixel normal.
-    float3 vBumpNormal = (float3)normalMap.Sample(sampleWrap, vTexcoord);
-    vBumpNormal = 2.0f * vBumpNormal - 1.0f;
+	// Compute per-pixel normal.
+	float3 vBumpNormal = (float3)normalMap.Sample(sampleWrap, vTexcoord);
+	vBumpNormal = 2.0f * vBumpNormal - 1.0f;
 
-    return mul(vBumpNormal, mTangentSpaceToWorldSpace);
+	return mul(vBumpNormal, mTangentSpaceToWorldSpace);
 }
 
 //--------------------------------------------------------------------------------------
@@ -73,24 +73,24 @@ float3 CalcPerPixelNormal(float2 vTexcoord, float3 vVertNormal, float3 vVertTang
 //--------------------------------------------------------------------------------------
 float4 CalcLightingColor(float3 vLightPos, float3 vLightDir, float4 vLightColor, float4 vFalloffs, float3 vPosWorld, float3 vPerPixelNormal)
 {
-    float3 vLightToPixelUnNormalized = vPosWorld - vLightPos;
+	float3 vLightToPixelUnNormalized = vPosWorld - vLightPos;
 
-    // Dist falloff = 0 at vFalloffs.x, 1 at vFalloffs.x - vFalloffs.y
-    float fDist = length(vLightToPixelUnNormalized);
+	// Dist falloff = 0 at vFalloffs.x, 1 at vFalloffs.x - vFalloffs.y
+	float fDist = length(vLightToPixelUnNormalized);
 
-    float fDistFalloff = saturate((vFalloffs.x - fDist) / vFalloffs.y);
+	float fDistFalloff = saturate((vFalloffs.x - fDist) / vFalloffs.y);
 
-    // Normalize from here on.
-    float3 vLightToPixelNormalized = vLightToPixelUnNormalized / fDist;
+	// Normalize from here on.
+	float3 vLightToPixelNormalized = vLightToPixelUnNormalized / fDist;
 
-    // Angle falloff = 0 at vFalloffs.z, 1 at vFalloffs.z - vFalloffs.w
-    float fCosAngle = dot(vLightToPixelNormalized, vLightDir / length(vLightDir));
-    float fAngleFalloff = saturate((fCosAngle - vFalloffs.z) / vFalloffs.w);
+	// Angle falloff = 0 at vFalloffs.z, 1 at vFalloffs.z - vFalloffs.w
+	float fCosAngle = dot(vLightToPixelNormalized, vLightDir / length(vLightDir));
+	float fAngleFalloff = saturate((fCosAngle - vFalloffs.z) / vFalloffs.w);
 
-    // Diffuse contribution.
-    float fNDotL = saturate(-dot(vLightToPixelNormalized, vPerPixelNormal));
+	// Diffuse contribution.
+	float fNDotL = saturate(-dot(vLightToPixelNormalized, vPerPixelNormal));
 
-    return vLightColor * fNDotL * fDistFalloff * fAngleFalloff;
+	return vLightColor * fNDotL * fDistFalloff * fAngleFalloff;
 }
 
 //--------------------------------------------------------------------------------------
@@ -98,77 +98,77 @@ float4 CalcLightingColor(float3 vLightPos, float3 vLightDir, float4 vLightColor,
 //--------------------------------------------------------------------------------------
 float4 CalcUnshadowedAmountPCF2x2(int lightIndex, float4 vPosWorld)
 {
-    // Compute pixel position in light space.
-    float4 vLightSpacePos = vPosWorld;
-    vLightSpacePos = mul(vLightSpacePos, lights[lightIndex].view);
-    vLightSpacePos = mul(vLightSpacePos, lights[lightIndex].projection);
+	// Compute pixel position in light space.
+	float4 vLightSpacePos = vPosWorld;
+	vLightSpacePos = mul(vLightSpacePos, lights[lightIndex].view);
+	vLightSpacePos = mul(vLightSpacePos, lights[lightIndex].projection);
 
-    vLightSpacePos.xyz /= vLightSpacePos.w;
+	vLightSpacePos.xyz /= vLightSpacePos.w;
 
-    // Translate from homogeneous coords to texture coords.
-    float2 vShadowTexCoord = 0.5f * vLightSpacePos.xy + 0.5f;
-    vShadowTexCoord.y = 1.0f - vShadowTexCoord.y;
+	// Translate from homogeneous coords to texture coords.
+	float2 vShadowTexCoord = 0.5f * vLightSpacePos.xy + 0.5f;
+	vShadowTexCoord.y = 1.0f - vShadowTexCoord.y;
 
-    // Depth bias to avoid pixel self-shadowing.
-    float vLightSpaceDepth = vLightSpacePos.z - SHADOW_DEPTH_BIAS;
+	// Depth bias to avoid pixel self-shadowing.
+	float vLightSpaceDepth = vLightSpacePos.z - SHADOW_DEPTH_BIAS;
 
-    // Find sub-pixel weights.
-    float2 vShadowMapDims = float2(1280.0f, 720.0f); // need to keep in sync with .cpp file
-    float4 vSubPixelCoords = float4(1.0f, 1.0f, 1.0f, 1.0f);
-    vSubPixelCoords.xy = frac(vShadowMapDims * vShadowTexCoord);
-    vSubPixelCoords.zw = 1.0f - vSubPixelCoords.xy;
-    float4 vBilinearWeights = vSubPixelCoords.zxzx * vSubPixelCoords.wwyy;
+	// Find sub-pixel weights.
+	float2 vShadowMapDims = float2(1280.0f, 720.0f); // need to keep in sync with .cpp file
+	float4 vSubPixelCoords = float4(1.0f, 1.0f, 1.0f, 1.0f);
+	vSubPixelCoords.xy = frac(vShadowMapDims * vShadowTexCoord);
+	vSubPixelCoords.zw = 1.0f - vSubPixelCoords.xy;
+	float4 vBilinearWeights = vSubPixelCoords.zxzx * vSubPixelCoords.wwyy;
 
-    // 2x2 percentage closer filtering.
-    float2 vTexelUnits = 1.0f / vShadowMapDims;
-    float4 vShadowDepths;
-    vShadowDepths.x = shadowMap.Sample(sampleClamp, vShadowTexCoord);
-    vShadowDepths.y = shadowMap.Sample(sampleClamp, vShadowTexCoord + float2(vTexelUnits.x, 0.0f));
-    vShadowDepths.z = shadowMap.Sample(sampleClamp, vShadowTexCoord + float2(0.0f, vTexelUnits.y));
-    vShadowDepths.w = shadowMap.Sample(sampleClamp, vShadowTexCoord + vTexelUnits);
+	// 2x2 percentage closer filtering.
+	float2 vTexelUnits = 1.0f / vShadowMapDims;
+	float4 vShadowDepths;
+	vShadowDepths.x = shadowMap.Sample(sampleClamp, vShadowTexCoord);
+	vShadowDepths.y = shadowMap.Sample(sampleClamp, vShadowTexCoord + float2(vTexelUnits.x, 0.0f));
+	vShadowDepths.z = shadowMap.Sample(sampleClamp, vShadowTexCoord + float2(0.0f, vTexelUnits.y));
+	vShadowDepths.w = shadowMap.Sample(sampleClamp, vShadowTexCoord + vTexelUnits);
 
-    // What weighted fraction of the 4 samples are nearer to the light than this pixel?
-    float4 vShadowTests = (vShadowDepths >= vLightSpaceDepth) ? 1.0f : 0.0f;
-    return dot(vBilinearWeights, vShadowTests);
+	// What weighted fraction of the 4 samples are nearer to the light than this pixel?
+	float4 vShadowTests = (vShadowDepths >= vLightSpaceDepth) ? 1.0f : 0.0f;
+	return dot(vBilinearWeights, vShadowTests);
 }
 
 PSInput VSMain(float3 position : POSITION, float3 normal : NORMAL, float2 uv : TEXCOORD0, float3 tangent : TANGENT)
 {
-    PSInput result;
+	PSInput result;
 
-    float4 newPosition = float4(position, 1.0f);
+	float4 newPosition = float4(position, 1.0f);
 
-    normal.z *= -1.0f;
-    newPosition = mul(newPosition, model);
+	normal.z *= -1.0f;
+	newPosition = mul(newPosition, model);
 
-    result.worldpos = newPosition;
+	result.worldpos = newPosition;
 
-    newPosition = mul(newPosition, view);
-    newPosition = mul(newPosition, projection);
+	newPosition = mul(newPosition, view);
+	newPosition = mul(newPosition, projection);
 
-    result.position = newPosition;
-    result.uv = uv;
-    result.normal = normal;
-    result.tangent = tangent;
+	result.position = newPosition;
+	result.uv = uv;
+	result.normal = normal;
+	result.tangent = tangent;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    float4 diffuseColor = diffuseMap.Sample(sampleWrap, input.uv);
-    float3 pixelNormal = CalcPerPixelNormal(input.uv, input.normal, input.tangent);
-    float4 totalLight = ambientColor;
+	float4 diffuseColor = diffuseMap.Sample(sampleWrap, input.uv);
+	float3 pixelNormal = CalcPerPixelNormal(input.uv, input.normal, input.tangent);
+	float4 totalLight = ambientColor;
 
-    for (int i = 0; i < NUM_LIGHTS; i++)
-    {
-        float4 lightPass = CalcLightingColor(lights[i].position, lights[i].direction, lights[i].color, lights[i].falloff, input.worldpos.xyz, pixelNormal);
-        if (sampleShadowMap && i == 0)
-        {
-            lightPass *= CalcUnshadowedAmountPCF2x2(i, input.worldpos);
-        }
-        totalLight += lightPass;
-    }
+	for (int i = 0; i < NUM_LIGHTS; i++)
+	{
+		float4 lightPass = CalcLightingColor(lights[i].position, lights[i].direction, lights[i].color, lights[i].falloff, input.worldpos.xyz, pixelNormal);
+		if (sampleShadowMap && i == 0)
+		{
+			lightPass *= CalcUnshadowedAmountPCF2x2(i, input.worldpos);
+		}
+		totalLight += lightPass;
+	}
 
-    return diffuseColor * saturate(totalLight);
+	return diffuseColor * saturate(totalLight);
 }

--- a/Samples/Desktop/D3D12Multithreading/src/stdafx.h
+++ b/Samples/Desktop/D3D12Multithreading/src/stdafx.h
@@ -16,13 +16,13 @@
 #pragma once
 
 #ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN            // Exclude rarely-used stuff from Windows headers.
+#define WIN32_LEAN_AND_MEAN			// Exclude rarely-used stuff from Windows headers.
 #endif
 
 #include <windows.h>
 
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"
@@ -38,9 +38,9 @@
 static const UINT FrameCount = 3;
 
 static const UINT NumContexts = 3;
-static const UINT NumLights = 3;        // Keep this in sync with "shaders.hlsl".
+static const UINT NumLights = 3;		// Keep this in sync with "shaders.hlsl".
 
-static const UINT TitleThrottle = 200;    // Only update the titlebar every X number of frames.
+static const UINT TitleThrottle = 200;	// Only update the titlebar every X number of frames.
 
 // Command list submissions from main thread.
 static const int CommandListCount = 3;

--- a/Samples/Desktop/D3D12PipelineStateCache/src/BlitPixelShader.hlsl
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/BlitPixelShader.hlsl
@@ -13,10 +13,10 @@
 
 float4 Blit(float2 uv)
 {
-    return g_tex.Sample(g_samp, uv);
+	return g_tex.Sample(g_samp, uv);
 }
 
 float4 mainBlit(PSInput input) : SV_TARGET
 {
-    return Blit(input.uv);
+	return Blit(input.uv);
 }

--- a/Samples/Desktop/D3D12PipelineStateCache/src/BlurPixelShader.hlsl
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/BlurPixelShader.hlsl
@@ -12,54 +12,54 @@
 #include "QuadVertexShader.hlsl"
 
 static const float weights[] = {
-    0.1061154f,
-    0.102850571f,
-    0.102850571f,
-    0.09364651f,
-    0.09364651f,
-    0.0801001f,
-    0.0801001f,
-    0.06436224f,
-    0.06436224f,
-    0.0485831723f,
-    0.0485831723f,
-    0.0344506279f,
-    0.0344506279f,
-    0.0229490642f,
-    0.0229490642f,
+	0.1061154f,
+	0.102850571f,
+	0.102850571f,
+	0.09364651f,
+	0.09364651f,
+	0.0801001f,
+	0.0801001f,
+	0.06436224f,
+	0.06436224f,
+	0.0485831723f,
+	0.0485831723f,
+	0.0344506279f,
+	0.0344506279f,
+	0.0229490642f,
+	0.0229490642f,
 };
 
 static const float2 offsets[] = {
-    float2(0.0f, 0.0f),
-    float2(0.00375f, 0.006250001f),
-    float2(-0.00375f, -0.006250001f),
-    float2(0.00875f, 0.01458333f),
-    float2(-0.00875f, -0.01458333f),
-    float2(0.01375f, 0.02291667f),
-    float2(-0.01375f, -0.02291667f),
-    float2(0.01875f, 0.03125f),
-    float2(-0.01875f, -0.03125f),
-    float2(0.02375f, 0.03958334f),
-    float2(-0.02375f, -0.03958334f),
-    float2(0.02875f, 0.04791667f),
-    float2(-0.02875f, -0.04791667f),
-    float2(0.03375f, 0.05625f),
-    float2(-0.03375f, -0.05625f),
+	float2(0.0f, 0.0f),
+	float2(0.00375f, 0.006250001f),
+	float2(-0.00375f, -0.006250001f),
+	float2(0.00875f, 0.01458333f),
+	float2(-0.00875f, -0.01458333f),
+	float2(0.01375f, 0.02291667f),
+	float2(-0.01375f, -0.02291667f),
+	float2(0.01875f, 0.03125f),
+	float2(-0.01875f, -0.03125f),
+	float2(0.02375f, 0.03958334f),
+	float2(-0.02375f, -0.03958334f),
+	float2(0.02875f, 0.04791667f),
+	float2(-0.02875f, -0.04791667f),
+	float2(0.03375f, 0.05625f),
+	float2(-0.03375f, -0.05625f),
 };
 
 float4 Blur(float2 uv)
 {
-    float4 color = float4(0.0f, 0.0f, 0.0f, 0.0f);
+	float4 color = float4(0.0f, 0.0f, 0.0f, 0.0f);
 
-    for (int i = 0; i < 15; i++)
-    {
-        color += g_tex.Sample(g_samp, uv + offsets[i]) * weights[i];
-    }
+	for (int i = 0; i < 15; i++)
+	{
+		color += g_tex.Sample(g_samp, uv + offsets[i]) * weights[i];
+	}
 
-    return color;
+	return color;
 }
 
 float4 mainBlur(PSInput input) : SV_TARGET
 {
-    return Blur(input.uv);
+	return Blur(input.uv);
 }

--- a/Samples/Desktop/D3D12PipelineStateCache/src/D3D12PipelineStateCache.cpp
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/D3D12PipelineStateCache.cpp
@@ -15,666 +15,709 @@
 const float D3D12PipelineStateCache::IntermediateClearColor[4] = { 0.0f, 0.2f, 0.3f, 1.0f };
 
 D3D12PipelineStateCache::D3D12PipelineStateCache(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_psoLibrary(FrameCount, RootParameterUberShaderCB),
-    m_frameIndex(0),
-    m_swapChainEvent(0),
-    m_drawIndex(0),
-    m_maxDrawsPerFrame(256),
-    m_dynamicCB(sizeof(DrawConstantBuffer), m_maxDrawsPerFrame, FrameCount),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0),
-    m_srvDescriptorSize(0),
-    m_fenceValues{}
+	DXSample(width, height, name),
+	m_psoLibrary(FrameCount, RootParameterUberShaderCB),
+	m_frameIndex(0),
+	m_swapChainEvent(0),
+	m_drawIndex(0),
+	m_maxDrawsPerFrame(256),
+	m_dynamicCB(sizeof(DrawConstantBuffer), m_maxDrawsPerFrame, FrameCount),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0),
+	m_srvDescriptorSize(0),
+	m_fenceValues{}
 {
-    memset(m_enabledEffects, true, sizeof(m_enabledEffects));
+	memset(m_enabledEffects, true, sizeof(m_enabledEffects));
+
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
 }
 
 void D3D12PipelineStateCache::OnInit()
 {
-    UpdateWindowTextPso();
-    m_camera.Init({ 0.0f, 0.0f, 5.0f });
-    m_camera.SetMoveSpeed(1.0f);
+	UpdateWindowTextPso();
+	m_camera.Init({ 0.0f, 0.0f, 5.0f });
+	m_camera.SetMoveSpeed(1.0f);
 
-    m_projectionMatrix = m_camera.GetProjectionMatrix(0.8f, m_aspectRatio);
+	m_projectionMatrix = m_camera.GetProjectionMatrix(0.8f, m_aspectRatio);
 
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12PipelineStateCache::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter, true);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
-    NAME_D3D12_OBJECT(m_commandQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	NAME_D3D12_OBJECT(m_commandQueue);
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
-    swapChainDesc.Flags = DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
+	swapChainDesc.Flags = DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    // This sample does not support fullscreen transitions.
-    ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
+	// This sample does not support fullscreen transitions.
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
-    m_swapChainEvent = m_swapChain->GetFrameLatencyWaitableObject();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	m_swapChainEvent = m_swapChain->GetFrameLatencyWaitableObject();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount + 1;    // A descriptor for each frame + 1 intermediate render target.
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount + 1;	// A descriptor for each frame + 1 intermediate render target.
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a shader resource view (SRV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
-        srvHeapDesc.NumDescriptors = 1;
-        srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
-        NAME_D3D12_OBJECT(m_srvHeap);
+		// Describe and create a shader resource view (SRV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
+		srvHeapDesc.NumDescriptors = 1;
+		srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
+		NAME_D3D12_OBJECT(m_srvHeap);
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-        m_srvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_srvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create RTVs and a command allocator for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
+		// Create RTVs and a command allocator for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-            NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
+			NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
 
-            ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
-        }
+			ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
+		}
 
-        D3D12_RESOURCE_DESC renderTargetDesc = m_renderTargets[0]->GetDesc();
+		D3D12_RESOURCE_DESC renderTargetDesc = m_renderTargets[0]->GetDesc();
 
-        D3D12_CLEAR_VALUE clearValue = {};
-        memcpy(clearValue.Color, IntermediateClearColor, sizeof(IntermediateClearColor));
-        clearValue.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+		D3D12_CLEAR_VALUE clearValue = {};
+		memcpy(clearValue.Color, IntermediateClearColor, sizeof(IntermediateClearColor));
+		clearValue.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
 
-        // Create an intermediate render target that is the same dimensions as the swap chain.
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &renderTargetDesc,
-            D3D12_RESOURCE_STATE_RENDER_TARGET,
-            &clearValue,
-            IID_PPV_ARGS(&m_intermediateRenderTarget)));
+		// Create an intermediate render target that is the same dimensions as the swap chain.
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&renderTargetDesc,
+			D3D12_RESOURCE_STATE_RENDER_TARGET,
+			&clearValue,
+			IID_PPV_ARGS(&m_intermediateRenderTarget)));
 
-        NAME_D3D12_OBJECT(m_intermediateRenderTarget);
+		NAME_D3D12_OBJECT(m_intermediateRenderTarget);
 
-        m_device->CreateRenderTargetView(m_intermediateRenderTarget.Get(), nullptr, rtvHandle);
-        rtvHandle.Offset(1, m_rtvDescriptorSize);
+		m_device->CreateRenderTargetView(m_intermediateRenderTarget.Get(), nullptr, rtvHandle);
+		rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-        // Create a SRV of the intermediate render target.
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Format = renderTargetDesc.Format;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = 1;
+		// Create a SRV of the intermediate render target.
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Format = renderTargetDesc.Format;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = 1;
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_srvHeap->GetCPUDescriptorHandleForHeapStart());
-        m_device->CreateShaderResourceView(m_intermediateRenderTarget.Get(), &srvDesc, srvHandle);
-    }
+		CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_srvHeap->GetCPUDescriptorHandleForHeapStart());
+		m_device->CreateShaderResourceView(m_intermediateRenderTarget.Get(), &srvDesc, srvHandle);
+	}
 }
 
 void D3D12PipelineStateCache::LoadAssets()
 {
-    // Create the root signature.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signature.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        // We don't modify the SRV in the command list after SetGraphicsRootDescriptorTable
-        // is executed on the GPU so we can use the default range behavior:
-        // D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[RootParametersCount];
-        ranges[RootParameterSRV].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
+		// We don't modify the SRV in the command list after SetGraphicsRootDescriptorTable
+		// is executed on the GPU so we can use the default range behavior:
+		// D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[RootParametersCount];
+		ranges[RootParameterSRV].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
 
-        CD3DX12_ROOT_PARAMETER1 rootParameters[RootParametersCount];
-        rootParameters[RootParameterUberShaderCB].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_ALL);
-        rootParameters[RootParameterCB].InitAsConstantBufferView(1, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_ALL);
-        rootParameters[RootParameterSRV].InitAsDescriptorTable(1, &ranges[RootParameterSRV], D3D12_SHADER_VISIBILITY_PIXEL);
+		CD3DX12_ROOT_PARAMETER1 rootParameters[RootParametersCount];
+		rootParameters[RootParameterUberShaderCB].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_ALL);
+		rootParameters[RootParameterCB].InitAsConstantBufferView(1, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_ALL);
+		rootParameters[RootParameterSRV].InitAsDescriptorTable(1, &ranges[RootParameterSRV], D3D12_SHADER_VISIBILITY_PIXEL);
 
-        D3D12_STATIC_SAMPLER_DESC sampler = {};
-        sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
-        sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.MipLODBias = 0;
-        sampler.MaxAnisotropy = 0;
-        sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
-        sampler.BorderColor = D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
-        sampler.MinLOD = 0.0f;
-        sampler.MaxLOD = 9999.0f;
-        sampler.ShaderRegister = 0;
-        sampler.RegisterSpace = 0;
-        sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+		D3D12_STATIC_SAMPLER_DESC sampler = {};
+		sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
+		sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.MipLODBias = 0;
+		sampler.MaxAnisotropy = 0;
+		sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
+		sampler.BorderColor = D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
+		sampler.MinLOD = 0.0f;
+		sampler.MaxLOD = 9999.0f;
+		sampler.ShaderRegister = 0;
+		sampler.RegisterSpace = 0;
+		sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &sampler, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &sampler, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-        NAME_D3D12_OBJECT(m_rootSignature);
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+		NAME_D3D12_OBJECT(m_rootSignature);
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), nullptr, IID_PPV_ARGS(&m_commandList)));
-    NAME_D3D12_OBJECT(m_commandList);
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), nullptr, IID_PPV_ARGS(&m_commandList)));
+	NAME_D3D12_OBJECT(m_commandList);
 
-    // Note: ComPtr's are CPU objects but this resource needs to stay in scope until
-    // the command list that references it has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resource is not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> vertexIndexBufferUpload;
+	// Note: ComPtr's are CPU objects but this resource needs to stay in scope until
+	// the command list that references it has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resource is not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> vertexIndexBufferUpload;
 
-    // Vertex and Index Buffer.
-    {
-        const VertexPositionColor cubeVertices[] = {
-            { { -1.0f, 1.0f, -1.0f, 1.0f }, { GetRandomColor(),GetRandomColor(), GetRandomColor() } },    // Back Top Left
-            { { 1.0f, 1.0f, -1.0f, 1.0f }, { GetRandomColor(), GetRandomColor(), GetRandomColor() } },    // Back Top Right
-            { { 1.0f, 1.0f, 1.0f, 1.0f }, { GetRandomColor(), GetRandomColor(), GetRandomColor() } },    // Front Top Right
-            { { -1.0f, 1.0f, 1.0f, 1.0f }, { GetRandomColor(), GetRandomColor(), GetRandomColor() } },    // Front Top Left
+	// Vertex and Index Buffer.
+	{
+		const VertexPositionColor cubeVertices[] = {
+			{ { -1.0f, 1.0f, -1.0f, 1.0f }, { GetRandomColor(),GetRandomColor(), GetRandomColor() } },	// Back Top Left
+			{ { 1.0f, 1.0f, -1.0f, 1.0f }, { GetRandomColor(), GetRandomColor(), GetRandomColor() } },	// Back Top Right
+			{ { 1.0f, 1.0f, 1.0f, 1.0f }, { GetRandomColor(), GetRandomColor(), GetRandomColor() } },	// Front Top Right
+			{ { -1.0f, 1.0f, 1.0f, 1.0f }, { GetRandomColor(), GetRandomColor(), GetRandomColor() } },	// Front Top Left
 
-            { { -1.0f, -1.0f, -1.0f, 1.0f }, { GetRandomColor(),GetRandomColor(), GetRandomColor() } },    // Back Bottom Left
-            { { 1.0f, -1.0f, -1.0f, 1.0f }, { GetRandomColor(),GetRandomColor(), GetRandomColor() } },    // Back Bottom Right
-            { { 1.0f, -1.0f, 1.0f, 1.0f }, { GetRandomColor(),GetRandomColor(), GetRandomColor() } },    // Front Bottom Right
-            { { -1.0f, -1.0f, 1.0f, 1.0f }, { GetRandomColor(),GetRandomColor(), GetRandomColor() } },    // Front Bottom Left
-        };
+			{ { -1.0f, -1.0f, -1.0f, 1.0f }, { GetRandomColor(),GetRandomColor(), GetRandomColor() } },	// Back Bottom Left
+			{ { 1.0f, -1.0f, -1.0f, 1.0f }, { GetRandomColor(),GetRandomColor(), GetRandomColor() } },	// Back Bottom Right
+			{ { 1.0f, -1.0f, 1.0f, 1.0f }, { GetRandomColor(),GetRandomColor(), GetRandomColor() } },	// Front Bottom Right
+			{ { -1.0f, -1.0f, 1.0f, 1.0f }, { GetRandomColor(),GetRandomColor(), GetRandomColor() } },	// Front Bottom Left
+		};
 
-        const UINT cubeIndices[] =
-        {
-            0, 1, 3,
-            1, 2, 3,
+		const UINT cubeIndices[] =
+		{
+			0, 1, 3,
+			1, 2, 3,
 
-            3, 2, 7,
-            6, 7, 2,
+			3, 2, 7,
+			6, 7, 2,
 
-            2, 1, 6,
-            5, 6, 1,
+			2, 1, 6,
+			5, 6, 1,
 
-            1, 0, 5,
-            4, 5, 0,
+			1, 0, 5,
+			4, 5, 0,
 
-            0, 3, 4,
-            7, 4, 3,
+			0, 3, 4,
+			7, 4, 3,
 
-            7, 6, 4,
-            5, 4, 6,
-        };
+			7, 6, 4,
+			5, 4, 6,
+		};
 
-        static const VertexPositionUV quadVertices[] =
-        {
-            { { -1.0f, -1.0f, 0.0f, 1.0f }, { 0.0f, 1.0f } },    // Bottom Left
-            { { -1.0f, 1.0f, 0.0f, 1.0f }, { 0.0f, 0.0f } },    // Top Left
-            { { 1.0f, -1.0f, 0.0f, 1.0f }, { 1.0f, 1.0f } },    // Bottom Right
-            { { 1.0f, 1.0f, 0.0f, 1.0f }, { 1.0f, 0.0f } },        // Top Right
-        };
+		static const VertexPositionUV quadVertices[] =
+		{
+			{ { -1.0f, -1.0f, 0.0f, 1.0f }, { 0.0f, 1.0f } },	// Bottom Left
+			{ { -1.0f, 1.0f, 0.0f, 1.0f }, { 0.0f, 0.0f } },	// Top Left
+			{ { 1.0f, -1.0f, 0.0f, 1.0f }, { 1.0f, 1.0f } },	// Bottom Right
+			{ { 1.0f, 1.0f, 0.0f, 1.0f }, { 1.0f, 0.0f } },		// Top Right
+		};
 
-        const UINT vertexIndexBufferSize = sizeof(cubeIndices) + sizeof(cubeVertices) + sizeof(quadVertices);
+		const UINT vertexIndexBufferSize = sizeof(cubeIndices) + sizeof(cubeVertices) + sizeof(quadVertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexIndexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexIndexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexIndexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexIndexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexIndexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&vertexIndexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexIndexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&vertexIndexBufferUpload)));
 
-        NAME_D3D12_OBJECT(m_vertexIndexBuffer);
+		NAME_D3D12_OBJECT(m_vertexIndexBuffer);
 
-        UINT8* mappedUploadHeap = nullptr;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(vertexIndexBufferUpload->Map(0, &readRange, reinterpret_cast<void**>(&mappedUploadHeap)));
+		UINT8* mappedUploadHeap = nullptr;
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(vertexIndexBufferUpload->Map(0, &readRange, reinterpret_cast<void**>(&mappedUploadHeap)));
 
-        // Fill in part of the upload heap with our index and vertex data.
-        UINT8* heapLocation = static_cast<UINT8*>(mappedUploadHeap);
-        memcpy(heapLocation, cubeVertices, sizeof(cubeVertices));
-        heapLocation += sizeof(cubeVertices);
-        memcpy(heapLocation, cubeIndices, sizeof(cubeIndices));
-        heapLocation += sizeof(cubeIndices);
-        memcpy(heapLocation, quadVertices, sizeof(quadVertices));
+		// Fill in part of the upload heap with our index and vertex data.
+		UINT8* heapLocation = static_cast<UINT8*>(mappedUploadHeap);
+		memcpy(heapLocation, cubeVertices, sizeof(cubeVertices));
+		heapLocation += sizeof(cubeVertices);
+		memcpy(heapLocation, cubeIndices, sizeof(cubeIndices));
+		heapLocation += sizeof(cubeIndices);
+		memcpy(heapLocation, quadVertices, sizeof(quadVertices));
 
-        // Pack the vertices and indices into their destination by copying from the upload heap.
-        m_commandList->CopyBufferRegion(m_vertexIndexBuffer.Get(), 0, vertexIndexBufferUpload.Get(), 0, vertexIndexBufferSize);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexIndexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER | D3D12_RESOURCE_STATE_INDEX_BUFFER));
+		// Pack the vertices and indices into their destination by copying from the upload heap.
+		m_commandList->CopyBufferRegion(m_vertexIndexBuffer.Get(), 0, vertexIndexBufferUpload.Get(), 0, vertexIndexBufferSize);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexIndexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER | D3D12_RESOURCE_STATE_INDEX_BUFFER));
 
-        // Create the index and vertex buffer views.
-        m_cubeVbv.BufferLocation = m_vertexIndexBuffer.Get()->GetGPUVirtualAddress();
-        m_cubeVbv.SizeInBytes = sizeof(cubeVertices);
-        m_cubeVbv.StrideInBytes = sizeof(VertexPositionColor);
+		// Create the index and vertex buffer views.
+		m_cubeVbv.BufferLocation = m_vertexIndexBuffer.Get()->GetGPUVirtualAddress();
+		m_cubeVbv.SizeInBytes = sizeof(cubeVertices);
+		m_cubeVbv.StrideInBytes = sizeof(VertexPositionColor);
 
-        m_cubeIbv.BufferLocation = m_cubeVbv.BufferLocation + sizeof(cubeVertices);
-        m_cubeIbv.SizeInBytes = sizeof(cubeIndices);
-        m_cubeIbv.Format = DXGI_FORMAT_R32_UINT;
+		m_cubeIbv.BufferLocation = m_cubeVbv.BufferLocation + sizeof(cubeVertices);
+		m_cubeIbv.SizeInBytes = sizeof(cubeIndices);
+		m_cubeIbv.Format = DXGI_FORMAT_R32_UINT;
 
-        m_quadVbv.BufferLocation = m_cubeIbv.BufferLocation + sizeof(cubeIndices);
-        m_quadVbv.SizeInBytes = sizeof(quadVertices);
-        m_quadVbv.StrideInBytes = sizeof(VertexPositionUV);
-    }
+		m_quadVbv.BufferLocation = m_cubeIbv.BufferLocation + sizeof(cubeIndices);
+		m_quadVbv.SizeInBytes = sizeof(quadVertices);
+		m_quadVbv.StrideInBytes = sizeof(VertexPositionUV);
+	}
 
-    // Create the constant buffer.
-    m_dynamicCB.Init(m_device.Get());
+	// Create the constant buffer.
+	m_dynamicCB.Init(m_device.Get());
 
-    // Close the command list and execute it to begin the vertex/index buffer copy
-    // into the default heap.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the vertex/index buffer copy
+	// into the default heap.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValues[m_frameIndex]++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValues[m_frameIndex]++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForGpu();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForGpu();
+	}
 
-    m_psoLibrary.Build(m_device.Get(), m_rootSignature.Get());
-    UpdateWindowTextPso();
+	m_psoLibrary.Build(m_device.Get(), m_rootSignature.Get());
+	UpdateWindowTextPso();
 }
 
 // Update frame-based values.
 void D3D12PipelineStateCache::OnUpdate()
 {
-    // Wait for the previous Present to complete.
-    WaitForSingleObjectEx(m_swapChainEvent, 100, FALSE);
+	// Wait for the previous Present to complete.
+	WaitForSingleObjectEx(m_swapChainEvent, 100, FALSE);
 
-    m_timer.Tick(NULL);
-    m_camera.Update(static_cast<float>(m_timer.GetElapsedSeconds()));
+	m_timer.Tick(NULL);
+	m_camera.Update(static_cast<float>(m_timer.GetElapsedSeconds()));
 }
 
 // Render the scene.
 void D3D12PipelineStateCache::OnRender()
 {
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+    try
+    {
+        PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
 
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+        // Record all the commands we need to render the scene into the command list.
+        PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+        // Execute the command list.
+        ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+        m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    PIXEndEvent(m_commandQueue.Get());
+        PIXEndEvent(m_commandQueue.Get());
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+        // Present the frame.
+        ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    m_drawIndex = 0;
-    m_psoLibrary.EndFrame();
+        m_drawIndex = 0;
+        m_psoLibrary.EndFrame();
 
-    MoveToNextFrame();
+        MoveToNextFrame();
+    }
+    catch (HrException& e)
+    {
+        if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
+        {
+            RestoreD3DResources();
+        }
+        else
+        {
+            throw;
+        }
+    }
 }
+
+// Release sample's D3D objects.
+void D3D12PipelineStateCache::ReleaseD3DResources()
+{
+    m_fence.Reset();
+    ResetComPtrArray(&m_renderTargets);
+    m_commandQueue.Reset();
+    m_swapChain.Reset();
+    m_device.Reset();
+}
+
+// Tears down D3D resources and reinitializes them.
+void D3D12PipelineStateCache::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
+    {
+        WaitForGpu();
+    }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
+}
+
 
 void D3D12PipelineStateCache::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForGpu();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForGpu();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12PipelineStateCache::OnKeyDown(UINT8 key)
 {
-    m_camera.OnKeyDown(key);
+	m_camera.OnKeyDown(key);
 }
 
 void D3D12PipelineStateCache::OnKeyUp(UINT8 key)
 {
-    m_camera.OnKeyUp(key);
-    
-    switch (key)
-    {
-    case 'C':
-        WaitForGpu();
-        m_psoLibrary.ClearPSOCache();
-        m_psoLibrary.Build(m_device.Get(), m_rootSignature.Get());
-        break;
+	m_camera.OnKeyUp(key);
+	
+	switch (key)
+	{
+	case 'C':
+		WaitForGpu();
+		m_psoLibrary.ClearPSOCache();
+		m_psoLibrary.Build(m_device.Get(), m_rootSignature.Get());
+		break;
 
-    case 'U':
-        m_psoLibrary.ToggleUberShader();
-        break;
+	case 'U':
+		m_psoLibrary.ToggleUberShader();
+		break;
 
-    case 'L':
-        m_psoLibrary.ToggleDiskLibrary();
-        break;
+	case 'L':
+		m_psoLibrary.ToggleDiskLibrary();
+		break;
 
-    case 'M':
-        m_psoLibrary.SwitchPSOCachingMechanism();
-        break;
+	case 'M':
+		m_psoLibrary.SwitchPSOCachingMechanism();
+		break;
 
-    case '1':
-        ToggleEffect(PostBlit);
-        break;
+	case '1':
+		ToggleEffect(PostBlit);
+		break;
 
-    case '2':
-        ToggleEffect(PostInvert);
-        break;
+	case '2':
+		ToggleEffect(PostInvert);
+		break;
 
-    case '3':
-        ToggleEffect(PostGrayScale);
-        break;
+	case '3':
+		ToggleEffect(PostGrayScale);
+		break;
 
-    case '4':
-        ToggleEffect(PostEdgeDetect);
-        break;
+	case '4':
+		ToggleEffect(PostEdgeDetect);
+		break;
 
-    case '5':
-        ToggleEffect(PostBlur);
-        break;
+	case '5':
+		ToggleEffect(PostBlur);
+		break;
 
-    case '6':
-        ToggleEffect(PostWarp);
-        break;
+	case '6':
+		ToggleEffect(PostWarp);
+		break;
 
-    case '7':
-        ToggleEffect(PostPixelate);
-        break;
+	case '7':
+		ToggleEffect(PostPixelate);
+		break;
 
-    case '8':
-        ToggleEffect(PostDistort);
-        break;
+	case '8':
+		ToggleEffect(PostDistort);
+		break;
 
-    case '9':
-        ToggleEffect(PostWave);
-        break;
+	case '9':
+		ToggleEffect(PostWave);
+		break;
 
-    default:
-        break;
-    }
+	default:
+		break;
+	}
 
-    UpdateWindowTextPso();
+	UpdateWindowTextPso();
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12PipelineStateCache::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated
-    // command lists have finished execution on the GPU; apps should use
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
+	// Command list allocators can only be reset when the associated
+	// command lists have finished execution on the GPU; apps should use
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command
-    // list, that command list can then be reset at any time and must be before
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), nullptr));
+	// However, when ExecuteCommandList() is called on a particular command
+	// list, that command list can then be reset at any time and must be before
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), nullptr));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
-    m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
+	m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE intermediateRtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSize);
-    CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_srvHeap->GetGPUDescriptorHandleForHeapStart());
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE intermediateRtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSize);
+	CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_srvHeap->GetGPUDescriptorHandleForHeapStart());
 
-    m_commandList->OMSetRenderTargets(1, &intermediateRtvHandle, FALSE, nullptr);
+	m_commandList->OMSetRenderTargets(1, &intermediateRtvHandle, FALSE, nullptr);
 
-    // Record commands.
-    m_commandList->ClearRenderTargetView(intermediateRtvHandle, IntermediateClearColor, 0, nullptr);
+	// Record commands.
+	m_commandList->ClearRenderTargetView(intermediateRtvHandle, IntermediateClearColor, 0, nullptr);
 
-    // Draw the scene as normal into the intermediate buffer.
-    PIXBeginEvent(m_commandList.Get(), 0, L"Draw cube");
-    {
-        static float rot = 0.0f;
-        DrawConstantBuffer* drawCB = (DrawConstantBuffer*)m_dynamicCB.GetMappedMemory(m_drawIndex, m_frameIndex);
-        drawCB->worldViewProjection = XMMatrixTranspose(XMMatrixRotationY(rot) * XMMatrixRotationX(-rot) * m_camera.GetViewMatrix() * m_projectionMatrix);
+	// Draw the scene as normal into the intermediate buffer.
+	PIXBeginEvent(m_commandList.Get(), 0, L"Draw cube");
+	{
+		static float rot = 0.0f;
+		DrawConstantBuffer* drawCB = (DrawConstantBuffer*)m_dynamicCB.GetMappedMemory(m_drawIndex, m_frameIndex);
+		drawCB->worldViewProjection = XMMatrixTranspose(XMMatrixRotationY(rot) * XMMatrixRotationX(-rot) * m_camera.GetViewMatrix() * m_projectionMatrix);
 
-        rot += 0.01f;
+		rot += 0.01f;
 
-        m_commandList->IASetVertexBuffers(0, 1, &m_cubeVbv);
-        m_commandList->IASetIndexBuffer(&m_cubeIbv);
-        m_psoLibrary.SetPipelineState(m_device.Get(), m_rootSignature.Get(), m_commandList.Get(), BaseNormal3DRender, m_frameIndex);
+		m_commandList->IASetVertexBuffers(0, 1, &m_cubeVbv);
+		m_commandList->IASetIndexBuffer(&m_cubeIbv);
+		m_psoLibrary.SetPipelineState(m_device.Get(), m_rootSignature.Get(), m_commandList.Get(), BaseNormal3DRender, m_frameIndex);
 
-        m_commandList->SetGraphicsRootConstantBufferView(RootParameterCB, m_dynamicCB.GetGpuVirtualAddress(m_drawIndex, m_frameIndex));
-        m_commandList->DrawIndexedInstanced(36, 1, 0, 0, 0);
-        m_drawIndex++;
-    }
-    PIXEndEvent(m_commandList.Get());
+		m_commandList->SetGraphicsRootConstantBufferView(RootParameterCB, m_dynamicCB.GetGpuVirtualAddress(m_drawIndex, m_frameIndex));
+		m_commandList->DrawIndexedInstanced(36, 1, 0, 0, 0);
+		m_drawIndex++;
+	}
+	PIXEndEvent(m_commandList.Get());
 
-    // Set up the state for a fullscreen quad.
-    m_commandList->IASetVertexBuffers(0, 1, &m_quadVbv);
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+	// Set up the state for a fullscreen quad.
+	m_commandList->IASetVertexBuffers(0, 1, &m_quadVbv);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
 
-    // Indicate that the back buffer will be used as a render target and the
-    // intermediate render target will be used as a SRV.
-    D3D12_RESOURCE_BARRIER barriers[] = {
-        CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET),
-        CD3DX12_RESOURCE_BARRIER::Transition(m_intermediateRenderTarget.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE)
-    };
+	// Indicate that the back buffer will be used as a render target and the
+	// intermediate render target will be used as a SRV.
+	D3D12_RESOURCE_BARRIER barriers[] = {
+		CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET),
+		CD3DX12_RESOURCE_BARRIER::Transition(m_intermediateRenderTarget.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE)
+	};
 
-    m_commandList->ResourceBarrier(_countof(barriers), barriers);
-    m_commandList->SetGraphicsRootDescriptorTable(RootParameterSRV, m_srvHeap->GetGPUDescriptorHandleForHeapStart());
+	m_commandList->ResourceBarrier(_countof(barriers), barriers);
+	m_commandList->SetGraphicsRootDescriptorTable(RootParameterSRV, m_srvHeap->GetGPUDescriptorHandleForHeapStart());
 
-    const float black[] = { 0.0f, 0.0f, 0.0f, 0.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, black, 0, nullptr);
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	const float black[] = { 0.0f, 0.0f, 0.0f, 0.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, black, 0, nullptr);
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Draw some quads using the rendered scene with some effect shaders.
-    PIXBeginEvent(m_commandList.Get(), 0, L"Post-processing");
-    {
-        UINT quadCount = 0;
-        static const UINT quadsX = 3;
-        static const UINT quadsY = 3;
+	// Draw some quads using the rendered scene with some effect shaders.
+	PIXBeginEvent(m_commandList.Get(), 0, L"Post-processing");
+	{
+		UINT quadCount = 0;
+		static const UINT quadsX = 3;
+		static const UINT quadsY = 3;
 
-        // Cycle through all of the effects.
-        for (UINT i = PostBlit; i < EffectPipelineTypeCount; i++)
-        {
-            if (m_enabledEffects[i])
-            {
-                CD3DX12_VIEWPORT viewport(
-                    (quadCount % quadsX) * (m_viewport.Width / quadsX),
-                    (quadCount / quadsY) * (m_viewport.Height / quadsY),
-                    m_viewport.Width / quadsX,
-                    m_viewport.Height / quadsY);
+		// Cycle through all of the effects.
+		for (UINT i = PostBlit; i < EffectPipelineTypeCount; i++)
+		{
+			if (m_enabledEffects[i])
+			{
+				CD3DX12_VIEWPORT viewport(
+					(quadCount % quadsX) * (m_viewport.Width / quadsX),
+					(quadCount / quadsY) * (m_viewport.Height / quadsY),
+					m_viewport.Width / quadsX,
+					m_viewport.Height / quadsY);
 
-                PIXBeginEvent(m_commandList.Get(), 0, g_cEffectNames[i]);
-                m_commandList->RSSetViewports(1, &viewport);
-                m_psoLibrary.SetPipelineState(m_device.Get(), m_rootSignature.Get(), m_commandList.Get(), static_cast<EffectPipelineType>(i), m_frameIndex);
-                m_commandList->DrawInstanced(4, 1, 0, 0);
-                PIXEndEvent(m_commandList.Get());
-            }
+				PIXBeginEvent(m_commandList.Get(), 0, g_cEffectNames[i]);
+				m_commandList->RSSetViewports(1, &viewport);
+				m_psoLibrary.SetPipelineState(m_device.Get(), m_rootSignature.Get(), m_commandList.Get(), static_cast<EffectPipelineType>(i), m_frameIndex);
+				m_commandList->DrawInstanced(4, 1, 0, 0);
+				PIXEndEvent(m_commandList.Get());
+			}
 
-            quadCount++;
-        }
-    }
-    PIXEndEvent(m_commandList.Get());
+			quadCount++;
+		}
+	}
+	PIXEndEvent(m_commandList.Get());
 
-    // Revert resource states back to original values.
-    barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barriers[0].Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
-    barriers[1].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-    barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	// Revert resource states back to original values.
+	barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barriers[0].Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
+	barriers[1].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
 
-    m_commandList->ResourceBarrier(_countof(barriers), barriers);
+	m_commandList->ResourceBarrier(_countof(barriers), barriers);
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 void D3D12PipelineStateCache::ToggleEffect(EffectPipelineType type)
 {
-    if (m_enabledEffects[type])
-    {
-        // Wait until all frames using the shader are rendered before destroying
-        // the shader.
-        WaitForGpu();
+	if (m_enabledEffects[type])
+	{
+		// Wait until all frames using the shader are rendered before destroying
+		// the shader.
+		WaitForGpu();
 
-        m_psoLibrary.DestroyShader(type);
-    }
+		m_psoLibrary.DestroyShader(type);
+	}
 
-    m_enabledEffects[type] = !m_enabledEffects[type];
+	m_enabledEffects[type] = !m_enabledEffects[type];
 }
 
 void D3D12PipelineStateCache::UpdateWindowTextPso()
 {
-    std::wstringstream stringStream;
-    stringStream << L"  [Use Uber Shader: ";
-    stringStream << (m_psoLibrary.UberShadersEnabled() ? L"true]" : L"false]");
-    stringStream << L"   [Use DiskCache: ";
+	std::wstringstream stringStream;
+	stringStream << L"  [Use Uber Shader: ";
+	stringStream << (m_psoLibrary.UberShadersEnabled() ? L"true]" : L"false]");
+	stringStream << L"   [Use DiskCache: ";
 
-    if (m_psoLibrary.DiskCacheEnabled())
-    {
-        stringStream << L"true, ";
-        switch (m_psoLibrary.GetPSOCachingMechanism())
-        {
-        case PSOCachingMechanism::CachedBlobs:
-                stringStream << L"CachedBlobs]";
-                break;
-        case PSOCachingMechanism::PipelineLibraries:
-            stringStream << L"PipelineLibraries]";
-            break;
-        }
-    }
-    else
-    {
-        stringStream <<  L"false]";
-    }
+	if (m_psoLibrary.DiskCacheEnabled())
+	{
+		stringStream << L"true, ";
+		switch (m_psoLibrary.GetPSOCachingMechanism())
+		{
+		case PSOCachingMechanism::CachedBlobs:
+				stringStream << L"CachedBlobs]";
+				break;
+		case PSOCachingMechanism::PipelineLibraries:
+			stringStream << L"PipelineLibraries]";
+			break;
+		}
+	}
+	else
+	{
+		stringStream <<  L"false]";
+	}
 
-    SetCustomWindowText(stringStream.str().c_str());
+	SetCustomWindowText(stringStream.str().c_str());
 }
 
 // Wait for pending GPU work to complete.
 void D3D12PipelineStateCache::WaitForGpu()
 {
-    // Schedule a Signal command in the queue.
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
+	// Schedule a Signal command in the queue.
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
 
-    // Wait until the fence has been processed.
-    ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-    WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	// Wait until the fence has been processed.
+	ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+	WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
 
-    // Increment the fence value for the current frame.
-    m_fenceValues[m_frameIndex]++;
+	// Increment the fence value for the current frame.
+	m_fenceValues[m_frameIndex]++;
 }
 
 // Prepare to render the next frame.
 void D3D12PipelineStateCache::MoveToNextFrame()
 {
-    // Schedule a Signal command in the queue.
-    const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
+	// Schedule a Signal command in the queue.
+	const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
 
-    // Update the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Update the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-        WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+		WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	}
 
-    // Set the fence value for the next frame.
-    m_fenceValues[m_frameIndex] = currentFenceValue + 1;
+	// Set the fence value for the next frame.
+	m_fenceValues[m_frameIndex] = currentFenceValue + 1;
 }

--- a/Samples/Desktop/D3D12PipelineStateCache/src/D3D12PipelineStateCache.h
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/D3D12PipelineStateCache.h
@@ -28,91 +28,93 @@ using Microsoft::WRL::ComPtr;
 class D3D12PipelineStateCache : public DXSample
 {
 public:
-    D3D12PipelineStateCache(UINT width, UINT height, std::wstring name);
+	D3D12PipelineStateCache(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
-    virtual void OnKeyDown(UINT8 key);
-    virtual void OnKeyUp(UINT8 key);
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
+	virtual void OnKeyDown(UINT8 key);
+	virtual void OnKeyUp(UINT8 key);
 
 private:
-    static const UINT FrameCount = 2;
-    static const float IntermediateClearColor[4];
+	static const UINT FrameCount = 2;
+	static const float IntermediateClearColor[4];
 
-    struct VertexPositionColor
-    {
-        XMFLOAT4 position;
-        XMFLOAT3 color;
-    };
+	struct VertexPositionColor
+	{
+		XMFLOAT4 position;
+		XMFLOAT3 color;
+	};
 
-    struct VertexPositionUV
-    {
-        XMFLOAT4 position;
-        XMFLOAT2 uv;
-    };
+	struct VertexPositionUV
+	{
+		XMFLOAT4 position;
+		XMFLOAT2 uv;
+	};
 
-    struct DrawConstantBuffer
-    {
-        XMMATRIX worldViewProjection;
-    };
+	struct DrawConstantBuffer
+	{
+		XMMATRIX worldViewProjection;
+	};
 
-    // Indices in the root parameter table.
-    enum RootParameters : UINT32
-    {
-        RootParameterUberShaderCB = 0,
-        RootParameterCB,
-        RootParameterSRV,
-        RootParametersCount
-    };
+	// Indices in the root parameter table.
+	enum RootParameters : UINT32
+	{
+		RootParameterUberShaderCB = 0,
+		RootParameterCB,
+		RootParameterSRV,
+		RootParametersCount
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12Resource> m_intermediateRenderTarget;
-    ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_srvHeap;
-    UINT m_rtvDescriptorSize;
-    UINT m_srvDescriptorSize;
-    UINT m_frameIndex;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12Resource> m_intermediateRenderTarget;
+	ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_srvHeap;
+	UINT m_rtvDescriptorSize;
+	UINT m_srvDescriptorSize;
+	UINT m_frameIndex;
 
-    // Asset objects.
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    ComPtr<ID3D12Resource> m_vertexIndexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_cubeVbv;
-    D3D12_VERTEX_BUFFER_VIEW m_quadVbv;
-    D3D12_INDEX_BUFFER_VIEW m_cubeIbv;
-    bool m_enabledEffects[EffectPipelineTypeCount];
+	// Asset objects.
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	ComPtr<ID3D12Resource> m_vertexIndexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_cubeVbv;
+	D3D12_VERTEX_BUFFER_VIEW m_quadVbv;
+	D3D12_INDEX_BUFFER_VIEW m_cubeIbv;
+	bool m_enabledEffects[EffectPipelineTypeCount];
 
-    // Synchronization objects.
-    HANDLE m_swapChainEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValues[FrameCount];
-    HANDLE m_fenceEvent;
+	// Synchronization objects.
+	HANDLE m_swapChainEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValues[FrameCount];
+	HANDLE m_fenceEvent;
 
-    UINT m_drawIndex;
-    UINT m_maxDrawsPerFrame;
+	UINT m_drawIndex;
+	UINT m_maxDrawsPerFrame;
 
-    SimpleCamera m_camera;
-    XMMATRIX m_projectionMatrix;
-    StepTimer m_timer;
-    PSOLibrary m_psoLibrary;
-    DynamicConstantBuffer m_dynamicCB;
+	SimpleCamera m_camera;
+	XMMATRIX m_projectionMatrix;
+	StepTimer m_timer;
+	PSOLibrary m_psoLibrary;
+	DynamicConstantBuffer m_dynamicCB;
 
-    inline float GetRandomColor() { return (rand() % 100) / 100.0f; }
+	inline float GetRandomColor() { return (rand() % 100) / 100.0f; }
 
-    void LoadPipeline();
-    void LoadAssets();
-    void PopulateCommandList();
-    void ToggleEffect(EffectPipelineType type);
-    void UpdateWindowTextPso();
-    void WaitForGpu();
-    void MoveToNextFrame();
+	void LoadPipeline();
+	void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
+	void PopulateCommandList();
+	void ToggleEffect(EffectPipelineType type);
+	void UpdateWindowTextPso();
+	void WaitForGpu();
+	void MoveToNextFrame();
 };

--- a/Samples/Desktop/D3D12PipelineStateCache/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,58 +34,103 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title + L": " + text;
-    SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
+	std::wstring windowText = m_title + L": " + text;
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/Desktop/D3D12PipelineStateCache/src/DXSample.h
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/DXSample.h
@@ -17,42 +17,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/Desktop/D3D12PipelineStateCache/src/DistortPixelShader.hlsl
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/DistortPixelShader.hlsl
@@ -13,22 +13,22 @@
 
 float4 Distort(float2 uv)
 {
-    // Calculate the distance of this pixel from the center.
-    float pixelDistance = distance(float2(0.5f, 0.5f), uv);
+	// Calculate the distance of this pixel from the center.
+	float pixelDistance = distance(float2(0.5f, 0.5f), uv);
 
-    // Weight the pixel by its distance.
-    float weight = 1.0f + pixelDistance;
+	// Weight the pixel by its distance.
+	float weight = 1.0f + pixelDistance;
 
-    float x = (uv.x - 0.5f) + 0.5f;
-    float y = (uv.y - 0.5f) + 0.5f;
+	float x = (uv.x - 0.5f) + 0.5f;
+	float y = (uv.y - 0.5f) + 0.5f;
 
-    x = pow(abs(x), weight);
-    y = pow(abs(y), weight);
+	x = pow(abs(x), weight);
+	y = pow(abs(y), weight);
 
-    return g_tex.Sample(g_samp, float2(x, y));
+	return g_tex.Sample(g_samp, float2(x, y));
 }
 
 float4 mainDistort(PSInput input) : SV_TARGET
 {
-    return Distort(input.uv);
+	return Distort(input.uv);
 }

--- a/Samples/Desktop/D3D12PipelineStateCache/src/DynamicConstantBuffer.cpp
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/DynamicConstantBuffer.cpp
@@ -14,55 +14,55 @@
 
 static UINT Align(UINT location, UINT align = D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT)
 {
-    return (location + (align - 1)) & ~(align - 1);
+	return (location + (align - 1)) & ~(align - 1);
 }
 
 DynamicConstantBuffer::DynamicConstantBuffer(UINT constantSize, UINT maxDrawsPerFrame, UINT frameCount) :
-    m_alignedPerDrawConstantBufferSize(Align(constantSize)),    // Constant buffers must be aligned for hardware requirements.
-    m_maxDrawsPerFrame(maxDrawsPerFrame),
-    m_frameCount(frameCount),
-    m_constantBuffer(nullptr)
+	m_alignedPerDrawConstantBufferSize(Align(constantSize)),	// Constant buffers must be aligned for hardware requirements.
+	m_maxDrawsPerFrame(maxDrawsPerFrame),
+	m_frameCount(frameCount),
+	m_constantBuffer(nullptr)
 {
-    m_perFrameConstantBufferSize = m_alignedPerDrawConstantBufferSize * m_maxDrawsPerFrame;
+	m_perFrameConstantBufferSize = m_alignedPerDrawConstantBufferSize * m_maxDrawsPerFrame;
 }
 
 DynamicConstantBuffer::~DynamicConstantBuffer()
 {
-    m_constantBuffer->Unmap(0, nullptr);
+	m_constantBuffer->Unmap(0, nullptr);
 }
 
 void DynamicConstantBuffer::Init(ID3D12Device* pDevice)
 {
-    const UINT bufferSize = m_perFrameConstantBufferSize * m_frameCount;
+	const UINT bufferSize = m_perFrameConstantBufferSize * m_frameCount;
 
-    ThrowIfFailed(pDevice->CreateCommittedResource(
-        &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-        D3D12_HEAP_FLAG_NONE,
-        &CD3DX12_RESOURCE_DESC::Buffer(bufferSize),
-        D3D12_RESOURCE_STATE_GENERIC_READ,
-        nullptr,
-        IID_PPV_ARGS(&m_constantBuffer)
-        ));
+	ThrowIfFailed(pDevice->CreateCommittedResource(
+		&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+		D3D12_HEAP_FLAG_NONE,
+		&CD3DX12_RESOURCE_DESC::Buffer(bufferSize),
+		D3D12_RESOURCE_STATE_GENERIC_READ,
+		nullptr,
+		IID_PPV_ARGS(&m_constantBuffer)
+		));
 
-    NAME_D3D12_OBJECT(m_constantBuffer);
+	NAME_D3D12_OBJECT(m_constantBuffer);
 
-    CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-    ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pMappedConstantBuffer)));
+	CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+	ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pMappedConstantBuffer)));
 }
 
 void* DynamicConstantBuffer::GetMappedMemory(UINT drawIndex, UINT frameIndex)
 {
-    assert(drawIndex < m_maxDrawsPerFrame);
-    UINT constantBufferOffset = (frameIndex * m_perFrameConstantBufferSize) + (drawIndex * m_alignedPerDrawConstantBufferSize);
+	assert(drawIndex < m_maxDrawsPerFrame);
+	UINT constantBufferOffset = (frameIndex * m_perFrameConstantBufferSize) + (drawIndex * m_alignedPerDrawConstantBufferSize);
 
-    UINT8* temp = reinterpret_cast<UINT8*>(m_pMappedConstantBuffer);
-    temp += constantBufferOffset;
+	UINT8* temp = reinterpret_cast<UINT8*>(m_pMappedConstantBuffer);
+	temp += constantBufferOffset;
 
-    return temp;
+	return temp;
 }
 
 D3D12_GPU_VIRTUAL_ADDRESS DynamicConstantBuffer::GetGpuVirtualAddress(UINT drawIndex, UINT frameIndex)
 {
-    UINT constantBufferOffset = (frameIndex * m_perFrameConstantBufferSize) + (drawIndex * m_alignedPerDrawConstantBufferSize);
-    return m_constantBuffer->GetGPUVirtualAddress() + constantBufferOffset;
+	UINT constantBufferOffset = (frameIndex * m_perFrameConstantBufferSize) + (drawIndex * m_alignedPerDrawConstantBufferSize);
+	return m_constantBuffer->GetGPUVirtualAddress() + constantBufferOffset;
 }

--- a/Samples/Desktop/D3D12PipelineStateCache/src/DynamicConstantBuffer.h
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/DynamicConstantBuffer.h
@@ -18,19 +18,19 @@ using namespace DirectX;
 class DynamicConstantBuffer
 {
 public:
-    DynamicConstantBuffer(UINT constantSize, UINT maxDrawsPerFrame, UINT frameCount);
-    ~DynamicConstantBuffer();
+	DynamicConstantBuffer(UINT constantSize, UINT maxDrawsPerFrame, UINT frameCount);
+	~DynamicConstantBuffer();
 
-    void Init(ID3D12Device* pDevice);
-    void* GetMappedMemory(UINT drawIndex, UINT frameIndex);
-    D3D12_GPU_VIRTUAL_ADDRESS GetGpuVirtualAddress(UINT drawIndex, UINT frameIndex);
+	void Init(ID3D12Device* pDevice);
+	void* GetMappedMemory(UINT drawIndex, UINT frameIndex);
+	D3D12_GPU_VIRTUAL_ADDRESS GetGpuVirtualAddress(UINT drawIndex, UINT frameIndex);
 
 private:
-    ComPtr<ID3D12Resource> m_constantBuffer;
-    void* m_pMappedConstantBuffer;
-    UINT  m_alignedPerDrawConstantBufferSize;
-    UINT  m_perFrameConstantBufferSize;
+	ComPtr<ID3D12Resource> m_constantBuffer;
+	void* m_pMappedConstantBuffer;
+	UINT  m_alignedPerDrawConstantBufferSize;
+	UINT  m_perFrameConstantBufferSize;
 
-    UINT m_frameCount;
-    UINT m_maxDrawsPerFrame;
+	UINT m_frameCount;
+	UINT m_maxDrawsPerFrame;
 };

--- a/Samples/Desktop/D3D12PipelineStateCache/src/EdgeDetectPixelShader.hlsl
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/EdgeDetectPixelShader.hlsl
@@ -11,19 +11,19 @@
 
 #include "QuadVertexShader.hlsl"
 
-static const float threshold = 0.015f;    // What do we consider an edge?
-static const float edgeSize = 0.001f;    // The offest to look for neighboring pixels.
+static const float threshold = 0.015f;	// What do we consider an edge?
+static const float edgeSize = 0.001f;	// The offest to look for neighboring pixels.
 
 static const float2 samplePoints[9] = {
-    float2(-edgeSize, edgeSize),
-    float2(0.0f, edgeSize),
-    float2(edgeSize, edgeSize),
-    float2(-edgeSize, 0.0f),
-    float2(0.0f, 0.0f),
-    float2(edgeSize, edgeSize),
-    float2(-edgeSize, -edgeSize),
-    float2(0.0f, -edgeSize),
-    float2(edgeSize, -edgeSize),
+	float2(-edgeSize, edgeSize),
+	float2(0.0f, edgeSize),
+	float2(edgeSize, edgeSize),
+	float2(-edgeSize, 0.0f),
+	float2(0.0f, 0.0f),
+	float2(edgeSize, edgeSize),
+	float2(-edgeSize, -edgeSize),
+	float2(0.0f, -edgeSize),
+	float2(edgeSize, -edgeSize),
 };
 
 float4 EdgeDetect(float2 uv)

--- a/Samples/Desktop/D3D12PipelineStateCache/src/GrayScalePixelShader.hlsl
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/GrayScalePixelShader.hlsl
@@ -13,14 +13,14 @@
 
 float4 GrayScale(float2 uv)
 {
-    float3 luminance = float3(0.21f, 0.72f, 0.07f);
-    float3 color = g_tex.Sample(g_samp, uv).xyz;
-    float output = dot(luminance, color);
+	float3 luminance = float3(0.21f, 0.72f, 0.07f);
+	float3 color = g_tex.Sample(g_samp, uv).xyz;
+	float output = dot(luminance, color);
 
-    return float4(output, output, output, 1.0f);
+	return float4(output, output, output, 1.0f);
 }
 
 float4 mainGray(PSInput input) : SV_TARGET
 {
-    return GrayScale(input.uv);
+	return GrayScale(input.uv);
 }

--- a/Samples/Desktop/D3D12PipelineStateCache/src/InvertPixelShader.hlsl
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/InvertPixelShader.hlsl
@@ -13,10 +13,10 @@
 
 float4 InvertPixel(float2 uv)
 {
-    return float4(1.0f, 1.0f, 1.0f, 1.0f) - g_tex.Sample(g_samp, uv);
+	return float4(1.0f, 1.0f, 1.0f, 1.0f) - g_tex.Sample(g_samp, uv);
 }
 
 float4 mainInvert(PSInput input) : SV_TARGET
 {
-    return InvertPixel(input.uv);
+	return InvertPixel(input.uv);
 }

--- a/Samples/Desktop/D3D12PipelineStateCache/src/Main.cpp
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/Main.cpp
@@ -14,43 +14,43 @@
 
 FILE* CreateConsoleAndPrintDemoInformation()
 {
-    AllocConsole();
-    FILE *pStreamOut = nullptr;
-    freopen_s(&pStreamOut, "CONOUT$", "w", stdout);
+	AllocConsole();
+	FILE *pStreamOut = nullptr;
+	freopen_s(&pStreamOut, "CONOUT$", "w", stdout);
 
-    cout << "=== D3D12 Pipeline State Cache Sample ===" << endl << endl;
-    cout << "\t Input Keys:" << endl;
-    cout << "\t\t U : Toggle Uber Shader usage (rendering will appear dim when in use)" << endl;
-    cout << "\t\t L : Toggle Pipeline State library enable (disk cache)" << endl;
-    cout << "\t\t M : Toggle PSO caching mechanism" << endl;
-    cout << "\t\t C : Clear app PSO's and disk cache" << endl;
-    cout << "\t\t 1 : Toggle Blit effect" << endl;
-    cout << "\t\t 2 : Toggle Invert effect" << endl;
-    cout << "\t\t 3 : Toggle Grayscale effect" << endl;
-    cout << "\t\t 4 : Toggle Edge Detect effect" << endl;
-    cout << "\t\t 5 : Toggle Blur effect" << endl;
-    cout << "\t\t 6 : Toggle Warp effect" << endl;
-    cout << "\t\t 7 : Toggle Pixelate effect" << endl;
-    cout << "\t\t 8 : Toggle Distort effect" << endl;
-    cout << "\t\t 9 : Toggle Wave effect" << endl;
+	cout << "=== D3D12 Pipeline State Cache Sample ===" << endl << endl;
+	cout << "\t Input Keys:" << endl;
+	cout << "\t\t U : Toggle Uber Shader usage (rendering will appear dim when in use)" << endl;
+	cout << "\t\t L : Toggle Pipeline State library enable (disk cache)" << endl;
+	cout << "\t\t M : Toggle PSO caching mechanism" << endl;
+	cout << "\t\t C : Clear app PSO's and disk cache" << endl;
+	cout << "\t\t 1 : Toggle Blit effect" << endl;
+	cout << "\t\t 2 : Toggle Invert effect" << endl;
+	cout << "\t\t 3 : Toggle Grayscale effect" << endl;
+	cout << "\t\t 4 : Toggle Edge Detect effect" << endl;
+	cout << "\t\t 5 : Toggle Blur effect" << endl;
+	cout << "\t\t 6 : Toggle Warp effect" << endl;
+	cout << "\t\t 7 : Toggle Pixelate effect" << endl;
+	cout << "\t\t 8 : Toggle Distort effect" << endl;
+	cout << "\t\t 9 : Toggle Wave effect" << endl;
 
-    return pStreamOut;
+	return pStreamOut;
 }
 
 void DestroyConsole(FILE* pStream)
 {
-    fclose(pStream);
-    FreeConsole();
+	fclose(pStream);
+	FreeConsole();
 }
 
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12PipelineStateCache sample(1280, 720, L"D3D12 Pipeline State Object Cache Sample");
+	D3D12PipelineStateCache sample(1280, 720, L"D3D12 Pipeline State Object Cache Sample");
 
-    FILE* pStreamOut = CreateConsoleAndPrintDemoInformation();
-    int result = Win32Application::Run(&sample, hInstance, nCmdShow);
-    DestroyConsole(pStreamOut);
+	FILE* pStreamOut = CreateConsoleAndPrintDemoInformation();
+	int result = Win32Application::Run(&sample, hInstance, nCmdShow);
+	DestroyConsole(pStreamOut);
 
-    return result;
+	return result;
 }

--- a/Samples/Desktop/D3D12PipelineStateCache/src/MemoryMappedFile.cpp
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/MemoryMappedFile.cpp
@@ -13,10 +13,10 @@
 #include "MemoryMappedFile.h"
 
 MemoryMappedFile::MemoryMappedFile() :
-    m_mapFile(INVALID_HANDLE_VALUE),
-    m_file(INVALID_HANDLE_VALUE),
-    m_mapAddress(nullptr),
-    m_currentFileSize(0)
+	m_mapFile(INVALID_HANDLE_VALUE),
+	m_file(INVALID_HANDLE_VALUE),
+	m_mapAddress(nullptr),
+	m_currentFileSize(0)
 {
 }
 
@@ -26,129 +26,129 @@ MemoryMappedFile::~MemoryMappedFile()
 
 void MemoryMappedFile::Init(std::wstring filename, UINT fileSize)
 {
-    m_filename = filename;
-    WIN32_FIND_DATA findFileData;
-    HANDLE handle = FindFirstFileEx(filename.c_str(), FindExInfoBasic, &findFileData, FindExSearchNameMatch, nullptr, 0);
-    bool found = handle != INVALID_HANDLE_VALUE;
+	m_filename = filename;
+	WIN32_FIND_DATA findFileData;
+	HANDLE handle = FindFirstFileEx(filename.c_str(), FindExInfoBasic, &findFileData, FindExSearchNameMatch, nullptr, 0);
+	bool found = handle != INVALID_HANDLE_VALUE;
 
-    if (found)
-    {
-        FindClose(handle);
-    }
+	if (found)
+	{
+		FindClose(handle);
+	}
 
-    m_file = CreateFile2(
-        filename.c_str(),
-        GENERIC_READ | GENERIC_WRITE,
-        0,
-        (found) ? OPEN_EXISTING : CREATE_NEW,
-        nullptr);
+	m_file = CreateFile2(
+		filename.c_str(),
+		GENERIC_READ | GENERIC_WRITE,
+		0,
+		(found) ? OPEN_EXISTING : CREATE_NEW,
+		nullptr);
 
-    if (m_file == INVALID_HANDLE_VALUE)
-    {
-        std::cerr << (L"m_file is invalid. Error %ld.\n", GetLastError());
-        std::cerr << (L"Target file is %s\n", filename.c_str());
-        return;
-    }
+	if (m_file == INVALID_HANDLE_VALUE)
+	{
+		std::cerr << (L"m_file is invalid. Error %ld.\n", GetLastError());
+		std::cerr << (L"Target file is %s\n", filename.c_str());
+		return;
+	}
 
-    LARGE_INTEGER realFileSize = {};
-    BOOL flag = GetFileSizeEx(m_file, &realFileSize);
-    if (!flag)
-    {
-        std::cerr << (L"\nError %ld occurred in GetFileSizeEx!", GetLastError());
-        assert(false);
-        return;
-    }
+	LARGE_INTEGER realFileSize = {};
+	BOOL flag = GetFileSizeEx(m_file, &realFileSize);
+	if (!flag)
+	{
+		std::cerr << (L"\nError %ld occurred in GetFileSizeEx!", GetLastError());
+		assert(false);
+		return;
+	}
 
-    assert(realFileSize.HighPart == 0);
-    m_currentFileSize = realFileSize.LowPart;
-    if (m_currentFileSize == 0)
-    {
-        // File mapping files with a size of 0 produces an error.
-        m_currentFileSize = DefaultFileSize;
-    }
-    else if(fileSize > m_currentFileSize)
-    {
-        // Grow to the specified size.
-        m_currentFileSize = fileSize;
-    }
+	assert(realFileSize.HighPart == 0);
+	m_currentFileSize = realFileSize.LowPart;
+	if (m_currentFileSize == 0)
+	{
+		// File mapping files with a size of 0 produces an error.
+		m_currentFileSize = DefaultFileSize;
+	}
+	else if(fileSize > m_currentFileSize)
+	{
+		// Grow to the specified size.
+		m_currentFileSize = fileSize;
+	}
 
-    m_mapFile = CreateFileMapping(m_file, nullptr, PAGE_READWRITE, 0, m_currentFileSize, nullptr);
+	m_mapFile = CreateFileMapping(m_file, nullptr, PAGE_READWRITE, 0, m_currentFileSize, nullptr);
 
-    if (m_mapFile == nullptr)
-    {
-        std::cerr << (L"m_mapFile is NULL: last error: %d\n", GetLastError());
-        assert(false);
-        return;
-    }
+	if (m_mapFile == nullptr)
+	{
+		std::cerr << (L"m_mapFile is NULL: last error: %d\n", GetLastError());
+		assert(false);
+		return;
+	}
 
-    m_mapAddress = MapViewOfFile(m_mapFile, FILE_MAP_ALL_ACCESS, 0, 0, m_currentFileSize);
+	m_mapAddress = MapViewOfFile(m_mapFile, FILE_MAP_ALL_ACCESS, 0, 0, m_currentFileSize);
 
-    if (m_mapAddress == nullptr)
-    {
-        std::cerr << (L"m_mapAddress is NULL: last error: %d\n", GetLastError());
-        assert(false);
-        return;
-    }
+	if (m_mapAddress == nullptr)
+	{
+		std::cerr << (L"m_mapAddress is NULL: last error: %d\n", GetLastError());
+		assert(false);
+		return;
+	}
 }
 
 void MemoryMappedFile::Destroy(bool deleteFile)
 {
-    if (m_mapAddress)
-    {
-        BOOL flag = UnmapViewOfFile(m_mapAddress);
-        if (!flag)
-        {
-            std::cerr << (L"\nError %ld occurred unmapping the view!", GetLastError());
-            assert(false);
-        }
+	if (m_mapAddress)
+	{
+		BOOL flag = UnmapViewOfFile(m_mapAddress);
+		if (!flag)
+		{
+			std::cerr << (L"\nError %ld occurred unmapping the view!", GetLastError());
+			assert(false);
+		}
 
-        m_mapAddress = nullptr;
+		m_mapAddress = nullptr;
 
-        flag = CloseHandle(m_mapFile);    // Close the file mapping object.
-        if (!flag)
-        {
-            std::cerr << (L"\nError %ld occurred closing the mapping object!", GetLastError());
-            assert(false);
-        }
+		flag = CloseHandle(m_mapFile);	// Close the file mapping object.
+		if (!flag)
+		{
+			std::cerr << (L"\nError %ld occurred closing the mapping object!", GetLastError());
+			assert(false);
+		}
 
-        flag = CloseHandle(m_file);        // Close the file itself.
-        if (!flag)
-        {
-            std::cerr << (L"\nError %ld occurred closing the file!", GetLastError());
-            assert(false);
-        }
-    }
+		flag = CloseHandle(m_file);		// Close the file itself.
+		if (!flag)
+		{
+			std::cerr << (L"\nError %ld occurred closing the file!", GetLastError());
+			assert(false);
+		}
+	}
 
-    if (deleteFile)
-    {
-        DeleteFile(m_filename.c_str());
-    }
+	if (deleteFile)
+	{
+		DeleteFile(m_filename.c_str());
+	}
 }
 
 void MemoryMappedFile::GrowMapping(UINT size)
 {
-    // Add space for the extra size at the beginning of the file.
-    size += sizeof(UINT);
+	// Add space for the extra size at the beginning of the file.
+	size += sizeof(UINT);
 
-    // Check the size.
-    if (size <= m_currentFileSize)
-    {
-        // Don't shrink.
-        return;
-    }
+	// Check the size.
+	if (size <= m_currentFileSize)
+	{
+		// Don't shrink.
+		return;
+	}
 
-    // Flush.
-    BOOL flag = FlushViewOfFile(m_mapAddress, 0);
-    if (!flag)
-    {
-        std::cerr << (L"\nError %ld occurred flushing the mapping object!", GetLastError());
-        assert(false);
-    }
+	// Flush.
+	BOOL flag = FlushViewOfFile(m_mapAddress, 0);
+	if (!flag)
+	{
+		std::cerr << (L"\nError %ld occurred flushing the mapping object!", GetLastError());
+		assert(false);
+	}
 
-    // Close the current mapping.
-    Destroy(false);
+	// Close the current mapping.
+	Destroy(false);
 
-    // Update the size and create a new mapping.
-    m_currentFileSize = size;
-    Init(m_filename, m_currentFileSize);
+	// Update the size and create a new mapping.
+	m_currentFileSize = size;
+	Init(m_filename, m_currentFileSize);
 }

--- a/Samples/Desktop/D3D12PipelineStateCache/src/MemoryMappedFile.h
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/MemoryMappedFile.h
@@ -14,50 +14,50 @@
 class MemoryMappedFile
 {
 protected:
-    MemoryMappedFile();
-    ~MemoryMappedFile();
+	MemoryMappedFile();
+	~MemoryMappedFile();
 
-    void Init(std::wstring filename, UINT filesize = DefaultFileSize);
-    void Destroy(bool deleteFile);
-    void GrowMapping(UINT size);
+	void Init(std::wstring filename, UINT filesize = DefaultFileSize);
+	void Destroy(bool deleteFile);
+	void GrowMapping(UINT size);
 
-    void SetSize(UINT size)
-    {
-        if(m_mapAddress)
-        {
-            static_cast<UINT*>(m_mapAddress)[0] = size;
-        }
-    }
+	void SetSize(UINT size)
+	{
+		if(m_mapAddress)
+		{
+			static_cast<UINT*>(m_mapAddress)[0] = size;
+		}
+	}
 
-    UINT GetSize() const
-    {
-        if (m_mapAddress)
-        {
-            return static_cast<UINT*>(m_mapAddress)[0];
-        }
-        return 0;
-    }
+	UINT GetSize() const
+	{
+		if (m_mapAddress)
+		{
+			return static_cast<UINT*>(m_mapAddress)[0];
+		}
+		return 0;
+	}
 
-    void* GetData()
-    {
-        if (m_mapAddress)
-        {
-            // The actual data comes after the length.
-            return &static_cast<UINT*>(m_mapAddress)[1];
-        }
-        return nullptr;
-    }
+	void* GetData()
+	{
+		if (m_mapAddress)
+		{
+			// The actual data comes after the length.
+			return &static_cast<UINT*>(m_mapAddress)[1];
+		}
+		return nullptr;
+	}
 
 public:
-    bool IsMapped() const { return m_mapAddress != nullptr; }
-    
+	bool IsMapped() const { return m_mapAddress != nullptr; }
+	
 protected:
-    static const UINT DefaultFileSize = 64;
+	static const UINT DefaultFileSize = 64;
 
-    HANDLE m_mapFile;
-    HANDLE m_file;
-    LPVOID m_mapAddress;
-    std::wstring m_filename;
+	HANDLE m_mapFile;
+	HANDLE m_file;
+	LPVOID m_mapAddress;
+	std::wstring m_filename;
 
-    UINT m_currentFileSize;
+	UINT m_currentFileSize;
 };

--- a/Samples/Desktop/D3D12PipelineStateCache/src/MemoryMappedPSOCache.cpp
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/MemoryMappedPSOCache.cpp
@@ -14,23 +14,23 @@
 
 void MemoryMappedPSOCache::Update(ID3DBlob* pBlob)
 {
-    if (pBlob)
-    {
-        assert(pBlob->GetBufferSize() <= UINT_MAX);    // Code below casts to UINT.
-        const UINT blobSize = static_cast<UINT>(pBlob->GetBufferSize());
-        if (blobSize > 0)
-        {
-            // Grow the file if needed.
-            const size_t neededSize = sizeof(UINT) + blobSize;
-            if (neededSize > m_currentFileSize)
-            {
-                MemoryMappedFile::GrowMapping(blobSize);
-            }
+	if (pBlob)
+	{
+		assert(pBlob->GetBufferSize() <= UINT_MAX);	// Code below casts to UINT.
+		const UINT blobSize = static_cast<UINT>(pBlob->GetBufferSize());
+		if (blobSize > 0)
+		{
+			// Grow the file if needed.
+			const size_t neededSize = sizeof(UINT) + blobSize;
+			if (neededSize > m_currentFileSize)
+			{
+				MemoryMappedFile::GrowMapping(blobSize);
+			}
 
-            // Save the size of the blob, and then the blob itself.
-            assert(neededSize <= m_currentFileSize);
-            MemoryMappedFile::SetSize(blobSize);
-            memcpy(GetCachedBlob(), pBlob->GetBufferPointer(), pBlob->GetBufferSize());
-        }
-    }
+			// Save the size of the blob, and then the blob itself.
+			assert(neededSize <= m_currentFileSize);
+			MemoryMappedFile::SetSize(blobSize);
+			memcpy(GetCachedBlob(), pBlob->GetBufferPointer(), pBlob->GetBufferSize());
+		}
+	}
 }

--- a/Samples/Desktop/D3D12PipelineStateCache/src/MemoryMappedPSOCache.h
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/MemoryMappedPSOCache.h
@@ -17,10 +17,10 @@
 class MemoryMappedPSOCache : public MemoryMappedFile
 {
 public:
-    void Init(std::wstring filename) { MemoryMappedFile::Init(filename); }
-    void Destroy(bool deleteFile) { MemoryMappedFile::Destroy(deleteFile); }
-    void Update(ID3DBlob *pBlob);
+	void Init(std::wstring filename) { MemoryMappedFile::Init(filename); }
+	void Destroy(bool deleteFile) { MemoryMappedFile::Destroy(deleteFile); }
+	void Update(ID3DBlob *pBlob);
 
-    size_t GetCachedBlobSize() const { return GetSize(); }
-    void* GetCachedBlob() { return GetData(); }
+	size_t GetCachedBlobSize() const { return GetSize(); }
+	void* GetCachedBlob() { return GetData(); }
 };

--- a/Samples/Desktop/D3D12PipelineStateCache/src/MemoryMappedPipelineLibrary.cpp
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/MemoryMappedPipelineLibrary.cpp
@@ -18,100 +18,100 @@ using Microsoft::WRL::ComPtr;
 
 bool MemoryMappedPipelineLibrary::Init(ID3D12Device* pDevice, std::wstring filename)
 {
-    // ID3D12PipelineLibrary usage requires OS and driver support.
-    //        - Pipeline Libraries require the ID3D12Device1 interface (OS support).
-    //        - All WDDM 2.1+ drivers are required to support Pipeline Libraries (driver support).
+	// ID3D12PipelineLibrary usage requires OS and driver support.
+	//		- Pipeline Libraries require the ID3D12Device1 interface (OS support).
+	//		- All WDDM 2.1+ drivers are required to support Pipeline Libraries (driver support).
 
 
-    // Note: Checking for Pipeline Library support is intended to be temporary during the transition period
-    // as customers update to the latest version of Windows 10 and drivers are updated to the latest driver model.
-    // All future versions of the OS and drivers will support Pipeline Libraries.
-    if (pDevice)
-    {
-        // Create the Pipeline Library.
-        ComPtr<ID3D12Device1> device1;
-        if (SUCCEEDED(pDevice->QueryInterface(IID_PPV_ARGS(&device1))))
-        {
-            // Init the memory mapped file.
-            MemoryMappedFile::Init(filename);
+	// Note: Checking for Pipeline Library support is intended to be temporary during the transition period
+	// as customers update to the latest version of Windows 10 and drivers are updated to the latest driver model.
+	// All future versions of the OS and drivers will support Pipeline Libraries.
+	if (pDevice)
+	{
+		// Create the Pipeline Library.
+		ComPtr<ID3D12Device1> device1;
+		if (SUCCEEDED(pDevice->QueryInterface(IID_PPV_ARGS(&device1))))
+		{
+			// Init the memory mapped file.
+			MemoryMappedFile::Init(filename);
 
-            // Create a Pipeline Library from the serialized blob.
-            // Note: The provided Library Blob must remain valid for the lifetime of the object returned - for efficiency, the data is not copied.
-            const HRESULT hr = device1->CreatePipelineLibrary(GetData(), GetSize(), IID_PPV_ARGS(&m_pipelineLibrary));
-            switch (hr)
-            {
-            case DXGI_ERROR_UNSUPPORTED: // The driver doesn't support Pipeline libraries. WDDM2.1 drivers must support it.
-                break;
+			// Create a Pipeline Library from the serialized blob.
+			// Note: The provided Library Blob must remain valid for the lifetime of the object returned - for efficiency, the data is not copied.
+			const HRESULT hr = device1->CreatePipelineLibrary(GetData(), GetSize(), IID_PPV_ARGS(&m_pipelineLibrary));
+			switch (hr)
+			{
+			case DXGI_ERROR_UNSUPPORTED: // The driver doesn't support Pipeline libraries. WDDM2.1 drivers must support it.
+				break;
 
-            case E_INVALIDARG: // The provided Library is corrupted or unrecognized.
-            case D3D12_ERROR_ADAPTER_NOT_FOUND: // The provided Library contains data for different hardware (Don't really need to clear the cache, could have a cache per adapter).
-            case D3D12_ERROR_DRIVER_VERSION_MISMATCH: // The provided Library contains data from an old driver or runtime. We need to re-create it.
-                MemoryMappedFile::Destroy(true);
-                MemoryMappedFile::Init(filename);
-                ThrowIfFailed(device1->CreatePipelineLibrary(GetData(), GetSize(), IID_PPV_ARGS(&m_pipelineLibrary)));
-                break;
+			case E_INVALIDARG: // The provided Library is corrupted or unrecognized.
+			case D3D12_ERROR_ADAPTER_NOT_FOUND: // The provided Library contains data for different hardware (Don't really need to clear the cache, could have a cache per adapter).
+			case D3D12_ERROR_DRIVER_VERSION_MISMATCH: // The provided Library contains data from an old driver or runtime. We need to re-create it.
+				MemoryMappedFile::Destroy(true);
+				MemoryMappedFile::Init(filename);
+				ThrowIfFailed(device1->CreatePipelineLibrary(GetData(), GetSize(), IID_PPV_ARGS(&m_pipelineLibrary)));
+				break;
 
-            default:
-                ThrowIfFailed(hr);
-            }
+			default:
+				ThrowIfFailed(hr);
+			}
 
-            if (m_pipelineLibrary)
-            {
-                NAME_D3D12_OBJECT(m_pipelineLibrary);
-            }
-        }
-    }
+			if (m_pipelineLibrary)
+			{
+				NAME_D3D12_OBJECT(m_pipelineLibrary);
+			}
+		}
+	}
 
-    return m_pipelineLibrary != nullptr;
+	return m_pipelineLibrary != nullptr;
 }
 
 void MemoryMappedPipelineLibrary::Destroy(bool deleteFile)
 {
-    // If we're not going to destroy the file, serialize the library to disk.
-    if (!deleteFile && m_pipelineLibrary)
-    {
-        // Important: An ID3D12PipelineLibrary object becomes undefined when the underlying memory, that was used to initalize it, changes.
+	// If we're not going to destroy the file, serialize the library to disk.
+	if (!deleteFile && m_pipelineLibrary)
+	{
+		// Important: An ID3D12PipelineLibrary object becomes undefined when the underlying memory, that was used to initalize it, changes.
 
-        assert(m_pipelineLibrary->GetSerializedSize() <= UINT_MAX);    // Code below casts to UINT.
-        const UINT librarySize = static_cast<UINT>(m_pipelineLibrary->GetSerializedSize());
-        if (librarySize > 0)
-        {
-            // Grow the file if needed.
-            const size_t neededSize = sizeof(UINT) + librarySize;
-            if (neededSize > m_currentFileSize)
-            {
-                // The file mapping is going to change thus it will invalidate the ID3D12PipelineLibrary object.
-                // Serialize the library contents to temporary memory first.
-                void* pTempData = new BYTE[librarySize];
-                if (pTempData)
-                {
-                    ThrowIfFailed(m_pipelineLibrary->Serialize(pTempData, librarySize));
+		assert(m_pipelineLibrary->GetSerializedSize() <= UINT_MAX);	// Code below casts to UINT.
+		const UINT librarySize = static_cast<UINT>(m_pipelineLibrary->GetSerializedSize());
+		if (librarySize > 0)
+		{
+			// Grow the file if needed.
+			const size_t neededSize = sizeof(UINT) + librarySize;
+			if (neededSize > m_currentFileSize)
+			{
+				// The file mapping is going to change thus it will invalidate the ID3D12PipelineLibrary object.
+				// Serialize the library contents to temporary memory first.
+				void* pTempData = new BYTE[librarySize];
+				if (pTempData)
+				{
+					ThrowIfFailed(m_pipelineLibrary->Serialize(pTempData, librarySize));
 
-                    // Now it's safe to grow the mapping.
-                    MemoryMappedFile::GrowMapping(librarySize);
+					// Now it's safe to grow the mapping.
+					MemoryMappedFile::GrowMapping(librarySize);
 
-                    // Save the size of the library and the library itself.
-                    memcpy(GetData(), pTempData, librarySize);
-                    MemoryMappedFile::SetSize(librarySize);
+					// Save the size of the library and the library itself.
+					memcpy(GetData(), pTempData, librarySize);
+					MemoryMappedFile::SetSize(librarySize);
 
-                    delete[] pTempData;
-                    pTempData = nullptr;
-                }
-            }
-            else
-            {
-                // The mapping didn't change, we can serialize directly to the mapped file.
-                // Save the size of the library and the library itself.
-                assert(neededSize <= m_currentFileSize);
-                ThrowIfFailed(m_pipelineLibrary->Serialize(GetData(), librarySize));
-                MemoryMappedFile::SetSize(librarySize);
-            }
+					delete[] pTempData;
+					pTempData = nullptr;
+				}
+			}
+			else
+			{
+				// The mapping didn't change, we can serialize directly to the mapped file.
+				// Save the size of the library and the library itself.
+				assert(neededSize <= m_currentFileSize);
+				ThrowIfFailed(m_pipelineLibrary->Serialize(GetData(), librarySize));
+				MemoryMappedFile::SetSize(librarySize);
+			}
 
-            // m_pipelineLibrary is now undefined because we just wrote to the mapped file, don't use it again.
-            // This is ok in this sample because we only write to the mapped file when the sample exits.
-        }
-    }
+			// m_pipelineLibrary is now undefined because we just wrote to the mapped file, don't use it again.
+			// This is ok in this sample because we only write to the mapped file when the sample exits.
+		}
+	}
 
-    MemoryMappedFile::Destroy(deleteFile);
-    m_pipelineLibrary = nullptr;
+	MemoryMappedFile::Destroy(deleteFile);
+	m_pipelineLibrary = nullptr;
 }

--- a/Samples/Desktop/D3D12PipelineStateCache/src/MemoryMappedPipelineLibrary.h
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/MemoryMappedPipelineLibrary.h
@@ -18,11 +18,11 @@
 class MemoryMappedPipelineLibrary : public MemoryMappedFile
 {
 public:
-    bool Init(ID3D12Device* pDevice, std::wstring filename);
-    void Destroy(bool deleteFile);
-    
-    ID3D12PipelineLibrary* GetPipelineLibrary() { return m_pipelineLibrary.Get(); }
+	bool Init(ID3D12Device* pDevice, std::wstring filename);
+	void Destroy(bool deleteFile);
+	
+	ID3D12PipelineLibrary* GetPipelineLibrary() { return m_pipelineLibrary.Get(); }
 
 private:
-    Microsoft::WRL::ComPtr<ID3D12PipelineLibrary> m_pipelineLibrary;
+	Microsoft::WRL::ComPtr<ID3D12PipelineLibrary> m_pipelineLibrary;
 };

--- a/Samples/Desktop/D3D12PipelineStateCache/src/PSOLibrary.cpp
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/PSOLibrary.cpp
@@ -15,375 +15,375 @@
 using namespace Microsoft::WRL::Wrappers;
 
 PSOLibrary::PSOLibrary(UINT frameCount, UINT cbvRootSignatureIndex) :
-    m_cbvRootSignatureIndex(cbvRootSignatureIndex),
-    m_maxDrawsPerFrame(256),
-    m_dynamicCB(sizeof(UberShaderConstantBuffer), m_maxDrawsPerFrame, frameCount),
-    m_flagsMutex(),
-    m_useUberShaders(true),
-    m_useDiskLibraries(true),
-    m_psoCachingMechanism(PSOCachingMechanism::PipelineLibraries),
-    m_drawIndex(0),
-    m_compiledPSOFlags{},
-    m_inflightPSOFlags{},
-    m_workerThreads{}
+	m_cbvRootSignatureIndex(cbvRootSignatureIndex),
+	m_maxDrawsPerFrame(256),
+	m_dynamicCB(sizeof(UberShaderConstantBuffer), m_maxDrawsPerFrame, frameCount),
+	m_flagsMutex(),
+	m_useUberShaders(true),
+	m_useDiskLibraries(true),
+	m_psoCachingMechanism(PSOCachingMechanism::PipelineLibraries),
+	m_drawIndex(0),
+	m_compiledPSOFlags{},
+	m_inflightPSOFlags{},
+	m_workerThreads{}
 {
-    WCHAR path[512];
-    GetAssetsPath(path, _countof(path));
-    m_cachePath = path;
+	WCHAR path[512];
+	GetAssetsPath(path, _countof(path));
+	m_cachePath = path;
 
-    m_flagsMutex = CreateMutex(nullptr, FALSE, nullptr);
+	m_flagsMutex = CreateMutex(nullptr, FALSE, nullptr);
 }
 
 PSOLibrary::~PSOLibrary()
 {
-    WaitForThreads();
+	WaitForThreads();
 
-    for (UINT i = 0; i < EffectPipelineTypeCount; i++)
-    {
-        m_diskCaches[i].Destroy(false);
-    }
+	for (UINT i = 0; i < EffectPipelineTypeCount; i++)
+	{
+		m_diskCaches[i].Destroy(false);
+	}
 
-    // The Pipeline Library is saved to disk on exit.
-    m_pipelineLibrary.Destroy(false);
+	// The Pipeline Library is saved to disk on exit.
+	m_pipelineLibrary.Destroy(false);
 }
 
 void PSOLibrary::WaitForThreads()
 {
-    for (auto& thread : m_workerThreads)
-    {
-        if (thread.threadHandle)
-        {
-            WaitForSingleObject(thread.threadHandle, INFINITE);
-            CloseHandle(thread.threadHandle);
-        }
-        thread.threadHandle = nullptr;
-    }
+	for (auto& thread : m_workerThreads)
+	{
+		if (thread.threadHandle)
+		{
+			WaitForSingleObject(thread.threadHandle, INFINITE);
+			CloseHandle(thread.threadHandle);
+		}
+		thread.threadHandle = nullptr;
+	}
 }
 
 void PSOLibrary::Build(ID3D12Device* pDevice, ID3D12RootSignature* pRootSignature)
 {
-    // Initialize all cache file mappings (file may be empty).
-    m_pipelineLibrariesSupported = m_pipelineLibrary.Init(pDevice, m_cachePath + g_cPipelineLibraryFileName);
-    for (UINT i = 0; i < EffectPipelineTypeCount; i++)
-    {
-        m_diskCaches[i].Init(m_cachePath + g_cCacheFileNames[i]);
-    }
+	// Initialize all cache file mappings (file may be empty).
+	m_pipelineLibrariesSupported = m_pipelineLibrary.Init(pDevice, m_cachePath + g_cPipelineLibraryFileName);
+	for (UINT i = 0; i < EffectPipelineTypeCount; i++)
+	{
+		m_diskCaches[i].Init(m_cachePath + g_cCacheFileNames[i]);
+	}
 
-    // Use Pipeline Libraries for PSO Caching, if available.
-    if (!m_pipelineLibrariesSupported)
-    {
-        // Fallback to Cached Blobs.
-        m_psoCachingMechanism = PSOCachingMechanism::CachedBlobs;
-    }
+	// Use Pipeline Libraries for PSO Caching, if available.
+	if (!m_pipelineLibrariesSupported)
+	{
+		// Fallback to Cached Blobs.
+		m_psoCachingMechanism = PSOCachingMechanism::CachedBlobs;
+	}
 
-    // Always compile the 3D shader and the Ubershader.
-    for (UINT i = 0; i < BaseEffectCount; i++)
-    {
-        m_workerThreads[i].pDevice = pDevice;
-        m_workerThreads[i].pRootSignature = pRootSignature;
-        m_workerThreads[i].type = EffectPipelineType(i);
-        m_workerThreads[i].pLibrary = this;
-        CompilePSO(&m_workerThreads[i]);
-    }
+	// Always compile the 3D shader and the Ubershader.
+	for (UINT i = 0; i < BaseEffectCount; i++)
+	{
+		m_workerThreads[i].pDevice = pDevice;
+		m_workerThreads[i].pRootSignature = pRootSignature;
+		m_workerThreads[i].type = EffectPipelineType(i);
+		m_workerThreads[i].pLibrary = this;
+		CompilePSO(&m_workerThreads[i]);
+	}
 
-    m_dynamicCB.Init(pDevice);
+	m_dynamicCB.Init(pDevice);
 }
 
 
 void PSOLibrary::SetPipelineState(
-    ID3D12Device* pDevice,
-    ID3D12RootSignature* pRootSignature,
-    ID3D12GraphicsCommandList* pCommandList,
-    _In_range_(0, EffectPipelineTypeCount-1) EffectPipelineType type,
-    UINT frameIndex)
+	ID3D12Device* pDevice,
+	ID3D12RootSignature* pRootSignature,
+	ID3D12GraphicsCommandList* pCommandList,
+	_In_range_(0, EffectPipelineTypeCount-1) EffectPipelineType type,
+	UINT frameIndex)
 {
-    assert(m_drawIndex < m_maxDrawsPerFrame);
+	assert(m_drawIndex < m_maxDrawsPerFrame);
 
-    bool isBuilt = false;
-    bool isInFlight = false;
+	bool isBuilt = false;
+	bool isInFlight = false;
 
-    {
-        // Take the lock to figure out if we need to build this thing or use an Uber shader.
-        auto lock = Mutex::Lock(m_flagsMutex);
+	{
+		// Take the lock to figure out if we need to build this thing or use an Uber shader.
+		auto lock = Mutex::Lock(m_flagsMutex);
 
-        isBuilt = m_compiledPSOFlags[type];
-        isInFlight = m_inflightPSOFlags[type];
-    }
+		isBuilt = m_compiledPSOFlags[type];
+		isInFlight = m_inflightPSOFlags[type];
+	}
 
-    if (type > BaseUberShader)
-    {
-        // If an effect hasn't been built yet.
-        if (!isBuilt && m_useUberShaders)
-        {
-            // Let the uber shader know what effect it should configure for.
-            UberShaderConstantBuffer* constantData = (UberShaderConstantBuffer*)m_dynamicCB.GetMappedMemory(m_drawIndex, frameIndex);
-            constantData->effectIndex = type;
-            pCommandList->SetGraphicsRootConstantBufferView(m_cbvRootSignatureIndex, m_dynamicCB.GetGpuVirtualAddress(m_drawIndex, frameIndex));
+	if (type > BaseUberShader)
+	{
+		// If an effect hasn't been built yet.
+		if (!isBuilt && m_useUberShaders)
+		{
+			// Let the uber shader know what effect it should configure for.
+			UberShaderConstantBuffer* constantData = (UberShaderConstantBuffer*)m_dynamicCB.GetMappedMemory(m_drawIndex, frameIndex);
+			constantData->effectIndex = type;
+			pCommandList->SetGraphicsRootConstantBufferView(m_cbvRootSignatureIndex, m_dynamicCB.GetGpuVirtualAddress(m_drawIndex, frameIndex));
 
-            // We don't want to double compile.
-            if (!isInFlight)
-            {
-                m_workerThreads[type].pDevice = pDevice;
-                m_workerThreads[type].pRootSignature = pRootSignature;
-                m_workerThreads[type].type = type;
-                m_workerThreads[type].pLibrary = this;
+			// We don't want to double compile.
+			if (!isInFlight)
+			{
+				m_workerThreads[type].pDevice = pDevice;
+				m_workerThreads[type].pRootSignature = pRootSignature;
+				m_workerThreads[type].type = type;
+				m_workerThreads[type].pLibrary = this;
 
-                // Compile the PSO on a background thread.
-                m_workerThreads[type].threadHandle = CreateThread(
-                    nullptr,
-                    0,
-                    reinterpret_cast<LPTHREAD_START_ROUTINE>(CompilePSO),
-                    reinterpret_cast<void*>(&m_workerThreads[type]),
-                    CREATE_SUSPENDED,
-                    nullptr);
+				// Compile the PSO on a background thread.
+				m_workerThreads[type].threadHandle = CreateThread(
+					nullptr,
+					0,
+					reinterpret_cast<LPTHREAD_START_ROUTINE>(CompilePSO),
+					reinterpret_cast<void*>(&m_workerThreads[type]),
+					CREATE_SUSPENDED,
+					nullptr);
 
-                if (!m_workerThreads[type].threadHandle)
-                {
-                    ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-                }
+				if (!m_workerThreads[type].threadHandle)
+				{
+					ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+				}
 
-                ResumeThread(m_workerThreads[type].threadHandle);
+				ResumeThread(m_workerThreads[type].threadHandle);
 
-                {
-                    auto lock = Mutex::Lock(m_flagsMutex);
+				{
+					auto lock = Mutex::Lock(m_flagsMutex);
 
-                    m_inflightPSOFlags[type] = true;
-                }
-            }
+					m_inflightPSOFlags[type] = true;
+				}
+			}
 
-            type = BaseUberShader;
-        }
-        else if (!isBuilt && !m_useUberShaders)
-        {
-            // When not using ubershaders this will take a long time and cause a hitch as the 
-            // CPU is stalled!
-            m_workerThreads[type].pDevice = pDevice;
-            m_workerThreads[type].pRootSignature = pRootSignature;
-            m_workerThreads[type].type = type;
-            m_workerThreads[type].pLibrary = this;
+			type = BaseUberShader;
+		}
+		else if (!isBuilt && !m_useUberShaders)
+		{
+			// When not using ubershaders this will take a long time and cause a hitch as the 
+			// CPU is stalled!
+			m_workerThreads[type].pDevice = pDevice;
+			m_workerThreads[type].pRootSignature = pRootSignature;
+			m_workerThreads[type].type = type;
+			m_workerThreads[type].pLibrary = this;
 
-            CompilePSO(&m_workerThreads[type]);
-        }
-    }
-    else
-    {
-        // We should always have the base shaders around.
-        assert(isBuilt);
-    }
+			CompilePSO(&m_workerThreads[type]);
+		}
+	}
+	else
+	{
+		// We should always have the base shaders around.
+		assert(isBuilt);
+	}
 
-    pCommandList->SetPipelineState(m_pipelineStates[type].Get());
+	pCommandList->SetPipelineState(m_pipelineStates[type].Get());
 
-    m_drawIndex++;
+	m_drawIndex++;
 }
 
 void PSOLibrary::CompilePSO(CompilePSOThreadData* pDataPackage)
 {
-    PSOLibrary* pLibrary = pDataPackage->pLibrary;
-    ID3D12Device* pDevice = pDataPackage->pDevice;
-    ID3D12RootSignature* pRootSignature = pDataPackage->pRootSignature;
-    EffectPipelineType type = pDataPackage->type;
-    bool useCache = false;
-    bool sleepToEmulateComplexCreatePSO = false;
+	PSOLibrary* pLibrary = pDataPackage->pLibrary;
+	ID3D12Device* pDevice = pDataPackage->pDevice;
+	ID3D12RootSignature* pRootSignature = pDataPackage->pRootSignature;
+	EffectPipelineType type = pDataPackage->type;
+	bool useCache = false;
+	bool sleepToEmulateComplexCreatePSO = false;
 
-    {
-        auto lock = Mutex::Lock(pLibrary->m_flagsMutex);
+	{
+		auto lock = Mutex::Lock(pLibrary->m_flagsMutex);
 
-        // When using the disk cache compilation should be extremely quick so don't sleep.
-        useCache = pLibrary->m_useDiskLibraries;
-    }
+		// When using the disk cache compilation should be extremely quick so don't sleep.
+		useCache = pLibrary->m_useDiskLibraries;
+	}
 
-    D3D12_GRAPHICS_PIPELINE_STATE_DESC baseDesc = {};
-    baseDesc.pRootSignature = pRootSignature;
-    baseDesc.SampleMask = UINT_MAX;
-    baseDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-    baseDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-    baseDesc.NumRenderTargets = 1;
-    baseDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-    baseDesc.SampleDesc.Count = 1;
-    baseDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-    baseDesc.DepthStencilState.DepthEnable = FALSE;
-    baseDesc.DepthStencilState.StencilEnable = FALSE;
+	D3D12_GRAPHICS_PIPELINE_STATE_DESC baseDesc = {};
+	baseDesc.pRootSignature = pRootSignature;
+	baseDesc.SampleMask = UINT_MAX;
+	baseDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+	baseDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+	baseDesc.NumRenderTargets = 1;
+	baseDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+	baseDesc.SampleDesc.Count = 1;
+	baseDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+	baseDesc.DepthStencilState.DepthEnable = FALSE;
+	baseDesc.DepthStencilState.StencilEnable = FALSE;
 
-    baseDesc.InputLayout = g_cEffectShaderData[type].inputLayout;
-    baseDesc.VS = g_cEffectShaderData[type].VS;
-    baseDesc.PS = g_cEffectShaderData[type].PS;
-    baseDesc.DS = g_cEffectShaderData[type].DS;
-    baseDesc.HS = g_cEffectShaderData[type].HS;
-    baseDesc.GS = g_cEffectShaderData[type].GS;
+	baseDesc.InputLayout = g_cEffectShaderData[type].inputLayout;
+	baseDesc.VS = g_cEffectShaderData[type].VS;
+	baseDesc.PS = g_cEffectShaderData[type].PS;
+	baseDesc.DS = g_cEffectShaderData[type].DS;
+	baseDesc.HS = g_cEffectShaderData[type].HS;
+	baseDesc.GS = g_cEffectShaderData[type].GS;
 
-    if (useCache && 
-        (pLibrary->m_psoCachingMechanism == PSOCachingMechanism::PipelineLibraries))
-    {
-        assert(pLibrary->m_pipelineLibrary.IsMapped());
-        ID3D12PipelineLibrary* pPipelineLibrary = pLibrary->m_pipelineLibrary.GetPipelineLibrary();
+	if (useCache && 
+		(pLibrary->m_psoCachingMechanism == PSOCachingMechanism::PipelineLibraries))
+	{
+		assert(pLibrary->m_pipelineLibrary.IsMapped());
+		ID3D12PipelineLibrary* pPipelineLibrary = pLibrary->m_pipelineLibrary.GetPipelineLibrary();
 
-        // Note: Load*Pipeline() will auto-name PSOs for you based on the provided name. However, this sample overrides those names.
-        HRESULT hr = pPipelineLibrary->LoadGraphicsPipeline(g_cEffectNames[type], &baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type]));
-        if (E_INVALIDARG == hr)
-        {
-            // A PSO with the specified name doesn’t exist, or the input desc doesn’t match the data in the library.
-            // Create the PSO and then store it in the library for next time.
-            ThrowIfFailed(pDevice->CreateGraphicsPipelineState(&baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type])));
+		// Note: Load*Pipeline() will auto-name PSOs for you based on the provided name. However, this sample overrides those names.
+		HRESULT hr = pPipelineLibrary->LoadGraphicsPipeline(g_cEffectNames[type], &baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type]));
+		if (E_INVALIDARG == hr)
+		{
+			// A PSO with the specified name doesn’t exist, or the input desc doesn’t match the data in the library.
+			// Create the PSO and then store it in the library for next time.
+			ThrowIfFailed(pDevice->CreateGraphicsPipelineState(&baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type])));
 
-            // Note: You don't need to pass StorePipeline() a name if the object is already named. If the name parameter is null, it will use the object's name.
-            hr = pPipelineLibrary->StorePipeline(g_cEffectNames[type], pLibrary->m_pipelineStates[type].Get());
-            if (E_INVALIDARG == hr)
-            {
-                // A PSO with the specified name already exists in the library.
-                // This shouldn't happen in this sample, but depending on how you name the PSOs collisions are possible.
-            }
-            else
-            {
-                ThrowIfFailed(hr);
-            }
+			// Note: You don't need to pass StorePipeline() a name if the object is already named. If the name parameter is null, it will use the object's name.
+			hr = pPipelineLibrary->StorePipeline(g_cEffectNames[type], pLibrary->m_pipelineStates[type].Get());
+			if (E_INVALIDARG == hr)
+			{
+				// A PSO with the specified name already exists in the library.
+				// This shouldn't happen in this sample, but depending on how you name the PSOs collisions are possible.
+			}
+			else
+			{
+				ThrowIfFailed(hr);
+			}
 
-            sleepToEmulateComplexCreatePSO = true;
-        }
-        else
-        {
-            ThrowIfFailed(hr);
-        }
-    }
-    else if (useCache && 
-        (pLibrary->m_psoCachingMechanism == PSOCachingMechanism::CachedBlobs))
-    {
-        // Read how long the cached shader blob is.
-        assert(pLibrary->m_diskCaches[type].IsMapped());
-        size_t size = pLibrary->m_diskCaches[type].GetCachedBlobSize();
+			sleepToEmulateComplexCreatePSO = true;
+		}
+		else
+		{
+			ThrowIfFailed(hr);
+		}
+	}
+	else if (useCache && 
+		(pLibrary->m_psoCachingMechanism == PSOCachingMechanism::CachedBlobs))
+	{
+		// Read how long the cached shader blob is.
+		assert(pLibrary->m_diskCaches[type].IsMapped());
+		size_t size = pLibrary->m_diskCaches[type].GetCachedBlobSize();
 
-        // If the size if 0 then this disk cache needs to be refreshed.
-        if (size == 0)
-        {
-            ThrowIfFailed(pDevice->CreateGraphicsPipelineState(&baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type])));
+		// If the size if 0 then this disk cache needs to be refreshed.
+		if (size == 0)
+		{
+			ThrowIfFailed(pDevice->CreateGraphicsPipelineState(&baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type])));
 
-            ComPtr<ID3DBlob> blob;
-            pLibrary->m_pipelineStates[type]->GetCachedBlob(&blob);
-            pLibrary->m_diskCaches[type].Update(blob.Get());
+			ComPtr<ID3DBlob> blob;
+			pLibrary->m_pipelineStates[type]->GetCachedBlob(&blob);
+			pLibrary->m_diskCaches[type].Update(blob.Get());
 
-            sleepToEmulateComplexCreatePSO = true;
-        }
-        else
-        {
-            // Read in the blob data from disk to avoid compiling it.
-            baseDesc.CachedPSO.pCachedBlob = pLibrary->m_diskCaches[type].GetCachedBlob();
-            baseDesc.CachedPSO.CachedBlobSizeInBytes = pLibrary->m_diskCaches[type].GetCachedBlobSize();
+			sleepToEmulateComplexCreatePSO = true;
+		}
+		else
+		{
+			// Read in the blob data from disk to avoid compiling it.
+			baseDesc.CachedPSO.pCachedBlob = pLibrary->m_diskCaches[type].GetCachedBlob();
+			baseDesc.CachedPSO.CachedBlobSizeInBytes = pLibrary->m_diskCaches[type].GetCachedBlobSize();
 
-            HRESULT hr = pDevice->CreateGraphicsPipelineState(&baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type]));
+			HRESULT hr = pDevice->CreateGraphicsPipelineState(&baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type]));
 
-            // If compilation fails the cache is probably stale. (old drivers etc.)
-            if (FAILED(hr))
-            {
-                baseDesc.CachedPSO = {};
-                ThrowIfFailed(pDevice->CreateGraphicsPipelineState(&baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type])));
+			// If compilation fails the cache is probably stale. (old drivers etc.)
+			if (FAILED(hr))
+			{
+				baseDesc.CachedPSO = {};
+				ThrowIfFailed(pDevice->CreateGraphicsPipelineState(&baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type])));
 
-                ComPtr<ID3DBlob> blob;
-                pLibrary->m_pipelineStates[type]->GetCachedBlob(&blob);
-                pLibrary->m_diskCaches[type].Update(blob.Get());
+				ComPtr<ID3DBlob> blob;
+				pLibrary->m_pipelineStates[type]->GetCachedBlob(&blob);
+				pLibrary->m_diskCaches[type].Update(blob.Get());
 
-                sleepToEmulateComplexCreatePSO = true;
-            }
-        }
-    }
-    else
-    {
-        ThrowIfFailed(pDevice->CreateGraphicsPipelineState(&baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type])));
+				sleepToEmulateComplexCreatePSO = true;
+			}
+		}
+	}
+	else
+	{
+		ThrowIfFailed(pDevice->CreateGraphicsPipelineState(&baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type])));
 
-        sleepToEmulateComplexCreatePSO = true;
-    }
+		sleepToEmulateComplexCreatePSO = true;
+	}
 
-    // The effects are very simple and should compile quickly so we'll sleep to emulate something more complex.
-    if (sleepToEmulateComplexCreatePSO && type > BaseUberShader)
-    {
-        Sleep(500);
-    }
+	// The effects are very simple and should compile quickly so we'll sleep to emulate something more complex.
+	if (sleepToEmulateComplexCreatePSO && type > BaseUberShader)
+	{
+		Sleep(500);
+	}
 
-    WCHAR name[50];
-    if (swprintf_s(name, L"m_pipelineStates[%s]", g_cEffectNames[type]) > 0)
-    {
-        SetName(pLibrary->m_pipelineStates[type].Get(), name);
-    }
+	WCHAR name[50];
+	if (swprintf_s(name, L"m_pipelineStates[%s]", g_cEffectNames[type]) > 0)
+	{
+		SetName(pLibrary->m_pipelineStates[type].Get(), name);
+	}
 
-    {
-        auto lock = Mutex::Lock(pLibrary->m_flagsMutex);
+	{
+		auto lock = Mutex::Lock(pLibrary->m_flagsMutex);
 
-        pLibrary->m_compiledPSOFlags[type] = true;
-        pLibrary->m_inflightPSOFlags[type] = false;
-    }
+		pLibrary->m_compiledPSOFlags[type] = true;
+		pLibrary->m_inflightPSOFlags[type] = false;
+	}
 }
 
 void PSOLibrary::EndFrame()
 {
-    m_drawIndex = 0;
+	m_drawIndex = 0;
 }
 
 void PSOLibrary::ClearPSOCache()
 {
-    WaitForThreads();
+	WaitForThreads();
 
-    for (size_t i = PostBlit; i < EffectPipelineTypeCount; i++)
-    {
-        if (m_pipelineStates[i])
-        {
-            m_pipelineStates[i] = nullptr;
-            m_compiledPSOFlags[i] = false;
-            m_inflightPSOFlags[i] = false;
-        }
-    }
+	for (size_t i = PostBlit; i < EffectPipelineTypeCount; i++)
+	{
+		if (m_pipelineStates[i])
+		{
+			m_pipelineStates[i] = nullptr;
+			m_compiledPSOFlags[i] = false;
+			m_inflightPSOFlags[i] = false;
+		}
+	}
 
-    // Clear the disk caches.
-    for (size_t i = 0; i < EffectPipelineTypeCount; i++)
-    {
-        m_diskCaches[i].Destroy(true);
-    }
+	// Clear the disk caches.
+	for (size_t i = 0; i < EffectPipelineTypeCount; i++)
+	{
+		m_diskCaches[i].Destroy(true);
+	}
 
-    m_pipelineLibrary.Destroy(true);
+	m_pipelineLibrary.Destroy(true);
 }
 
 void PSOLibrary::ToggleUberShader()
 {
-    m_useUberShaders = !m_useUberShaders;
+	m_useUberShaders = !m_useUberShaders;
 }
 
 void PSOLibrary::ToggleDiskLibrary()
 {
-    {
-        auto lock = Mutex::Lock(m_flagsMutex);
+	{
+		auto lock = Mutex::Lock(m_flagsMutex);
 
-        m_useDiskLibraries = !m_useDiskLibraries;
-    }
+		m_useDiskLibraries = !m_useDiskLibraries;
+	}
 
-    WaitForThreads();
+	WaitForThreads();
 }
 
 void PSOLibrary::SwitchPSOCachingMechanism()
 {
-    {
-        auto lock = Mutex::Lock(m_flagsMutex);
+	{
+		auto lock = Mutex::Lock(m_flagsMutex);
 
-        UINT newMechanism = static_cast<UINT>(m_psoCachingMechanism) + 1;
-        newMechanism = newMechanism % PSOCachingMechanism::PSOCachingMechanismCount;
+		UINT newMechanism = static_cast<UINT>(m_psoCachingMechanism) + 1;
+		newMechanism = newMechanism % PSOCachingMechanism::PSOCachingMechanismCount;
 
-        // Don't allow Pipeline Libraries if they're not available.
-        if (!m_pipelineLibrariesSupported && (newMechanism == PSOCachingMechanism::PipelineLibraries))
-        {
-            newMechanism++;
-            newMechanism = newMechanism % PSOCachingMechanism::PSOCachingMechanismCount;
-        }
-        
-        m_psoCachingMechanism = static_cast<PSOCachingMechanism>(newMechanism);
-    }
+		// Don't allow Pipeline Libraries if they're not available.
+		if (!m_pipelineLibrariesSupported && (newMechanism == PSOCachingMechanism::PipelineLibraries))
+		{
+			newMechanism++;
+			newMechanism = newMechanism % PSOCachingMechanism::PSOCachingMechanismCount;
+		}
+		
+		m_psoCachingMechanism = static_cast<PSOCachingMechanism>(newMechanism);
+	}
 
-    WaitForThreads();
+	WaitForThreads();
 }
 
 void PSOLibrary::DestroyShader(EffectPipelineType type)
 {
-    WaitForThreads();
+	WaitForThreads();
 
-    if (m_pipelineStates[type])
-    {
-        m_pipelineStates[type] = nullptr;
-        m_compiledPSOFlags[type] = false;
-        m_inflightPSOFlags[type] = false;
-    }
+	if (m_pipelineStates[type])
+	{
+		m_pipelineStates[type] = nullptr;
+		m_compiledPSOFlags[type] = false;
+		m_inflightPSOFlags[type] = false;
+	}
 }

--- a/Samples/Desktop/D3D12PipelineStateCache/src/PSOLibrary.h
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/PSOLibrary.h
@@ -34,53 +34,53 @@ using namespace std;
 
 enum PSOCachingMechanism
 {
-    CachedBlobs,
+	CachedBlobs,
 
-    // Enables applications to explicitly group PSOs which are expected to share data. Recommended over Cached Blobs.
-    PipelineLibraries,
+	// Enables applications to explicitly group PSOs which are expected to share data. Recommended over Cached Blobs.
+	PipelineLibraries,
 
-    PSOCachingMechanismCount
+	PSOCachingMechanismCount
 };
 
 enum EffectPipelineType : UINT
 {
-    // These always get compiled at startup.
-    BaseNormal3DRender,
-    BaseUberShader,
+	// These always get compiled at startup.
+	BaseNormal3DRender,
+	BaseUberShader,
 
-    // These are compiled a la carte.
-    PostBlit,
-    PostInvert,
-    PostGrayScale,
-    PostEdgeDetect,
-    PostBlur,
-    PostWarp,
-    PostPixelate,
-    PostDistort,
-    PostWave,
-    EffectPipelineTypeCount
+	// These are compiled a la carte.
+	PostBlit,
+	PostInvert,
+	PostGrayScale,
+	PostEdgeDetect,
+	PostBlur,
+	PostWarp,
+	PostPixelate,
+	PostDistort,
+	PostWave,
+	EffectPipelineTypeCount
 };
 
 struct GraphicsShaderSet
 {
-    D3D12_INPUT_LAYOUT_DESC inputLayout;
-    D3D12_SHADER_BYTECODE VS;
-    D3D12_SHADER_BYTECODE PS;
-    D3D12_SHADER_BYTECODE DS;
-    D3D12_SHADER_BYTECODE HS;
-    D3D12_SHADER_BYTECODE GS;
+	D3D12_INPUT_LAYOUT_DESC inputLayout;
+	D3D12_SHADER_BYTECODE VS;
+	D3D12_SHADER_BYTECODE PS;
+	D3D12_SHADER_BYTECODE DS;
+	D3D12_SHADER_BYTECODE HS;
+	D3D12_SHADER_BYTECODE GS;
 };
 
 static const D3D12_INPUT_ELEMENT_DESC g_cSimpleInputElementDescs[] =
 {
-    { "POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-    { "COLOR", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+	{ "POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+	{ "COLOR", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
 };
 
 static const D3D12_INPUT_ELEMENT_DESC g_cQuadInputElementDescs[] =
 {
-    { "POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-    { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+	{ "POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+	{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
 };
 
 static const D3D12_INPUT_LAYOUT_DESC g_cForwardRenderInputLayout = { g_cSimpleInputElementDescs, _countof(g_cSimpleInputElementDescs) };
@@ -88,193 +88,193 @@ static const D3D12_INPUT_LAYOUT_DESC g_cQuadInputLayout = { g_cQuadInputElementD
 
 static const GraphicsShaderSet g_cEffectShaderData[EffectPipelineTypeCount] =
 {
-    {
-        g_cForwardRenderInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_SimpleVertexShader, sizeof(g_SimpleVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_SimplePixelShader, sizeof(g_SimplePixelShader)),
-        {},
-        {},
-        {},
-    },
-    {
-        g_cQuadInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_UberPixelShader, sizeof(g_UberPixelShader)),
-        {},
-        {},
-        {},
-    },
-    {
-        g_cQuadInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_BlitPixelShader, sizeof(g_BlitPixelShader)),
-        {},
-        {},
-        {},
-    },
-    {
-        g_cQuadInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_InvertPixelShader, sizeof(g_InvertPixelShader)),
-        {},
-        {},
-        {},
-    },
-    {
-        g_cQuadInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_GrayScalePixelShader, sizeof(g_GrayScalePixelShader)),
-        {},
-        {},
-        {},
-    },
-    {
-        g_cQuadInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_EdgeDetectPixelShader, sizeof(g_EdgeDetectPixelShader)),
-        {},
-        {},
-        {},
-    },
-    {
-        g_cQuadInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_BlurPixelShader, sizeof(g_BlurPixelShader)),
-        {},
-        {},
-        {},
-    },
-    {
-        g_cQuadInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_WarpPixelShader, sizeof(g_WarpPixelShader)),
-        {},
-        {},
-        {},
-    },
-    {
-        g_cQuadInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_PixelatePixelShader, sizeof(g_PixelatePixelShader)),
-        {},
-        {},
-        {},
-    },
-    {
-        g_cQuadInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_DistortPixelShader, sizeof(g_DistortPixelShader)),
-        {},
-        {},
-        {},
-    },
-    {
-        g_cQuadInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_WavePixelShader, sizeof(g_WavePixelShader)),
-        {},
-        {},
-        {},
-    },
+	{
+		g_cForwardRenderInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_SimpleVertexShader, sizeof(g_SimpleVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_SimplePixelShader, sizeof(g_SimplePixelShader)),
+		{},
+		{},
+		{},
+	},
+	{
+		g_cQuadInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_UberPixelShader, sizeof(g_UberPixelShader)),
+		{},
+		{},
+		{},
+	},
+	{
+		g_cQuadInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_BlitPixelShader, sizeof(g_BlitPixelShader)),
+		{},
+		{},
+		{},
+	},
+	{
+		g_cQuadInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_InvertPixelShader, sizeof(g_InvertPixelShader)),
+		{},
+		{},
+		{},
+	},
+	{
+		g_cQuadInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_GrayScalePixelShader, sizeof(g_GrayScalePixelShader)),
+		{},
+		{},
+		{},
+	},
+	{
+		g_cQuadInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_EdgeDetectPixelShader, sizeof(g_EdgeDetectPixelShader)),
+		{},
+		{},
+		{},
+	},
+	{
+		g_cQuadInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_BlurPixelShader, sizeof(g_BlurPixelShader)),
+		{},
+		{},
+		{},
+	},
+	{
+		g_cQuadInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_WarpPixelShader, sizeof(g_WarpPixelShader)),
+		{},
+		{},
+		{},
+	},
+	{
+		g_cQuadInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_PixelatePixelShader, sizeof(g_PixelatePixelShader)),
+		{},
+		{},
+		{},
+	},
+	{
+		g_cQuadInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_DistortPixelShader, sizeof(g_DistortPixelShader)),
+		{},
+		{},
+		{},
+	},
+	{
+		g_cQuadInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_WavePixelShader, sizeof(g_WavePixelShader)),
+		{},
+		{},
+		{},
+	},
 };
 
 static const LPWCH g_cPipelineLibraryFileName = L"pipelineLibrary.cache";
 
 static const LPWCH g_cCacheFileNames[EffectPipelineTypeCount] =
 {
-    L"normal3dPSO.cache",
-    L"ubershaderPSO.cache",
-    L"blitEffectPSO.cache",
-    L"invertEffectPSO.cache",
-    L"grayscaleEffectPSO.cache",
-    L"edgeDetectEffectPSO.cache",
-    L"blurEffectPSO.cache",
-    L"warpEffectPSO.cache",
-    L"pixelateEffectPSO.cache",
-    L"distortEffectPSO.cache",
-    L"waveEffectPSO.cache",
+	L"normal3dPSO.cache",
+	L"ubershaderPSO.cache",
+	L"blitEffectPSO.cache",
+	L"invertEffectPSO.cache",
+	L"grayscaleEffectPSO.cache",
+	L"edgeDetectEffectPSO.cache",
+	L"blurEffectPSO.cache",
+	L"warpEffectPSO.cache",
+	L"pixelateEffectPSO.cache",
+	L"distortEffectPSO.cache",
+	L"waveEffectPSO.cache",
 };
 
 static const LPWCH g_cEffectNames[EffectPipelineTypeCount] =
 {
-    L"Normal 3D",
-    L"Generic post effect",
-    L"Blit",
-    L"Invert",
-    L"Grayscale",
-    L"Edge detect",
-    L"Blur",
-    L"Warp",
-    L"Pixelate",
-    L"Distort",
-    L"Wave",
+	L"Normal 3D",
+	L"Generic post effect",
+	L"Blit",
+	L"Invert",
+	L"Grayscale",
+	L"Edge detect",
+	L"Blur",
+	L"Warp",
+	L"Pixelate",
+	L"Distort",
+	L"Wave",
 };
 
 class PSOLibrary
 {
 public:
-    PSOLibrary(UINT frameCount, UINT cbvRootSignatureIndex);
-    ~PSOLibrary();
+	PSOLibrary(UINT frameCount, UINT cbvRootSignatureIndex);
+	~PSOLibrary();
 
-    void Build(ID3D12Device* pDevice, ID3D12RootSignature* pRootSignature);
+	void Build(ID3D12Device* pDevice, ID3D12RootSignature* pRootSignature);
 
-    void SetPipelineState(
-        ID3D12Device* pDevice,
-        ID3D12RootSignature* pRootSignature,
-        ID3D12GraphicsCommandList* pCommandList,
-        _In_range_(0, EffectPipelineTypeCount-1) EffectPipelineType type,
-        UINT frameIndex);
+	void SetPipelineState(
+		ID3D12Device* pDevice,
+		ID3D12RootSignature* pRootSignature,
+		ID3D12GraphicsCommandList* pCommandList,
+		_In_range_(0, EffectPipelineTypeCount-1) EffectPipelineType type,
+		UINT frameIndex);
 
-    void EndFrame();
-    void ClearPSOCache();
-    void ToggleUberShader();
-    void ToggleDiskLibrary();
-    void SwitchPSOCachingMechanism();
-    void DestroyShader(EffectPipelineType type);
+	void EndFrame();
+	void ClearPSOCache();
+	void ToggleUberShader();
+	void ToggleDiskLibrary();
+	void SwitchPSOCachingMechanism();
+	void DestroyShader(EffectPipelineType type);
 
-    bool UberShadersEnabled() { return m_useUberShaders; }
-    bool DiskCacheEnabled() { return m_useDiskLibraries; }
-    PSOCachingMechanism GetPSOCachingMechanism() { return m_psoCachingMechanism; }
+	bool UberShadersEnabled() { return m_useUberShaders; }
+	bool DiskCacheEnabled() { return m_useDiskLibraries; }
+	PSOCachingMechanism GetPSOCachingMechanism() { return m_psoCachingMechanism; }
 
 private:
-    static const UINT BaseEffectCount = 2;
+	static const UINT BaseEffectCount = 2;
 
-    struct CompilePSOThreadData
-    {
-        PSOLibrary* pLibrary;
-        ID3D12Device* pDevice;
-        ID3D12RootSignature* pRootSignature;
-        EffectPipelineType type;
+	struct CompilePSOThreadData
+	{
+		PSOLibrary* pLibrary;
+		ID3D12Device* pDevice;
+		ID3D12RootSignature* pRootSignature;
+		EffectPipelineType type;
 
-        HANDLE threadHandle;
-    };
+		HANDLE threadHandle;
+	};
 
-    // This will be used to tell the uber shader which effect to use.
-    struct UberShaderConstantBuffer
-    {
-        UINT32 effectIndex;
-    };
+	// This will be used to tell the uber shader which effect to use.
+	struct UberShaderConstantBuffer
+	{
+		UINT32 effectIndex;
+	};
 
-    static void CompilePSO(CompilePSOThreadData* pDataPackage);
-    void WaitForThreads();
+	static void CompilePSO(CompilePSOThreadData* pDataPackage);
+	void WaitForThreads();
 
-    ComPtr<ID3D12PipelineState> m_pipelineStates[EffectPipelineTypeCount];
-    bool m_compiledPSOFlags[EffectPipelineTypeCount];
-    bool m_inflightPSOFlags[EffectPipelineTypeCount];
-    MemoryMappedPSOCache m_diskCaches[EffectPipelineTypeCount];    // Cached blobs.
-    MemoryMappedPipelineLibrary m_pipelineLibrary; // Pipeline Library.
-    HANDLE m_flagsMutex;
-    CompilePSOThreadData m_workerThreads[EffectPipelineTypeCount];
+	ComPtr<ID3D12PipelineState> m_pipelineStates[EffectPipelineTypeCount];
+	bool m_compiledPSOFlags[EffectPipelineTypeCount];
+	bool m_inflightPSOFlags[EffectPipelineTypeCount];
+	MemoryMappedPSOCache m_diskCaches[EffectPipelineTypeCount];	// Cached blobs.
+	MemoryMappedPipelineLibrary m_pipelineLibrary; // Pipeline Library.
+	HANDLE m_flagsMutex;
+	CompilePSOThreadData m_workerThreads[EffectPipelineTypeCount];
 
-    bool m_useUberShaders;
-    bool m_useDiskLibraries;
-    bool m_pipelineLibrariesSupported;
-    PSOCachingMechanism m_psoCachingMechanism;
-    std::wstring m_cachePath;
+	bool m_useUberShaders;
+	bool m_useDiskLibraries;
+	bool m_pipelineLibrariesSupported;
+	PSOCachingMechanism m_psoCachingMechanism;
+	std::wstring m_cachePath;
 
-    UINT m_cbvRootSignatureIndex;
-    UINT m_maxDrawsPerFrame;
-    UINT m_drawIndex;
+	UINT m_cbvRootSignatureIndex;
+	UINT m_maxDrawsPerFrame;
+	UINT m_drawIndex;
 
-    DynamicConstantBuffer m_dynamicCB;
+	DynamicConstantBuffer m_dynamicCB;
 };

--- a/Samples/Desktop/D3D12PipelineStateCache/src/PixelatePixelShader.hlsl
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/PixelatePixelShader.hlsl
@@ -13,13 +13,13 @@
 
 float4 Pixelate(float2 uv)
 {
-    uint2 var = uint2(uv.x * 100, uv.y * 100);
-    uv = float2((float)var.x / 100, (float)var.y / 100);
+	uint2 var = uint2(uv.x * 100, uv.y * 100);
+	uv = float2((float)var.x / 100, (float)var.y / 100);
 
-    return g_tex.Sample(g_samp, uv);
+	return g_tex.Sample(g_samp, uv);
 }
 
 float4 mainPixel(PSInput input) : SV_TARGET
 {
-    return Pixelate(input.uv);
+	return Pixelate(input.uv);
 }

--- a/Samples/Desktop/D3D12PipelineStateCache/src/QuadVertexShader.hlsl
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/QuadVertexShader.hlsl
@@ -14,14 +14,14 @@
 
 struct VSInput
 {
-    float4 position : POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : POSITION;
+	float2 uv : TEXCOORD;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 Texture2D g_tex : register(t0);
@@ -29,11 +29,11 @@ SamplerState g_samp : register(s0);
 
 PSInput mainQuad(VSInput input)
 {
-    PSInput result;
-    result.position = input.position;
-    result.uv = input.uv;
+	PSInput result;
+	result.position = input.position;
+	result.uv = input.uv;
 
-    return result;
+	return result;
 }
 
 #endif

--- a/Samples/Desktop/D3D12PipelineStateCache/src/SimpleCamera.cpp
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/SimpleCamera.cpp
@@ -13,163 +13,163 @@
 #include "SimpleCamera.h"
 
 SimpleCamera::SimpleCamera():
-    m_initialPosition(0, 0, 0),
-    m_position(m_initialPosition),
-    m_yaw(XM_PI),
-    m_pitch(0.0f),
-    m_lookDirection(0, 0, -1),
-    m_upDirection(0, 1, 0),
-    m_moveSpeed(20.0f),
-    m_turnSpeed(XM_PIDIV2),
-    m_keysPressed{}
+	m_initialPosition(0, 0, 0),
+	m_position(m_initialPosition),
+	m_yaw(XM_PI),
+	m_pitch(0.0f),
+	m_lookDirection(0, 0, -1),
+	m_upDirection(0, 1, 0),
+	m_moveSpeed(20.0f),
+	m_turnSpeed(XM_PIDIV2),
+	m_keysPressed{}
 {
 }
 
 void SimpleCamera::Init(XMFLOAT3 position)
 {
-    m_initialPosition = position;
-    Reset();
+	m_initialPosition = position;
+	Reset();
 }
 
 void SimpleCamera::SetMoveSpeed(float unitsPerSecond)
 {
-    m_moveSpeed = unitsPerSecond;
+	m_moveSpeed = unitsPerSecond;
 }
 
 void SimpleCamera::SetTurnSpeed(float radiansPerSecond)
 {
-    m_turnSpeed = radiansPerSecond;
+	m_turnSpeed = radiansPerSecond;
 }
 
 void SimpleCamera::Reset()
 {
-    m_position = m_initialPosition;
-    m_yaw = XM_PI;
-    m_pitch = 0.0f;
-    m_lookDirection = { 0, 0, -1 };
+	m_position = m_initialPosition;
+	m_yaw = XM_PI;
+	m_pitch = 0.0f;
+	m_lookDirection = { 0, 0, -1 };
 }
 
 void SimpleCamera::Update(float elapsedSeconds)
 {
-    // Calculate the move vector in camera space.
-    XMFLOAT3 move(0, 0, 0);
+	// Calculate the move vector in camera space.
+	XMFLOAT3 move(0, 0, 0);
 
-    if (m_keysPressed.a)
-        move.x -= 1.0f;
-    if (m_keysPressed.d)
-        move.x += 1.0f;
-    if (m_keysPressed.w)
-        move.z -= 1.0f;
-    if (m_keysPressed.s)
-        move.z += 1.0f;
+	if (m_keysPressed.a)
+		move.x -= 1.0f;
+	if (m_keysPressed.d)
+		move.x += 1.0f;
+	if (m_keysPressed.w)
+		move.z -= 1.0f;
+	if (m_keysPressed.s)
+		move.z += 1.0f;
 
-    if (fabs(move.x) > 0.1f && fabs(move.z) > 0.1f)
-    {
-        XMVECTOR vector = XMVector3Normalize(XMLoadFloat3(&move));
-        move.x = XMVectorGetX(vector);
-        move.z = XMVectorGetZ(vector);
-    }
+	if (fabs(move.x) > 0.1f && fabs(move.z) > 0.1f)
+	{
+		XMVECTOR vector = XMVector3Normalize(XMLoadFloat3(&move));
+		move.x = XMVectorGetX(vector);
+		move.z = XMVectorGetZ(vector);
+	}
 
-    float moveInterval = m_moveSpeed * elapsedSeconds;
-    float rotateInterval = m_turnSpeed * elapsedSeconds;
+	float moveInterval = m_moveSpeed * elapsedSeconds;
+	float rotateInterval = m_turnSpeed * elapsedSeconds;
 
-    if (m_keysPressed.left)
-        m_yaw += rotateInterval;
-    if (m_keysPressed.right)
-        m_yaw -= rotateInterval;
-    if (m_keysPressed.up)
-        m_pitch += rotateInterval;
-    if (m_keysPressed.down)
-        m_pitch -= rotateInterval;
+	if (m_keysPressed.left)
+		m_yaw += rotateInterval;
+	if (m_keysPressed.right)
+		m_yaw -= rotateInterval;
+	if (m_keysPressed.up)
+		m_pitch += rotateInterval;
+	if (m_keysPressed.down)
+		m_pitch -= rotateInterval;
 
-    // Prevent looking too far up or down.
-    m_pitch = min(m_pitch, XM_PIDIV4);
-    m_pitch = max(-XM_PIDIV4, m_pitch);
+	// Prevent looking too far up or down.
+	m_pitch = min(m_pitch, XM_PIDIV4);
+	m_pitch = max(-XM_PIDIV4, m_pitch);
 
-    // Move the camera in model space.
-    float x = move.x * -cosf(m_yaw) - move.z * sinf(m_yaw);
-    float z = move.x * sinf(m_yaw) - move.z * cosf(m_yaw);
-    m_position.x += x * moveInterval;
-    m_position.z += z * moveInterval;
+	// Move the camera in model space.
+	float x = move.x * -cosf(m_yaw) - move.z * sinf(m_yaw);
+	float z = move.x * sinf(m_yaw) - move.z * cosf(m_yaw);
+	m_position.x += x * moveInterval;
+	m_position.z += z * moveInterval;
 
-    // Determine the look direction.
-    float r = cosf(m_pitch);
-    m_lookDirection.x = r * sinf(m_yaw);
-    m_lookDirection.y = sinf(m_pitch);
-    m_lookDirection.z = r * cosf(m_yaw);
+	// Determine the look direction.
+	float r = cosf(m_pitch);
+	m_lookDirection.x = r * sinf(m_yaw);
+	m_lookDirection.y = sinf(m_pitch);
+	m_lookDirection.z = r * cosf(m_yaw);
 }
 
 XMMATRIX SimpleCamera::GetViewMatrix()
 {
-    return XMMatrixLookToRH(XMLoadFloat3(&m_position), XMLoadFloat3(&m_lookDirection), XMLoadFloat3(&m_upDirection));
+	return XMMatrixLookToRH(XMLoadFloat3(&m_position), XMLoadFloat3(&m_lookDirection), XMLoadFloat3(&m_upDirection));
 }
 
 XMMATRIX SimpleCamera::GetProjectionMatrix(float fov, float aspectRatio, float nearPlane, float farPlane)
 {
-    return XMMatrixPerspectiveFovRH(fov, aspectRatio, nearPlane, farPlane);
+	return XMMatrixPerspectiveFovRH(fov, aspectRatio, nearPlane, farPlane);
 }
 
 void SimpleCamera::OnKeyDown(WPARAM key)
 {
-    switch (key)
-    {
-    case 'W':
-        m_keysPressed.w = true;
-        break;
-    case 'A':
-        m_keysPressed.a = true;
-        break;
-    case 'S':
-        m_keysPressed.s = true;
-        break;
-    case 'D':
-        m_keysPressed.d = true;
-        break;
-    case VK_LEFT:
-        m_keysPressed.left = true;
-        break;
-    case VK_RIGHT:
-        m_keysPressed.right = true;
-        break;
-    case VK_UP:
-        m_keysPressed.up = true;
-        break;
-    case VK_DOWN:
-        m_keysPressed.down = true;
-        break;
-    case VK_ESCAPE:
-        Reset();
-        break;
-    }
+	switch (key)
+	{
+	case 'W':
+		m_keysPressed.w = true;
+		break;
+	case 'A':
+		m_keysPressed.a = true;
+		break;
+	case 'S':
+		m_keysPressed.s = true;
+		break;
+	case 'D':
+		m_keysPressed.d = true;
+		break;
+	case VK_LEFT:
+		m_keysPressed.left = true;
+		break;
+	case VK_RIGHT:
+		m_keysPressed.right = true;
+		break;
+	case VK_UP:
+		m_keysPressed.up = true;
+		break;
+	case VK_DOWN:
+		m_keysPressed.down = true;
+		break;
+	case VK_ESCAPE:
+		Reset();
+		break;
+	}
 }
 
 void SimpleCamera::OnKeyUp(WPARAM key)
 {
-    switch (key)
-    {
-    case 'W':
-        m_keysPressed.w = false;
-        break;
-    case 'A':
-        m_keysPressed.a = false;
-        break;
-    case 'S':
-        m_keysPressed.s = false;
-        break;
-    case 'D':
-        m_keysPressed.d = false;
-        break;
-    case VK_LEFT:
-        m_keysPressed.left = false;
-        break;
-    case VK_RIGHT:
-        m_keysPressed.right = false;
-        break;
-    case VK_UP:
-        m_keysPressed.up = false;
-        break;
-    case VK_DOWN:
-        m_keysPressed.down = false;
-        break;
-    }
+	switch (key)
+	{
+	case 'W':
+		m_keysPressed.w = false;
+		break;
+	case 'A':
+		m_keysPressed.a = false;
+		break;
+	case 'S':
+		m_keysPressed.s = false;
+		break;
+	case 'D':
+		m_keysPressed.d = false;
+		break;
+	case VK_LEFT:
+		m_keysPressed.left = false;
+		break;
+	case VK_RIGHT:
+		m_keysPressed.right = false;
+		break;
+	case VK_UP:
+		m_keysPressed.up = false;
+		break;
+	case VK_DOWN:
+		m_keysPressed.down = false;
+		break;
+	}
 }

--- a/Samples/Desktop/D3D12PipelineStateCache/src/SimpleCamera.h
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/SimpleCamera.h
@@ -16,42 +16,42 @@ using namespace DirectX;
 class SimpleCamera
 {
 public:
-    SimpleCamera();
+	SimpleCamera();
 
-    void Init(XMFLOAT3 position);
-    void Update(float elapsedSeconds);
-    XMMATRIX GetViewMatrix();
-    XMMATRIX GetProjectionMatrix(float fov, float aspectRatio, float nearPlane = 1.0f, float farPlane = 1000.0f);
-    void SetMoveSpeed(float unitsPerSecond);
-    void SetTurnSpeed(float radiansPerSecond);
+	void Init(XMFLOAT3 position);
+	void Update(float elapsedSeconds);
+	XMMATRIX GetViewMatrix();
+	XMMATRIX GetProjectionMatrix(float fov, float aspectRatio, float nearPlane = 1.0f, float farPlane = 1000.0f);
+	void SetMoveSpeed(float unitsPerSecond);
+	void SetTurnSpeed(float radiansPerSecond);
 
-    void OnKeyDown(WPARAM key);
-    void OnKeyUp(WPARAM key);
+	void OnKeyDown(WPARAM key);
+	void OnKeyUp(WPARAM key);
 
 private:
-    void Reset();
+	void Reset();
 
-    struct KeysPressed
-    {
-        bool w;
-        bool a;
-        bool s;
-        bool d;
+	struct KeysPressed
+	{
+		bool w;
+		bool a;
+		bool s;
+		bool d;
 
-        bool left;
-        bool right;
-        bool up;
-        bool down;
-    };
+		bool left;
+		bool right;
+		bool up;
+		bool down;
+	};
 
-    XMFLOAT3 m_initialPosition;
-    XMFLOAT3 m_position;
-    float m_yaw;                // Relative to the +z axis.
-    float m_pitch;                // Relative to the xz plane.
-    XMFLOAT3 m_lookDirection;
-    XMFLOAT3 m_upDirection;
-    float m_moveSpeed;            // Speed at which the camera moves, in units per second.
-    float m_turnSpeed;            // Speed at which the camera turns, in radians per second.
+	XMFLOAT3 m_initialPosition;
+	XMFLOAT3 m_position;
+	float m_yaw;				// Relative to the +z axis.
+	float m_pitch;				// Relative to the xz plane.
+	XMFLOAT3 m_lookDirection;
+	XMFLOAT3 m_upDirection;
+	float m_moveSpeed;			// Speed at which the camera moves, in units per second.
+	float m_turnSpeed;			// Speed at which the camera turns, in radians per second.
 
-    KeysPressed m_keysPressed;
+	KeysPressed m_keysPressed;
 };

--- a/Samples/Desktop/D3D12PipelineStateCache/src/SimplePixelShader.hlsl
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/SimplePixelShader.hlsl
@@ -13,5 +13,5 @@
 
 float4 main(PSInput input) : SV_TARGET
 {
-    return float4(input.color, 1.0f);
+	return float4(input.color, 1.0f);
 }

--- a/Samples/Desktop/D3D12PipelineStateCache/src/SimpleVertexShader.hlsl
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/SimpleVertexShader.hlsl
@@ -11,27 +11,27 @@
 
 struct VSInput
 {
-    float4 position : POSITION;
-    float3 color : COLOR;
+	float4 position : POSITION;
+	float3 color : COLOR;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float3 color : COLOR;
+	float4 position : SV_POSITION;
+	float3 color : COLOR;
 };
 
 cbuffer PerDraw : register(b1)
 {
-    float4x4 worldViewProjection;
+	float4x4 worldViewProjection;
 };
 
 PSInput main(VSInput input) 
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = mul(input.position, worldViewProjection);
-    result.color = input.color;
+	result.position = mul(input.position, worldViewProjection);
+	result.color = input.color;
 
-    return result;
+	return result;
 }

--- a/Samples/Desktop/D3D12PipelineStateCache/src/UberPixelShader.hlsl
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/UberPixelShader.hlsl
@@ -22,7 +22,7 @@
 
 cbuffer cb : register(b0)
 {
-    uint shaderType;
+	uint shaderType;
 };
 
 #define PostBlit 2
@@ -37,52 +37,52 @@ cbuffer cb : register(b0)
 
 float4 mainUber(PSInput input) : SV_TARGET
 {
-    float4 color = float4(0.0f, 0.0f, 0.0f, 1.0f);
+	float4 color = float4(0.0f, 0.0f, 0.0f, 1.0f);
 
-    [branch] switch (shaderType)
-    {
-    case PostBlit:
-        color = Blit(input.uv);
-        break;
+	[branch] switch (shaderType)
+	{
+	case PostBlit:
+		color = Blit(input.uv);
+		break;
 
-    case PostInvert:
-        color = InvertPixel(input.uv);
-        break;
+	case PostInvert:
+		color = InvertPixel(input.uv);
+		break;
 
-    case PostGrayScale:
-        color = GrayScale(input.uv);
-        break;
+	case PostGrayScale:
+		color = GrayScale(input.uv);
+		break;
 
-    case PostEdgeDetect:
-        color = EdgeDetect(input.uv);
-        break;
+	case PostEdgeDetect:
+		color = EdgeDetect(input.uv);
+		break;
 
-    case PostBlur:
-        color = Blur(input.uv);
-        break;
+	case PostBlur:
+		color = Blur(input.uv);
+		break;
 
-    case PostWarp:
-        color = Warp(input.uv);
-        break;
+	case PostWarp:
+		color = Warp(input.uv);
+		break;
 
-    case PostPixelate:
-        color = Pixelate(input.uv);
-        break;
+	case PostPixelate:
+		color = Pixelate(input.uv);
+		break;
 
-    case PostDistort:
-        color = Distort(input.uv);
-        break;
+	case PostDistort:
+		color = Distort(input.uv);
+		break;
 
-    case PostWave:
-        color = Wave(input.uv);
-        break;
+	case PostWave:
+		color = Wave(input.uv);
+		break;
 
-    default:
-        break;
-    }
+	default:
+		break;
+	}
 
-    // Indicate that the Uber shader is running.
-    color *= 0.4f;
+	// Indicate that the Uber shader is running.
+	color *= 0.4f;
 
-    return color;
+	return color;
 }

--- a/Samples/Desktop/D3D12PipelineStateCache/src/WarpPixelShader.hlsl
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/WarpPixelShader.hlsl
@@ -13,14 +13,14 @@
 
 float4 Warp(float2 uv)
 {
-    float2 dir = uv - float2(0.5f, 0.5f);
-    float len = length(dir) * 6.0f;
-    float2 newCoord = uv + dir * sin(pow(2.0f, len));
+	float2 dir = uv - float2(0.5f, 0.5f);
+	float len = length(dir) * 6.0f;
+	float2 newCoord = uv + dir * sin(pow(2.0f, len));
 
-    return g_tex.Sample(g_samp, newCoord);
+	return g_tex.Sample(g_samp, newCoord);
 }
 
 float4 mainWarp(PSInput input) : SV_TARGET
 {
-    return Warp(input.uv);
+	return Warp(input.uv);
 }

--- a/Samples/Desktop/D3D12PipelineStateCache/src/WavePixelShader.hlsl
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/WavePixelShader.hlsl
@@ -13,14 +13,14 @@
 
 float4 Wave(float2 uv)
 {
-    float angle = distance(float2(0.5f, 0.5f), uv) * 50.0f;
-    uv.x = 0.5f + (uv.x - 0.5f) * cos(angle) - (uv.y - 0.5f) * sin(angle);
-    uv.y = 0.5f + (uv.x - 0.5f) * sin(angle) + (uv.y - 0.5f) * cos(angle);
+	float angle = distance(float2(0.5f, 0.5f), uv) * 50.0f;
+	uv.x = 0.5f + (uv.x - 0.5f) * cos(angle) - (uv.y - 0.5f) * sin(angle);
+	uv.y = 0.5f + (uv.x - 0.5f) * sin(angle) + (uv.y - 0.5f) * cos(angle);
 
-    return g_tex.Sample(g_samp, uv);
+	return g_tex.Sample(g_samp, uv);
 }
 
 float4 mainWave(PSInput input) : SV_TARGET
 {
-    return Wave(input.uv);
+	return Wave(input.uv);
 }

--- a/Samples/Desktop/D3D12PipelineStateCache/src/Win32Application.cpp
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/Win32Application.cpp
@@ -16,104 +16,104 @@ HWND Win32Application::m_hwnd = nullptr;
 
 int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
 {
-    // Parse the command line parameters
-    int argc;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    pSample->ParseCommandLineArgs(argv, argc);
-    LocalFree(argv);
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
 
-    // Initialize the window class.
-    WNDCLASSEX windowClass = { 0 };
-    windowClass.cbSize = sizeof(WNDCLASSEX);
-    windowClass.style = CS_HREDRAW | CS_VREDRAW;
-    windowClass.lpfnWndProc = WindowProc;
-    windowClass.hInstance = hInstance;
-    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-    windowClass.lpszClassName = L"DXSampleClass";
-    RegisterClassEx(&windowClass);
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
 
-    RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
-    AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
 
-    // Create the window and store a handle to it.
-    m_hwnd = CreateWindow(
-        windowClass.lpszClassName,
-        pSample->GetTitle(),
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        windowRect.right - windowRect.left,
-        windowRect.bottom - windowRect.top,
-        nullptr,        // We have no parent window.
-        nullptr,        // We aren't using menus.
-        hInstance,
-        pSample);
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
 
-    // Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-    pSample->OnInit();
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
 
-    ShowWindow(m_hwnd, nCmdShow);
+	ShowWindow(m_hwnd, nCmdShow);
 
-    // Main sample loop.
-    MSG msg = {};
-    while (msg.message != WM_QUIT)
-    {
-        // Process any messages in the queue.
-        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
-    }
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
 
-    pSample->OnDestroy();
+	pSample->OnDestroy();
 
-    // Return this part of the WM_QUIT message to Windows.
-    return static_cast<char>(msg.wParam);
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
 }
 
 // Main message handler for the sample.
 LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
-    switch (message)
-    {
-    case WM_CREATE:
-        {
-            // Save the DXSample* passed in to CreateWindow.
-            LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
-            SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
-        }
-        return 0;
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
 
-    case WM_KEYDOWN:
-        if (pSample)
-        {
-            pSample->OnKeyDown(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_KEYUP:
-        if (pSample)
-        {
-            pSample->OnKeyUp(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_PAINT:
-        if (pSample)
-        {
-            pSample->OnUpdate();
-            pSample->OnRender();
-        }
-        return 0;
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
 
-    case WM_DESTROY:
-        PostQuitMessage(0);
-        return 0;
-    }
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
 
-    // Handle any messages the switch statement didn't.
-    return DefWindowProc(hWnd, message, wParam, lParam);
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/Desktop/D3D12PipelineStateCache/src/Win32Application.h
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/Win32Application.h
@@ -18,12 +18,12 @@ class DXSample;
 class Win32Application
 {
 public:
-    static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
-    static HWND GetHwnd() { return m_hwnd; }
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
 
 protected:
-    static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
-    static HWND m_hwnd;
+	static HWND m_hwnd;
 };

--- a/Samples/Desktop/D3D12PipelineStateCache/src/d3dx12.h
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12PipelineStateCache/src/stdafx.h
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>

--- a/Samples/Desktop/D3D12PredicationQueries/src/D3D12PredicationQueries.cpp
+++ b/Samples/Desktop/D3D12PredicationQueries/src/D3D12PredicationQueries.cpp
@@ -13,590 +13,633 @@
 #include "D3D12PredicationQueries.h"
 
 D3D12PredicationQueries::D3D12PredicationQueries(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0),
-    m_cbvSrvDescriptorSize(0),
-    m_constantBufferData{},
-    m_fenceValues{}
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0),
+	m_cbvSrvDescriptorSize(0),
+	m_constantBufferData{},
+	m_fenceValues{}
 {
+#if !defined(_XBOX_ONE)
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
+#endif
 }
 
 void D3D12PredicationQueries::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12PredicationQueries::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter, true);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
-    NAME_D3D12_OBJECT(m_commandQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	NAME_D3D12_OBJECT(m_commandQueue);
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    // This sample does not support fullscreen transitions.
-    ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
+	// This sample does not support fullscreen transitions.
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a depth stencil view (DSV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
-        dsvHeapDesc.NumDescriptors = 1;
-        dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-        dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
+		// Describe and create a depth stencil view (DSV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
+		dsvHeapDesc.NumDescriptors = 1;
+		dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+		dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
 
-        // Describe and create a constant buffer view (CBV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
-        cbvHeapDesc.NumDescriptors = CbvCountPerFrame * FrameCount;
-        cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_cbvHeap)));
-        NAME_D3D12_OBJECT(m_cbvHeap);
+		// Describe and create a constant buffer view (CBV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
+		cbvHeapDesc.NumDescriptors = CbvCountPerFrame * FrameCount;
+		cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_cbvHeap)));
+		NAME_D3D12_OBJECT(m_cbvHeap);
 
-        // Describe and create a heap for occlusion queries.
-        D3D12_QUERY_HEAP_DESC queryHeapDesc = {};
-        queryHeapDesc.Count = 1;
-        queryHeapDesc.Type = D3D12_QUERY_HEAP_TYPE_OCCLUSION;
-        ThrowIfFailed(m_device->CreateQueryHeap(&queryHeapDesc, IID_PPV_ARGS(&m_queryHeap)));
+		// Describe and create a heap for occlusion queries.
+		D3D12_QUERY_HEAP_DESC queryHeapDesc = {};
+		queryHeapDesc.Count = 1;
+		queryHeapDesc.Type = D3D12_QUERY_HEAP_TYPE_OCCLUSION;
+		ThrowIfFailed(m_device->CreateQueryHeap(&queryHeapDesc, IID_PPV_ARGS(&m_queryHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-        m_cbvSrvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_cbvSrvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV and a command allocator for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
+		// Create a RTV and a command allocator for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-            NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
+			NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
 
-            ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
-        }
-    }
+			ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
+		}
+	}
 }
 
 // Load the sample assets.
 void D3D12PredicationQueries::LoadAssets()
 {
-    // Create a root signature consisting of a single CBV parameter.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create a root signature consisting of a single CBV parameter.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
-        CD3DX12_ROOT_PARAMETER1 rootParameters[1];
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
+		CD3DX12_ROOT_PARAMETER1 rootParameters[1];
 
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_VERTEX);
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_VERTEX);
 
-        // Allow input layout and deny uneccessary access to certain pipeline stages.
-        D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
-            D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_PIXEL_SHADER_ROOT_ACCESS;
+		// Allow input layout and deny uneccessary access to certain pipeline stages.
+		D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
+			D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_PIXEL_SHADER_ROOT_ACCESS;
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, rootSignatureFlags);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, rootSignatureFlags);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-        NAME_D3D12_OBJECT(m_rootSignature);
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+		NAME_D3D12_OBJECT(m_rootSignature);
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Enable alpha blending so we can visualize the occlusion query results.
-        CD3DX12_BLEND_DESC blendDesc(D3D12_DEFAULT);
-        blendDesc.RenderTarget[0] =
-        {
-            TRUE, FALSE,
-            D3D12_BLEND_SRC_ALPHA, D3D12_BLEND_INV_SRC_ALPHA, D3D12_BLEND_OP_ADD,
-            D3D12_BLEND_ONE, D3D12_BLEND_ZERO, D3D12_BLEND_OP_ADD,
-            D3D12_LOGIC_OP_NOOP,
-            D3D12_COLOR_WRITE_ENABLE_ALL,
-        };
+		// Enable alpha blending so we can visualize the occlusion query results.
+		CD3DX12_BLEND_DESC blendDesc(D3D12_DEFAULT);
+		blendDesc.RenderTarget[0] =
+		{
+			TRUE, FALSE,
+			D3D12_BLEND_SRC_ALPHA, D3D12_BLEND_INV_SRC_ALPHA, D3D12_BLEND_OP_ADD,
+			D3D12_BLEND_ONE, D3D12_BLEND_ZERO, D3D12_BLEND_OP_ADD,
+			D3D12_LOGIC_OP_NOOP,
+			D3D12_COLOR_WRITE_ENABLE_ALL,
+		};
 
-        // Describe and create the graphics pipeline state objects (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = blendDesc;
-        psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state objects (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = blendDesc;
+		psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-        NAME_D3D12_OBJECT(m_pipelineState);
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+		NAME_D3D12_OBJECT(m_pipelineState);
 
-        // Disable color writes and depth writes for the occlusion query's state.
-        psoDesc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0;
-        psoDesc.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ZERO;
+		// Disable color writes and depth writes for the occlusion query's state.
+		psoDesc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0;
+		psoDesc.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ZERO;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_queryState)));
-        NAME_D3D12_OBJECT(m_queryState);
-    }
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_queryState)));
+		NAME_D3D12_OBJECT(m_queryState);
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
-    NAME_D3D12_OBJECT(m_commandList);
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	NAME_D3D12_OBJECT(m_commandList);
 
-    // Note: ComPtr's are CPU objects but this resource needs to stay in scope until
-    // the command list that references it has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resource is not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> vertexBufferUpload;
+	// Note: ComPtr's are CPU objects but this resource needs to stay in scope until
+	// the command list that references it has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resource is not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> vertexBufferUpload;
 
-    // Create the vertex buffer.
-    {
-        // Create geometry for two quads and a bounding box for the occlusion query.
-        // Geometry will be rendered back-to-front to support transparency in the scene.
-        Vertex quadVertices[] =
-        {
-            // Far quad - in practice this would be a complex geometry.
-            { { -0.25f, -0.25f * m_aspectRatio, 0.5f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
-            { { -0.25f, 0.25f * m_aspectRatio, 0.5f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
-            { { 0.25f, -0.25f * m_aspectRatio, 0.5f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
-            { { 0.25f, 0.25f * m_aspectRatio, 0.5f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
+	// Create the vertex buffer.
+	{
+		// Create geometry for two quads and a bounding box for the occlusion query.
+		// Geometry will be rendered back-to-front to support transparency in the scene.
+		Vertex quadVertices[] =
+		{
+			// Far quad - in practice this would be a complex geometry.
+			{ { -0.25f, -0.25f * m_aspectRatio, 0.5f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
+			{ { -0.25f, 0.25f * m_aspectRatio, 0.5f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
+			{ { 0.25f, -0.25f * m_aspectRatio, 0.5f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
+			{ { 0.25f, 0.25f * m_aspectRatio, 0.5f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
 
-            // Near quad.
-            { { -0.5f, -0.35f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 0.65f } },
-            { { -0.5f, 0.35f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 0.65f } },
-            { { 0.5f, -0.35f * m_aspectRatio, 0.0f }, { 1.0f, 1.0f, 0.0f, 0.65f } },
-            { { 0.5f, 0.35f * m_aspectRatio, 0.0f }, { 1.0f, 1.0f, 0.0f, 0.65f } },
+			// Near quad.
+			{ { -0.5f, -0.35f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 0.65f } },
+			{ { -0.5f, 0.35f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 0.65f } },
+			{ { 0.5f, -0.35f * m_aspectRatio, 0.0f }, { 1.0f, 1.0f, 0.0f, 0.65f } },
+			{ { 0.5f, 0.35f * m_aspectRatio, 0.0f }, { 1.0f, 1.0f, 0.0f, 0.65f } },
 
-            // Far quad bounding box used for occlusion query (offset slightly to avoid z-fighting).
-            { { -0.25f, -0.25f * m_aspectRatio, 0.4999f }, { 0.0f, 0.0f, 0.0f, 1.0f } },
-            { { -0.25f, 0.25f * m_aspectRatio, 0.4999f }, { 0.0f, 0.0f, 0.0f, 1.0f } },
-            { { 0.25f, -0.25f * m_aspectRatio, 0.4999f }, { 0.0f, 0.0f, 0.0f, 1.0f } },
-            { { 0.25f, 0.25f * m_aspectRatio, 0.4999f }, { 0.0f, 0.0f, 0.0f, 1.0f } },
-        };
+			// Far quad bounding box used for occlusion query (offset slightly to avoid z-fighting).
+			{ { -0.25f, -0.25f * m_aspectRatio, 0.4999f }, { 0.0f, 0.0f, 0.0f, 1.0f } },
+			{ { -0.25f, 0.25f * m_aspectRatio, 0.4999f }, { 0.0f, 0.0f, 0.0f, 1.0f } },
+			{ { 0.25f, -0.25f * m_aspectRatio, 0.4999f }, { 0.0f, 0.0f, 0.0f, 1.0f } },
+			{ { 0.25f, 0.25f * m_aspectRatio, 0.4999f }, { 0.0f, 0.0f, 0.0f, 1.0f } },
+		};
 
-        const UINT vertexBufferSize = sizeof(quadVertices);
+		const UINT vertexBufferSize = sizeof(quadVertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&vertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&vertexBufferUpload)));
 
-        NAME_D3D12_OBJECT(m_vertexBuffer);
+		NAME_D3D12_OBJECT(m_vertexBuffer);
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(quadVertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(quadVertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = sizeof(quadVertices);
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = sizeof(quadVertices);
+	}
 
-    // Create the constant buffers.
-    {
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(FrameCount * sizeof(m_constantBufferData)),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_constantBuffer)));
+	// Create the constant buffers.
+	{
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(FrameCount * sizeof(m_constantBufferData)),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_constantBuffer)));
 
-        NAME_D3D12_OBJECT(m_constantBuffer);
+		NAME_D3D12_OBJECT(m_constantBuffer);
 
-        // Map and initialize the constant buffer. We don't unmap this until the
-        // app closes. Keeping things mapped for the lifetime of the resource is okay.
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbvDataBegin)));
-        ZeroMemory(m_pCbvDataBegin, FrameCount * sizeof(m_constantBufferData));
+		// Map and initialize the constant buffer. We don't unmap this until the
+		// app closes. Keeping things mapped for the lifetime of the resource is okay.
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbvDataBegin)));
+		ZeroMemory(m_pCbvDataBegin, FrameCount * sizeof(m_constantBufferData));
 
-        // Create constant buffer views to access the upload buffer.
-        CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_cbvHeap->GetCPUDescriptorHandleForHeapStart());
-        D3D12_GPU_VIRTUAL_ADDRESS gpuAddress = m_constantBuffer->GetGPUVirtualAddress();
+		// Create constant buffer views to access the upload buffer.
+		CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_cbvHeap->GetCPUDescriptorHandleForHeapStart());
+		D3D12_GPU_VIRTUAL_ADDRESS gpuAddress = m_constantBuffer->GetGPUVirtualAddress();
 
-        D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
-        cbvDesc.SizeInBytes = sizeof(SceneConstantBuffer);
+		D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
+		cbvDesc.SizeInBytes = sizeof(SceneConstantBuffer);
 
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            cbvDesc.BufferLocation = gpuAddress;
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			cbvDesc.BufferLocation = gpuAddress;
 
-            m_device->CreateConstantBufferView(&cbvDesc, cpuHandle);
+			m_device->CreateConstantBufferView(&cbvDesc, cpuHandle);
 
-            cpuHandle.Offset(m_cbvSrvDescriptorSize);
-            gpuAddress += cbvDesc.SizeInBytes;
-            cbvDesc.BufferLocation = gpuAddress;
+			cpuHandle.Offset(m_cbvSrvDescriptorSize);
+			gpuAddress += cbvDesc.SizeInBytes;
+			cbvDesc.BufferLocation = gpuAddress;
 
-            m_device->CreateConstantBufferView(&cbvDesc, cpuHandle);
+			m_device->CreateConstantBufferView(&cbvDesc, cpuHandle);
 
-            cpuHandle.Offset(m_cbvSrvDescriptorSize);
-            gpuAddress += cbvDesc.SizeInBytes;
-        }
-    }
+			cpuHandle.Offset(m_cbvSrvDescriptorSize);
+			gpuAddress += cbvDesc.SizeInBytes;
+		}
+	}
 
-    // Create the depth stencil view.
-    {
-        D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
-        depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
-        depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
-        depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
+	// Create the depth stencil view.
+	{
+		D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
+		depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
+		depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+		depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
 
-        D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
-        depthOptimizedClearValue.Format = DXGI_FORMAT_D32_FLOAT;
-        depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
-        depthOptimizedClearValue.DepthStencil.Stencil = 0;
+		D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
+		depthOptimizedClearValue.Format = DXGI_FORMAT_D32_FLOAT;
+		depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
+		depthOptimizedClearValue.DepthStencil.Stencil = 0;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
-            D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            &depthOptimizedClearValue,
-            IID_PPV_ARGS(&m_depthStencil)
-            ));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
+			D3D12_RESOURCE_STATE_DEPTH_WRITE,
+			&depthOptimizedClearValue,
+			IID_PPV_ARGS(&m_depthStencil)
+			));
 
-        NAME_D3D12_OBJECT(m_depthStencil);
+		NAME_D3D12_OBJECT(m_depthStencil);
 
-        m_device->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		m_device->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    // Create the query result buffer.
-    {
-        D3D12_RESOURCE_DESC queryResultDesc = CD3DX12_RESOURCE_DESC::Buffer(8);
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &queryResultDesc,
-            D3D12_RESOURCE_STATE_PREDICATION,
-            nullptr,
-            IID_PPV_ARGS(&m_queryResult)
-            ));
+	// Create the query result buffer.
+	{
+		D3D12_RESOURCE_DESC queryResultDesc = CD3DX12_RESOURCE_DESC::Buffer(8);
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&queryResultDesc,
+			D3D12_RESOURCE_STATE_PREDICATION,
+			nullptr,
+			IID_PPV_ARGS(&m_queryResult)
+			));
 
-        NAME_D3D12_OBJECT(m_queryResult);
-    }
+		NAME_D3D12_OBJECT(m_queryResult);
+	}
 
-    // Close the command list and execute it to begin the vertex buffer copy into
-    // the default heap.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the vertex buffer copy into
+	// the default heap.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValues[m_frameIndex]++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValues[m_frameIndex]++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForGpu();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForGpu();
+	}
 }
 
 // Update frame-based values.
 void D3D12PredicationQueries::OnUpdate()
 {
-    const float translationSpeed = 0.01f;
-    const float offsetBounds = 1.5f;
+	const float translationSpeed = 0.01f;
+	const float offsetBounds = 1.5f;
 
-    // Animate the near quad.
-    m_constantBufferData[1].offset.x += translationSpeed;
-    if (m_constantBufferData[1].offset.x > offsetBounds)
-    {
-        m_constantBufferData[1].offset.x = -offsetBounds;
-    }
+	// Animate the near quad.
+	m_constantBufferData[1].offset.x += translationSpeed;
+	if (m_constantBufferData[1].offset.x > offsetBounds)
+	{
+		m_constantBufferData[1].offset.x = -offsetBounds;
+	}
 
-    UINT cbvIndex = m_frameIndex * CbvCountPerFrame + 1;
-    UINT8* destination = m_pCbvDataBegin + (cbvIndex * sizeof(SceneConstantBuffer));
-    memcpy(destination, &m_constantBufferData[1], sizeof(SceneConstantBuffer));
+	UINT cbvIndex = m_frameIndex * CbvCountPerFrame + 1;
+	UINT8* destination = m_pCbvDataBegin + (cbvIndex * sizeof(SceneConstantBuffer));
+	memcpy(destination, &m_constantBufferData[1], sizeof(SceneConstantBuffer));
 }
 
 // Render the scene.
 void D3D12PredicationQueries::OnRender()
 {
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+    try
+    {
+        PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
 
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+        // Record all the commands we need to render the scene into the command list.
+        PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+        // Execute the command list.
+        ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+        m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    PIXEndEvent(m_commandQueue.Get());
+        PIXEndEvent(m_commandQueue.Get());
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+        // Present the frame.
+        ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    MoveToNextFrame();
+        MoveToNextFrame();
+    }
+    catch (HrException& e)
+    {
+        if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
+        {
+            RestoreD3DResources();
+        }
+        else
+        {
+            throw;
+        }
+    }
+}
+
+// Release sample's D3D objects.
+void D3D12PredicationQueries::ReleaseD3DResources()
+{
+    m_fence.Reset();
+    ResetComPtrArray(&m_renderTargets);
+    m_commandQueue.Reset();
+    m_swapChain.Reset();
+    m_device.Reset();
+}
+
+// Tears down D3D resources and reinitializes them.
+void D3D12PredicationQueries::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
+    {
+        WaitForGpu();
+    }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
 }
 
 void D3D12PredicationQueries::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForGpu();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForGpu();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12PredicationQueries::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_cbvHeap.Get() };
-    m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_cbvHeap.Get() };
+	m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    m_commandList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	m_commandList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
 
-    // Draw the quads and perform the occlusion query.
-    {
-        CD3DX12_GPU_DESCRIPTOR_HANDLE cbvFarQuad(m_cbvHeap->GetGPUDescriptorHandleForHeapStart(), m_frameIndex * CbvCountPerFrame, m_cbvSrvDescriptorSize);
-        CD3DX12_GPU_DESCRIPTOR_HANDLE cbvNearQuad(cbvFarQuad, m_cbvSrvDescriptorSize);
+	// Draw the quads and perform the occlusion query.
+	{
+		CD3DX12_GPU_DESCRIPTOR_HANDLE cbvFarQuad(m_cbvHeap->GetGPUDescriptorHandleForHeapStart(), m_frameIndex * CbvCountPerFrame, m_cbvSrvDescriptorSize);
+		CD3DX12_GPU_DESCRIPTOR_HANDLE cbvNearQuad(cbvFarQuad, m_cbvSrvDescriptorSize);
 
-        m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-        m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+		m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+		m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
 
-        // Draw the far quad conditionally based on the result of the occlusion query
-        // from the previous frame.
-        PIXBeginEvent(m_commandList.Get(), 0, L"Draw potentially occluded geometry");
-        m_commandList->SetGraphicsRootDescriptorTable(0, cbvFarQuad);
-        m_commandList->SetPredication(m_queryResult.Get(), 0, D3D12_PREDICATION_OP_EQUAL_ZERO);
-        m_commandList->DrawInstanced(4, 1, 0, 0);
-        PIXEndEvent(m_commandList.Get());
+		// Draw the far quad conditionally based on the result of the occlusion query
+		// from the previous frame.
+		PIXBeginEvent(m_commandList.Get(), 0, L"Draw potentially occluded geometry");
+		m_commandList->SetGraphicsRootDescriptorTable(0, cbvFarQuad);
+		m_commandList->SetPredication(m_queryResult.Get(), 0, D3D12_PREDICATION_OP_EQUAL_ZERO);
+		m_commandList->DrawInstanced(4, 1, 0, 0);
+		PIXEndEvent(m_commandList.Get());
 
-        // Disable predication and always draw the near quad.
-        PIXBeginEvent(m_commandList.Get(), 0, L"Draw animating geometry");
-        m_commandList->SetPredication(nullptr, 0, D3D12_PREDICATION_OP_EQUAL_ZERO);
-        m_commandList->SetGraphicsRootDescriptorTable(0, cbvNearQuad);
-        m_commandList->DrawInstanced(4, 1, 4, 0);
-        PIXEndEvent(m_commandList.Get());
+		// Disable predication and always draw the near quad.
+		PIXBeginEvent(m_commandList.Get(), 0, L"Draw animating geometry");
+		m_commandList->SetPredication(nullptr, 0, D3D12_PREDICATION_OP_EQUAL_ZERO);
+		m_commandList->SetGraphicsRootDescriptorTable(0, cbvNearQuad);
+		m_commandList->DrawInstanced(4, 1, 4, 0);
+		PIXEndEvent(m_commandList.Get());
 
-        // Run the occlusion query with the bounding box quad.
-        PIXBeginEvent(m_commandList.Get(), 0, L"Execute occlusion query");
-        m_commandList->SetGraphicsRootDescriptorTable(0, cbvFarQuad);
-        m_commandList->SetPipelineState(m_queryState.Get());
-        m_commandList->BeginQuery(m_queryHeap.Get(), D3D12_QUERY_TYPE_BINARY_OCCLUSION, 0);
-        m_commandList->DrawInstanced(4, 1, 8, 0);
-        m_commandList->EndQuery(m_queryHeap.Get(), D3D12_QUERY_TYPE_BINARY_OCCLUSION, 0);
-        PIXEndEvent(m_commandList.Get());
+		// Run the occlusion query with the bounding box quad.
+		PIXBeginEvent(m_commandList.Get(), 0, L"Execute occlusion query");
+		m_commandList->SetGraphicsRootDescriptorTable(0, cbvFarQuad);
+		m_commandList->SetPipelineState(m_queryState.Get());
+		m_commandList->BeginQuery(m_queryHeap.Get(), D3D12_QUERY_TYPE_BINARY_OCCLUSION, 0);
+		m_commandList->DrawInstanced(4, 1, 8, 0);
+		m_commandList->EndQuery(m_queryHeap.Get(), D3D12_QUERY_TYPE_BINARY_OCCLUSION, 0);
+		PIXEndEvent(m_commandList.Get());
 
-        // Resolve the occlusion query and store the results in the query result buffer
-        // to be used on the subsequent frame.
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_queryResult.Get(), D3D12_RESOURCE_STATE_PREDICATION, D3D12_RESOURCE_STATE_COPY_DEST));
-        m_commandList->ResolveQueryData(m_queryHeap.Get(), D3D12_QUERY_TYPE_BINARY_OCCLUSION, 0, 1, m_queryResult.Get(), 0);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_queryResult.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PREDICATION));
-    }
+		// Resolve the occlusion query and store the results in the query result buffer
+		// to be used on the subsequent frame.
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_queryResult.Get(), D3D12_RESOURCE_STATE_PREDICATION, D3D12_RESOURCE_STATE_COPY_DEST));
+		m_commandList->ResolveQueryData(m_queryHeap.Get(), D3D12_QUERY_TYPE_BINARY_OCCLUSION, 0, 1, m_queryResult.Get(), 0);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_queryResult.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PREDICATION));
+	}
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 // Wait for pending GPU work to complete.
 void D3D12PredicationQueries::WaitForGpu()
 {
-    // Schedule a Signal command in the queue.
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
+	// Schedule a Signal command in the queue.
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
 
-    // Wait until the fence has been processed.
-    ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-    WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	// Wait until the fence has been processed.
+	ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+	WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
 
-    // Increment the fence value for the current frame.
-    m_fenceValues[m_frameIndex]++;
+	// Increment the fence value for the current frame.
+	m_fenceValues[m_frameIndex]++;
 }
 
 // Prepare to render the next frame.
 void D3D12PredicationQueries::MoveToNextFrame()
 {
-    // Schedule a Signal command in the queue.
-    const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
+	// Schedule a Signal command in the queue.
+	const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
 
-    // Update the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Update the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-        WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+		WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	}
 
-    // Set the fence value for the next frame.
-    m_fenceValues[m_frameIndex] = currentFenceValue + 1;
+	// Set the fence value for the next frame.
+	m_fenceValues[m_frameIndex] = currentFenceValue + 1;
 }

--- a/Samples/Desktop/D3D12PredicationQueries/src/D3D12PredicationQueries.h
+++ b/Samples/Desktop/D3D12PredicationQueries/src/D3D12PredicationQueries.h
@@ -26,73 +26,75 @@ using Microsoft::WRL::ComPtr;
 class D3D12PredicationQueries : public DXSample
 {
 public:
-    D3D12PredicationQueries(UINT width, UINT height, std::wstring name);
+	D3D12PredicationQueries(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    static const UINT FrameCount = 2;
-    static const UINT CbvCountPerFrame = 2;
+	static const UINT FrameCount = 2;
+	static const UINT CbvCountPerFrame = 2;
 
-    // Vertex definition.
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT4 color;
-    };
+	// Vertex definition.
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT4 color;
+	};
 
-    // Constant buffer definition.
-    struct SceneConstantBuffer
-    {
-        XMFLOAT4 offset;
+	// Constant buffer definition.
+	struct SceneConstantBuffer
+	{
+		XMFLOAT4 offset;
 
-        // Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
-        // to be array-indexed.
-        FLOAT padding[60];
-    };
+		// Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
+		// to be array-indexed.
+		FLOAT padding[60];
+	};
 
-    // Each geometry gets its own constant buffer.
-    SceneConstantBuffer m_constantBufferData[CbvCountPerFrame];
-    UINT8* m_pCbvDataBegin;
+	// Each geometry gets its own constant buffer.
+	SceneConstantBuffer m_constantBufferData[CbvCountPerFrame];
+	UINT8* m_pCbvDataBegin;
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_cbvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
-    ComPtr<ID3D12QueryHeap> m_queryHeap;
-    UINT m_rtvDescriptorSize;
-    UINT m_cbvSrvDescriptorSize;
-    UINT m_frameIndex;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_cbvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
+	ComPtr<ID3D12QueryHeap> m_queryHeap;
+	UINT m_rtvDescriptorSize;
+	UINT m_cbvSrvDescriptorSize;
+	UINT m_frameIndex;
 
-    // Synchronization objects.
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValues[FrameCount];
-    HANDLE m_fenceEvent;
+	// Synchronization objects.
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValues[FrameCount];
+	HANDLE m_fenceEvent;
 
-    // Asset objects.
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12PipelineState> m_queryState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    ComPtr<ID3D12Resource> m_constantBuffer;
-    ComPtr<ID3D12Resource> m_depthStencil;
-    ComPtr<ID3D12Resource> m_queryResult;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	// Asset objects.
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12PipelineState> m_queryState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	ComPtr<ID3D12Resource> m_constantBuffer;
+	ComPtr<ID3D12Resource> m_depthStencil;
+	ComPtr<ID3D12Resource> m_queryResult;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void PopulateCommandList();
-    void WaitForGpu();
-    void MoveToNextFrame();
+	void LoadPipeline();
+	void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
+	void PopulateCommandList();
+	void WaitForGpu();
+	void MoveToNextFrame();
 };

--- a/Samples/Desktop/D3D12PredicationQueries/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12PredicationQueries/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,58 +34,103 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title + L": " + text;
-    SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
+	std::wstring windowText = m_title + L": " + text;
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/Desktop/D3D12PredicationQueries/src/DXSample.h
+++ b/Samples/Desktop/D3D12PredicationQueries/src/DXSample.h
@@ -17,42 +17,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/Desktop/D3D12PredicationQueries/src/Main.cpp
+++ b/Samples/Desktop/D3D12PredicationQueries/src/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12PredicationQueries sample(1280, 720, L"D3D12 Predication and Queries sample");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12PredicationQueries sample(1280, 720, L"D3D12 Predication and Queries sample");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12PredicationQueries/src/Win32Application.cpp
+++ b/Samples/Desktop/D3D12PredicationQueries/src/Win32Application.cpp
@@ -16,104 +16,104 @@ HWND Win32Application::m_hwnd = nullptr;
 
 int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
 {
-    // Parse the command line parameters
-    int argc;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    pSample->ParseCommandLineArgs(argv, argc);
-    LocalFree(argv);
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
 
-    // Initialize the window class.
-    WNDCLASSEX windowClass = { 0 };
-    windowClass.cbSize = sizeof(WNDCLASSEX);
-    windowClass.style = CS_HREDRAW | CS_VREDRAW;
-    windowClass.lpfnWndProc = WindowProc;
-    windowClass.hInstance = hInstance;
-    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-    windowClass.lpszClassName = L"DXSampleClass";
-    RegisterClassEx(&windowClass);
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
 
-    RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
-    AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
 
-    // Create the window and store a handle to it.
-    m_hwnd = CreateWindow(
-        windowClass.lpszClassName,
-        pSample->GetTitle(),
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        windowRect.right - windowRect.left,
-        windowRect.bottom - windowRect.top,
-        nullptr,        // We have no parent window.
-        nullptr,        // We aren't using menus.
-        hInstance,
-        pSample);
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
 
-    // Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-    pSample->OnInit();
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
 
-    ShowWindow(m_hwnd, nCmdShow);
+	ShowWindow(m_hwnd, nCmdShow);
 
-    // Main sample loop.
-    MSG msg = {};
-    while (msg.message != WM_QUIT)
-    {
-        // Process any messages in the queue.
-        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
-    }
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
 
-    pSample->OnDestroy();
+	pSample->OnDestroy();
 
-    // Return this part of the WM_QUIT message to Windows.
-    return static_cast<char>(msg.wParam);
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
 }
 
 // Main message handler for the sample.
 LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
-    switch (message)
-    {
-    case WM_CREATE:
-        {
-            // Save the DXSample* passed in to CreateWindow.
-            LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
-            SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
-        }
-        return 0;
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
 
-    case WM_KEYDOWN:
-        if (pSample)
-        {
-            pSample->OnKeyDown(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_KEYUP:
-        if (pSample)
-        {
-            pSample->OnKeyUp(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_PAINT:
-        if (pSample)
-        {
-            pSample->OnUpdate();
-            pSample->OnRender();
-        }
-        return 0;
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
 
-    case WM_DESTROY:
-        PostQuitMessage(0);
-        return 0;
-    }
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
 
-    // Handle any messages the switch statement didn't.
-    return DefWindowProc(hWnd, message, wParam, lParam);
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/Desktop/D3D12PredicationQueries/src/Win32Application.h
+++ b/Samples/Desktop/D3D12PredicationQueries/src/Win32Application.h
@@ -18,12 +18,12 @@ class DXSample;
 class Win32Application
 {
 public:
-    static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
-    static HWND GetHwnd() { return m_hwnd; }
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
 
 protected:
-    static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
-    static HWND m_hwnd;
+	static HWND m_hwnd;
 };

--- a/Samples/Desktop/D3D12PredicationQueries/src/d3dx12.h
+++ b/Samples/Desktop/D3D12PredicationQueries/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12PredicationQueries/src/shaders.hlsl
+++ b/Samples/Desktop/D3D12PredicationQueries/src/shaders.hlsl
@@ -11,26 +11,26 @@
 
 cbuffer SceneConstantBuffer : register(b0)
 {
-    float4 offset;
+	float4 offset;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VSMain(float4 position : POSITION, float4 color : COLOR)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position + offset;
-    result.color = color;
+	result.position = position + offset;
+	result.color = color;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/Desktop/D3D12PredicationQueries/src/stdafx.h
+++ b/Samples/Desktop/D3D12PredicationQueries/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>

--- a/Samples/Desktop/D3D12ReservedResources/src/D3D12ReservedResources.cpp
+++ b/Samples/Desktop/D3D12ReservedResources/src/D3D12ReservedResources.cpp
@@ -13,583 +13,583 @@
 #include "D3D12ReservedResources.h"
 
 D3D12ReservedResources::D3D12ReservedResources(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0),
-    m_tilingSupport(false),
-    m_packedMipInfo(),
-    m_activeMip(0),
-    m_activeMipChanged(true),
-    m_fenceValues{}
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0),
+	m_tilingSupport(false),
+	m_packedMipInfo(),
+	m_activeMip(0),
+	m_activeMipChanged(true),
+	m_fenceValues{}
 {
-    UINT mipLevels = 0;
-    for (UINT w = TextureWidth, h = TextureHeight; w > 0 && h > 0; w >>= 1, h >>= 1)
-    {
-        mipLevels++;
-    }
-    m_activeMip = mipLevels - 1;    // Show the least detailed mip first.
-    m_mips.resize(mipLevels);
+	UINT mipLevels = 0;
+	for (UINT w = TextureWidth, h = TextureHeight; w > 0 && h > 0; w >>= 1, h >>= 1)
+	{
+		mipLevels++;
+	}
+	m_activeMip = mipLevels - 1;	// Show the least detailed mip first.
+	m_mips.resize(mipLevels);
 }
 
 void D3D12ReservedResources::OnInit()
 {
-    LoadPipeline();
-    if (m_tilingSupport)
-    {
-        LoadAssets();
-    }
+	LoadPipeline();
+	if (m_tilingSupport)
+	{
+		LoadAssets();
+	}
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12ReservedResources::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Check to see which support tier the GPU has for tiled resources.
-    D3D12_FEATURE_DATA_D3D12_OPTIONS options = {};
-    m_device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options));
-    m_tilingSupport = options.TiledResourcesTier != D3D12_TILED_RESOURCES_TIER_NOT_SUPPORTED;
-    if (!m_tilingSupport)
-    {
-        MessageBox(
-            Win32Application::GetHwnd(),
-            L"Reserved resources are not supported by your GPU.\n"
-                L"Add '/warp' to the command line to run the sample with WARP.\n"
-                L"The sample will now exit.",
-            L"Feature unavailable",
-            MB_OK);
-        PostQuitMessage(0);
-        return;
-    }
+	// Check to see which support tier the GPU has for tiled resources.
+	D3D12_FEATURE_DATA_D3D12_OPTIONS options = {};
+	m_device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options));
+	m_tilingSupport = options.TiledResourcesTier != D3D12_TILED_RESOURCES_TIER_NOT_SUPPORTED;
+	if (!m_tilingSupport)
+	{
+		MessageBox(
+			Win32Application::GetHwnd(),
+			L"Reserved resources are not supported by your GPU.\n"
+				L"Add '/warp' to the command line to run the sample with WARP.\n"
+				L"The sample will now exit.",
+			L"Feature unavailable",
+			MB_OK);
+		PostQuitMessage(0);
+		return;
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    // This sample does not support fullscreen transitions.
-    ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
+	// This sample does not support fullscreen transitions.
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a shader resource view (SRV) heap for the reserved resource.
-        D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
-        srvHeapDesc.NumDescriptors = 1;
-        srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
+		// Describe and create a shader resource view (SRV) heap for the reserved resource.
+		D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
+		srvHeapDesc.NumDescriptors = 1;
+		srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV and a command allocator for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
+		// Create a RTV and a command allocator for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-            ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
-        }
-    }
+			ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
+		}
+	}
 }
 
 // Load the sample assets.
 void D3D12ReservedResources::LoadAssets()
 {
-    // Create the root signature.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signature.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        // We don't modify the SRV in the command list after SetGraphicsRootDescriptorTable
-        // is executed on the GPU so we can use the default range behavior:
-        // D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
+		// We don't modify the SRV in the command list after SetGraphicsRootDescriptorTable
+		// is executed on the GPU so we can use the default range behavior:
+		// D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
 
-        CD3DX12_ROOT_PARAMETER1 rootParameters[2];
-        rootParameters[0].InitAsConstants(1, 0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
-        rootParameters[1].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
+		CD3DX12_ROOT_PARAMETER1 rootParameters[2];
+		rootParameters[0].InitAsConstants(1, 0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
+		rootParameters[1].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
 
-        D3D12_STATIC_SAMPLER_DESC sampler = {};
-        sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-        sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.MipLODBias = 0;
-        sampler.MaxAnisotropy = 0;
-        sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
-        sampler.BorderColor = D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
-        sampler.MinLOD = 0.0f;
-        sampler.MaxLOD = D3D12_FLOAT32_MAX;
-        sampler.ShaderRegister = 0;
-        sampler.RegisterSpace = 0;
-        sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+		D3D12_STATIC_SAMPLER_DESC sampler = {};
+		sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.MipLODBias = 0;
+		sampler.MaxAnisotropy = 0;
+		sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
+		sampler.BorderColor = D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
+		sampler.MinLOD = 0.0f;
+		sampler.MaxLOD = D3D12_FLOAT32_MAX;
+		sampler.ShaderRegister = 0;
+		sampler.RegisterSpace = 0;
+		sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &sampler, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &sampler, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
-        ComPtr<ID3DBlob> error;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
+		ComPtr<ID3DBlob> error;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, &error));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, &error));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Describe and create the graphics pipeline state objects (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state objects (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-    }
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
 
-    // Note: ComPtr's are CPU objects but this resource needs to stay in scope until
-    // the command list that references it has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resource is not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> vertexBufferUpload;
+	// Note: ComPtr's are CPU objects but this resource needs to stay in scope until
+	// the command list that references it has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resource is not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> vertexBufferUpload;
 
-    // Create the vertex buffer.
-    {
-        // Create geometry for a quad.
-        Vertex quadVertices[] =
-        {
-            { { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f } },    // Bottom left.
-            { { -0.25f, 0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f } },    // Top left.
-            { { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 1.0f, 1.0f } },    // Bottom right.
-            { { 0.25f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f } },        // Top right.
-        };
+	// Create the vertex buffer.
+	{
+		// Create geometry for a quad.
+		Vertex quadVertices[] =
+		{
+			{ { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f } },	// Bottom left.
+			{ { -0.25f, 0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f } },	// Top left.
+			{ { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 1.0f, 1.0f } },	// Bottom right.
+			{ { 0.25f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f } },		// Top right.
+		};
 
-        const UINT vertexBufferSize = sizeof(quadVertices);
+		const UINT vertexBufferSize = sizeof(quadVertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&vertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&vertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(quadVertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(quadVertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = sizeof(quadVertices);
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = sizeof(quadVertices);
+	}
 
-    // Create the reserved texture and map the low-resolution mips into it.
-    {
-        // Describe and create a reserved Texture2D. This resource has no backing texture
-        // when it is created. It will be mapped to a physical resource dynamically.
-        D3D12_RESOURCE_DESC reservedTextureDesc = {};
-        reservedTextureDesc.MipLevels = static_cast<UINT16>(m_mips.size());
-        reservedTextureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        reservedTextureDesc.Width = TextureWidth;
-        reservedTextureDesc.Height = TextureHeight;
-        reservedTextureDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
-        reservedTextureDesc.DepthOrArraySize = 1;
-        reservedTextureDesc.SampleDesc.Count = 1;
-        reservedTextureDesc.SampleDesc.Quality = 0;
-        reservedTextureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
-        reservedTextureDesc.Layout = D3D12_TEXTURE_LAYOUT_64KB_UNDEFINED_SWIZZLE;
+	// Create the reserved texture and map the low-resolution mips into it.
+	{
+		// Describe and create a reserved Texture2D. This resource has no backing texture
+		// when it is created. It will be mapped to a physical resource dynamically.
+		D3D12_RESOURCE_DESC reservedTextureDesc = {};
+		reservedTextureDesc.MipLevels = static_cast<UINT16>(m_mips.size());
+		reservedTextureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+		reservedTextureDesc.Width = TextureWidth;
+		reservedTextureDesc.Height = TextureHeight;
+		reservedTextureDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
+		reservedTextureDesc.DepthOrArraySize = 1;
+		reservedTextureDesc.SampleDesc.Count = 1;
+		reservedTextureDesc.SampleDesc.Quality = 0;
+		reservedTextureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+		reservedTextureDesc.Layout = D3D12_TEXTURE_LAYOUT_64KB_UNDEFINED_SWIZZLE;
 
-        ThrowIfFailed(m_device->CreateReservedResource(
-            &reservedTextureDesc,
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_reservedResource)));
+		ThrowIfFailed(m_device->CreateReservedResource(
+			&reservedTextureDesc,
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_reservedResource)));
 
-        // Describe and create a SRV for the resource.
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Format = reservedTextureDesc.Format;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = reservedTextureDesc.MipLevels;
-        m_device->CreateShaderResourceView(m_reservedResource.Get(), &srvDesc, m_srvHeap->GetCPUDescriptorHandleForHeapStart());
+		// Describe and create a SRV for the resource.
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Format = reservedTextureDesc.Format;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = reservedTextureDesc.MipLevels;
+		m_device->CreateShaderResourceView(m_reservedResource.Get(), &srvDesc, m_srvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create an upload heap big enough to fit the largest mip.
-        const UINT64 resourceSize = GetRequiredIntermediateSize(m_reservedResource.Get(), 0, 1);
+		// Create an upload heap big enough to fit the largest mip.
+		const UINT64 resourceSize = GetRequiredIntermediateSize(m_reservedResource.Get(), 0, 1);
 
-        // Create the GPU upload buffer.
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(resourceSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_uploadHeap)));
+		// Create the GPU upload buffer.
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(resourceSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_uploadHeap)));
 
-        // Get information about the tile layout for the resource.
-        //
-        // The GetResourceTiling method should always be used rather than manually
-        // calculating it since the tile information is dependent on the driver
-        // implementation.
+		// Get information about the tile layout for the resource.
+		//
+		// The GetResourceTiling method should always be used rather than manually
+		// calculating it since the tile information is dependent on the driver
+		// implementation.
 
-        UINT numTiles = 0;
-        D3D12_TILE_SHAPE tileShape = {};
-        UINT subresourceCount = reservedTextureDesc.MipLevels;
-        std::vector<D3D12_SUBRESOURCE_TILING> tilings(subresourceCount);
-        m_device->GetResourceTiling(m_reservedResource.Get(), &numTiles, &m_packedMipInfo, &tileShape, &subresourceCount, 0, &tilings[0]);
+		UINT numTiles = 0;
+		D3D12_TILE_SHAPE tileShape = {};
+		UINT subresourceCount = reservedTextureDesc.MipLevels;
+		std::vector<D3D12_SUBRESOURCE_TILING> tilings(subresourceCount);
+		m_device->GetResourceTiling(m_reservedResource.Get(), &numTiles, &m_packedMipInfo, &tileShape, &subresourceCount, 0, &tilings[0]);
 
-        UINT heapCount = m_packedMipInfo.NumStandardMips + (m_packedMipInfo.NumPackedMips > 0 ? 1 : 0);
-        for (UINT n = 0; n < m_mips.size(); n++)
-        {
-            if (n < m_packedMipInfo.NumStandardMips)
-            {
-                m_mips[n].heapIndex = n;
-                m_mips[n].packedMip = false;
-                m_mips[n].mapped = false;
-                m_mips[n].startCoordinate = CD3DX12_TILED_RESOURCE_COORDINATE(0, 0, 0, n);
-                m_mips[n].regionSize.Width = tilings[n].WidthInTiles;
-                m_mips[n].regionSize.Height = tilings[n].HeightInTiles;
-                m_mips[n].regionSize.Depth = tilings[n].DepthInTiles;
-                m_mips[n].regionSize.NumTiles = tilings[n].WidthInTiles * tilings[n].HeightInTiles * tilings[n].DepthInTiles;
-                m_mips[n].regionSize.UseBox = TRUE;
-            }
-            else
-            {
-                // All of the packed mips will go into the last heap.
-                m_mips[n].heapIndex = heapCount - 1;
-                m_mips[n].packedMip = true;
-                m_mips[n].mapped = false;
+		UINT heapCount = m_packedMipInfo.NumStandardMips + (m_packedMipInfo.NumPackedMips > 0 ? 1 : 0);
+		for (UINT n = 0; n < m_mips.size(); n++)
+		{
+			if (n < m_packedMipInfo.NumStandardMips)
+			{
+				m_mips[n].heapIndex = n;
+				m_mips[n].packedMip = false;
+				m_mips[n].mapped = false;
+				m_mips[n].startCoordinate = CD3DX12_TILED_RESOURCE_COORDINATE(0, 0, 0, n);
+				m_mips[n].regionSize.Width = tilings[n].WidthInTiles;
+				m_mips[n].regionSize.Height = tilings[n].HeightInTiles;
+				m_mips[n].regionSize.Depth = tilings[n].DepthInTiles;
+				m_mips[n].regionSize.NumTiles = tilings[n].WidthInTiles * tilings[n].HeightInTiles * tilings[n].DepthInTiles;
+				m_mips[n].regionSize.UseBox = TRUE;
+			}
+			else
+			{
+				// All of the packed mips will go into the last heap.
+				m_mips[n].heapIndex = heapCount - 1;
+				m_mips[n].packedMip = true;
+				m_mips[n].mapped = false;
 
-                // Mark all of the packed mips as having the same start coordinate and size.
-                m_mips[n].startCoordinate = CD3DX12_TILED_RESOURCE_COORDINATE(0, 0, 0, heapCount - 1);
-                m_mips[n].regionSize.NumTiles = m_packedMipInfo.NumTilesForPackedMips;
-                m_mips[n].regionSize.UseBox = FALSE;    // regionSize.Width/Height/Depth will be ignored.
-            }
-        }
+				// Mark all of the packed mips as having the same start coordinate and size.
+				m_mips[n].startCoordinate = CD3DX12_TILED_RESOURCE_COORDINATE(0, 0, 0, heapCount - 1);
+				m_mips[n].regionSize.NumTiles = m_packedMipInfo.NumTilesForPackedMips;
+				m_mips[n].regionSize.UseBox = FALSE;	// regionSize.Width/Height/Depth will be ignored.
+			}
+		}
 
-        // Describe and create heaps for the mips in the mip chain to be used by the
-        // reserved resource. The packed mips will all be stored in the same heap.
-        // 
-        // You could also put all of the mips in the same heap, but we do it this way
-        // in the sample to illustrate the ability to map tiles from multiple heaps
-        // into the same reserved resource.
+		// Describe and create heaps for the mips in the mip chain to be used by the
+		// reserved resource. The packed mips will all be stored in the same heap.
+		// 
+		// You could also put all of the mips in the same heap, but we do it this way
+		// in the sample to illustrate the ability to map tiles from multiple heaps
+		// into the same reserved resource.
 
-        m_heaps.resize(heapCount);
-        for (UINT n = 0; n < heapCount; n++)
-        {
-            const UINT heapSize = m_mips[n].regionSize.NumTiles * D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
+		m_heaps.resize(heapCount);
+		for (UINT n = 0; n < heapCount; n++)
+		{
+			const UINT heapSize = m_mips[n].regionSize.NumTiles * D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
 
-            CD3DX12_HEAP_DESC heapDesc(heapSize, D3D12_HEAP_TYPE_DEFAULT, 0, D3D12_HEAP_FLAG_DENY_BUFFERS | D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES);
-            ThrowIfFailed(m_device->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_heaps[n])));
-        }
+			CD3DX12_HEAP_DESC heapDesc(heapSize, D3D12_HEAP_TYPE_DEFAULT, 0, D3D12_HEAP_FLAG_DENY_BUFFERS | D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES);
+			ThrowIfFailed(m_device->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_heaps[n])));
+		}
 
-        UpdateTileMapping();
+		UpdateTileMapping();
 
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_reservedResource.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
-    }
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_reservedResource.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
+	}
 
-    // Close the command list and execute it to begin the vertex buffer copy into
-    // the default heap.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the vertex buffer copy into
+	// the default heap.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValues[m_frameIndex]++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValues[m_frameIndex]++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForGpu();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForGpu();
+	}
 }
 
 // Generate and upload the texture corresponding to the active mip level then
 // map it to the reserved resource.
 void D3D12ReservedResources::UpdateTileMapping()
 {
-    UINT firstSubresource = m_mips[m_activeMip].heapIndex;
-    UINT subresourceCount = m_mips[m_activeMip].packedMip ? m_packedMipInfo.NumPackedMips : 1;
+	UINT firstSubresource = m_mips[m_activeMip].heapIndex;
+	UINT subresourceCount = m_mips[m_activeMip].packedMip ? m_packedMipInfo.NumPackedMips : 1;
 
-    // Only update tile mappings if necessary.
-    if (!m_mips[firstSubresource].mapped)
-    {
-        // Generate the texture data for the active mip level.
-        // If the mip level corresponds to a packed mip, generate all the packed mips.
-        std::vector<UINT8> texture = GenerateTextureData(firstSubresource, subresourceCount);
+	// Only update tile mappings if necessary.
+	if (!m_mips[firstSubresource].mapped)
+	{
+		// Generate the texture data for the active mip level.
+		// If the mip level corresponds to a packed mip, generate all the packed mips.
+		std::vector<UINT8> texture = GenerateTextureData(firstSubresource, subresourceCount);
 
-        // Update the tile mappings on the reserved resource.
-        {
-            UINT updatedRegions = 0;
-            std::vector<D3D12_TILED_RESOURCE_COORDINATE> startCoordinates;
-            std::vector<D3D12_TILE_REGION_SIZE> regionSizes;
-            std::vector<D3D12_TILE_RANGE_FLAGS> rangeFlags;
-            std::vector<UINT> heapRangeStartOffsets;
-            std::vector<UINT> rangeTileCounts;
+		// Update the tile mappings on the reserved resource.
+		{
+			UINT updatedRegions = 0;
+			std::vector<D3D12_TILED_RESOURCE_COORDINATE> startCoordinates;
+			std::vector<D3D12_TILE_REGION_SIZE> regionSizes;
+			std::vector<D3D12_TILE_RANGE_FLAGS> rangeFlags;
+			std::vector<UINT> heapRangeStartOffsets;
+			std::vector<UINT> rangeTileCounts;
 
-            for (UINT n = 0; n < m_heaps.size(); n++)
-            {
-                if (!m_mips[n].mapped && n != firstSubresource)
-                {
-                    // Skip unchanged tile regions.
-                    continue;
-                }
+			for (UINT n = 0; n < m_heaps.size(); n++)
+			{
+				if (!m_mips[n].mapped && n != firstSubresource)
+				{
+					// Skip unchanged tile regions.
+					continue;
+				}
 
-                startCoordinates.push_back(m_mips[n].startCoordinate);
-                regionSizes.push_back(m_mips[n].regionSize);
+				startCoordinates.push_back(m_mips[n].startCoordinate);
+				regionSizes.push_back(m_mips[n].regionSize);
 
-                if (n == firstSubresource)
-                {
-                    // Map the currently active mip.
-                    rangeFlags.push_back(D3D12_TILE_RANGE_FLAG_NONE);
-                    m_mips[n].mapped = true;
-                }
-                else
-                {
-                    // Unmap the previously active mip.
-                    assert(m_mips[n].mapped);
+				if (n == firstSubresource)
+				{
+					// Map the currently active mip.
+					rangeFlags.push_back(D3D12_TILE_RANGE_FLAG_NONE);
+					m_mips[n].mapped = true;
+				}
+				else
+				{
+					// Unmap the previously active mip.
+					assert(m_mips[n].mapped);
 
-                    rangeFlags.push_back(D3D12_TILE_RANGE_FLAG_NULL);
-                    m_mips[n].mapped = false;
-                }
-                heapRangeStartOffsets.push_back(0);        // In this sample, each heap contains only one tile region.
-                rangeTileCounts.push_back(m_mips[n].regionSize.NumTiles);
+					rangeFlags.push_back(D3D12_TILE_RANGE_FLAG_NULL);
+					m_mips[n].mapped = false;
+				}
+				heapRangeStartOffsets.push_back(0);		// In this sample, each heap contains only one tile region.
+				rangeTileCounts.push_back(m_mips[n].regionSize.NumTiles);
 
-                updatedRegions++;
-            }
+				updatedRegions++;
+			}
 
-            m_commandQueue->UpdateTileMappings(
-                m_reservedResource.Get(),
-                updatedRegions,
-                &startCoordinates[0],
-                &regionSizes[0],
-                m_heaps[firstSubresource].Get(),
-                updatedRegions,
-                &rangeFlags[0],
-                &heapRangeStartOffsets[0],
-                &rangeTileCounts[0],
-                D3D12_TILE_MAPPING_FLAG_NONE
-                );
-        }
+			m_commandQueue->UpdateTileMappings(
+				m_reservedResource.Get(),
+				updatedRegions,
+				&startCoordinates[0],
+				&regionSizes[0],
+				m_heaps[firstSubresource].Get(),
+				updatedRegions,
+				&rangeFlags[0],
+				&heapRangeStartOffsets[0],
+				&rangeTileCounts[0],
+				D3D12_TILE_MAPPING_FLAG_NONE
+				);
+		}
 
-        // Upload the mip(s) to the GPU and copy them to the reserved resource.
-        {
-            UINT mipOffset = 0;
-            std::vector<D3D12_SUBRESOURCE_DATA> data(subresourceCount);
-            for (UINT n = 0; n < subresourceCount; n++)
-            {
-                UINT currentMip = firstSubresource + n;
+		// Upload the mip(s) to the GPU and copy them to the reserved resource.
+		{
+			UINT mipOffset = 0;
+			std::vector<D3D12_SUBRESOURCE_DATA> data(subresourceCount);
+			for (UINT n = 0; n < subresourceCount; n++)
+			{
+				UINT currentMip = firstSubresource + n;
 
-                data[n].pData = &texture[mipOffset];
-                data[n].RowPitch = (TextureWidth >> currentMip) * TexturePixelSizeInBytes;
-                data[n].SlicePitch = data[n].RowPitch * (TextureHeight >> currentMip);
+				data[n].pData = &texture[mipOffset];
+				data[n].RowPitch = (TextureWidth >> currentMip) * TexturePixelSizeInBytes;
+				data[n].SlicePitch = data[n].RowPitch * (TextureHeight >> currentMip);
 
-                mipOffset += static_cast<UINT>(data[n].SlicePitch);
-            }
+				mipOffset += static_cast<UINT>(data[n].SlicePitch);
+			}
 
-            UpdateSubresources(m_commandList.Get(), m_reservedResource.Get(), m_uploadHeap.Get(), 0, firstSubresource, subresourceCount, &data[0]);
-        }
-    }
+			UpdateSubresources(m_commandList.Get(), m_reservedResource.Get(), m_uploadHeap.Get(), 0, firstSubresource, subresourceCount, &data[0]);
+		}
+	}
 
-    m_activeMipChanged = false;
+	m_activeMipChanged = false;
 
-    WCHAR message[100];
-    swprintf_s(message, L"Mip Level: %d", m_activeMip);
-    SetCustomWindowText(message);
+	WCHAR message[100];
+	swprintf_s(message, L"Mip Level: %d", m_activeMip);
+	SetCustomWindowText(message);
 }
 
 // Generate a simple red and white checkerboard texture.
 std::vector<UINT8> D3D12ReservedResources::GenerateTextureData(UINT firstMip, UINT mipCount)
 {
-    // Determine the size of the data required by the mips(s).
-    UINT dataSize = (TextureWidth >> firstMip) * (TextureHeight >> firstMip) * TexturePixelSizeInBytes;
-    if (mipCount > 1)
-    {
-        // If generating more than 1 mip, double the size of the texture allocation
-        // (you will never need more than this).
-        dataSize *= 2;
-    }
-    std::vector<UINT8> data(dataSize);
-    UINT8* pData = &data[0];
+	// Determine the size of the data required by the mips(s).
+	UINT dataSize = (TextureWidth >> firstMip) * (TextureHeight >> firstMip) * TexturePixelSizeInBytes;
+	if (mipCount > 1)
+	{
+		// If generating more than 1 mip, double the size of the texture allocation
+		// (you will never need more than this).
+		dataSize *= 2;
+	}
+	std::vector<UINT8> data(dataSize);
+	UINT8* pData = &data[0];
 
-    UINT index = 0;
-    for (UINT n = 0; n < mipCount; n++)
-    {
-        const UINT currentMip = firstMip + n;
-        const UINT width = TextureWidth >> currentMip;
-        const UINT height = TextureHeight >> currentMip;
-        const UINT rowPitch = width * TexturePixelSizeInBytes;
-        const UINT cellPitch = max(rowPitch >> 3, TexturePixelSizeInBytes);    // The width of a cell in the checkboard texture.
-        const UINT cellHeight = max(height >> 3, 1);                        // The height of a cell in the checkerboard texture.
-        const UINT textureSize = rowPitch * height;
+	UINT index = 0;
+	for (UINT n = 0; n < mipCount; n++)
+	{
+		const UINT currentMip = firstMip + n;
+		const UINT width = TextureWidth >> currentMip;
+		const UINT height = TextureHeight >> currentMip;
+		const UINT rowPitch = width * TexturePixelSizeInBytes;
+		const UINT cellPitch = max(rowPitch >> 3, TexturePixelSizeInBytes);	// The width of a cell in the checkboard texture.
+		const UINT cellHeight = max(height >> 3, 1);						// The height of a cell in the checkerboard texture.
+		const UINT textureSize = rowPitch * height;
 
-        for (UINT m = 0; m < textureSize; m += TexturePixelSizeInBytes)
-        {
-            UINT x = m % rowPitch;
-            UINT y = m / rowPitch;
-            UINT i = x / cellPitch;
-            UINT j = y / cellHeight;
+		for (UINT m = 0; m < textureSize; m += TexturePixelSizeInBytes)
+		{
+			UINT x = m % rowPitch;
+			UINT y = m / rowPitch;
+			UINT i = x / cellPitch;
+			UINT j = y / cellHeight;
 
-            if (i % 2 == j % 2)
-            {
-                pData[index++] = 0xff;    // R
-                pData[index++] = 0x00;    // G
-                pData[index++] = 0x00;    // B
-                pData[index++] = 0xff;    // A
-            }
-            else
-            {
-                pData[index++] = 0xff;    // R
-                pData[index++] = 0xff;    // G
-                pData[index++] = 0xff;    // B
-                pData[index++] = 0xff;    // A
-            }
-        }
-    }
-    return data;
+			if (i % 2 == j % 2)
+			{
+				pData[index++] = 0xff;	// R
+				pData[index++] = 0x00;	// G
+				pData[index++] = 0x00;	// B
+				pData[index++] = 0xff;	// A
+			}
+			else
+			{
+				pData[index++] = 0xff;	// R
+				pData[index++] = 0xff;	// G
+				pData[index++] = 0xff;	// B
+				pData[index++] = 0xff;	// A
+			}
+		}
+	}
+	return data;
 }
 
 // Update frame-based values.
@@ -600,139 +600,139 @@ void D3D12ReservedResources::OnUpdate()
 // Render the scene.
 void D3D12ReservedResources::OnRender()
 {
-    if (m_tilingSupport)
-    {
-        // Record all the commands we need to render the scene into the command list.
-        PopulateCommandList();
+	if (m_tilingSupport)
+	{
+		// Record all the commands we need to render the scene into the command list.
+		PopulateCommandList();
 
-        // Execute the command list.
-        ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-        m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+		// Execute the command list.
+		ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+		m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-        // Present the frame.
-        ThrowIfFailed(m_swapChain->Present(1, 0));
+		// Present the frame.
+		ThrowIfFailed(m_swapChain->Present(1, 0));
 
-        MoveToNextFrame();
-    }
+		MoveToNextFrame();
+	}
 }
 
 void D3D12ReservedResources::OnDestroy()
 {
-    if (m_tilingSupport)
-    {
-        // Ensure that the GPU is no longer referencing resources that are about to be
-        // cleaned up by the destructor.
-        WaitForGpu();
+	if (m_tilingSupport)
+	{
+		// Ensure that the GPU is no longer referencing resources that are about to be
+		// cleaned up by the destructor.
+		WaitForGpu();
 
-        CloseHandle(m_fenceEvent);
-    }
+		CloseHandle(m_fenceEvent);
+	}
 }
 
 void D3D12ReservedResources::OnKeyDown(UINT8 key)
 {
-    switch (key)
-    {
-    case VK_LEFT:
-    case VK_UP:
-        if (m_activeMip != 0)
-        {
-            m_activeMip--;
-            m_activeMipChanged = true;
-        }
-        break;
+	switch (key)
+	{
+	case VK_LEFT:
+	case VK_UP:
+		if (m_activeMip != 0)
+		{
+			m_activeMip--;
+			m_activeMipChanged = true;
+		}
+		break;
 
-    case VK_RIGHT:
-    case VK_DOWN:
-        if (m_activeMip < m_mips.size() - 1)
-        {
-            m_activeMip++;
-            m_activeMipChanged = true;
-        }
-        break;
-    }
+	case VK_RIGHT:
+	case VK_DOWN:
+		if (m_activeMip < m_mips.size() - 1)
+		{
+			m_activeMip++;
+			m_activeMipChanged = true;
+		}
+		break;
+	}
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12ReservedResources::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
 
-    if (m_activeMipChanged)
-    {
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_reservedResource.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST));
-        UpdateTileMapping();
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_reservedResource.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
-    }
+	if (m_activeMipChanged)
+	{
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_reservedResource.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST));
+		UpdateTileMapping();
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_reservedResource.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
+	}
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
-    m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
+	m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_commandList->SetGraphicsRoot32BitConstant(0, m_activeMip, 0);
-    m_commandList->SetGraphicsRootDescriptorTable(1, m_srvHeap->GetGPUDescriptorHandleForHeapStart());
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	m_commandList->SetGraphicsRoot32BitConstant(0, m_activeMip, 0);
+	m_commandList->SetGraphicsRootDescriptorTable(1, m_srvHeap->GetGPUDescriptorHandleForHeapStart());
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-    m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
-    m_commandList->DrawInstanced(4, 1, 0, 0);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+	m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+	m_commandList->DrawInstanced(4, 1, 0, 0);
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 // Wait for pending GPU work to complete.
 void D3D12ReservedResources::WaitForGpu()
 {
-    // Schedule a Signal command in the queue.
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
+	// Schedule a Signal command in the queue.
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
 
-    // Wait until the fence has been processed.
-    ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-    WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	// Wait until the fence has been processed.
+	ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+	WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
 
-    // Increment the fence value for the current frame.
-    m_fenceValues[m_frameIndex]++;
+	// Increment the fence value for the current frame.
+	m_fenceValues[m_frameIndex]++;
 }
 
 // Prepare to render the next frame.
 void D3D12ReservedResources::MoveToNextFrame()
 {
-    // Schedule a Signal command in the queue.
-    const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
+	// Schedule a Signal command in the queue.
+	const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
 
-    // Update the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Update the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-        WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+		WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	}
 
-    // Set the fence value for the next frame.
-    m_fenceValues[m_frameIndex] = currentFenceValue + 1;
+	// Set the fence value for the next frame.
+	m_fenceValues[m_frameIndex] = currentFenceValue + 1;
 }

--- a/Samples/Desktop/D3D12ReservedResources/src/D3D12ReservedResources.h
+++ b/Samples/Desktop/D3D12ReservedResources/src/D3D12ReservedResources.h
@@ -25,75 +25,75 @@ using Microsoft::WRL::ComPtr;
 class D3D12ReservedResources : public DXSample
 {
 public:
-    D3D12ReservedResources(UINT width, UINT height, std::wstring name);
+	D3D12ReservedResources(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
-    virtual void OnKeyDown(UINT8 key);
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
+	virtual void OnKeyDown(UINT8 key);
 
 private:
-    static const UINT FrameCount = 2;
-    static const UINT TextureWidth = 256;
-    static const UINT TextureHeight = 256;
-    static const UINT TexturePixelSizeInBytes = 4;
+	static const UINT FrameCount = 2;
+	static const UINT TextureWidth = 256;
+	static const UINT TextureHeight = 256;
+	static const UINT TexturePixelSizeInBytes = 4;
 
-    // Vertex definition.
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT2 uv;
-    };
+	// Vertex definition.
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT2 uv;
+	};
 
-    // Information about the mips in the reserved resource.
-    struct MipInfo
-    {
-        UINT heapIndex;
-        bool packedMip;
-        bool mapped;
-        D3D12_TILED_RESOURCE_COORDINATE startCoordinate;
-        D3D12_TILE_REGION_SIZE regionSize;
-    };
+	// Information about the mips in the reserved resource.
+	struct MipInfo
+	{
+		UINT heapIndex;
+		bool packedMip;
+		bool mapped;
+		D3D12_TILED_RESOURCE_COORDINATE startCoordinate;
+		D3D12_TILE_REGION_SIZE regionSize;
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_srvHeap;
-    UINT m_rtvDescriptorSize;
-    UINT m_frameIndex;
-    bool m_tilingSupport;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_srvHeap;
+	UINT m_rtvDescriptorSize;
+	UINT m_frameIndex;
+	bool m_tilingSupport;
 
-    // Synchronization objects.
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValues[FrameCount];
-    HANDLE m_fenceEvent;
+	// Synchronization objects.
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValues[FrameCount];
+	HANDLE m_fenceEvent;
 
-    // Asset objects.
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
-    ComPtr<ID3D12Resource> m_uploadHeap;
-    ComPtr<ID3D12Resource> m_reservedResource;
-    std::vector<ComPtr<ID3D12Heap>> m_heaps;
-    std::vector<MipInfo> m_mips;
-    D3D12_PACKED_MIP_INFO m_packedMipInfo;
-    UINT m_activeMip;
-    bool m_activeMipChanged;
+	// Asset objects.
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	ComPtr<ID3D12Resource> m_uploadHeap;
+	ComPtr<ID3D12Resource> m_reservedResource;
+	std::vector<ComPtr<ID3D12Heap>> m_heaps;
+	std::vector<MipInfo> m_mips;
+	D3D12_PACKED_MIP_INFO m_packedMipInfo;
+	UINT m_activeMip;
+	bool m_activeMipChanged;
 
-    void LoadPipeline();
-    void LoadAssets();
-    std::vector<UINT8> GenerateTextureData(UINT firstMip, UINT lastMip);
-    void UpdateTileMapping();
-    void PopulateCommandList();
-    void WaitForGpu();
-    void MoveToNextFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	std::vector<UINT8> GenerateTextureData(UINT firstMip, UINT lastMip);
+	void UpdateTileMapping();
+	void PopulateCommandList();
+	void WaitForGpu();
+	void MoveToNextFrame();
 };

--- a/Samples/Desktop/D3D12ReservedResources/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12ReservedResources/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,58 +34,103 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title + L": " + text;
-    SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
+	std::wstring windowText = m_title + L": " + text;
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/Desktop/D3D12ReservedResources/src/DXSample.h
+++ b/Samples/Desktop/D3D12ReservedResources/src/DXSample.h
@@ -17,42 +17,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/Desktop/D3D12ReservedResources/src/Main.cpp
+++ b/Samples/Desktop/D3D12ReservedResources/src/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12ReservedResources sample(1280, 720, L"D3D12 Reserved resources sample - Use arrow keys to cycle through resources");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12ReservedResources sample(1280, 720, L"D3D12 Reserved resources sample - Use arrow keys to cycle through resources");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12ReservedResources/src/Win32Application.cpp
+++ b/Samples/Desktop/D3D12ReservedResources/src/Win32Application.cpp
@@ -16,104 +16,104 @@ HWND Win32Application::m_hwnd = nullptr;
 
 int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
 {
-    // Parse the command line parameters
-    int argc;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    pSample->ParseCommandLineArgs(argv, argc);
-    LocalFree(argv);
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
 
-    // Initialize the window class.
-    WNDCLASSEX windowClass = { 0 };
-    windowClass.cbSize = sizeof(WNDCLASSEX);
-    windowClass.style = CS_HREDRAW | CS_VREDRAW;
-    windowClass.lpfnWndProc = WindowProc;
-    windowClass.hInstance = hInstance;
-    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-    windowClass.lpszClassName = L"DXSampleClass";
-    RegisterClassEx(&windowClass);
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
 
-    RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
-    AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
 
-    // Create the window and store a handle to it.
-    m_hwnd = CreateWindow(
-        windowClass.lpszClassName,
-        pSample->GetTitle(),
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        windowRect.right - windowRect.left,
-        windowRect.bottom - windowRect.top,
-        nullptr,        // We have no parent window.
-        nullptr,        // We aren't using menus.
-        hInstance,
-        pSample);
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
 
-    // Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-    pSample->OnInit();
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
 
-    ShowWindow(m_hwnd, nCmdShow);
+	ShowWindow(m_hwnd, nCmdShow);
 
-    // Main sample loop.
-    MSG msg = {};
-    while (msg.message != WM_QUIT)
-    {
-        // Process any messages in the queue.
-        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
-    }
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
 
-    pSample->OnDestroy();
+	pSample->OnDestroy();
 
-    // Return this part of the WM_QUIT message to Windows.
-    return static_cast<char>(msg.wParam);
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
 }
 
 // Main message handler for the sample.
 LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
-    switch (message)
-    {
-    case WM_CREATE:
-        {
-            // Save the DXSample* passed in to CreateWindow.
-            LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
-            SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
-        }
-        return 0;
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
 
-    case WM_KEYDOWN:
-        if (pSample)
-        {
-            pSample->OnKeyDown(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_KEYUP:
-        if (pSample)
-        {
-            pSample->OnKeyUp(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_PAINT:
-        if (pSample)
-        {
-            pSample->OnUpdate();
-            pSample->OnRender();
-        }
-        return 0;
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
 
-    case WM_DESTROY:
-        PostQuitMessage(0);
-        return 0;
-    }
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
 
-    // Handle any messages the switch statement didn't.
-    return DefWindowProc(hWnd, message, wParam, lParam);
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/Desktop/D3D12ReservedResources/src/Win32Application.h
+++ b/Samples/Desktop/D3D12ReservedResources/src/Win32Application.h
@@ -18,12 +18,12 @@ class DXSample;
 class Win32Application
 {
 public:
-    static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
-    static HWND GetHwnd() { return m_hwnd; }
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
 
 protected:
-    static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
-    static HWND m_hwnd;
+	static HWND m_hwnd;
 };

--- a/Samples/Desktop/D3D12ReservedResources/src/d3dx12.h
+++ b/Samples/Desktop/D3D12ReservedResources/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12ReservedResources/src/shaders.hlsl
+++ b/Samples/Desktop/D3D12ReservedResources/src/shaders.hlsl
@@ -11,13 +11,13 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 cbuffer RootConstants : register(b0)
 {
-    uint activeMip;
+	uint activeMip;
 }
 
 Texture2D g_texture : register(t0);
@@ -25,15 +25,15 @@ SamplerState g_sampler : register(s0);
 
 PSInput VSMain(float4 position : POSITION, float4 uv : TEXCOORD)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.uv = uv;
+	result.position = position;
+	result.uv = uv;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return g_texture.SampleLevel(g_sampler, input.uv, activeMip);
+	return g_texture.SampleLevel(g_sampler, input.uv, activeMip);
 }

--- a/Samples/Desktop/D3D12Residency/src/D3D12Residency.cpp
+++ b/Samples/Desktop/D3D12Residency/src/D3D12Residency.cpp
@@ -13,456 +13,456 @@
 #include "D3D12Residency.h"
 
 D3D12Residency::D3D12Residency(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0),
-    m_totalAllocations(0),
-    m_textureIndex(0),
-    m_cancel(false),
-    m_loadedTextureCount(0)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0),
+	m_totalAllocations(0),
+	m_textureIndex(0),
+	m_cancel(false),
+	m_loadedTextureCount(0)
 {
 }
 
 void D3D12Residency::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
-    LoadTexturesAsync();
+	LoadPipeline();
+	LoadAssets();
+	LoadTexturesAsync();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12Residency::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
 
-        ThrowIfFailed(warpAdapter.As(&m_adapter));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(warpAdapter.As(&m_adapter));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
 
-        ThrowIfFailed(hardwareAdapter.As(&m_adapter));
-    }
+		ThrowIfFailed(hardwareAdapter.As(&m_adapter));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    // This sample does not support fullscreen transitions.
-    ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
+	// This sample does not support fullscreen transitions.
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a shader resource view (SRV) heap for the texture.
-        D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
-        srvHeapDesc.NumDescriptors = NumTextures;
-        srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
+		// Describe and create a shader resource view (SRV) heap for the texture.
+		D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
+		srvHeapDesc.NumDescriptors = NumTextures;
+		srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-        m_srvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_srvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
-        }
-    }
+		// Create a RTV for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
+		}
+	}
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
 }
 
 // Load the sample assets.
 void D3D12Residency::LoadAssets()
 {
-    // Create the root signature.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signature.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DESCRIPTORS_VOLATILE);
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DESCRIPTORS_VOLATILE);
 
-        CD3DX12_ROOT_PARAMETER1 rootParameters[1];
-        rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
+		CD3DX12_ROOT_PARAMETER1 rootParameters[1];
+		rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
 
-        CD3DX12_STATIC_SAMPLER_DESC sampler(0, D3D12_FILTER_MIN_MAG_MIP_POINT);
-        sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+		CD3DX12_STATIC_SAMPLER_DESC sampler(0, D3D12_FILTER_MIN_MAG_MIP_POINT);
+		sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &sampler, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &sampler, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Describe and create the graphics pipeline state object (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.SampleDesc.Count = 1;
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-    }
+		// Describe and create the graphics pipeline state object (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.SampleDesc.Count = 1;
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
 
-    // Note: ComPtr's are CPU objects but this resource needs to stay in scope until
-    // the command list that references it has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resource is not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> vertexBufferUpload;
+	// Note: ComPtr's are CPU objects but this resource needs to stay in scope until
+	// the command list that references it has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resource is not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> vertexBufferUpload;
 
-    // Create the vertex buffer.
-    {
-        // Define the geometry for a quad.
-        Vertex quadVertices[] =
-        {
-            { { -1.0f, -1.0f, 0.0f }, { 0.0f, 0.0f } },
-            { { -1.0f, 1.0f, 0.0f }, { 0.0f, 1.0f } },
-            { { 1.0f, -1.0f, 0.0f }, { 1.0f, 0.0f } },
-            { { 1.0f, 1.0f, 0.0f }, { 1.0f, 1.0f } },
-        };
+	// Create the vertex buffer.
+	{
+		// Define the geometry for a quad.
+		Vertex quadVertices[] =
+		{
+			{ { -1.0f, -1.0f, 0.0f }, { 0.0f, 0.0f } },
+			{ { -1.0f, 1.0f, 0.0f }, { 0.0f, 1.0f } },
+			{ { 1.0f, -1.0f, 0.0f }, { 1.0f, 0.0f } },
+			{ { 1.0f, 1.0f, 0.0f }, { 1.0f, 1.0f } },
+		};
 
-        const UINT vertexBufferSize = sizeof(quadVertices);
+		const UINT vertexBufferSize = sizeof(quadVertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&vertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&vertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(quadVertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(quadVertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = vertexBufferSize;
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = vertexBufferSize;
+	}
 
-    // Close the command list and execute it to begin the initial GPU setup.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the initial GPU setup.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValue = 1;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValue = 1;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        FlushGpu();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		FlushGpu();
+	}
 }
 
 // Create and upload textures asynchronously. When textures are uploaded, they may
 // then be used for rendering.
 void D3D12Residency::LoadTexturesAsync()
 {
-    // For this sample we will only track the residency of the textures.
-    // Other resources could also be tracked by adding them to the ResidencySets in the
-    // managed command lists.
-    m_residencyManager.Initialize(m_device.Get(), 0, m_adapter.Get(), MaxResidencyLatency);
-    m_loadedTextures.resize(NumTextures);
+	// For this sample we will only track the residency of the textures.
+	// Other resources could also be tracked by adding them to the ResidencySets in the
+	// managed command lists.
+	m_residencyManager.Initialize(m_device.Get(), 0, m_adapter.Get(), MaxResidencyLatency);
+	m_loadedTextures.resize(NumTextures);
 
-    // Initialize the queue of incomplete textures that will be loaded asynchronously.
-    for (UINT n = 0; n < NumTextures; n++)
-    {
-        auto pTexture = std::make_shared<ManagedTexture>();
-        pTexture->index = n;
-        m_incompleteTextures.push(pTexture);
-    }
+	// Initialize the queue of incomplete textures that will be loaded asynchronously.
+	for (UINT n = 0; n < NumTextures; n++)
+	{
+		auto pTexture = std::make_shared<ManagedTexture>();
+		pTexture->index = n;
+		m_incompleteTextures.push(pTexture);
+	}
 
-    // Async method that pulls textures out of the m_incompleteTextures queue,
-    // initializes them, and then moves them into the m_loadedTextures vector.
-    const auto& CreateAndUpload = [this]()
-    {
-        // Create a copy queue and associated resources to facilitate uploading textures.
-        D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-        queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-        queueDesc.Type = D3D12_COMMAND_LIST_TYPE_COPY;
+	// Async method that pulls textures out of the m_incompleteTextures queue,
+	// initializes them, and then moves them into the m_loadedTextures vector.
+	const auto& CreateAndUpload = [this]()
+	{
+		// Create a copy queue and associated resources to facilitate uploading textures.
+		D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+		queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+		queueDesc.Type = D3D12_COMMAND_LIST_TYPE_COPY;
 
-        ComPtr<ID3D12CommandQueue> copyQueue;
-        ComPtr<ID3D12CommandAllocator> commandAllocator;
-        ComPtr<ID3D12GraphicsCommandList> commandList;
-        std::shared_ptr<D3DX12Residency::ResidencySet> residencySet(m_residencyManager.CreateResidencySet());
-        ComPtr<ID3D12Fence> fence;
-        UINT64 fenceValue = 1;
-        HANDLE fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		ComPtr<ID3D12CommandQueue> copyQueue;
+		ComPtr<ID3D12CommandAllocator> commandAllocator;
+		ComPtr<ID3D12GraphicsCommandList> commandList;
+		std::shared_ptr<D3DX12Residency::ResidencySet> residencySet(m_residencyManager.CreateResidencySet());
+		ComPtr<ID3D12Fence> fence;
+		UINT64 fenceValue = 1;
+		HANDLE fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&copyQueue)));
-        ThrowIfFailed(m_device->CreateCommandAllocator(queueDesc.Type, IID_PPV_ARGS(&commandAllocator)));
-        ThrowIfFailed(m_device->CreateCommandList(0, queueDesc.Type, commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&commandList)));
-        ThrowIfFailed(commandList->Close());
-        ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&fence)));
+		ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&copyQueue)));
+		ThrowIfFailed(m_device->CreateCommandAllocator(queueDesc.Type, IID_PPV_ARGS(&commandAllocator)));
+		ThrowIfFailed(m_device->CreateCommandList(0, queueDesc.Type, commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&commandList)));
+		ThrowIfFailed(commandList->Close());
+		ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&fence)));
 
-        // Allocate the CPU-side memory backing the texture.
-        const UINT textureSize = TextureWidth * TextureHeight * TexturePixelSize;
-        std::vector<UINT8> textureData(textureSize);
-        UINT8* pData = textureData.data();
+		// Allocate the CPU-side memory backing the texture.
+		const UINT textureSize = TextureWidth * TextureHeight * TexturePixelSize;
+		std::vector<UINT8> textureData(textureSize);
+		UINT8* pData = textureData.data();
 
-        // Describe the texture.
-        D3D12_RESOURCE_DESC textureDesc = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R8G8B8A8_UNORM, TextureWidth, TextureHeight, 1, 1);
-        D3D12_RESOURCE_ALLOCATION_INFO info = m_device->GetResourceAllocationInfo(0, 1, &textureDesc);
+		// Describe the texture.
+		D3D12_RESOURCE_DESC textureDesc = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R8G8B8A8_UNORM, TextureWidth, TextureHeight, 1, 1);
+		D3D12_RESOURCE_ALLOCATION_INFO info = m_device->GetResourceAllocationInfo(0, 1, &textureDesc);
 
-        // Create a GPU upload buffer.
-        ComPtr<ID3D12Resource> textureUploadHeap;
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(info.SizeInBytes),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&textureUploadHeap)));
+		// Create a GPU upload buffer.
+		ComPtr<ID3D12Resource> textureUploadHeap;
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(info.SizeInBytes),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&textureUploadHeap)));
 
-        auto pTexture = GetNextIncompleteTexture();
+		auto pTexture = GetNextIncompleteTexture();
 
-        // Create and upload the next texture.
-        while (pTexture && !m_cancel)
-        {
-            // Create the backing resource for the texture and initialize the ManagedTexture.
-            ThrowIfFailed(m_device->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-                D3D12_HEAP_FLAG_NONE,
-                &textureDesc,
-                D3D12_RESOURCE_STATE_COMMON,
-                nullptr,
-                IID_PPV_ARGS(&pTexture->texture)));
+		// Create and upload the next texture.
+		while (pTexture && !m_cancel)
+		{
+			// Create the backing resource for the texture and initialize the ManagedTexture.
+			ThrowIfFailed(m_device->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+				D3D12_HEAP_FLAG_NONE,
+				&textureDesc,
+				D3D12_RESOURCE_STATE_COMMON,
+				nullptr,
+				IID_PPV_ARGS(&pTexture->texture)));
 
-            SetNameIndexed(pTexture->texture.Get(), L"texture", pTexture->index);
+			SetNameIndexed(pTexture->texture.Get(), L"texture", pTexture->index);
 
-            pTexture->trackingHandle.Initialize(pTexture->texture.Get(), info.SizeInBytes);
-            pTexture->size = info.SizeInBytes;
-            m_totalAllocations += info.SizeInBytes;
+			pTexture->trackingHandle.Initialize(pTexture->texture.Get(), info.SizeInBytes);
+			pTexture->size = info.SizeInBytes;
+			m_totalAllocations += info.SizeInBytes;
 
-            // Turn on residency tracking for this texture.
-            m_residencyManager.BeginTrackingObject(&pTexture->trackingHandle);
+			// Turn on residency tracking for this texture.
+			m_residencyManager.BeginTrackingObject(&pTexture->trackingHandle);
 
-            // Describe and create a SRV for the texture.
-            D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-            srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-            srvDesc.Format = textureDesc.Format;
-            srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-            srvDesc.Texture2D.MipLevels = 1;
+			// Describe and create a SRV for the texture.
+			D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+			srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+			srvDesc.Format = textureDesc.Format;
+			srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+			srvDesc.Texture2D.MipLevels = 1;
 
-            CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_srvHeap->GetCPUDescriptorHandleForHeapStart(), pTexture->index, m_srvDescriptorSize);
-            m_device->CreateShaderResourceView(pTexture->texture.Get(), &srvDesc, cpuHandle);
+			CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_srvHeap->GetCPUDescriptorHandleForHeapStart(), pTexture->index, m_srvDescriptorSize);
+			m_device->CreateShaderResourceView(pTexture->texture.Get(), &srvDesc, cpuHandle);
 
-            // Reclaim upload resources for initializing the current texture.
-            ThrowIfFailed(commandAllocator->Reset());
-            ThrowIfFailed(commandList->Reset(commandAllocator.Get(), m_pipelineState.Get()));
-            residencySet->Open();
+			// Reclaim upload resources for initializing the current texture.
+			ThrowIfFailed(commandAllocator->Reset());
+			ThrowIfFailed(commandList->Reset(commandAllocator.Get(), m_pipelineState.Get()));
+			residencySet->Open();
 
-            // Upload the texture data.
-            {
-                XMFLOAT3 hsv(static_cast<float>(pTexture->index) / (m_width >> 1), 0.75f, 0.85f);
-                XMFLOAT3 rgb;
-                XMStoreFloat3(&rgb, XMColorHSVToRGB(XMLoadFloat3(&hsv)));
-                UINT8 r = static_cast<UINT8>(rgb.x * 255.0f);
-                UINT8 g = static_cast<UINT8>(rgb.y * 255.0f);
-                UINT8 b = static_cast<UINT8>(rgb.z * 255.0f);
-                UINT8 a = 0xff;
+			// Upload the texture data.
+			{
+				XMFLOAT3 hsv(static_cast<float>(pTexture->index) / (m_width >> 1), 0.75f, 0.85f);
+				XMFLOAT3 rgb;
+				XMStoreFloat3(&rgb, XMColorHSVToRGB(XMLoadFloat3(&hsv)));
+				UINT8 r = static_cast<UINT8>(rgb.x * 255.0f);
+				UINT8 g = static_cast<UINT8>(rgb.y * 255.0f);
+				UINT8 b = static_cast<UINT8>(rgb.z * 255.0f);
+				UINT8 a = 0xff;
 
-                for (UINT n = 0; n < textureSize; n += TexturePixelSize)
-                {
-                    pData[n] = r;
-                    pData[n + 1] = g;
-                    pData[n + 2] = b;
-                    pData[n + 3] = a;
-                }
+				for (UINT n = 0; n < textureSize; n += TexturePixelSize)
+				{
+					pData[n] = r;
+					pData[n + 1] = g;
+					pData[n + 2] = b;
+					pData[n + 3] = a;
+				}
 
-                // Copy data to the intermediate upload heap and then schedule a copy
-                // from the upload heap to the texture resource.
-                D3D12_SUBRESOURCE_DATA textureData = {};
-                textureData.pData = pData;
-                textureData.RowPitch = TextureWidth * TexturePixelSize;
-                textureData.SlicePitch = textureData.RowPitch * TextureHeight;
+				// Copy data to the intermediate upload heap and then schedule a copy
+				// from the upload heap to the texture resource.
+				D3D12_SUBRESOURCE_DATA textureData = {};
+				textureData.pData = pData;
+				textureData.RowPitch = TextureWidth * TexturePixelSize;
+				textureData.SlicePitch = textureData.RowPitch * TextureHeight;
 
-                UpdateSubresources<1>(commandList.Get(), pTexture->texture.Get(), textureUploadHeap.Get(), 0, 0, 1, &textureData);
-            }
+				UpdateSubresources<1>(commandList.Get(), pTexture->texture.Get(), textureUploadHeap.Get(), 0, 0, 1, &textureData);
+			}
 
-            // Add this resource to the set of resources the command list needs resident.
-            residencySet->Insert(&pTexture->trackingHandle);
+			// Add this resource to the set of resources the command list needs resident.
+			residencySet->Insert(&pTexture->trackingHandle);
 
-            ThrowIfFailed(commandList->Close());
-            ThrowIfFailed(residencySet->Close());
+			ThrowIfFailed(commandList->Close());
+			ThrowIfFailed(residencySet->Close());
 
-            ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
-            D3DX12Residency::ResidencySet* ppResidencySets[] = { residencySet.get() };
+			ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
+			D3DX12Residency::ResidencySet* ppResidencySets[] = { residencySet.get() };
 
-            // Schedule the upload and wait for it to complete.
-            m_residencyManager.ExecuteCommandLists(copyQueue.Get(), ppCommandLists, ppResidencySets, _countof(ppCommandLists));
+			// Schedule the upload and wait for it to complete.
+			m_residencyManager.ExecuteCommandLists(copyQueue.Get(), ppCommandLists, ppResidencySets, _countof(ppCommandLists));
 
-            copyQueue->Signal(fence.Get(), fenceValue);
-            ThrowIfFailed(fence->SetEventOnCompletion(fenceValue, fenceEvent));
-            WaitForSingleObject(fenceEvent, INFINITE);
-            fenceValue++;
+			copyQueue->Signal(fence.Get(), fenceValue);
+			ThrowIfFailed(fence->SetEventOnCompletion(fenceValue, fenceEvent));
+			WaitForSingleObject(fenceEvent, INFINITE);
+			fenceValue++;
 
-            StoreCompletedTexture(pTexture);
-            pTexture = GetNextIncompleteTexture();
-        }
+			StoreCompletedTexture(pTexture);
+			pTexture = GetNextIncompleteTexture();
+		}
 
-        CloseHandle(fenceEvent);
-    };
+		CloseHandle(fenceEvent);
+	};
 
-    const UINT numThreads = MaxResidencyLatency + 1;
-    m_threads.resize(numThreads);
+	const UINT numThreads = MaxResidencyLatency + 1;
+	m_threads.resize(numThreads);
 
-    for (UINT n = 0; n < numThreads; n++)
-    {
-        m_threads[n] = std::async(std::launch::async, CreateAndUpload);
-    }
+	for (UINT n = 0; n < numThreads; n++)
+	{
+		m_threads[n] = std::async(std::launch::async, CreateAndUpload);
+	}
 }
 
 // Update frame-based values.
@@ -473,165 +473,165 @@ void D3D12Residency::OnUpdate()
 // Render the scene.
 void D3D12Residency::OnRender()
 {
-    std::shared_ptr<ManagedCommandList> pManagedCommandList;
+	std::shared_ptr<ManagedCommandList> pManagedCommandList;
 
-    if (m_commandListPool.empty() || m_commandListPool.front()->fenceValue > m_fence->GetCompletedValue())
-    {
-        pManagedCommandList = std::make_shared<ManagedCommandList>();
-        ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&pManagedCommandList->commandAllocator)));
-        ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, pManagedCommandList->commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&pManagedCommandList->commandList)));
-        pManagedCommandList->residencySet = std::shared_ptr<D3DX12Residency::ResidencySet>(m_residencyManager.CreateResidencySet());
-    }
-    else
-    {
-        pManagedCommandList = m_commandListPool.front();
-        m_commandListPool.pop();
+	if (m_commandListPool.empty() || m_commandListPool.front()->fenceValue > m_fence->GetCompletedValue())
+	{
+		pManagedCommandList = std::make_shared<ManagedCommandList>();
+		ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&pManagedCommandList->commandAllocator)));
+		ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, pManagedCommandList->commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&pManagedCommandList->commandList)));
+		pManagedCommandList->residencySet = std::shared_ptr<D3DX12Residency::ResidencySet>(m_residencyManager.CreateResidencySet());
+	}
+	else
+	{
+		pManagedCommandList = m_commandListPool.front();
+		m_commandListPool.pop();
 
-        ThrowIfFailed(pManagedCommandList->commandAllocator->Reset());
-        ThrowIfFailed(pManagedCommandList->commandList->Reset(pManagedCommandList->commandAllocator.Get(), m_pipelineState.Get()));
-    }
+		ThrowIfFailed(pManagedCommandList->commandAllocator->Reset());
+		ThrowIfFailed(pManagedCommandList->commandList->Reset(pManagedCommandList->commandAllocator.Get(), m_pipelineState.Get()));
+	}
 
-    m_commandListPool.push(pManagedCommandList);
+	m_commandListPool.push(pManagedCommandList);
 
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList(pManagedCommandList);
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList(pManagedCommandList);
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { pManagedCommandList->commandList.Get() };
-    D3DX12Residency::ResidencySet* ppSets[] = { pManagedCommandList->residencySet.get() };
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { pManagedCommandList->commandList.Get() };
+	D3DX12Residency::ResidencySet* ppSets[] = { pManagedCommandList->residencySet.get() };
 
-    m_residencyManager.ExecuteCommandLists(m_commandQueue.Get(), ppCommandLists, ppSets, 1);
+	m_residencyManager.ExecuteCommandLists(m_commandQueue.Get(), ppCommandLists, ppSets, 1);
 
-    const UINT64 fence = m_fenceValue;
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
-    m_fenceValue++;
+	const UINT64 fence = m_fenceValue;
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
+	m_fenceValue++;
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Present the frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    pManagedCommandList->fenceValue = fence;
+	pManagedCommandList->fenceValue = fence;
 }
 
 void D3D12Residency::OnDestroy()
 {
-    // Cancel all of the texture loading threads and wait for them to exit.
-    m_cancel = true;
-    for (UINT n = 0; n < m_threads.size(); n++)
-    {
-        m_threads[n].wait();
-    }
+	// Cancel all of the texture loading threads and wait for them to exit.
+	m_cancel = true;
+	for (UINT n = 0; n < m_threads.size(); n++)
+	{
+		m_threads[n].wait();
+	}
 
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up.
-    FlushGpu();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up.
+	FlushGpu();
 
-    CloseHandle(m_fenceEvent);
-    m_residencyManager.Destroy();
+	CloseHandle(m_fenceEvent);
+	m_residencyManager.Destroy();
 }
 
 void D3D12Residency::PopulateCommandList(std::shared_ptr<ManagedCommandList> pManagedCommandList)
 {
-    DXGI_QUERY_VIDEO_MEMORY_INFO memoryInfo = {};
-    ThrowIfFailed(m_adapter->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &memoryInfo));
+	DXGI_QUERY_VIDEO_MEMORY_INFO memoryInfo = {};
+	ThrowIfFailed(m_adapter->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &memoryInfo));
 
-    WCHAR message[200];
-    swprintf_s(message, L"Total Allocated: %llu MB | Budget: %llu MB | Using: %llu MB", m_totalAllocations >> 20, memoryInfo.Budget >> 20, memoryInfo.CurrentUsage >> 20);
-    this->SetCustomWindowText(message);
+	WCHAR message[200];
+	swprintf_s(message, L"Total Allocated: %llu MB | Budget: %llu MB | Using: %llu MB", m_totalAllocations >> 20, memoryInfo.Budget >> 20, memoryInfo.CurrentUsage >> 20);
+	this->SetCustomWindowText(message);
 
-    auto commandList = pManagedCommandList->commandList;
-    ThrowIfFailed(pManagedCommandList->residencySet->Open());
+	auto commandList = pManagedCommandList->commandList;
+	ThrowIfFailed(pManagedCommandList->residencySet->Open());
 
-    // Set necessary state.
-    commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
-    commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
+	commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    commandList->SetGraphicsRootDescriptorTable(0, m_srvHeap->GetGPUDescriptorHandleForHeapStart());
-    commandList->RSSetViewports(1, &m_viewport);
-    commandList->RSSetScissorRects(1, &m_scissorRect);
+	commandList->SetGraphicsRootDescriptorTable(0, m_srvHeap->GetGPUDescriptorHandleForHeapStart());
+	commandList->RSSetViewports(1, &m_viewport);
+	commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-    commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+	commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
 
-    // Draw each texture in a thin strip.
-    const UINT texturesPerRow = m_width >> 1;
-    D3D12_VIEWPORT movingViewport = m_viewport;
-    movingViewport.Width = 2.0f;
-    movingViewport.Height = floorf(m_height / ceilf(NumTextures / static_cast<float>(texturesPerRow)));
+	// Draw each texture in a thin strip.
+	const UINT texturesPerRow = m_width >> 1;
+	D3D12_VIEWPORT movingViewport = m_viewport;
+	movingViewport.Width = 2.0f;
+	movingViewport.Height = floorf(m_height / ceilf(NumTextures / static_cast<float>(texturesPerRow)));
 
-    // Only reference as much memory in this command list as the budget allows to
-    // be resident at any given time.
-    UINT64 memoryToUse = UINT64 (float(memoryInfo.Budget) * 0.95f);
-    UINT textureCount = LoadedTextureCount();
-    if (textureCount > 0)
-    {
-        UINT textureIndex = m_textureIndex;
-        UINT64 sizeUsed = 0;
+	// Only reference as much memory in this command list as the budget allows to
+	// be resident at any given time.
+	UINT64 memoryToUse = UINT64 (float(memoryInfo.Budget) * 0.95f);
+	UINT textureCount = LoadedTextureCount();
+	if (textureCount > 0)
+	{
+		UINT textureIndex = m_textureIndex;
+		UINT64 sizeUsed = 0;
 
-        // Draw as many textures as we have available up until we reach our memory
-        // usage budget for the command list.
-        do
-        {
-            auto pTexture = m_loadedTextures[textureIndex];
-            if (pTexture)
-            {
-                CD3DX12_GPU_DESCRIPTOR_HANDLE gpuHandle(m_srvHeap->GetGPUDescriptorHandleForHeapStart(), pTexture->index, m_srvDescriptorSize);
-                commandList->SetGraphicsRootDescriptorTable(0, gpuHandle);
+		// Draw as many textures as we have available up until we reach our memory
+		// usage budget for the command list.
+		do
+		{
+			auto pTexture = m_loadedTextures[textureIndex];
+			if (pTexture)
+			{
+				CD3DX12_GPU_DESCRIPTOR_HANDLE gpuHandle(m_srvHeap->GetGPUDescriptorHandleForHeapStart(), pTexture->index, m_srvDescriptorSize);
+				commandList->SetGraphicsRootDescriptorTable(0, gpuHandle);
 
-                // Indicate that this texture was used in the current command list.
-                pManagedCommandList->residencySet->Insert(&pTexture->trackingHandle);
-                sizeUsed += pTexture->size;
+				// Indicate that this texture was used in the current command list.
+				pManagedCommandList->residencySet->Insert(&pTexture->trackingHandle);
+				sizeUsed += pTexture->size;
 
-                // Position this quad on the render target.
-                UINT x = textureIndex % texturesPerRow;
-                UINT y = textureIndex / texturesPerRow;
-                movingViewport.TopLeftX = x * movingViewport.Width;
-                movingViewport.TopLeftY = y * movingViewport.Height;
-                commandList->RSSetViewports(1, &movingViewport);
-                commandList->DrawInstanced(4, 1, 0, 0);
-            }
+				// Position this quad on the render target.
+				UINT x = textureIndex % texturesPerRow;
+				UINT y = textureIndex / texturesPerRow;
+				movingViewport.TopLeftX = x * movingViewport.Width;
+				movingViewport.TopLeftY = y * movingViewport.Height;
+				commandList->RSSetViewports(1, &movingViewport);
+				commandList->DrawInstanced(4, 1, 0, 0);
+			}
 
-            textureIndex = (textureIndex + 1) % textureCount;
+			textureIndex = (textureIndex + 1) % textureCount;
 
-        } while (sizeUsed < memoryToUse && textureIndex != m_textureIndex);
+		} while (sizeUsed < memoryToUse && textureIndex != m_textureIndex);
 
-        // Once we have more textures loaded that we have budget to draw at a time,
-        // move the window of textures drawn.
-        if (textureIndex != m_textureIndex)
-        {
-            m_textureIndex = (m_textureIndex + 1) % textureCount;
-        }
-    }
+		// Once we have more textures loaded that we have budget to draw at a time,
+		// move the window of textures drawn.
+		if (textureIndex != m_textureIndex)
+		{
+			m_textureIndex = (m_textureIndex + 1) % textureCount;
+		}
+	}
 
-    // Indicate that the back buffer will now be used to present.
-    commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(commandList->Close());
-    ThrowIfFailed(pManagedCommandList->residencySet->Close());
+	ThrowIfFailed(commandList->Close());
+	ThrowIfFailed(pManagedCommandList->residencySet->Close());
 }
 
 void D3D12Residency::FlushGpu()
 {
-    // Signal and increment the fence value.
-    const UINT64 fence = m_fenceValue;
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
-    m_fenceValue++;
+	// Signal and increment the fence value.
+	const UINT64 fence = m_fenceValue;
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
+	m_fenceValue++;
 
-    // Wait until the fence has been completed.
-    if (m_fence->GetCompletedValue() < fence)
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+	// Wait until the fence has been completed.
+	if (m_fence->GetCompletedValue() < fence)
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 }

--- a/Samples/Desktop/D3D12Residency/src/D3D12Residency.h
+++ b/Samples/Desktop/D3D12Residency/src/D3D12Residency.h
@@ -27,118 +27,118 @@ using Microsoft::WRL::ComPtr;
 class D3D12Residency : public DXSample
 {
 public:
-    D3D12Residency(UINT width, UINT height, std::wstring name);
+	D3D12Residency(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    static const UINT FrameCount = 3;
-    static const UINT TextureWidth = 512;
-    static const UINT TextureHeight = 512;
-    static const UINT TexturePixelSize = 4;    // The number of bytes used to represent a pixel in the texture.
+	static const UINT FrameCount = 3;
+	static const UINT TextureWidth = 512;
+	static const UINT TextureHeight = 512;
+	static const UINT TexturePixelSize = 4;	// The number of bytes used to represent a pixel in the texture.
 
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT2 uv;
-    };
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT2 uv;
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGIAdapter3> m_adapter;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_srvHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    UINT m_rtvDescriptorSize;
-    UINT m_srvDescriptorSize;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGIAdapter3> m_adapter;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_srvHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	UINT m_rtvDescriptorSize;
+	UINT m_srvDescriptorSize;
 
-    // App resources.
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	// App resources.
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValue;
+	// Synchronization objects.
+	UINT m_frameIndex;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValue;
 
-    // Resource residency management.
-    static const UINT NumTextures = 1024 * 8;                // Should make for ~8GB of VRAM.
-    static const UINT CommandListSubmissionsPerFrame = 1;
-    static const UINT MaxResidencyLatency = FrameCount * CommandListSubmissionsPerFrame;
+	// Resource residency management.
+	static const UINT NumTextures = 1024 * 8;				// Should make for ~8GB of VRAM.
+	static const UINT CommandListSubmissionsPerFrame = 1;
+	static const UINT MaxResidencyLatency = FrameCount * CommandListSubmissionsPerFrame;
 
-    struct ManagedCommandList
-    {
-        ComPtr<ID3D12CommandAllocator> commandAllocator;
-        ComPtr<ID3D12GraphicsCommandList> commandList;
-        std::shared_ptr<D3DX12Residency::ResidencySet> residencySet;    // The set of resources that must be resident on the GPU to render this command list.
-        UINT64 fenceValue = 0;
-    };
+	struct ManagedCommandList
+	{
+		ComPtr<ID3D12CommandAllocator> commandAllocator;
+		ComPtr<ID3D12GraphicsCommandList> commandList;
+		std::shared_ptr<D3DX12Residency::ResidencySet> residencySet;	// The set of resources that must be resident on the GPU to render this command list.
+		UINT64 fenceValue = 0;
+	};
 
-    struct ManagedTexture
-    {
-        ComPtr<ID3D12Resource> texture;                        // The D3D12 texture resource that will be managed by the residency library.
-        D3DX12Residency::ManagedObject trackingHandle;        // The residency library works in units of ManagedObjects. They can be treated opaquely like a handle.
-        UINT64 size = 0;
-        UINT index = 0;
-    };
+	struct ManagedTexture
+	{
+		ComPtr<ID3D12Resource> texture;						// The D3D12 texture resource that will be managed by the residency library.
+		D3DX12Residency::ManagedObject trackingHandle;		// The residency library works in units of ManagedObjects. They can be treated opaquely like a handle.
+		UINT64 size = 0;
+		UINT index = 0;
+	};
 
-    UINT64 m_totalAllocations;
-    UINT m_textureIndex;
-    D3DX12Residency::ResidencyManager m_residencyManager;
-    std::queue<std::shared_ptr<ManagedCommandList>> m_commandListPool;
+	UINT64 m_totalAllocations;
+	UINT m_textureIndex;
+	D3DX12Residency::ResidencyManager m_residencyManager;
+	std::queue<std::shared_ptr<ManagedCommandList>> m_commandListPool;
 
-    // Thread and texture loading management.
-    std::vector<std::future<void>> m_threads;
-    bool m_cancel;
-    std::mutex m_mutex;
-    std::queue<std::shared_ptr<ManagedTexture>> m_incompleteTextures;    // Textures that are not initialized yet.
-    std::vector<std::shared_ptr<ManagedTexture>> m_loadedTextures;        // Textures that are ready to be used.
-    UINT m_loadedTextureCount;
+	// Thread and texture loading management.
+	std::vector<std::future<void>> m_threads;
+	bool m_cancel;
+	std::mutex m_mutex;
+	std::queue<std::shared_ptr<ManagedTexture>> m_incompleteTextures;	// Textures that are not initialized yet.
+	std::vector<std::shared_ptr<ManagedTexture>> m_loadedTextures;		// Textures that are ready to be used.
+	UINT m_loadedTextureCount;
 
-    inline std::shared_ptr<ManagedTexture> GetNextIncompleteTexture()
-    {
-        std::lock_guard<std::mutex> lock(m_mutex);
+	inline std::shared_ptr<ManagedTexture> GetNextIncompleteTexture()
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 
-        if (m_incompleteTextures.size() == 0)
-        {
-            return nullptr;
-        }
-        else
-        {
-            auto pTexture = m_incompleteTextures.front();
-            m_incompleteTextures.pop();
-            return pTexture;
-        }
-    }
+		if (m_incompleteTextures.size() == 0)
+		{
+			return nullptr;
+		}
+		else
+		{
+			auto pTexture = m_incompleteTextures.front();
+			m_incompleteTextures.pop();
+			return pTexture;
+		}
+	}
 
-    inline void StoreCompletedTexture(std::shared_ptr<ManagedTexture> pTexture)
-    {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        m_loadedTextures[pTexture->index] = pTexture;
-        m_loadedTextureCount++;
-    }
+	inline void StoreCompletedTexture(std::shared_ptr<ManagedTexture> pTexture)
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		m_loadedTextures[pTexture->index] = pTexture;
+		m_loadedTextureCount++;
+	}
 
-    inline UINT LoadedTextureCount()
-    {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        return m_loadedTextureCount;
-    }
+	inline UINT LoadedTextureCount()
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		return m_loadedTextureCount;
+	}
 
-    void LoadPipeline();
-    void LoadAssets();
-    void LoadTexturesAsync();
-    void PopulateCommandList(std::shared_ptr<ManagedCommandList> pManagedCommandList);
-    void FlushGpu();
+	void LoadPipeline();
+	void LoadAssets();
+	void LoadTexturesAsync();
+	void PopulateCommandList(std::shared_ptr<ManagedCommandList> pManagedCommandList);
+	void FlushGpu();
 };

--- a/Samples/Desktop/D3D12Residency/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12Residency/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,58 +34,103 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title + L": " + text;
-    SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
+	std::wstring windowText = m_title + L": " + text;
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/Desktop/D3D12Residency/src/DXSample.h
+++ b/Samples/Desktop/D3D12Residency/src/DXSample.h
@@ -17,42 +17,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/Desktop/D3D12Residency/src/Main.cpp
+++ b/Samples/Desktop/D3D12Residency/src/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12Residency sample(1280, 720, L"D3D12 Residency Sample");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12Residency sample(1280, 720, L"D3D12 Residency Sample");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12Residency/src/Win32Application.cpp
+++ b/Samples/Desktop/D3D12Residency/src/Win32Application.cpp
@@ -16,104 +16,104 @@ HWND Win32Application::m_hwnd = nullptr;
 
 int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
 {
-    // Parse the command line parameters
-    int argc;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    pSample->ParseCommandLineArgs(argv, argc);
-    LocalFree(argv);
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
 
-    // Initialize the window class.
-    WNDCLASSEX windowClass = { 0 };
-    windowClass.cbSize = sizeof(WNDCLASSEX);
-    windowClass.style = CS_HREDRAW | CS_VREDRAW;
-    windowClass.lpfnWndProc = WindowProc;
-    windowClass.hInstance = hInstance;
-    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-    windowClass.lpszClassName = L"DXSampleClass";
-    RegisterClassEx(&windowClass);
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
 
-    RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
-    AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
 
-    // Create the window and store a handle to it.
-    m_hwnd = CreateWindow(
-        windowClass.lpszClassName,
-        pSample->GetTitle(),
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        windowRect.right - windowRect.left,
-        windowRect.bottom - windowRect.top,
-        nullptr,        // We have no parent window.
-        nullptr,        // We aren't using menus.
-        hInstance,
-        pSample);
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
 
-    // Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-    pSample->OnInit();
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
 
-    ShowWindow(m_hwnd, nCmdShow);
+	ShowWindow(m_hwnd, nCmdShow);
 
-    // Main sample loop.
-    MSG msg = {};
-    while (msg.message != WM_QUIT)
-    {
-        // Process any messages in the queue.
-        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
-    }
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
 
-    pSample->OnDestroy();
+	pSample->OnDestroy();
 
-    // Return this part of the WM_QUIT message to Windows.
-    return static_cast<char>(msg.wParam);
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
 }
 
 // Main message handler for the sample.
 LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
-    switch (message)
-    {
-    case WM_CREATE:
-        {
-            // Save the DXSample* passed in to CreateWindow.
-            LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
-            SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
-        }
-        return 0;
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
 
-    case WM_KEYDOWN:
-        if (pSample)
-        {
-            pSample->OnKeyDown(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_KEYUP:
-        if (pSample)
-        {
-            pSample->OnKeyUp(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_PAINT:
-        if (pSample)
-        {
-            pSample->OnUpdate();
-            pSample->OnRender();
-        }
-        return 0;
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
 
-    case WM_DESTROY:
-        PostQuitMessage(0);
-        return 0;
-    }
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
 
-    // Handle any messages the switch statement didn't.
-    return DefWindowProc(hWnd, message, wParam, lParam);
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/Desktop/D3D12Residency/src/Win32Application.h
+++ b/Samples/Desktop/D3D12Residency/src/Win32Application.h
@@ -18,12 +18,12 @@ class DXSample;
 class Win32Application
 {
 public:
-    static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
-    static HWND GetHwnd() { return m_hwnd; }
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
 
 protected:
-    static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
-    static HWND m_hwnd;
+	static HWND m_hwnd;
 };

--- a/Samples/Desktop/D3D12Residency/src/d3dx12.h
+++ b/Samples/Desktop/D3D12Residency/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12Residency/src/d3dx12Residency.h
+++ b/Samples/Desktop/D3D12Residency/src/d3dx12Residency.h
@@ -12,14 +12,14 @@
 #pragma once
 namespace D3DX12Residency
 {
-    __declspec(selectany) INT64 g_ResidencyManagerUniqueID = 0;
+	__declspec(selectany) INT64 g_ResidencyManagerUniqueID = 0;
 
 #if 0
 #define RESIDENCY_CHECK(x) \
-    if((x) == false) { DebugBreak(); }
+	if((x) == false) { DebugBreak(); }
 
 #define RESIDENCY_CHECK_RESULT(x) \
-    if((x) != S_OK) { DebugBreak(); }
+	if((x) != S_OK) { DebugBreak(); }
 #else
 #define RESIDENCY_CHECK(x)
 #define RESIDENCY_CHECK_RESULT(x) x
@@ -30,1486 +30,1486 @@ namespace D3DX12Residency
 #define RESIDENCY_MIN(x,y) ((x) < (y) ? (x) : (y))
 #define RESIDENCY_MAX(x,y) ((x) > (y) ? (x) : (y))
 
-    // This size can be tuned to your app in order to save space
+	// This size can be tuned to your app in order to save space
 #define MAX_NUM_CONCURRENT_CMD_LISTS 32
 
-    namespace Internal
-    {
-        class CriticalSection
-        {
-            friend class ScopedLock;
-        public:
-            CriticalSection()
-            {
-                InitializeCriticalSectionAndSpinCount(&CS, 8);
-            }
-
-            ~CriticalSection()
-            {
-                DeleteCriticalSection(&CS);
-            }
-
-        private:
-            CRITICAL_SECTION CS;
-        };
-
-        class ScopedLock
-        {
-        public:
-
-            ScopedLock() : pCS(nullptr) {};
-            ScopedLock(CriticalSection* pCSIn) : pCS(pCSIn)
-            {
-                if (pCS)
-                {
-                    EnterCriticalSection(&pCS->CS);
-                }
-            };
-
-            ~ScopedLock()
-            {
-                if (pCS)
-                {
-                    LeaveCriticalSection(&pCS->CS);
-                }
-            }
-
-        private:
-
-            CriticalSection* pCS;
-        };
-
-        // One per Residency Manager
-        class SyncManager
-        {
-        public:
-            SyncManager()
-            {
-                for (UINT32 i = 0; i < ARRAYSIZE(AvailableCommandLists); i++)
-                {
-                    AvailableCommandLists[i] = false;
-                }
-            }
-
-            Internal::CriticalSection MaskCriticalSection;
-
-            static const UINT32 sUnsetValue = UINT32(-1);
-            // Represents which command lists are currently open for recording
-            bool AvailableCommandLists[MAX_NUM_CONCURRENT_CMD_LISTS];
-        };
-
-        //Forward Declaration
-        class ResidencyManagerInternal;
-    }
-
-    // Used to track meta data for each object the app potentially wants
-    // to make resident or evict.
-    class ManagedObject
-    {
-    public:
-        enum class RESIDENCY_STATUS
-        {
-            RESIDENT,
-            EVICTED
-        };
-
-        ManagedObject() :
-            pUnderlying(nullptr),
-            Size(0),
-            ResidencyStatus(RESIDENCY_STATUS::RESIDENT),
-            LastGPUSyncPoint(0),
-            LastUsedTimestamp(0)
-        {
-            memset(CommandListsUsedOn, 0, sizeof(CommandListsUsedOn));
-        }
-
-        void Initialize(ID3D12Pageable* pUnderlyingIn, UINT64 ObjectSize, UINT64 InitialGPUSyncPoint = 0)
-        {
-            RESIDENCY_CHECK(pUnderlying == nullptr);
-            pUnderlying = pUnderlyingIn;
-            Size = ObjectSize;
-            LastGPUSyncPoint = InitialGPUSyncPoint;
-        }
-
-        inline bool IsInitialized() { return pUnderlying != nullptr; }
-
-        // Wether the object is resident or not
-        RESIDENCY_STATUS ResidencyStatus;
-
-        // The underlying D3D Object being tracked
-        ID3D12Pageable* pUnderlying;
-        // The size of the D3D Object in bytes
-        UINT64 Size;
-
-        UINT64 LastGPUSyncPoint;
-        UINT64 LastUsedTimestamp;
-
-        // This is used to track which open command lists this resource is currently used on.
-        bool CommandListsUsedOn[MAX_NUM_CONCURRENT_CMD_LISTS];
-
-        // Linked list entry
-        LIST_ENTRY ListEntry;
-    };
-
-    // This represents a set of objects which are referenced by a command list i.e. every time a resource
-    // is bound for rendering, clearing, copy etc. the set must be updated to ensure the it is resident 
-    // for execution.
-    class ResidencySet
-    {
-        friend class ResidencyManager;
-        friend class Internal::ResidencyManagerInternal;
-    public:
-
-        static const UINT32 InvalidIndex = (UINT32)-1;
-
-        ResidencySet() :
-            CommandListIndex(InvalidIndex),
-            MaxResidencySetSize(0),
-            CurrentSetSize(0),
-            ppSet(nullptr),
-            IsOpen(false),
-            OutOfMemory(false),
-            pSyncManager(nullptr)
-        {
-        };
-
-        ~ResidencySet()
-        {
-            delete[](ppSet);
-        }
-
-        // Returns true if the object was inserted, false otherwise
-        inline bool Insert(ManagedObject* pObject)
-        {
-            RESIDENCY_CHECK(IsOpen);
-            RESIDENCY_CHECK(CommandListIndex != InvalidIndex);
-
-            // If we haven't seen this object on this command list mark it
-            if (pObject->CommandListsUsedOn[CommandListIndex] == false)
-            {
-                pObject->CommandListsUsedOn[CommandListIndex] = true;
-                if (ppSet == nullptr || CurrentSetSize >= MaxResidencySetSize)
-                {
-                    Realloc();
-                }
-                if (ppSet == nullptr)
-                {
-                    OutOfMemory = true;
-                    return false;
-                }
-
-                ppSet[CurrentSetSize++] = pObject;
-
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-
-        HRESULT Open()
-        {
-            Internal::ScopedLock Lock(&pSyncManager->MaskCriticalSection);
-
-            // It's invalid to open a set that is already open
-            if (IsOpen)
-            {
-                return E_INVALIDARG;
-            }
-
-            RESIDENCY_CHECK(CommandListIndex == InvalidIndex);
-
-            bool CommandlistAvailable = false;
-            // Find the first available command list by bitscanning
-            for (UINT32 i = 0; i < ARRAYSIZE(pSyncManager->AvailableCommandLists); i++)
-            {
-                if (pSyncManager->AvailableCommandLists[i] == false)
-                {
-                    CommandListIndex = i;
-                    pSyncManager->AvailableCommandLists[i] = true;
-                    CommandlistAvailable = true;
-                    break;
-                }
-            }
-
-            if (CommandlistAvailable == false)
-            {
-                // There are too many open residency sets, consider using less or increasing the value of MAX_NUM_CONCURRENT_CMD_LISTS
-                RESIDENCY_CHECK(false);
-                return E_OUTOFMEMORY;
-            }
-
-            CurrentSetSize = 0;
-
-            IsOpen = true;
-            OutOfMemory = false;
-            return S_OK;
-        }
-
-        HRESULT Close()
-        {
-            if (IsOpen == false)
-            {
-                return E_INVALIDARG;
-            }
-
-            if (OutOfMemory == true)
-            {
-                return E_OUTOFMEMORY;
-            }
-
-            for (INT32 i = 0; i < CurrentSetSize; i++)
-            {
-                Remove(ppSet[i]);
-            }
-
-            ReturnCommandListReservation();
-
-            IsOpen = false;
-
-            return S_OK;
-        }
-
-    private:
-
-        inline void Remove(ManagedObject* pObject)
-        {
-            pObject->CommandListsUsedOn[CommandListIndex] = false;
-        }
-
-        inline void ReturnCommandListReservation()
-        {
-            Internal::ScopedLock Lock(&pSyncManager->MaskCriticalSection);
-
-            pSyncManager->AvailableCommandLists[CommandListIndex] = false;
-
-            CommandListIndex = ResidencySet::InvalidIndex;
-
-            IsOpen = false;
-        }
-
-        void Initialize(Internal::SyncManager* pSyncManagerIn)
-        {
-            pSyncManager = pSyncManagerIn;
-        }
-
-        bool Initialize(Internal::SyncManager* pSyncManagerIn, UINT32 MaxSize)
-        {
-            pSyncManager = pSyncManagerIn;
-            MaxResidencySetSize = MaxSize;
-
-            ppSet = new ManagedObject*[MaxResidencySetSize];
-
-            return ppSet != nullptr;
-        }
-
-        inline void Realloc()
-        {
-            MaxResidencySetSize = (MaxResidencySetSize == 0) ? 4096 : INT32(MaxResidencySetSize + (MaxResidencySetSize / 2.0f));
-            ManagedObject** ppNewAlloc = new ManagedObject*[MaxResidencySetSize];
-
-            if (ppSet && ppNewAlloc)
-            {
-                memcpy(ppNewAlloc, ppSet, CurrentSetSize * sizeof(ManagedObject*));
-                delete[](ppSet);
-            }
-
-            ppSet = ppNewAlloc;
-        }
-
-        UINT32 CommandListIndex;
-
-        ManagedObject** ppSet;
-        INT32 MaxResidencySetSize;
-        INT32 CurrentSetSize;
-
-        bool IsOpen;
-        bool OutOfMemory;
-
-        Internal::SyncManager* pSyncManager;
-    };
-
-    namespace Internal
-    {
-        /* List Helpers */
-        inline void InitializeListHead(LIST_ENTRY* pHead)
-        {
-            pHead->Flink = pHead->Blink = pHead;
-        }
-
-        inline void InsertHeadList(LIST_ENTRY* pHead, LIST_ENTRY* pEntry)
-        {
-            pEntry->Blink = pHead;
-            pEntry->Flink = pHead->Flink;
-
-            pHead->Flink->Blink = pEntry;
-            pHead->Flink = pEntry;
-        }
-
-        inline void InsertTailList(LIST_ENTRY* pHead, LIST_ENTRY* pEntry)
-        {
-            pEntry->Flink = pHead;
-            pEntry->Blink = pHead->Blink;
-
-            pHead->Blink->Flink = pEntry;
-            pHead->Blink = pEntry;
-        }
-
-        inline void RemoveEntryList(LIST_ENTRY* pEntry)
-        {
-            pEntry->Blink->Flink = pEntry->Flink;
-            pEntry->Flink->Blink = pEntry->Blink;
-        }
-
-        inline LIST_ENTRY* RemoveHeadList(LIST_ENTRY* pHead)
-        {
-            LIST_ENTRY* pEntry = pHead->Flink;
-            Internal::RemoveEntryList(pEntry);
-            return pEntry;
-        }
-
-        inline LIST_ENTRY* RemoveTailList(LIST_ENTRY* pHead)
-        {
-            LIST_ENTRY* pEntry = pHead->Blink;
-            Internal::RemoveEntryList(pEntry);
-            return pEntry;
-        }
-
-        inline bool IsListEmpty(LIST_ENTRY* pEntry)
-        {
-            return pEntry->Flink == pEntry;
-        }
-
-        struct Fence
-        {
-            Fence(UINT64 StartingValue) : pFence(nullptr), FenceValue(StartingValue)
-            {
-                Internal::InitializeListHead(&ListEntry);
-            };
-
-            HRESULT Initialize(ID3D12Device* pDevice)
-            {
-                HRESULT hr = pDevice->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&pFence));
-                RESIDENCY_CHECK_RESULT(hr);
-
-                return hr;
-            }
-
-            void Destroy()
-            {
-                if (pFence)
-                {
-                    pFence->Release();
-                    pFence = nullptr;
-                }
-            }
-
-            HRESULT GPUWait(ID3D12CommandQueue* pQueue)
-            {
-                HRESULT hr = pQueue->Wait(pFence, FenceValue);
-                RESIDENCY_CHECK_RESULT(hr);
-                return hr;
-            }
-
-            HRESULT GPUSignal(ID3D12CommandQueue* pQueue)
-            {
-                HRESULT hr = pQueue->Signal(pFence, FenceValue);
-                RESIDENCY_CHECK_RESULT(hr);
-                return hr;
-            }
-
-            inline void Increment()
-            {
-                FenceValue++;
-            }
-
-            ID3D12Fence* pFence;
-            UINT64 FenceValue;
-            LIST_ENTRY ListEntry;
-        };
-
-        // Represents a time on a particular queue that a resource was used
-        struct QueueSyncPoint
-        {
-            QueueSyncPoint() : pFence(nullptr), LastUsedValue(0) {};
-
-            inline bool IsCompleted() { return LastUsedValue <= pFence->pFence->GetCompletedValue(); }
-
-            inline void WaitForCompletion(HANDLE Event)
-            {
-                RESIDENCY_CHECK_RESULT(pFence->pFence->SetEventOnCompletion(LastUsedValue, Event));
-                RESIDENCY_CHECK_RESULT(WaitForSingleObject(Event, INFINITE));
-            }
-
-            Fence* pFence;
-            UINT64 LastUsedValue;
-        };
-
-        struct DeviceWideSyncPoint
-        {
-            DeviceWideSyncPoint(UINT32 NumQueues, UINT64 Generation) :
-                GenerationID(Generation), NumQueueSyncPoints(NumQueues) {};
-
-            // Create the whole structure in one allocation for locality
-            static DeviceWideSyncPoint* CreateSyncPoint(UINT32 NumQueues, UINT64 Generation)
-            {
-                DeviceWideSyncPoint* pSyncPoint = nullptr;
-                const SIZE_T Size = sizeof(DeviceWideSyncPoint) + (sizeof(QueueSyncPoint) * (NumQueues - 1));
-
-                BYTE* pAlloc = new BYTE[Size];
-                if (pAlloc && Size >= sizeof(DeviceWideSyncPoint))
-                {
-                    pSyncPoint = new (pAlloc) DeviceWideSyncPoint(NumQueues, Generation);
-                }
-
-                return pSyncPoint;
-            }
-
-            // A device wide fence is completed if all of the queues that were active at that point are completed
-            inline bool IsCompleted()
-            {
-                for (UINT32 i = 0; i < NumQueueSyncPoints; i++)
-                {
-                    if (pQueueSyncPoints[i].IsCompleted() == false)
-                    {
-                        return false;
-                    }
-                }
-                return true;
-            }
-
-            inline void WaitForCompletion(HANDLE Event)
-            {
-                for (UINT32 i = 0; i < NumQueueSyncPoints; i++)
-                {
-                    if (pQueueSyncPoints[i].IsCompleted() == false)
-                    {
-                        pQueueSyncPoints[i].WaitForCompletion(Event);
-                    }
-                }
-            }
-
-            const UINT64 GenerationID;
-            const UINT32 NumQueueSyncPoints;
-            LIST_ENTRY ListEntry;
-            // NumQueueSyncPoints QueueSyncPoints will be placed below here
-            QueueSyncPoint pQueueSyncPoints[1];
-        };
-
-        // A Least Recently Used Cache. Tracks all of the objects requested by the app so that objects
-        // that aren't used freqently can get evicted to help the app stay under buget.
-        class LRUCache
-        {
-        public:
-            LRUCache() :
-                NumResidentObjects(0),
-                NumEvictedObjects(0),
-                ResidentSize(0)
-            {
-                Internal::InitializeListHead(&ResidentObjectListHead);
-                Internal::InitializeListHead(&EvictedObjectListHead);
-            };
-
-            void Insert(ManagedObject* pObject)
-            {
-                if (pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT)
-                {
-                    Internal::InsertHeadList(&ResidentObjectListHead, &pObject->ListEntry);
-                    NumResidentObjects++;
-                    ResidentSize += pObject->Size;
-                }
-                else
-                {
-                    Internal::InsertHeadList(&EvictedObjectListHead, &pObject->ListEntry);
-                    NumEvictedObjects++;
-                }
-            }
-
-            void Remove(ManagedObject* pObject)
-            {
-                Internal::RemoveEntryList(&pObject->ListEntry);
-                if (pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT)
-                {
-                    NumResidentObjects--;
-                    ResidentSize -= pObject->Size;
-                }
-                else
-                {
-                    NumEvictedObjects--;
-                }
-            }
-
-            // When an object is used by the GPU we move it to the end of the list.
-            // This way things closer to the head of the list are the objects which
-            // are stale and better candidates for eviction
-            void ObjectReferenced(ManagedObject* pObject)
-            {
-                RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT);
-
-                Internal::RemoveEntryList(&pObject->ListEntry);
-                Internal::InsertTailList(&ResidentObjectListHead, &pObject->ListEntry);
-            }
-
-            void MakeResident(ManagedObject* pObject)
-            {
-                RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::EVICTED);
-
-                pObject->ResidencyStatus = ManagedObject::RESIDENCY_STATUS::RESIDENT;
-                Internal::RemoveEntryList(&pObject->ListEntry);
-                Internal::InsertTailList(&ResidentObjectListHead, &pObject->ListEntry);
-
-                NumEvictedObjects--;
-                NumResidentObjects++;
-                ResidentSize += pObject->Size;
-            }
-
-            void Evict(ManagedObject* pObject)
-            {
-                RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT);
-
-                pObject->ResidencyStatus = ManagedObject::RESIDENCY_STATUS::EVICTED;
-                Internal::RemoveEntryList(&pObject->ListEntry);
-                Internal::InsertTailList(&EvictedObjectListHead, &pObject->ListEntry);
-
-                NumResidentObjects--;
-                ResidentSize -= pObject->Size;
-                NumEvictedObjects++;
-            }
-
-            // Evict all of the resident objects used in sync points up to the specficied one (inclusive)
-            void TrimToSyncPointInclusive(INT64 CurrentUsage, INT64 CurrentBudget, ID3D12Pageable** EvictionList, UINT32& NumObjectsToEvict, UINT64 SyncPoint)
-            {
-                NumObjectsToEvict = 0;
-
-                LIST_ENTRY* pResourceEntry = ResidentObjectListHead.Flink;
-                while (pResourceEntry != &ResidentObjectListHead)
-                {
-                    ManagedObject* pObject = CONTAINING_RECORD(pResourceEntry, ManagedObject, ListEntry);
-
-                    if (pObject->LastGPUSyncPoint > SyncPoint || CurrentUsage < CurrentBudget)
-                    {
-                        break;
-                    }
-
-                    RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT);
-
-                    EvictionList[NumObjectsToEvict++] = pObject->pUnderlying;
-                    Evict(pObject);
-
-                    CurrentUsage -= pObject->Size;
-
-                    pResourceEntry = ResidentObjectListHead.Flink;
-                }
-            }
-
-            // Trim all objects which are older than the specified time
-            void TrimAgedAllocations(DeviceWideSyncPoint* MaxSyncPoint, ID3D12Pageable** EvictionList, UINT32& NumObjectsToEvict, UINT64 CurrentTimeStamp, UINT64 MinDelta)
-            {
-                LIST_ENTRY* pResourceEntry = ResidentObjectListHead.Flink;
-                while (pResourceEntry != &ResidentObjectListHead)
-                {
-                    ManagedObject* pObject = CONTAINING_RECORD(pResourceEntry, ManagedObject, ListEntry);
-
-                    if ((MaxSyncPoint && pObject->LastGPUSyncPoint >= MaxSyncPoint->GenerationID) || // Only trim allocations done on the GPU
-                        CurrentTimeStamp - pObject->LastUsedTimestamp <= MinDelta) // Don't evict things which have been used recently
-                    {
-                        break;
-                    }
-
-                    RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT);
-                    EvictionList[NumObjectsToEvict++] = pObject->pUnderlying;
-                    Evict(pObject);
-
-                    pResourceEntry = ResidentObjectListHead.Flink;
-                }
-            }
-
-            ManagedObject* GetResidentListHead()
-            {
-                if (IsListEmpty(&ResidentObjectListHead))
-                {
-                    return nullptr;
-                }
-                return CONTAINING_RECORD(ResidentObjectListHead.Flink, ManagedObject, ListEntry);
-            }
-
-            LIST_ENTRY ResidentObjectListHead;
-            LIST_ENTRY EvictedObjectListHead;
-
-            UINT32 NumResidentObjects;
-            UINT32 NumEvictedObjects;
-
-            UINT64 ResidentSize;
-        };
-
-        class ResidencyManagerInternal
-        {
-        public:
-            ResidencyManagerInternal(SyncManager* pSyncManagerIn) :
-                Device(nullptr),
-                AsyncThreadFence(1),
-                CompletionEvent(INVALID_HANDLE_VALUE),
-                AsyncThreadWorkCompletionEvent(INVALID_HANDLE_VALUE),
-                Adapter(nullptr),
-                AsyncWorkEvent(INVALID_HANDLE_VALUE),
-                AsyncWorkThread(INVALID_HANDLE_VALUE),
-                FinishAsyncWork(false),
-                cStartEvicted(false),
-                CurrentSyncPointGeneration(0),
-                NumQueuesSeen(0),
-                NodeIndex(0),
-                CurrentAsyncWorkloadHead(0),
-                CurrentAsyncWorkloadTail(0),
-                cMinEvictionGracePeriod(1.0f),
-                cMaxEvictionGracePeriod(60.0f),
-                cTrimPercentageMemoryUsageThreshold(0.7f),
-                AsyncWorkQueue(nullptr),
-                MaxSoftwareQueueLatency(6),
-                AsyncWorkQueueSize(7),
-                pSyncManager(pSyncManagerIn)
-            {
-                Internal::InitializeListHead(&QueueFencesListHead);
-                Internal::InitializeListHead(&InFlightSyncPointsHead);
-
-                ResidencyManagerUniqueID = InterlockedIncrement64(&g_ResidencyManagerUniqueID);
-            };
-
-            // NOTE: DeviceNodeIndex is an index not a mask. The majority of D3D12 uses bit masks to identify a GPU node whereas DXGI uses 0 based indices.
-            HRESULT Initialize(ID3D12Device* ParentDevice, UINT DeviceNodeIndex, IDXGIAdapter3* ParentAdapter, UINT32 MaxLatency)
-            {
-                Device = ParentDevice;
-                NodeIndex = DeviceNodeIndex;
-                Adapter = ParentAdapter;
-                MaxSoftwareQueueLatency = MaxLatency;
-
-                AsyncWorkQueueSize = MaxLatency + 1;
-                AsyncWorkQueue = new AsyncWorkload[AsyncWorkQueueSize];
-
-                if (AsyncWorkQueue == nullptr)
-                {
-                    return E_OUTOFMEMORY;
-                }
-
-                LARGE_INTEGER Frequency;
-                QueryPerformanceFrequency(&Frequency);
-
-                // Calculate how many QPC ticks are equivalent to the given time in seconds
-                MinEvictionGracePeriodTicks = UINT64(Frequency.QuadPart * cMinEvictionGracePeriod);
-                MaxEvictionGracePeriodTicks = UINT64(Frequency.QuadPart * cMaxEvictionGracePeriod);
-
-                HRESULT hr = S_OK;
-                hr = AsyncThreadFence.Initialize(Device);
-
-                if (SUCCEEDED(hr))
-                {
-                    CompletionEvent = CreateEvent(nullptr, false, false, nullptr);
-                    if (CompletionEvent == INVALID_HANDLE_VALUE)
-                    {
-                        hr = HRESULT_FROM_WIN32(GetLastError());
-                    }
-                }
-
-                if (SUCCEEDED(hr))
-                {
-                    AsyncThreadWorkCompletionEvent = CreateEvent(nullptr, false, false, nullptr);
-                    if (AsyncThreadWorkCompletionEvent == INVALID_HANDLE_VALUE)
-                    {
-                        hr = HRESULT_FROM_WIN32(GetLastError());
-                    }
-                }
-
-                if (SUCCEEDED(hr))
-                {
-                    AsyncWorkEvent = CreateEvent(nullptr, true, false, nullptr);
-                    if (AsyncWorkEvent == INVALID_HANDLE_VALUE)
-                    {
-                        hr = HRESULT_FROM_WIN32(GetLastError());
-                    }
-                }
+	namespace Internal
+	{
+		class CriticalSection
+		{
+			friend class ScopedLock;
+		public:
+			CriticalSection()
+			{
+				InitializeCriticalSectionAndSpinCount(&CS, 8);
+			}
+
+			~CriticalSection()
+			{
+				DeleteCriticalSection(&CS);
+			}
+
+		private:
+			CRITICAL_SECTION CS;
+		};
+
+		class ScopedLock
+		{
+		public:
+
+			ScopedLock() : pCS(nullptr) {};
+			ScopedLock(CriticalSection* pCSIn) : pCS(pCSIn)
+			{
+				if (pCS)
+				{
+					EnterCriticalSection(&pCS->CS);
+				}
+			};
+
+			~ScopedLock()
+			{
+				if (pCS)
+				{
+					LeaveCriticalSection(&pCS->CS);
+				}
+			}
+
+		private:
+
+			CriticalSection* pCS;
+		};
+
+		// One per Residency Manager
+		class SyncManager
+		{
+		public:
+			SyncManager()
+			{
+				for (UINT32 i = 0; i < ARRAYSIZE(AvailableCommandLists); i++)
+				{
+					AvailableCommandLists[i] = false;
+				}
+			}
+
+			Internal::CriticalSection MaskCriticalSection;
+
+			static const UINT32 sUnsetValue = UINT32(-1);
+			// Represents which command lists are currently open for recording
+			bool AvailableCommandLists[MAX_NUM_CONCURRENT_CMD_LISTS];
+		};
+
+		//Forward Declaration
+		class ResidencyManagerInternal;
+	}
+
+	// Used to track meta data for each object the app potentially wants
+	// to make resident or evict.
+	class ManagedObject
+	{
+	public:
+		enum class RESIDENCY_STATUS
+		{
+			RESIDENT,
+			EVICTED
+		};
+
+		ManagedObject() :
+			pUnderlying(nullptr),
+			Size(0),
+			ResidencyStatus(RESIDENCY_STATUS::RESIDENT),
+			LastGPUSyncPoint(0),
+			LastUsedTimestamp(0)
+		{
+			memset(CommandListsUsedOn, 0, sizeof(CommandListsUsedOn));
+		}
+
+		void Initialize(ID3D12Pageable* pUnderlyingIn, UINT64 ObjectSize, UINT64 InitialGPUSyncPoint = 0)
+		{
+			RESIDENCY_CHECK(pUnderlying == nullptr);
+			pUnderlying = pUnderlyingIn;
+			Size = ObjectSize;
+			LastGPUSyncPoint = InitialGPUSyncPoint;
+		}
+
+		inline bool IsInitialized() { return pUnderlying != nullptr; }
+
+		// Wether the object is resident or not
+		RESIDENCY_STATUS ResidencyStatus;
+
+		// The underlying D3D Object being tracked
+		ID3D12Pageable* pUnderlying;
+		// The size of the D3D Object in bytes
+		UINT64 Size;
+
+		UINT64 LastGPUSyncPoint;
+		UINT64 LastUsedTimestamp;
+
+		// This is used to track which open command lists this resource is currently used on.
+		bool CommandListsUsedOn[MAX_NUM_CONCURRENT_CMD_LISTS];
+
+		// Linked list entry
+		LIST_ENTRY ListEntry;
+	};
+
+	// This represents a set of objects which are referenced by a command list i.e. every time a resource
+	// is bound for rendering, clearing, copy etc. the set must be updated to ensure the it is resident 
+	// for execution.
+	class ResidencySet
+	{
+		friend class ResidencyManager;
+		friend class Internal::ResidencyManagerInternal;
+	public:
+
+		static const UINT32 InvalidIndex = (UINT32)-1;
+
+		ResidencySet() :
+			CommandListIndex(InvalidIndex),
+			MaxResidencySetSize(0),
+			CurrentSetSize(0),
+			ppSet(nullptr),
+			IsOpen(false),
+			OutOfMemory(false),
+			pSyncManager(nullptr)
+		{
+		};
+
+		~ResidencySet()
+		{
+			delete[](ppSet);
+		}
+
+		// Returns true if the object was inserted, false otherwise
+		inline bool Insert(ManagedObject* pObject)
+		{
+			RESIDENCY_CHECK(IsOpen);
+			RESIDENCY_CHECK(CommandListIndex != InvalidIndex);
+
+			// If we haven't seen this object on this command list mark it
+			if (pObject->CommandListsUsedOn[CommandListIndex] == false)
+			{
+				pObject->CommandListsUsedOn[CommandListIndex] = true;
+				if (ppSet == nullptr || CurrentSetSize >= MaxResidencySetSize)
+				{
+					Realloc();
+				}
+				if (ppSet == nullptr)
+				{
+					OutOfMemory = true;
+					return false;
+				}
+
+				ppSet[CurrentSetSize++] = pObject;
+
+				return true;
+			}
+			else
+			{
+				return false;
+			}
+		}
+
+		HRESULT Open()
+		{
+			Internal::ScopedLock Lock(&pSyncManager->MaskCriticalSection);
+
+			// It's invalid to open a set that is already open
+			if (IsOpen)
+			{
+				return E_INVALIDARG;
+			}
+
+			RESIDENCY_CHECK(CommandListIndex == InvalidIndex);
+
+			bool CommandlistAvailable = false;
+			// Find the first available command list by bitscanning
+			for (UINT32 i = 0; i < ARRAYSIZE(pSyncManager->AvailableCommandLists); i++)
+			{
+				if (pSyncManager->AvailableCommandLists[i] == false)
+				{
+					CommandListIndex = i;
+					pSyncManager->AvailableCommandLists[i] = true;
+					CommandlistAvailable = true;
+					break;
+				}
+			}
+
+			if (CommandlistAvailable == false)
+			{
+				// There are too many open residency sets, consider using less or increasing the value of MAX_NUM_CONCURRENT_CMD_LISTS
+				RESIDENCY_CHECK(false);
+				return E_OUTOFMEMORY;
+			}
+
+			CurrentSetSize = 0;
+
+			IsOpen = true;
+			OutOfMemory = false;
+			return S_OK;
+		}
+
+		HRESULT Close()
+		{
+			if (IsOpen == false)
+			{
+				return E_INVALIDARG;
+			}
+
+			if (OutOfMemory == true)
+			{
+				return E_OUTOFMEMORY;
+			}
+
+			for (INT32 i = 0; i < CurrentSetSize; i++)
+			{
+				Remove(ppSet[i]);
+			}
+
+			ReturnCommandListReservation();
+
+			IsOpen = false;
+
+			return S_OK;
+		}
+
+	private:
+
+		inline void Remove(ManagedObject* pObject)
+		{
+			pObject->CommandListsUsedOn[CommandListIndex] = false;
+		}
+
+		inline void ReturnCommandListReservation()
+		{
+			Internal::ScopedLock Lock(&pSyncManager->MaskCriticalSection);
+
+			pSyncManager->AvailableCommandLists[CommandListIndex] = false;
+
+			CommandListIndex = ResidencySet::InvalidIndex;
+
+			IsOpen = false;
+		}
+
+		void Initialize(Internal::SyncManager* pSyncManagerIn)
+		{
+			pSyncManager = pSyncManagerIn;
+		}
+
+		bool Initialize(Internal::SyncManager* pSyncManagerIn, UINT32 MaxSize)
+		{
+			pSyncManager = pSyncManagerIn;
+			MaxResidencySetSize = MaxSize;
+
+			ppSet = new ManagedObject*[MaxResidencySetSize];
+
+			return ppSet != nullptr;
+		}
+
+		inline void Realloc()
+		{
+			MaxResidencySetSize = (MaxResidencySetSize == 0) ? 4096 : INT32(MaxResidencySetSize + (MaxResidencySetSize / 2.0f));
+			ManagedObject** ppNewAlloc = new ManagedObject*[MaxResidencySetSize];
+
+			if (ppSet && ppNewAlloc)
+			{
+				memcpy(ppNewAlloc, ppSet, CurrentSetSize * sizeof(ManagedObject*));
+				delete[](ppSet);
+			}
+
+			ppSet = ppNewAlloc;
+		}
+
+		UINT32 CommandListIndex;
+
+		ManagedObject** ppSet;
+		INT32 MaxResidencySetSize;
+		INT32 CurrentSetSize;
+
+		bool IsOpen;
+		bool OutOfMemory;
+
+		Internal::SyncManager* pSyncManager;
+	};
+
+	namespace Internal
+	{
+		/* List Helpers */
+		inline void InitializeListHead(LIST_ENTRY* pHead)
+		{
+			pHead->Flink = pHead->Blink = pHead;
+		}
+
+		inline void InsertHeadList(LIST_ENTRY* pHead, LIST_ENTRY* pEntry)
+		{
+			pEntry->Blink = pHead;
+			pEntry->Flink = pHead->Flink;
+
+			pHead->Flink->Blink = pEntry;
+			pHead->Flink = pEntry;
+		}
+
+		inline void InsertTailList(LIST_ENTRY* pHead, LIST_ENTRY* pEntry)
+		{
+			pEntry->Flink = pHead;
+			pEntry->Blink = pHead->Blink;
+
+			pHead->Blink->Flink = pEntry;
+			pHead->Blink = pEntry;
+		}
+
+		inline void RemoveEntryList(LIST_ENTRY* pEntry)
+		{
+			pEntry->Blink->Flink = pEntry->Flink;
+			pEntry->Flink->Blink = pEntry->Blink;
+		}
+
+		inline LIST_ENTRY* RemoveHeadList(LIST_ENTRY* pHead)
+		{
+			LIST_ENTRY* pEntry = pHead->Flink;
+			Internal::RemoveEntryList(pEntry);
+			return pEntry;
+		}
+
+		inline LIST_ENTRY* RemoveTailList(LIST_ENTRY* pHead)
+		{
+			LIST_ENTRY* pEntry = pHead->Blink;
+			Internal::RemoveEntryList(pEntry);
+			return pEntry;
+		}
+
+		inline bool IsListEmpty(LIST_ENTRY* pEntry)
+		{
+			return pEntry->Flink == pEntry;
+		}
+
+		struct Fence
+		{
+			Fence(UINT64 StartingValue) : pFence(nullptr), FenceValue(StartingValue)
+			{
+				Internal::InitializeListHead(&ListEntry);
+			};
+
+			HRESULT Initialize(ID3D12Device* pDevice)
+			{
+				HRESULT hr = pDevice->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&pFence));
+				RESIDENCY_CHECK_RESULT(hr);
+
+				return hr;
+			}
+
+			void Destroy()
+			{
+				if (pFence)
+				{
+					pFence->Release();
+					pFence = nullptr;
+				}
+			}
+
+			HRESULT GPUWait(ID3D12CommandQueue* pQueue)
+			{
+				HRESULT hr = pQueue->Wait(pFence, FenceValue);
+				RESIDENCY_CHECK_RESULT(hr);
+				return hr;
+			}
+
+			HRESULT GPUSignal(ID3D12CommandQueue* pQueue)
+			{
+				HRESULT hr = pQueue->Signal(pFence, FenceValue);
+				RESIDENCY_CHECK_RESULT(hr);
+				return hr;
+			}
+
+			inline void Increment()
+			{
+				FenceValue++;
+			}
+
+			ID3D12Fence* pFence;
+			UINT64 FenceValue;
+			LIST_ENTRY ListEntry;
+		};
+
+		// Represents a time on a particular queue that a resource was used
+		struct QueueSyncPoint
+		{
+			QueueSyncPoint() : pFence(nullptr), LastUsedValue(0) {};
+
+			inline bool IsCompleted() { return LastUsedValue <= pFence->pFence->GetCompletedValue(); }
+
+			inline void WaitForCompletion(HANDLE Event)
+			{
+				RESIDENCY_CHECK_RESULT(pFence->pFence->SetEventOnCompletion(LastUsedValue, Event));
+				RESIDENCY_CHECK_RESULT(WaitForSingleObject(Event, INFINITE));
+			}
+
+			Fence* pFence;
+			UINT64 LastUsedValue;
+		};
+
+		struct DeviceWideSyncPoint
+		{
+			DeviceWideSyncPoint(UINT32 NumQueues, UINT64 Generation) :
+				GenerationID(Generation), NumQueueSyncPoints(NumQueues) {};
+
+			// Create the whole structure in one allocation for locality
+			static DeviceWideSyncPoint* CreateSyncPoint(UINT32 NumQueues, UINT64 Generation)
+			{
+				DeviceWideSyncPoint* pSyncPoint = nullptr;
+				const SIZE_T Size = sizeof(DeviceWideSyncPoint) + (sizeof(QueueSyncPoint) * (NumQueues - 1));
+
+				BYTE* pAlloc = new BYTE[Size];
+				if (pAlloc && Size >= sizeof(DeviceWideSyncPoint))
+				{
+					pSyncPoint = new (pAlloc) DeviceWideSyncPoint(NumQueues, Generation);
+				}
+
+				return pSyncPoint;
+			}
+
+			// A device wide fence is completed if all of the queues that were active at that point are completed
+			inline bool IsCompleted()
+			{
+				for (UINT32 i = 0; i < NumQueueSyncPoints; i++)
+				{
+					if (pQueueSyncPoints[i].IsCompleted() == false)
+					{
+						return false;
+					}
+				}
+				return true;
+			}
+
+			inline void WaitForCompletion(HANDLE Event)
+			{
+				for (UINT32 i = 0; i < NumQueueSyncPoints; i++)
+				{
+					if (pQueueSyncPoints[i].IsCompleted() == false)
+					{
+						pQueueSyncPoints[i].WaitForCompletion(Event);
+					}
+				}
+			}
+
+			const UINT64 GenerationID;
+			const UINT32 NumQueueSyncPoints;
+			LIST_ENTRY ListEntry;
+			// NumQueueSyncPoints QueueSyncPoints will be placed below here
+			QueueSyncPoint pQueueSyncPoints[1];
+		};
+
+		// A Least Recently Used Cache. Tracks all of the objects requested by the app so that objects
+		// that aren't used freqently can get evicted to help the app stay under buget.
+		class LRUCache
+		{
+		public:
+			LRUCache() :
+				NumResidentObjects(0),
+				NumEvictedObjects(0),
+				ResidentSize(0)
+			{
+				Internal::InitializeListHead(&ResidentObjectListHead);
+				Internal::InitializeListHead(&EvictedObjectListHead);
+			};
+
+			void Insert(ManagedObject* pObject)
+			{
+				if (pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT)
+				{
+					Internal::InsertHeadList(&ResidentObjectListHead, &pObject->ListEntry);
+					NumResidentObjects++;
+					ResidentSize += pObject->Size;
+				}
+				else
+				{
+					Internal::InsertHeadList(&EvictedObjectListHead, &pObject->ListEntry);
+					NumEvictedObjects++;
+				}
+			}
+
+			void Remove(ManagedObject* pObject)
+			{
+				Internal::RemoveEntryList(&pObject->ListEntry);
+				if (pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT)
+				{
+					NumResidentObjects--;
+					ResidentSize -= pObject->Size;
+				}
+				else
+				{
+					NumEvictedObjects--;
+				}
+			}
+
+			// When an object is used by the GPU we move it to the end of the list.
+			// This way things closer to the head of the list are the objects which
+			// are stale and better candidates for eviction
+			void ObjectReferenced(ManagedObject* pObject)
+			{
+				RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT);
+
+				Internal::RemoveEntryList(&pObject->ListEntry);
+				Internal::InsertTailList(&ResidentObjectListHead, &pObject->ListEntry);
+			}
+
+			void MakeResident(ManagedObject* pObject)
+			{
+				RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::EVICTED);
+
+				pObject->ResidencyStatus = ManagedObject::RESIDENCY_STATUS::RESIDENT;
+				Internal::RemoveEntryList(&pObject->ListEntry);
+				Internal::InsertTailList(&ResidentObjectListHead, &pObject->ListEntry);
+
+				NumEvictedObjects--;
+				NumResidentObjects++;
+				ResidentSize += pObject->Size;
+			}
+
+			void Evict(ManagedObject* pObject)
+			{
+				RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT);
+
+				pObject->ResidencyStatus = ManagedObject::RESIDENCY_STATUS::EVICTED;
+				Internal::RemoveEntryList(&pObject->ListEntry);
+				Internal::InsertTailList(&EvictedObjectListHead, &pObject->ListEntry);
+
+				NumResidentObjects--;
+				ResidentSize -= pObject->Size;
+				NumEvictedObjects++;
+			}
+
+			// Evict all of the resident objects used in sync points up to the specficied one (inclusive)
+			void TrimToSyncPointInclusive(INT64 CurrentUsage, INT64 CurrentBudget, ID3D12Pageable** EvictionList, UINT32& NumObjectsToEvict, UINT64 SyncPoint)
+			{
+				NumObjectsToEvict = 0;
+
+				LIST_ENTRY* pResourceEntry = ResidentObjectListHead.Flink;
+				while (pResourceEntry != &ResidentObjectListHead)
+				{
+					ManagedObject* pObject = CONTAINING_RECORD(pResourceEntry, ManagedObject, ListEntry);
+
+					if (pObject->LastGPUSyncPoint > SyncPoint || CurrentUsage < CurrentBudget)
+					{
+						break;
+					}
+
+					RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT);
+
+					EvictionList[NumObjectsToEvict++] = pObject->pUnderlying;
+					Evict(pObject);
+
+					CurrentUsage -= pObject->Size;
+
+					pResourceEntry = ResidentObjectListHead.Flink;
+				}
+			}
+
+			// Trim all objects which are older than the specified time
+			void TrimAgedAllocations(DeviceWideSyncPoint* MaxSyncPoint, ID3D12Pageable** EvictionList, UINT32& NumObjectsToEvict, UINT64 CurrentTimeStamp, UINT64 MinDelta)
+			{
+				LIST_ENTRY* pResourceEntry = ResidentObjectListHead.Flink;
+				while (pResourceEntry != &ResidentObjectListHead)
+				{
+					ManagedObject* pObject = CONTAINING_RECORD(pResourceEntry, ManagedObject, ListEntry);
+
+					if ((MaxSyncPoint && pObject->LastGPUSyncPoint >= MaxSyncPoint->GenerationID) || // Only trim allocations done on the GPU
+						CurrentTimeStamp - pObject->LastUsedTimestamp <= MinDelta) // Don't evict things which have been used recently
+					{
+						break;
+					}
+
+					RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT);
+					EvictionList[NumObjectsToEvict++] = pObject->pUnderlying;
+					Evict(pObject);
+
+					pResourceEntry = ResidentObjectListHead.Flink;
+				}
+			}
+
+			ManagedObject* GetResidentListHead()
+			{
+				if (IsListEmpty(&ResidentObjectListHead))
+				{
+					return nullptr;
+				}
+				return CONTAINING_RECORD(ResidentObjectListHead.Flink, ManagedObject, ListEntry);
+			}
+
+			LIST_ENTRY ResidentObjectListHead;
+			LIST_ENTRY EvictedObjectListHead;
+
+			UINT32 NumResidentObjects;
+			UINT32 NumEvictedObjects;
+
+			UINT64 ResidentSize;
+		};
+
+		class ResidencyManagerInternal
+		{
+		public:
+			ResidencyManagerInternal(SyncManager* pSyncManagerIn) :
+				Device(nullptr),
+				AsyncThreadFence(1),
+				CompletionEvent(INVALID_HANDLE_VALUE),
+				AsyncThreadWorkCompletionEvent(INVALID_HANDLE_VALUE),
+				Adapter(nullptr),
+				AsyncWorkEvent(INVALID_HANDLE_VALUE),
+				AsyncWorkThread(INVALID_HANDLE_VALUE),
+				FinishAsyncWork(false),
+				cStartEvicted(false),
+				CurrentSyncPointGeneration(0),
+				NumQueuesSeen(0),
+				NodeIndex(0),
+				CurrentAsyncWorkloadHead(0),
+				CurrentAsyncWorkloadTail(0),
+				cMinEvictionGracePeriod(1.0f),
+				cMaxEvictionGracePeriod(60.0f),
+				cTrimPercentageMemoryUsageThreshold(0.7f),
+				AsyncWorkQueue(nullptr),
+				MaxSoftwareQueueLatency(6),
+				AsyncWorkQueueSize(7),
+				pSyncManager(pSyncManagerIn)
+			{
+				Internal::InitializeListHead(&QueueFencesListHead);
+				Internal::InitializeListHead(&InFlightSyncPointsHead);
+
+				ResidencyManagerUniqueID = InterlockedIncrement64(&g_ResidencyManagerUniqueID);
+			};
+
+			// NOTE: DeviceNodeIndex is an index not a mask. The majority of D3D12 uses bit masks to identify a GPU node whereas DXGI uses 0 based indices.
+			HRESULT Initialize(ID3D12Device* ParentDevice, UINT DeviceNodeIndex, IDXGIAdapter3* ParentAdapter, UINT32 MaxLatency)
+			{
+				Device = ParentDevice;
+				NodeIndex = DeviceNodeIndex;
+				Adapter = ParentAdapter;
+				MaxSoftwareQueueLatency = MaxLatency;
+
+				AsyncWorkQueueSize = MaxLatency + 1;
+				AsyncWorkQueue = new AsyncWorkload[AsyncWorkQueueSize];
+
+				if (AsyncWorkQueue == nullptr)
+				{
+					return E_OUTOFMEMORY;
+				}
+
+				LARGE_INTEGER Frequency;
+				QueryPerformanceFrequency(&Frequency);
+
+				// Calculate how many QPC ticks are equivalent to the given time in seconds
+				MinEvictionGracePeriodTicks = UINT64(Frequency.QuadPart * cMinEvictionGracePeriod);
+				MaxEvictionGracePeriodTicks = UINT64(Frequency.QuadPart * cMaxEvictionGracePeriod);
+
+				HRESULT hr = S_OK;
+				hr = AsyncThreadFence.Initialize(Device);
+
+				if (SUCCEEDED(hr))
+				{
+					CompletionEvent = CreateEvent(nullptr, false, false, nullptr);
+					if (CompletionEvent == INVALID_HANDLE_VALUE)
+					{
+						hr = HRESULT_FROM_WIN32(GetLastError());
+					}
+				}
+
+				if (SUCCEEDED(hr))
+				{
+					AsyncThreadWorkCompletionEvent = CreateEvent(nullptr, false, false, nullptr);
+					if (AsyncThreadWorkCompletionEvent == INVALID_HANDLE_VALUE)
+					{
+						hr = HRESULT_FROM_WIN32(GetLastError());
+					}
+				}
+
+				if (SUCCEEDED(hr))
+				{
+					AsyncWorkEvent = CreateEvent(nullptr, true, false, nullptr);
+					if (AsyncWorkEvent == INVALID_HANDLE_VALUE)
+					{
+						hr = HRESULT_FROM_WIN32(GetLastError());
+					}
+				}
 
 #if !RESIDENCY_SINGLE_THREADED
-                if (SUCCEEDED(hr))
-                {
-                    AsyncWorkThread = CreateThread(nullptr, 0, AsyncThreadStart, (void*) this, 0, nullptr);
+				if (SUCCEEDED(hr))
+				{
+					AsyncWorkThread = CreateThread(nullptr, 0, AsyncThreadStart, (void*) this, 0, nullptr);
 
-                    if (AsyncWorkThread == INVALID_HANDLE_VALUE)
-                    {
-                        hr = HRESULT_FROM_WIN32(GetLastError());
-                    }
-                }
+					if (AsyncWorkThread == INVALID_HANDLE_VALUE)
+					{
+						hr = HRESULT_FROM_WIN32(GetLastError());
+					}
+				}
 #endif
 
-                return hr;
-            }
+				return hr;
+			}
 
-            void Destroy()
-            {
-                AsyncThreadFence.Destroy();
+			void Destroy()
+			{
+				AsyncThreadFence.Destroy();
 
-                if (CompletionEvent != INVALID_HANDLE_VALUE)
-                {
-                    CloseHandle(CompletionEvent);
-                    CompletionEvent = INVALID_HANDLE_VALUE;
-                }
+				if (CompletionEvent != INVALID_HANDLE_VALUE)
+				{
+					CloseHandle(CompletionEvent);
+					CompletionEvent = INVALID_HANDLE_VALUE;
+				}
 
 #if !RESIDENCY_SINGLE_THREADED
-                AsyncWorkload* pWork = DequeueAsyncWork();
+				AsyncWorkload* pWork = DequeueAsyncWork();
 
-                while (pWork)
-                {
-                    pWork = DequeueAsyncWork();
-                }
+				while (pWork)
+				{
+					pWork = DequeueAsyncWork();
+				}
 
-                FinishAsyncWork = true;
-                if (SetEvent(AsyncWorkEvent) == false)
-                {
-                    RESIDENCY_CHECK_RESULT(HRESULT_FROM_WIN32(GetLastError()));
-                }
+				FinishAsyncWork = true;
+				if (SetEvent(AsyncWorkEvent) == false)
+				{
+					RESIDENCY_CHECK_RESULT(HRESULT_FROM_WIN32(GetLastError()));
+				}
 
-                // Make sure the async worker thread is finished to prevent dereferencing
-                // dangling pointers to ResidencyManagerInternal
-                WaitForSingleObject(AsyncWorkThread, INFINITE);
-                if (AsyncWorkThread != INVALID_HANDLE_VALUE)
-                {
-                    CloseHandle(AsyncWorkThread);
-                    AsyncWorkThread = INVALID_HANDLE_VALUE;
-                }
+				// Make sure the async worker thread is finished to prevent dereferencing
+				// dangling pointers to ResidencyManagerInternal
+				WaitForSingleObject(AsyncWorkThread, INFINITE);
+				if (AsyncWorkThread != INVALID_HANDLE_VALUE)
+				{
+					CloseHandle(AsyncWorkThread);
+					AsyncWorkThread = INVALID_HANDLE_VALUE;
+				}
 
-                if (AsyncWorkEvent != INVALID_HANDLE_VALUE)
-                {
-                    CloseHandle(AsyncWorkEvent);
-                    AsyncWorkEvent = INVALID_HANDLE_VALUE;
-                }
+				if (AsyncWorkEvent != INVALID_HANDLE_VALUE)
+				{
+					CloseHandle(AsyncWorkEvent);
+					AsyncWorkEvent = INVALID_HANDLE_VALUE;
+				}
 #endif
 
-                if (AsyncThreadWorkCompletionEvent != INVALID_HANDLE_VALUE)
-                {
-                    CloseHandle(AsyncThreadWorkCompletionEvent);
-                    AsyncThreadWorkCompletionEvent = INVALID_HANDLE_VALUE;
-                }
+				if (AsyncThreadWorkCompletionEvent != INVALID_HANDLE_VALUE)
+				{
+					CloseHandle(AsyncThreadWorkCompletionEvent);
+					AsyncThreadWorkCompletionEvent = INVALID_HANDLE_VALUE;
+				}
 
-                while (Internal::IsListEmpty(&QueueFencesListHead) == false)
-                {
-                    Internal::Fence* pObject =
-                        CONTAINING_RECORD(QueueFencesListHead.Flink, Internal::Fence, ListEntry);
+				while (Internal::IsListEmpty(&QueueFencesListHead) == false)
+				{
+					Internal::Fence* pObject =
+						CONTAINING_RECORD(QueueFencesListHead.Flink, Internal::Fence, ListEntry);
 
-                    pObject->Destroy();
-                    Internal::RemoveHeadList(&QueueFencesListHead);
-                    delete(pObject);
-                }
-            }
+					pObject->Destroy();
+					Internal::RemoveHeadList(&QueueFencesListHead);
+					delete(pObject);
+				}
+			}
 
-            void BeginTrackingObject(ManagedObject* pObject)
-            {
-                Internal::ScopedLock Lock(&Mutex);
+			void BeginTrackingObject(ManagedObject* pObject)
+			{
+				Internal::ScopedLock Lock(&Mutex);
 
-                if (pObject)
-                {
-                    RESIDENCY_CHECK(pObject->pUnderlying != nullptr);
-                    if (cStartEvicted)
-                    {
-                        pObject->ResidencyStatus = ManagedObject::RESIDENCY_STATUS::EVICTED;
-                        RESIDENCY_CHECK_RESULT(Device->Evict(1, &pObject->pUnderlying));
-                    }
+				if (pObject)
+				{
+					RESIDENCY_CHECK(pObject->pUnderlying != nullptr);
+					if (cStartEvicted)
+					{
+						pObject->ResidencyStatus = ManagedObject::RESIDENCY_STATUS::EVICTED;
+						RESIDENCY_CHECK_RESULT(Device->Evict(1, &pObject->pUnderlying));
+					}
 
-                    LRU.Insert(pObject);
-                }
-            }
+					LRU.Insert(pObject);
+				}
+			}
 
-            void EndTrackingObject(ManagedObject* pObject)
-            {
-                Internal::ScopedLock Lock(&Mutex);
+			void EndTrackingObject(ManagedObject* pObject)
+			{
+				Internal::ScopedLock Lock(&Mutex);
 
-                LRU.Remove(pObject);
-            }
+				LRU.Remove(pObject);
+			}
 
-            // One residency set per command-list
-            HRESULT ExecuteCommandLists(ID3D12CommandQueue* Queue, ID3D12CommandList** CommandLists, ResidencySet** ResidencySets, UINT32 Count)
-            {
-                return ExecuteSubset(Queue, CommandLists, ResidencySets, Count);
-            }
+			// One residency set per command-list
+			HRESULT ExecuteCommandLists(ID3D12CommandQueue* Queue, ID3D12CommandList** CommandLists, ResidencySet** ResidencySets, UINT32 Count)
+			{
+				return ExecuteSubset(Queue, CommandLists, ResidencySets, Count);
+			}
 
-            HRESULT GetCurrentGPUSyncPoint(ID3D12CommandQueue* Queue, UINT64 *pGPUSyncPoint)
-            {
-                Internal::Fence* QueueFence = nullptr;
-                HRESULT hr = GetFence(Queue, QueueFence);
+			HRESULT GetCurrentGPUSyncPoint(ID3D12CommandQueue* Queue, UINT64 *pGPUSyncPoint)
+			{
+				Internal::Fence* QueueFence = nullptr;
+				HRESULT hr = GetFence(Queue, QueueFence);
 
-                // The signal and increment need to be atomic
-                if(SUCCEEDED(hr))
-                {
-                    Internal::ScopedLock Lock(&ExecutionCS);
-                    *pGPUSyncPoint = QueueFence->FenceValue;
-                    hr = SignalFence(Queue, QueueFence);
-                }
-                return hr;
-            }
+				// The signal and increment need to be atomic
+				if(SUCCEEDED(hr))
+				{
+					Internal::ScopedLock Lock(&ExecutionCS);
+					*pGPUSyncPoint = QueueFence->FenceValue;
+					hr = SignalFence(Queue, QueueFence);
+				}
+				return hr;
+			}
 
-        private:
-            HRESULT GetFence(ID3D12CommandQueue *Queue, Internal::Fence *&QueueFence)
-            {
-                // We have to track each object on each queue so we know when it is safe to evict them. Therefore, for every queue that we
-                // see, associate a fence with it
-                GUID FenceGuid = { 0xf0, 0, 0xd, { 0, 0, 0, 0, 0, 0, 0, 0 } };
+		private:
+			HRESULT GetFence(ID3D12CommandQueue *Queue, Internal::Fence *&QueueFence)
+			{
+				// We have to track each object on each queue so we know when it is safe to evict them. Therefore, for every queue that we
+				// see, associate a fence with it
+				GUID FenceGuid = { 0xf0, 0, 0xd, { 0, 0, 0, 0, 0, 0, 0, 0 } };
 
-                // Generate a GUID based on this queue
-                memcpy((void*)FenceGuid.Data4, Queue, sizeof(ID3D12CommandQueue*));
+				// Generate a GUID based on this queue
+				memcpy((void*)FenceGuid.Data4, Queue, sizeof(ID3D12CommandQueue*));
 
-                QueueFence = nullptr;
-                HRESULT hr = S_OK;
+				QueueFence = nullptr;
+				HRESULT hr = S_OK;
 
-                struct
-                {
-                    Internal::Fence* pFence;
-                    INT64 ResidencyManagerUniqueID;
-                } CommandQueuePrivateData;
+				struct
+				{
+					Internal::Fence* pFence;
+					INT64 ResidencyManagerUniqueID;
+				} CommandQueuePrivateData;
 
-                // Find or create the fence for this queue
-                {
-                    UINT32 Size = sizeof(CommandQueuePrivateData);
-                    hr = Queue->GetPrivateData(FenceGuid, &Size, &CommandQueuePrivateData);
-                    if (FAILED(hr) || ResidencyManagerUniqueID != CommandQueuePrivateData.ResidencyManagerUniqueID)
-                    {
-                        QueueFence = new Internal::Fence(1);
-                        hr = QueueFence->Initialize(Device);
-                        Internal::InsertTailList(&QueueFencesListHead, &QueueFence->ListEntry);
+				// Find or create the fence for this queue
+				{
+					UINT32 Size = sizeof(CommandQueuePrivateData);
+					hr = Queue->GetPrivateData(FenceGuid, &Size, &CommandQueuePrivateData);
+					if (FAILED(hr) || ResidencyManagerUniqueID != CommandQueuePrivateData.ResidencyManagerUniqueID)
+					{
+						QueueFence = new Internal::Fence(1);
+						hr = QueueFence->Initialize(Device);
+						Internal::InsertTailList(&QueueFencesListHead, &QueueFence->ListEntry);
 
-                        InterlockedIncrement(&NumQueuesSeen);
+						InterlockedIncrement(&NumQueuesSeen);
 
-                        if (SUCCEEDED(hr))
-                        {
-                            CommandQueuePrivateData = { QueueFence, ResidencyManagerUniqueID };
-                            hr = Queue->SetPrivateData(FenceGuid, UINT32(sizeof(CommandQueuePrivateData)), &CommandQueuePrivateData);
-                            RESIDENCY_CHECK_RESULT(hr);
-                        }
-                    }
-                    QueueFence = CommandQueuePrivateData.pFence;
-                    RESIDENCY_CHECK(QueueFence != nullptr);
-                }
+						if (SUCCEEDED(hr))
+						{
+							CommandQueuePrivateData = { QueueFence, ResidencyManagerUniqueID };
+							hr = Queue->SetPrivateData(FenceGuid, UINT32(sizeof(CommandQueuePrivateData)), &CommandQueuePrivateData);
+							RESIDENCY_CHECK_RESULT(hr);
+						}
+					}
+					QueueFence = CommandQueuePrivateData.pFence;
+					RESIDENCY_CHECK(QueueFence != nullptr);
+				}
 
-                return hr;
-            }
+				return hr;
+			}
 
-            HRESULT SignalFence(ID3D12CommandQueue *Queue, Internal::Fence *QueueFence)
-            {
-                // When this fence is passed it is safe to evict the resources used in the list just submitted
-                HRESULT hr = QueueFence->GPUSignal(Queue);
-                QueueFence->Increment();
+			HRESULT SignalFence(ID3D12CommandQueue *Queue, Internal::Fence *QueueFence)
+			{
+				// When this fence is passed it is safe to evict the resources used in the list just submitted
+				HRESULT hr = QueueFence->GPUSignal(Queue);
+				QueueFence->Increment();
 
-                if (SUCCEEDED(hr))
-                {
-                    hr = EnqueueSyncPoint();
-                    RESIDENCY_CHECK_RESULT(hr);
-                }
+				if (SUCCEEDED(hr))
+				{
+					hr = EnqueueSyncPoint();
+					RESIDENCY_CHECK_RESULT(hr);
+				}
 
-                CurrentSyncPointGeneration++;
-                return hr;
-            }
+				CurrentSyncPointGeneration++;
+				return hr;
+			}
 
-            HRESULT ExecuteSubset(ID3D12CommandQueue* Queue, ID3D12CommandList** CommandLists, ResidencySet** ResidencySets, UINT32 Count)
-            {
-                HRESULT hr = S_OK;
+			HRESULT ExecuteSubset(ID3D12CommandQueue* Queue, ID3D12CommandList** CommandLists, ResidencySet** ResidencySets, UINT32 Count)
+			{
+				HRESULT hr = S_OK;
 
-                DXGI_QUERY_VIDEO_MEMORY_INFO LocalMemory;
-                ZeroMemory(&LocalMemory, sizeof(LocalMemory));
-                GetCurrentBudget(&LocalMemory, DXGI_MEMORY_SEGMENT_GROUP_LOCAL);
+				DXGI_QUERY_VIDEO_MEMORY_INFO LocalMemory;
+				ZeroMemory(&LocalMemory, sizeof(LocalMemory));
+				GetCurrentBudget(&LocalMemory, DXGI_MEMORY_SEGMENT_GROUP_LOCAL);
 
-                DXGI_QUERY_VIDEO_MEMORY_INFO NonLocalMemory;
-                ZeroMemory(&NonLocalMemory, sizeof(NonLocalMemory));
-                GetCurrentBudget(&NonLocalMemory, DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL);
+				DXGI_QUERY_VIDEO_MEMORY_INFO NonLocalMemory;
+				ZeroMemory(&NonLocalMemory, sizeof(NonLocalMemory));
+				GetCurrentBudget(&NonLocalMemory, DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL);
 
-                UINT64 TotalSizeNeeded = 0;
+				UINT64 TotalSizeNeeded = 0;
 
-                UINT32 MaxObjectsReferenced = 0;
-                for (UINT32 i = 0; i < Count; i++)
-                {
-                    if (ResidencySets[i])
-                    {
-                        if (ResidencySets[i]->IsOpen)
-                        {
-                            // Residency Sets must be closed before execution just like Command Lists
-                            return E_INVALIDARG;
-                        }
-                        MaxObjectsReferenced += ResidencySets[i]->CurrentSetSize;
-                    }
-                }
+				UINT32 MaxObjectsReferenced = 0;
+				for (UINT32 i = 0; i < Count; i++)
+				{
+					if (ResidencySets[i])
+					{
+						if (ResidencySets[i]->IsOpen)
+						{
+							// Residency Sets must be closed before execution just like Command Lists
+							return E_INVALIDARG;
+						}
+						MaxObjectsReferenced += ResidencySets[i]->CurrentSetSize;
+					}
+				}
 
-                // Create a set to gather up all unique resources required by this call
-                ResidencySet* pMasterSet = new ResidencySet();
-                if (pMasterSet == nullptr || pMasterSet->Initialize(pSyncManager, MaxObjectsReferenced) == false)
-                {
-                    return E_OUTOFMEMORY;
-                }
+				// Create a set to gather up all unique resources required by this call
+				ResidencySet* pMasterSet = new ResidencySet();
+				if (pMasterSet == nullptr || pMasterSet->Initialize(pSyncManager, MaxObjectsReferenced) == false)
+				{
+					return E_OUTOFMEMORY;
+				}
 
-                hr = pMasterSet->Open();
-                if (FAILED(hr))
-                {
-                    return hr;
-                }
+				hr = pMasterSet->Open();
+				if (FAILED(hr))
+				{
+					return hr;
+				}
 
-                // For each residency set
-                for (UINT32 i = 0; i < Count; i++)
-                {
-                    if (ResidencySets[i])
-                    {
-                        // For each object in this set
-                        for (INT32 x = 0; x < ResidencySets[i]->CurrentSetSize; x++)
-                        {
-                            if (pMasterSet->Insert(ResidencySets[i]->ppSet[x]))
-                            {
-                                TotalSizeNeeded += ResidencySets[i]->ppSet[x]->Size;
-                            }
-                        }
-                    }
-                }
-                // Close this set to free it's slot up for the app
-                hr = pMasterSet->Close();
-                if (FAILED(hr))
-                {
-                    return hr;
-                }
+				// For each residency set
+				for (UINT32 i = 0; i < Count; i++)
+				{
+					if (ResidencySets[i])
+					{
+						// For each object in this set
+						for (INT32 x = 0; x < ResidencySets[i]->CurrentSetSize; x++)
+						{
+							if (pMasterSet->Insert(ResidencySets[i]->ppSet[x]))
+							{
+								TotalSizeNeeded += ResidencySets[i]->ppSet[x]->Size;
+							}
+						}
+					}
+				}
+				// Close this set to free it's slot up for the app
+				hr = pMasterSet->Close();
+				if (FAILED(hr))
+				{
+					return hr;
+				}
 
-                // This set of commandlists can't possibly fit within the budget, they need to be split up. If the number of command lists is 1 there is
-                // nothing we can do
-                if (Count > 1 && TotalSizeNeeded > LocalMemory.Budget + NonLocalMemory.Budget)
-                {
-                    delete(pMasterSet);
+				// This set of commandlists can't possibly fit within the budget, they need to be split up. If the number of command lists is 1 there is
+				// nothing we can do
+				if (Count > 1 && TotalSizeNeeded > LocalMemory.Budget + NonLocalMemory.Budget)
+				{
+					delete(pMasterSet);
 
-                    // Recursively try to find a small enough set to fit in memory
-                    const UINT32 Half = Count / 2;
-                    const HRESULT LowerHR = ExecuteSubset(Queue, CommandLists, ResidencySets, Half);
-                    const HRESULT UpperHR = ExecuteSubset(Queue, &CommandLists[Half], &ResidencySets[Half], Count - Half);
+					// Recursively try to find a small enough set to fit in memory
+					const UINT32 Half = Count / 2;
+					const HRESULT LowerHR = ExecuteSubset(Queue, CommandLists, ResidencySets, Half);
+					const HRESULT UpperHR = ExecuteSubset(Queue, &CommandLists[Half], &ResidencySets[Half], Count - Half);
 
-                    return (LowerHR == S_OK && UpperHR == S_OK) ? S_OK : E_FAIL;
-                }
+					return (LowerHR == S_OK && UpperHR == S_OK) ? S_OK : E_FAIL;
+				}
 
 
-                Internal::Fence* QueueFence = nullptr;
-                hr = GetFence(Queue, QueueFence);
+				Internal::Fence* QueueFence = nullptr;
+				hr = GetFence(Queue, QueueFence);
 
-                if (SUCCEEDED(hr))
-                {
-                    // The following code must be atomic so that things get ordered correctly
+				if (SUCCEEDED(hr))
+				{
+					// The following code must be atomic so that things get ordered correctly
 
-                    Internal::ScopedLock Lock(&ExecutionCS);
-                    // Evict or make resident all of the objects we identified above.
-                    // This will run on an async thread, allowing the current to continue while still blocking the GPU if required
-                    hr = EnqueueAsyncWork(pMasterSet, AsyncThreadFence.FenceValue, CurrentSyncPointGeneration);
+					Internal::ScopedLock Lock(&ExecutionCS);
+					// Evict or make resident all of the objects we identified above.
+					// This will run on an async thread, allowing the current to continue while still blocking the GPU if required
+					hr = EnqueueAsyncWork(pMasterSet, AsyncThreadFence.FenceValue, CurrentSyncPointGeneration);
 #if RESIDENCY_SINGLE_THREADED
-                    AsyncWorkload* pWorkload = DequeueAsyncWork();
-                    ProcessPagingWork(pWorkload);
+					AsyncWorkload* pWorkload = DequeueAsyncWork();
+					ProcessPagingWork(pWorkload);
 #endif
 
-                    // If there are some things that need to be made resident we need to make sure that the GPU
-                    // doesn't execute until the async thread signals that the MakeResident call has returned.
-                    if (SUCCEEDED(hr))
-                    {
-                        hr = AsyncThreadFence.GPUWait(Queue);
-                        AsyncThreadFence.Increment();
-                    }
-
-                    Queue->ExecuteCommandLists(Count, CommandLists);
-
-                    if (SUCCEEDED(hr))
-                    {
-                        hr = SignalFence(Queue, QueueFence);
-                    }
-                }
-                return hr;
-            }
-
-            struct AsyncWorkload
-            {
-                AsyncWorkload() :
-                    pMasterSet(nullptr),
-                    FenceValueToSignal(0),
-                    SyncPointGeneration(0)
-                {}
-
-                UINT64 SyncPointGeneration;
-
-                // List of objects to make resident
-                ResidencySet* pMasterSet;
-
-                // The GPU will wait on this value so that it doesn't execute until the objects are made resident
-                UINT64 FenceValueToSignal;
-            };
-
-            SIZE_T AsyncWorkQueueSize;
-            AsyncWorkload* AsyncWorkQueue;
-
-            HANDLE AsyncWorkEvent;
-            HANDLE AsyncWorkThread;
-            Internal::CriticalSection AsyncWorkMutex;
-            volatile bool FinishAsyncWork;
-            volatile SIZE_T CurrentAsyncWorkloadHead;
-            volatile SIZE_T CurrentAsyncWorkloadTail;
-
-            static unsigned long WINAPI AsyncThreadStart(void* pData)
-            {
-                ResidencyManagerInternal* pManager = (ResidencyManagerInternal*)pData;
-
-                while (1)
-                {
-                    AsyncWorkload* pWork = pManager->DequeueAsyncWork();
-
-                    while (pWork)
-                    {
-                        // Submit the work
-                        pManager->ProcessPagingWork(pWork);
-                        if (SetEvent(pManager->AsyncThreadWorkCompletionEvent) == false)
-                        {
-                            RESIDENCY_CHECK_RESULT(HRESULT_FROM_WIN32(GetLastError()));
-                        }
-
-                        // Get more work
-                        pWork = pManager->DequeueAsyncWork();
-                    }
-
-                    //Wait until there is more work do be done
-                    WaitForSingleObject(pManager->AsyncWorkEvent, INFINITE);
-                    if (ResetEvent(pManager->AsyncWorkEvent) == false)
-                    {
-                        RESIDENCY_CHECK_RESULT(HRESULT_FROM_WIN32(GetLastError()));
-                    }
-
-                    if (pManager->FinishAsyncWork)
-                    {
-                        return 0;
-                    }
-                }
-
-                return 0;
-            }
-
-            // This will be run from a worker thread and will emulate a software queue for making gpu resources resident or evicted.
-            // The GPU will be synchronized by this queue to ensure that it never executes using an evicted resource.
-            void ProcessPagingWork(AsyncWorkload* pWork)
-            {
-                Internal::DeviceWideSyncPoint* FirstUncompletedSyncPoint = DequeueCompletedSyncPoints();
-
-                // Use a union so that we only need 1 allocation
-                union ResidentScratchSpace
-                {
-                    ManagedObject* pManagedObject;
-                    ID3D12Pageable* pUnderlying;
-                };
-
-                ResidentScratchSpace* pMakeResidentList = nullptr;
-                UINT32 NumObjectsToMakeResident = 0;
-
-                ID3D12Pageable** pEvictionList = nullptr;
-                UINT32 NumObjectsToEvict = 0;
-
-                // the size of all the objects which will need to be made resident in order to execute this set.
-                UINT64 SizeToMakeResident = 0;
-
-                LARGE_INTEGER CurrentTime;
-                QueryPerformanceCounter(&CurrentTime);
-
-                {
-                    // A lock must be taken here as the state of the objects will be altered
-                    Internal::ScopedLock Lock(&Mutex);
-
-                    pMakeResidentList = new ResidentScratchSpace[pWork->pMasterSet->CurrentSetSize];
-                    pEvictionList = new ID3D12Pageable*[LRU.NumResidentObjects];
-
-                    // Mark the objects used by this command list to be made resident
-                    for (INT32 i = 0; i < pWork->pMasterSet->CurrentSetSize; i++)
-                    {
-                        ManagedObject*& pObject = pWork->pMasterSet->ppSet[i];
-                        // If it's evicted we need to make it resident again
-                        if (pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::EVICTED)
-                        {
-                            pMakeResidentList[NumObjectsToMakeResident++].pManagedObject = pObject;
-                            LRU.MakeResident(pObject);
-
-                            SizeToMakeResident += pObject->Size;
-                        }
-
-                        // Update the last sync point that this was used on
-                        pObject->LastGPUSyncPoint = pWork->SyncPointGeneration;
-
-                        pObject->LastUsedTimestamp = CurrentTime.QuadPart;
-                        LRU.ObjectReferenced(pObject);
-                    }
-
-                    DXGI_QUERY_VIDEO_MEMORY_INFO LocalMemory;
-                    ZeroMemory(&LocalMemory, sizeof(LocalMemory));
-                    GetCurrentBudget(&LocalMemory, DXGI_MEMORY_SEGMENT_GROUP_LOCAL);
-
-                    UINT64 EvictionGracePeriod = GetCurrentEvictionGracePeriod(&LocalMemory);
-                    LRU.TrimAgedAllocations(FirstUncompletedSyncPoint, pEvictionList, NumObjectsToEvict, CurrentTime.QuadPart, EvictionGracePeriod);
-
-                    if (NumObjectsToEvict)
-                    {
-                        RESIDENCY_CHECK_RESULT(Device->Evict(NumObjectsToEvict, pEvictionList));
-                        NumObjectsToEvict = 0;
-                    }
-
-                    if (NumObjectsToMakeResident)
-                    {
-                        UINT32 ObjectsMadeResident = 0;
-                        UINT32 MakeResidentIndex = 0;
-                        while (true)
-                        {
-                            ZeroMemory(&LocalMemory, sizeof(LocalMemory));
-
-                            GetCurrentBudget(&LocalMemory, DXGI_MEMORY_SEGMENT_GROUP_LOCAL);
-                            DXGI_QUERY_VIDEO_MEMORY_INFO NonLocalMemory;
-                            ZeroMemory(&NonLocalMemory, sizeof(NonLocalMemory));
-                            GetCurrentBudget(&NonLocalMemory, DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL);
-
-                            INT64 TotalUsage = LocalMemory.CurrentUsage + NonLocalMemory.CurrentUsage;
-                            INT64 TotalBudget = LocalMemory.Budget + NonLocalMemory.Budget;
-
-                            INT64 AvailableSpace = TotalBudget - TotalUsage;
-
-                            UINT64 BatchSize = 0;
-                            UINT32 NumObjectsInBatch = 0;
-                            UINT32 BatchStart = MakeResidentIndex;
-
-                            HRESULT hr = S_OK;
-                            if (AvailableSpace > 0)
-                            {
-                                for (UINT32 i = MakeResidentIndex; i < NumObjectsToMakeResident; i++)
-                                {
-                                    // If we try to make this object resident, will we go over budget?
-                                    if (BatchSize + pMakeResidentList[i].pManagedObject->Size > UINT64(AvailableSpace))
-                                    {
-                                        // Next time we will start here
-                                        MakeResidentIndex = i;
-                                        break;
-                                    }
-                                    else
-                                    {
-                                        BatchSize += pMakeResidentList[i].pManagedObject->Size;
-                                        NumObjectsInBatch++;
-                                        ObjectsMadeResident++;
-
-                                        pMakeResidentList[i].pUnderlying = pMakeResidentList[i].pManagedObject->pUnderlying;
-                                    }
-                                }
-
-                                hr = Device->MakeResident(NumObjectsInBatch, &pMakeResidentList[BatchStart].pUnderlying);
-                                if (SUCCEEDED(hr))
-                                {
-                                    SizeToMakeResident -= BatchSize;
-                                }
-                            }
-
-                            if (FAILED(hr) || ObjectsMadeResident != NumObjectsToMakeResident)
-                            {
-                                ManagedObject* pResidentHead = LRU.GetResidentListHead();
-
-                                // Get the next sync point to wait for
-                                FirstUncompletedSyncPoint = DequeueCompletedSyncPoints();
-
-                                // If there is nothing to trim OR the only objects 'Resident' are the ones about to be used by this execute.
-                                if (pResidentHead == nullptr ||
-                                    pResidentHead->LastGPUSyncPoint >= pWork->SyncPointGeneration ||
-                                    FirstUncompletedSyncPoint == nullptr)
-                                {
-                                    // Make resident the rest of the objects as there is nothing left to trim
-                                    UINT32 NumObjects = NumObjectsToMakeResident - ObjectsMadeResident;
-
-                                    // Gather up the remaining underlying objects
-                                    for (UINT32 i = MakeResidentIndex; i < NumObjectsToMakeResident; i++)
-                                    {
-                                        pMakeResidentList[i].pUnderlying = pMakeResidentList[i].pManagedObject->pUnderlying;
-                                    }
-
-                                    hr = Device->MakeResident(NumObjects, &pMakeResidentList[MakeResidentIndex].pUnderlying);
-                                    if (FAILED(hr))
-                                    {
-                                        // TODO: What should we do if this fails? This is a catastrophic failure in which the app is trying to use more memory
-                                        //       in 1 command list than can possibly be made resident by the system.
-                                        RESIDENCY_CHECK_RESULT(hr);
-                                    }
-                                    break;
-                                }
-
-                                UINT64 GenerationToWaitFor = FirstUncompletedSyncPoint->GenerationID;
-
-                                // We can't wait for the sync-point that this work is intended for
-                                if (GenerationToWaitFor == pWork->SyncPointGeneration)
-                                {
-                                    RESIDENCY_CHECK(GenerationToWaitFor >= 0);
-                                    GenerationToWaitFor -= 1;
-                                }
-                                // Wait until the GPU is done
-                                WaitForSyncPoint(GenerationToWaitFor);
-
-                                LRU.TrimToSyncPointInclusive(TotalUsage + INT64(SizeToMakeResident), TotalBudget, pEvictionList, NumObjectsToEvict, GenerationToWaitFor);
-
-                                RESIDENCY_CHECK_RESULT(Device->Evict(NumObjectsToEvict, pEvictionList));
-                            }
-                            else
-                            {
-                                // We made everything resident, mission accomplished
-                                break;
-                            }
-                        }
-                    }
-
-                    delete[](pMakeResidentList);
-                    delete[](pEvictionList);
-                }
-
-                // Tell the GPU that it's safe to execute since we made things resident
-                RESIDENCY_CHECK_RESULT(AsyncThreadFence.pFence->Signal(pWork->FenceValueToSignal));
-
-                delete(pWork->pMasterSet);
-                pWork->pMasterSet = nullptr;
-            }
-            // The Enqueue and Dequeue Async Work functions are threadsafe as there is only 1 producer and 1 consumer, if that changes
-            // Synchronisation will be required
-            HRESULT EnqueueAsyncWork(ResidencySet* pMasterSet, UINT64 FenceValueToSignal, UINT64 SyncPointGeneration)
-            {
-                // We can't get too far ahead of the worker thread otherwise huge hitches occur
-                while ((CurrentAsyncWorkloadTail - CurrentAsyncWorkloadHead) >= MaxSoftwareQueueLatency)
-                {
-                    WaitForSingleObject(AsyncThreadWorkCompletionEvent, INFINITE);
-                }
-
-                RESIDENCY_CHECK(CurrentAsyncWorkloadTail >= CurrentAsyncWorkloadHead);
-
-                const SIZE_T currentIndex = CurrentAsyncWorkloadTail % AsyncWorkQueueSize;
-                AsyncWorkQueue[currentIndex].pMasterSet = pMasterSet;
-                AsyncWorkQueue[currentIndex].FenceValueToSignal = FenceValueToSignal;
-                AsyncWorkQueue[currentIndex].SyncPointGeneration = SyncPointGeneration;
-
-                CurrentAsyncWorkloadTail++;
-                if (SetEvent(AsyncWorkEvent) == false)
-                {
-                    return HRESULT_FROM_WIN32(GetLastError());
-                }
-
-                return S_OK;
-            }
-
-            AsyncWorkload* DequeueAsyncWork()
-            {
-                if (CurrentAsyncWorkloadHead == CurrentAsyncWorkloadTail)
-                {
-                    return nullptr;
-                }
-
-                const SIZE_T currentHead = CurrentAsyncWorkloadHead % AsyncWorkQueueSize;
-                AsyncWorkload* pWork = &AsyncWorkQueue[currentHead];
-
-                CurrentAsyncWorkloadHead++;
-                return pWork;
-            }
-
-            void GetCurrentBudget(DXGI_QUERY_VIDEO_MEMORY_INFO* InfoOut, DXGI_MEMORY_SEGMENT_GROUP Segment)
-            {
-                RESIDENCY_CHECK_RESULT(Adapter->QueryVideoMemoryInfo(NodeIndex, Segment, InfoOut));
-            }
-
-            HRESULT EnqueueSyncPoint()
-            {
-                Internal::ScopedLock Lock(&AsyncWorkMutex);
-
-                Internal::DeviceWideSyncPoint* pPoint = Internal::DeviceWideSyncPoint::CreateSyncPoint(NumQueuesSeen, CurrentSyncPointGeneration);
-                if (pPoint == nullptr)
-                {
-                    return E_OUTOFMEMORY;
-                }
-
-                UINT32 i = 0;
-                LIST_ENTRY* pFenceEntry = QueueFencesListHead.Flink;
-                // Record the current state of each queue we track into this sync point
-                while (pFenceEntry != &QueueFencesListHead)
-                {
-                    Internal::Fence* pFence = CONTAINING_RECORD(pFenceEntry, Internal::Fence, ListEntry);
-                    pFenceEntry = pFenceEntry->Flink;
-
-                    pPoint->pQueueSyncPoints[i].pFence = pFence;
-                    pPoint->pQueueSyncPoints[i].LastUsedValue = pFence->FenceValue - 1;//Minus one as we want the last submitted
-
-                    i++;
-                }
-
-                Internal::InsertTailList(&InFlightSyncPointsHead, &pPoint->ListEntry);
-
-                return S_OK;
-            }
-
-            // Returns a pointer to the first synch point which is not completed
-            Internal::DeviceWideSyncPoint* DequeueCompletedSyncPoints()
-            {
-                Internal::ScopedLock Lock(&AsyncWorkMutex);
-
-                while (Internal::IsListEmpty(&InFlightSyncPointsHead) == false)
-                {
-                    Internal::DeviceWideSyncPoint* pPoint =
-                        CONTAINING_RECORD(InFlightSyncPointsHead.Flink, Internal::DeviceWideSyncPoint, ListEntry);
-
-                    if (pPoint->IsCompleted())
-                    {
-                        Internal::RemoveHeadList(&InFlightSyncPointsHead);
-                        delete pPoint;
-                    }
-                    else
-                    {
-                        return pPoint;
-                    }
-                }
-
-                return nullptr;
-            }
-
-            void WaitForSyncPoint(UINT64 SyncPointID)
-            {
-                Internal::ScopedLock Lock(&AsyncWorkMutex);
-
-                LIST_ENTRY* pPointEntry = InFlightSyncPointsHead.Flink;
-                while (pPointEntry != &InFlightSyncPointsHead)
-                {
-                    Internal::DeviceWideSyncPoint* pPoint =
-                        CONTAINING_RECORD(InFlightSyncPointsHead.Flink, Internal::DeviceWideSyncPoint, ListEntry);
-
-                    if (pPoint->GenerationID > SyncPointID)
-                    {
-                        // this point is already done
-                        return;
-                    }
-                    else if (pPoint->GenerationID < SyncPointID)
-                    {
-                        // Keep popping off until we find the one to wait on
-                        Internal::RemoveHeadList(&InFlightSyncPointsHead);
-                        delete(pPoint);
-                    }
-                    else
-                    {
-                        pPoint->WaitForCompletion(CompletionEvent);
-                        Internal::RemoveHeadList(&InFlightSyncPointsHead);
-                        delete(pPoint);
-                        return;
-                    }
-                }
-            }
-
-            // Generate a result between the minimum period and the maximum period based on the current
-            // local memory pressure. I.e. when memory pressure is low, objects will persist longer before
-            // being evicted.
-            UINT64 GetCurrentEvictionGracePeriod(DXGI_QUERY_VIDEO_MEMORY_INFO* LocalMemoryState)
-            {
-                // 1 == full pressure, 0 == no pressure
-                double Pressure = (double(LocalMemoryState->CurrentUsage) / double(LocalMemoryState->Budget));
-                Pressure = RESIDENCY_MIN(Pressure, 1.0);
-
-                if (Pressure > cTrimPercentageMemoryUsageThreshold)
-                {
-                    // Normalize the pressure for the range 0 to cTrimPercentageMemoryUsageThreshold
-                    Pressure = (Pressure - cTrimPercentageMemoryUsageThreshold) / (1.0 - cTrimPercentageMemoryUsageThreshold);
-
-                    // Linearly interpolate between the min period and the max period based on the pressure
-                    return UINT64((MaxEvictionGracePeriodTicks - MinEvictionGracePeriodTicks) * (1.0 - Pressure)) + MinEvictionGracePeriodTicks;
-                }
-                else
-                {
-                    // Essentially don't trim at all
-                    return MAXUINT64;
-                }
-            }
-
-            LIST_ENTRY QueueFencesListHead;
-            UINT32 NumQueuesSeen;
-            Internal::Fence AsyncThreadFence;
-
-            LIST_ENTRY InFlightSyncPointsHead;
-            UINT64 CurrentSyncPointGeneration;
-
-            HANDLE CompletionEvent;
-            HANDLE AsyncThreadWorkCompletionEvent;
-
-            ID3D12Device* Device;
-            // NOTE: This is an index not a mask. The majority of D3D12 uses bit masks to identify a GPU node whereas DXGI uses 0 based indices.
-            UINT NodeIndex;
-            IDXGIAdapter3* Adapter;
-            Internal::LRUCache LRU;
-
-            Internal::CriticalSection Mutex;
-
-            Internal::CriticalSection ExecutionCS;
-
-            const bool cStartEvicted;
-
-            const float cMinEvictionGracePeriod;
-            UINT64 MinEvictionGracePeriodTicks;
-            const float cMaxEvictionGracePeriod;
-            UINT64 MaxEvictionGracePeriodTicks;
-            // When the app is using more than this % of its budgeted local VidMem trimming will occur
-            // (valid between 0.0 - 1.0)
-            const float cTrimPercentageMemoryUsageThreshold;
-
-            UINT32 MaxSoftwareQueueLatency;
-            INT64 ResidencyManagerUniqueID;
-
-            SyncManager* pSyncManager;
-        };
-    }
-
-    class ResidencyManager
-    {
-    public:
-        ResidencyManager() :
-            Manager(&SyncManager)
-        {
-        }
-
-        // NOTE: DeviceNodeIndex is an index not a mask. The majority of D3D12 uses bit masks to identify a GPU node whereas DXGI uses 0 based indices.
-        FORCEINLINE HRESULT Initialize(ID3D12Device* ParentDevice, UINT DeviceNodeIndex, IDXGIAdapter3* ParentAdapter, UINT32 MaxLatency)
-        {
-            return Manager.Initialize(ParentDevice, DeviceNodeIndex, ParentAdapter, MaxLatency);
-        }
-
-        FORCEINLINE void Destroy()
-        {
-            Manager.Destroy();
-        }
-
-        FORCEINLINE void BeginTrackingObject(ManagedObject* pObject)
-        {
-            Manager.BeginTrackingObject(pObject);
-        }
-
-        FORCEINLINE void EndTrackingObject(ManagedObject* pObject)
-        {
-            Manager.EndTrackingObject(pObject);
-        }
-
-        HRESULT GetCurrentGPUSyncPoint(ID3D12CommandQueue* Queue, UINT64 *pCurrentGPUSyncPoint)
-        {
-            return Manager.GetCurrentGPUSyncPoint(Queue, pCurrentGPUSyncPoint);
-        }
-
-        // One residency set per command-list
-        FORCEINLINE HRESULT ExecuteCommandLists(ID3D12CommandQueue* Queue, ID3D12CommandList** CommandLists, ResidencySet** ResidencySets, UINT32 Count)
-        {
-            return Manager.ExecuteCommandLists(Queue, CommandLists, ResidencySets, Count);
-        }
-
-        FORCEINLINE ResidencySet* CreateResidencySet()
-        {
-            ResidencySet* pSet = new ResidencySet();
-
-            if (pSet)
-            {
-                pSet->Initialize(&SyncManager);
-            }
-            return pSet;
-        }
-
-        FORCEINLINE void DestroyResidencySet(ResidencySet* pSet)
-        {
-            delete(pSet);
-        }
-
-    private:
-        Internal::ResidencyManagerInternal Manager;
-        Internal::SyncManager SyncManager;
-    };
+					// If there are some things that need to be made resident we need to make sure that the GPU
+					// doesn't execute until the async thread signals that the MakeResident call has returned.
+					if (SUCCEEDED(hr))
+					{
+						hr = AsyncThreadFence.GPUWait(Queue);
+						AsyncThreadFence.Increment();
+					}
+
+					Queue->ExecuteCommandLists(Count, CommandLists);
+
+					if (SUCCEEDED(hr))
+					{
+						hr = SignalFence(Queue, QueueFence);
+					}
+				}
+				return hr;
+			}
+
+			struct AsyncWorkload
+			{
+				AsyncWorkload() :
+					pMasterSet(nullptr),
+					FenceValueToSignal(0),
+					SyncPointGeneration(0)
+				{}
+
+				UINT64 SyncPointGeneration;
+
+				// List of objects to make resident
+				ResidencySet* pMasterSet;
+
+				// The GPU will wait on this value so that it doesn't execute until the objects are made resident
+				UINT64 FenceValueToSignal;
+			};
+
+			SIZE_T AsyncWorkQueueSize;
+			AsyncWorkload* AsyncWorkQueue;
+
+			HANDLE AsyncWorkEvent;
+			HANDLE AsyncWorkThread;
+			Internal::CriticalSection AsyncWorkMutex;
+			volatile bool FinishAsyncWork;
+			volatile SIZE_T CurrentAsyncWorkloadHead;
+			volatile SIZE_T CurrentAsyncWorkloadTail;
+
+			static unsigned long WINAPI AsyncThreadStart(void* pData)
+			{
+				ResidencyManagerInternal* pManager = (ResidencyManagerInternal*)pData;
+
+				while (1)
+				{
+					AsyncWorkload* pWork = pManager->DequeueAsyncWork();
+
+					while (pWork)
+					{
+						// Submit the work
+						pManager->ProcessPagingWork(pWork);
+						if (SetEvent(pManager->AsyncThreadWorkCompletionEvent) == false)
+						{
+							RESIDENCY_CHECK_RESULT(HRESULT_FROM_WIN32(GetLastError()));
+						}
+
+						// Get more work
+						pWork = pManager->DequeueAsyncWork();
+					}
+
+					//Wait until there is more work do be done
+					WaitForSingleObject(pManager->AsyncWorkEvent, INFINITE);
+					if (ResetEvent(pManager->AsyncWorkEvent) == false)
+					{
+						RESIDENCY_CHECK_RESULT(HRESULT_FROM_WIN32(GetLastError()));
+					}
+
+					if (pManager->FinishAsyncWork)
+					{
+						return 0;
+					}
+				}
+
+				return 0;
+			}
+
+			// This will be run from a worker thread and will emulate a software queue for making gpu resources resident or evicted.
+			// The GPU will be synchronized by this queue to ensure that it never executes using an evicted resource.
+			void ProcessPagingWork(AsyncWorkload* pWork)
+			{
+				Internal::DeviceWideSyncPoint* FirstUncompletedSyncPoint = DequeueCompletedSyncPoints();
+
+				// Use a union so that we only need 1 allocation
+				union ResidentScratchSpace
+				{
+					ManagedObject* pManagedObject;
+					ID3D12Pageable* pUnderlying;
+				};
+
+				ResidentScratchSpace* pMakeResidentList = nullptr;
+				UINT32 NumObjectsToMakeResident = 0;
+
+				ID3D12Pageable** pEvictionList = nullptr;
+				UINT32 NumObjectsToEvict = 0;
+
+				// the size of all the objects which will need to be made resident in order to execute this set.
+				UINT64 SizeToMakeResident = 0;
+
+				LARGE_INTEGER CurrentTime;
+				QueryPerformanceCounter(&CurrentTime);
+
+				{
+					// A lock must be taken here as the state of the objects will be altered
+					Internal::ScopedLock Lock(&Mutex);
+
+					pMakeResidentList = new ResidentScratchSpace[pWork->pMasterSet->CurrentSetSize];
+					pEvictionList = new ID3D12Pageable*[LRU.NumResidentObjects];
+
+					// Mark the objects used by this command list to be made resident
+					for (INT32 i = 0; i < pWork->pMasterSet->CurrentSetSize; i++)
+					{
+						ManagedObject*& pObject = pWork->pMasterSet->ppSet[i];
+						// If it's evicted we need to make it resident again
+						if (pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::EVICTED)
+						{
+							pMakeResidentList[NumObjectsToMakeResident++].pManagedObject = pObject;
+							LRU.MakeResident(pObject);
+
+							SizeToMakeResident += pObject->Size;
+						}
+
+						// Update the last sync point that this was used on
+						pObject->LastGPUSyncPoint = pWork->SyncPointGeneration;
+
+						pObject->LastUsedTimestamp = CurrentTime.QuadPart;
+						LRU.ObjectReferenced(pObject);
+					}
+
+					DXGI_QUERY_VIDEO_MEMORY_INFO LocalMemory;
+					ZeroMemory(&LocalMemory, sizeof(LocalMemory));
+					GetCurrentBudget(&LocalMemory, DXGI_MEMORY_SEGMENT_GROUP_LOCAL);
+
+					UINT64 EvictionGracePeriod = GetCurrentEvictionGracePeriod(&LocalMemory);
+					LRU.TrimAgedAllocations(FirstUncompletedSyncPoint, pEvictionList, NumObjectsToEvict, CurrentTime.QuadPart, EvictionGracePeriod);
+
+					if (NumObjectsToEvict)
+					{
+						RESIDENCY_CHECK_RESULT(Device->Evict(NumObjectsToEvict, pEvictionList));
+						NumObjectsToEvict = 0;
+					}
+
+					if (NumObjectsToMakeResident)
+					{
+						UINT32 ObjectsMadeResident = 0;
+						UINT32 MakeResidentIndex = 0;
+						while (true)
+						{
+							ZeroMemory(&LocalMemory, sizeof(LocalMemory));
+
+							GetCurrentBudget(&LocalMemory, DXGI_MEMORY_SEGMENT_GROUP_LOCAL);
+							DXGI_QUERY_VIDEO_MEMORY_INFO NonLocalMemory;
+							ZeroMemory(&NonLocalMemory, sizeof(NonLocalMemory));
+							GetCurrentBudget(&NonLocalMemory, DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL);
+
+							INT64 TotalUsage = LocalMemory.CurrentUsage + NonLocalMemory.CurrentUsage;
+							INT64 TotalBudget = LocalMemory.Budget + NonLocalMemory.Budget;
+
+							INT64 AvailableSpace = TotalBudget - TotalUsage;
+
+							UINT64 BatchSize = 0;
+							UINT32 NumObjectsInBatch = 0;
+							UINT32 BatchStart = MakeResidentIndex;
+
+							HRESULT hr = S_OK;
+							if (AvailableSpace > 0)
+							{
+								for (UINT32 i = MakeResidentIndex; i < NumObjectsToMakeResident; i++)
+								{
+									// If we try to make this object resident, will we go over budget?
+									if (BatchSize + pMakeResidentList[i].pManagedObject->Size > UINT64(AvailableSpace))
+									{
+										// Next time we will start here
+										MakeResidentIndex = i;
+										break;
+									}
+									else
+									{
+										BatchSize += pMakeResidentList[i].pManagedObject->Size;
+										NumObjectsInBatch++;
+										ObjectsMadeResident++;
+
+										pMakeResidentList[i].pUnderlying = pMakeResidentList[i].pManagedObject->pUnderlying;
+									}
+								}
+
+								hr = Device->MakeResident(NumObjectsInBatch, &pMakeResidentList[BatchStart].pUnderlying);
+								if (SUCCEEDED(hr))
+								{
+									SizeToMakeResident -= BatchSize;
+								}
+							}
+
+							if (FAILED(hr) || ObjectsMadeResident != NumObjectsToMakeResident)
+							{
+								ManagedObject* pResidentHead = LRU.GetResidentListHead();
+
+								// Get the next sync point to wait for
+								FirstUncompletedSyncPoint = DequeueCompletedSyncPoints();
+
+								// If there is nothing to trim OR the only objects 'Resident' are the ones about to be used by this execute.
+								if (pResidentHead == nullptr ||
+									pResidentHead->LastGPUSyncPoint >= pWork->SyncPointGeneration ||
+									FirstUncompletedSyncPoint == nullptr)
+								{
+									// Make resident the rest of the objects as there is nothing left to trim
+									UINT32 NumObjects = NumObjectsToMakeResident - ObjectsMadeResident;
+
+									// Gather up the remaining underlying objects
+									for (UINT32 i = MakeResidentIndex; i < NumObjectsToMakeResident; i++)
+									{
+										pMakeResidentList[i].pUnderlying = pMakeResidentList[i].pManagedObject->pUnderlying;
+									}
+
+									hr = Device->MakeResident(NumObjects, &pMakeResidentList[MakeResidentIndex].pUnderlying);
+									if (FAILED(hr))
+									{
+										// TODO: What should we do if this fails? This is a catastrophic failure in which the app is trying to use more memory
+										//       in 1 command list than can possibly be made resident by the system.
+										RESIDENCY_CHECK_RESULT(hr);
+									}
+									break;
+								}
+
+								UINT64 GenerationToWaitFor = FirstUncompletedSyncPoint->GenerationID;
+
+								// We can't wait for the sync-point that this work is intended for
+								if (GenerationToWaitFor == pWork->SyncPointGeneration)
+								{
+									RESIDENCY_CHECK(GenerationToWaitFor >= 0);
+									GenerationToWaitFor -= 1;
+								}
+								// Wait until the GPU is done
+								WaitForSyncPoint(GenerationToWaitFor);
+
+								LRU.TrimToSyncPointInclusive(TotalUsage + INT64(SizeToMakeResident), TotalBudget, pEvictionList, NumObjectsToEvict, GenerationToWaitFor);
+
+								RESIDENCY_CHECK_RESULT(Device->Evict(NumObjectsToEvict, pEvictionList));
+							}
+							else
+							{
+								// We made everything resident, mission accomplished
+								break;
+							}
+						}
+					}
+
+					delete[](pMakeResidentList);
+					delete[](pEvictionList);
+				}
+
+				// Tell the GPU that it's safe to execute since we made things resident
+				RESIDENCY_CHECK_RESULT(AsyncThreadFence.pFence->Signal(pWork->FenceValueToSignal));
+
+				delete(pWork->pMasterSet);
+				pWork->pMasterSet = nullptr;
+			}
+			// The Enqueue and Dequeue Async Work functions are threadsafe as there is only 1 producer and 1 consumer, if that changes
+			// Synchronisation will be required
+			HRESULT EnqueueAsyncWork(ResidencySet* pMasterSet, UINT64 FenceValueToSignal, UINT64 SyncPointGeneration)
+			{
+				// We can't get too far ahead of the worker thread otherwise huge hitches occur
+				while ((CurrentAsyncWorkloadTail - CurrentAsyncWorkloadHead) >= MaxSoftwareQueueLatency)
+				{
+					WaitForSingleObject(AsyncThreadWorkCompletionEvent, INFINITE);
+				}
+
+				RESIDENCY_CHECK(CurrentAsyncWorkloadTail >= CurrentAsyncWorkloadHead);
+
+				const SIZE_T currentIndex = CurrentAsyncWorkloadTail % AsyncWorkQueueSize;
+				AsyncWorkQueue[currentIndex].pMasterSet = pMasterSet;
+				AsyncWorkQueue[currentIndex].FenceValueToSignal = FenceValueToSignal;
+				AsyncWorkQueue[currentIndex].SyncPointGeneration = SyncPointGeneration;
+
+				CurrentAsyncWorkloadTail++;
+				if (SetEvent(AsyncWorkEvent) == false)
+				{
+					return HRESULT_FROM_WIN32(GetLastError());
+				}
+
+				return S_OK;
+			}
+
+			AsyncWorkload* DequeueAsyncWork()
+			{
+				if (CurrentAsyncWorkloadHead == CurrentAsyncWorkloadTail)
+				{
+					return nullptr;
+				}
+
+				const SIZE_T currentHead = CurrentAsyncWorkloadHead % AsyncWorkQueueSize;
+				AsyncWorkload* pWork = &AsyncWorkQueue[currentHead];
+
+				CurrentAsyncWorkloadHead++;
+				return pWork;
+			}
+
+			void GetCurrentBudget(DXGI_QUERY_VIDEO_MEMORY_INFO* InfoOut, DXGI_MEMORY_SEGMENT_GROUP Segment)
+			{
+				RESIDENCY_CHECK_RESULT(Adapter->QueryVideoMemoryInfo(NodeIndex, Segment, InfoOut));
+			}
+
+			HRESULT EnqueueSyncPoint()
+			{
+				Internal::ScopedLock Lock(&AsyncWorkMutex);
+
+				Internal::DeviceWideSyncPoint* pPoint = Internal::DeviceWideSyncPoint::CreateSyncPoint(NumQueuesSeen, CurrentSyncPointGeneration);
+				if (pPoint == nullptr)
+				{
+					return E_OUTOFMEMORY;
+				}
+
+				UINT32 i = 0;
+				LIST_ENTRY* pFenceEntry = QueueFencesListHead.Flink;
+				// Record the current state of each queue we track into this sync point
+				while (pFenceEntry != &QueueFencesListHead)
+				{
+					Internal::Fence* pFence = CONTAINING_RECORD(pFenceEntry, Internal::Fence, ListEntry);
+					pFenceEntry = pFenceEntry->Flink;
+
+					pPoint->pQueueSyncPoints[i].pFence = pFence;
+					pPoint->pQueueSyncPoints[i].LastUsedValue = pFence->FenceValue - 1;//Minus one as we want the last submitted
+
+					i++;
+				}
+
+				Internal::InsertTailList(&InFlightSyncPointsHead, &pPoint->ListEntry);
+
+				return S_OK;
+			}
+
+			// Returns a pointer to the first synch point which is not completed
+			Internal::DeviceWideSyncPoint* DequeueCompletedSyncPoints()
+			{
+				Internal::ScopedLock Lock(&AsyncWorkMutex);
+
+				while (Internal::IsListEmpty(&InFlightSyncPointsHead) == false)
+				{
+					Internal::DeviceWideSyncPoint* pPoint =
+						CONTAINING_RECORD(InFlightSyncPointsHead.Flink, Internal::DeviceWideSyncPoint, ListEntry);
+
+					if (pPoint->IsCompleted())
+					{
+						Internal::RemoveHeadList(&InFlightSyncPointsHead);
+						delete pPoint;
+					}
+					else
+					{
+						return pPoint;
+					}
+				}
+
+				return nullptr;
+			}
+
+			void WaitForSyncPoint(UINT64 SyncPointID)
+			{
+				Internal::ScopedLock Lock(&AsyncWorkMutex);
+
+				LIST_ENTRY* pPointEntry = InFlightSyncPointsHead.Flink;
+				while (pPointEntry != &InFlightSyncPointsHead)
+				{
+					Internal::DeviceWideSyncPoint* pPoint =
+						CONTAINING_RECORD(InFlightSyncPointsHead.Flink, Internal::DeviceWideSyncPoint, ListEntry);
+
+					if (pPoint->GenerationID > SyncPointID)
+					{
+						// this point is already done
+						return;
+					}
+					else if (pPoint->GenerationID < SyncPointID)
+					{
+						// Keep popping off until we find the one to wait on
+						Internal::RemoveHeadList(&InFlightSyncPointsHead);
+						delete(pPoint);
+					}
+					else
+					{
+						pPoint->WaitForCompletion(CompletionEvent);
+						Internal::RemoveHeadList(&InFlightSyncPointsHead);
+						delete(pPoint);
+						return;
+					}
+				}
+			}
+
+			// Generate a result between the minimum period and the maximum period based on the current
+			// local memory pressure. I.e. when memory pressure is low, objects will persist longer before
+			// being evicted.
+			UINT64 GetCurrentEvictionGracePeriod(DXGI_QUERY_VIDEO_MEMORY_INFO* LocalMemoryState)
+			{
+				// 1 == full pressure, 0 == no pressure
+				double Pressure = (double(LocalMemoryState->CurrentUsage) / double(LocalMemoryState->Budget));
+				Pressure = RESIDENCY_MIN(Pressure, 1.0);
+
+				if (Pressure > cTrimPercentageMemoryUsageThreshold)
+				{
+					// Normalize the pressure for the range 0 to cTrimPercentageMemoryUsageThreshold
+					Pressure = (Pressure - cTrimPercentageMemoryUsageThreshold) / (1.0 - cTrimPercentageMemoryUsageThreshold);
+
+					// Linearly interpolate between the min period and the max period based on the pressure
+					return UINT64((MaxEvictionGracePeriodTicks - MinEvictionGracePeriodTicks) * (1.0 - Pressure)) + MinEvictionGracePeriodTicks;
+				}
+				else
+				{
+					// Essentially don't trim at all
+					return MAXUINT64;
+				}
+			}
+
+			LIST_ENTRY QueueFencesListHead;
+			UINT32 NumQueuesSeen;
+			Internal::Fence AsyncThreadFence;
+
+			LIST_ENTRY InFlightSyncPointsHead;
+			UINT64 CurrentSyncPointGeneration;
+
+			HANDLE CompletionEvent;
+			HANDLE AsyncThreadWorkCompletionEvent;
+
+			ID3D12Device* Device;
+			// NOTE: This is an index not a mask. The majority of D3D12 uses bit masks to identify a GPU node whereas DXGI uses 0 based indices.
+			UINT NodeIndex;
+			IDXGIAdapter3* Adapter;
+			Internal::LRUCache LRU;
+
+			Internal::CriticalSection Mutex;
+
+			Internal::CriticalSection ExecutionCS;
+
+			const bool cStartEvicted;
+
+			const float cMinEvictionGracePeriod;
+			UINT64 MinEvictionGracePeriodTicks;
+			const float cMaxEvictionGracePeriod;
+			UINT64 MaxEvictionGracePeriodTicks;
+			// When the app is using more than this % of its budgeted local VidMem trimming will occur
+			// (valid between 0.0 - 1.0)
+			const float cTrimPercentageMemoryUsageThreshold;
+
+			UINT32 MaxSoftwareQueueLatency;
+			INT64 ResidencyManagerUniqueID;
+
+			SyncManager* pSyncManager;
+		};
+	}
+
+	class ResidencyManager
+	{
+	public:
+		ResidencyManager() :
+			Manager(&SyncManager)
+		{
+		}
+
+		// NOTE: DeviceNodeIndex is an index not a mask. The majority of D3D12 uses bit masks to identify a GPU node whereas DXGI uses 0 based indices.
+		FORCEINLINE HRESULT Initialize(ID3D12Device* ParentDevice, UINT DeviceNodeIndex, IDXGIAdapter3* ParentAdapter, UINT32 MaxLatency)
+		{
+			return Manager.Initialize(ParentDevice, DeviceNodeIndex, ParentAdapter, MaxLatency);
+		}
+
+		FORCEINLINE void Destroy()
+		{
+			Manager.Destroy();
+		}
+
+		FORCEINLINE void BeginTrackingObject(ManagedObject* pObject)
+		{
+			Manager.BeginTrackingObject(pObject);
+		}
+
+		FORCEINLINE void EndTrackingObject(ManagedObject* pObject)
+		{
+			Manager.EndTrackingObject(pObject);
+		}
+
+		HRESULT GetCurrentGPUSyncPoint(ID3D12CommandQueue* Queue, UINT64 *pCurrentGPUSyncPoint)
+		{
+			return Manager.GetCurrentGPUSyncPoint(Queue, pCurrentGPUSyncPoint);
+		}
+
+		// One residency set per command-list
+		FORCEINLINE HRESULT ExecuteCommandLists(ID3D12CommandQueue* Queue, ID3D12CommandList** CommandLists, ResidencySet** ResidencySets, UINT32 Count)
+		{
+			return Manager.ExecuteCommandLists(Queue, CommandLists, ResidencySets, Count);
+		}
+
+		FORCEINLINE ResidencySet* CreateResidencySet()
+		{
+			ResidencySet* pSet = new ResidencySet();
+
+			if (pSet)
+			{
+				pSet->Initialize(&SyncManager);
+			}
+			return pSet;
+		}
+
+		FORCEINLINE void DestroyResidencySet(ResidencySet* pSet)
+		{
+			delete(pSet);
+		}
+
+	private:
+		Internal::ResidencyManagerInternal Manager;
+		Internal::SyncManager SyncManager;
+	};
 };

--- a/Samples/Desktop/D3D12Residency/src/shaders.hlsl
+++ b/Samples/Desktop/D3D12Residency/src/shaders.hlsl
@@ -11,8 +11,8 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 Texture2D g_texture : register(t0);
@@ -20,15 +20,15 @@ SamplerState g_sampler : register(s0);
 
 PSInput VSMain(float4 position : POSITION, float4 uv : TEXCOORD)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.uv = uv;
+	result.position = position;
+	result.uv = uv;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return g_texture.Sample(g_sampler, input.uv);
+	return g_texture.Sample(g_sampler, input.uv);
 }

--- a/Samples/Desktop/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.cpp
+++ b/Samples/Desktop/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.cpp
@@ -41,9 +41,10 @@ D3D12SM6WaveIntrinsics::D3D12SM6WaveIntrinsics(UINT width, UINT height, std::wst
     m_cbSrvDescriptorSize(0),
     m_constantBufferData{},
     m_mousePosition{ width*0.5f, height*0.5f },
-    m_mouseLeftButtonDown(false),
+	m_mouseLeftButtonDown(false),
     m_rendermode{ 1 }
 {
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
 }
 
 void D3D12SM6WaveIntrinsics::OnInit()
@@ -69,7 +70,7 @@ void D3D12SM6WaveIntrinsics::CreateDevice(const ComPtr<IDXGIFactory4>& factory)
     else
     {
         ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+        GetHardwareAdapter(factory.Get(), &hardwareAdapter, true);
 
         ThrowIfFailed(D3D12CreateDevice(
             hardwareAdapter.Get(),
@@ -104,8 +105,8 @@ void D3D12SM6WaveIntrinsics::LoadPipeline()
     ComPtr<IDXGIFactory4> factory;
     ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    // Create device.
-    CreateDevice(factory);
+	// Create device.
+	CreateDevice(factory);
 
     // Query the level of support of Shader Model.
     D3D12_FEATURE_DATA_SHADER_MODEL shaderModelSupport = { D3D_SHADER_MODEL_6_0 };
@@ -132,8 +133,8 @@ void D3D12SM6WaveIntrinsics::LoadPipeline()
         {
             exit(-1);
         }
-    }    
-    
+    }	
+	
     // Describe and create the command queue.
     D3D12_COMMAND_QUEUE_DESC queueDesc = {};
     queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
@@ -155,7 +156,7 @@ void D3D12SM6WaveIntrinsics::LoadPipeline()
     ComPtr<IDXGISwapChain1> swapChain;
 
     ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
+        m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
         Win32Application::GetHwnd(),
         &swapChainDesc,
         nullptr,
@@ -353,13 +354,13 @@ void D3D12SM6WaveIntrinsics::LoadAssets()
         // Describe and create a constant buffer view.
         D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
         cbvDesc.BufferLocation = m_constantBuffer->GetGPUVirtualAddress();
-        cbvDesc.SizeInBytes = (sizeof(SceneConstantBuffer) + 255) & ~255;    // CB size is required to be 256-byte aligned.
+        cbvDesc.SizeInBytes = (sizeof(SceneConstantBuffer) + 255) & ~255;	// CB size is required to be 256-byte aligned.
         CD3DX12_CPU_DESCRIPTOR_HANDLE cbHandle(m_cbSrvHeap->GetCPUDescriptorHandleForHeapStart());
         m_d3d12Device->CreateConstantBufferView(&cbvDesc, cbHandle);
 
         // Map and initialize the constant buffer. We don't unmap this until the
         // app closes. Keeping things mapped for the lifetime of the resource is okay.
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
+        CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
         ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbSrvDataBegin)));
         memcpy(m_pCbSrvDataBegin, &m_constantBufferData, sizeof(m_constantBufferData));
     }
@@ -420,7 +421,7 @@ void D3D12SM6WaveIntrinsics::LoadSizeDependentResources()
 
         // Copy the triangle data to the vertex buffer.
         UINT8* pVertexDataBegin;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
+        CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
         ThrowIfFailed(m_renderPass1VertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
         memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
         m_renderPass1VertexBuffer->Unmap(0, nullptr);
@@ -461,7 +462,7 @@ void D3D12SM6WaveIntrinsics::LoadSizeDependentResources()
 
         // Copy the triangle data to the vertex buffer.
         UINT8* pVertexDataBegin;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
+        CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
         ThrowIfFailed(m_renderPass2VertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
         memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
         m_renderPass2VertexBuffer->Unmap(0, nullptr);
@@ -602,14 +603,56 @@ void D3D12SM6WaveIntrinsics::OnUpdate()
 // Render the scene.
 void D3D12SM6WaveIntrinsics::OnRender()
 {
-    RenderUI();
-    // Record all the commands we need to render the scene into the command list.
-    RenderScene();
+    try
+    {
+        RenderUI();
+        // Record all the commands we need to render the scene into the command list.
+        RenderScene();
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+        // Present the frame.
+        ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    MoveToNextFrame();
+        MoveToNextFrame();
+    }
+    catch (HrException& e)
+    {
+        if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
+        {
+            RestoreD3DResources();
+        }
+        else
+        {
+            throw;
+        }
+    }
+}
+
+// Release sample's D3D objects.
+void D3D12SM6WaveIntrinsics::ReleaseD3DResources()
+{
+    m_fence.Reset();
+    m_renderPass1RenderTargets.Reset();
+    m_uiRenderTarget.Reset();
+    ResetComPtrArray(&m_renderPass2RenderTargets);
+    m_commandQueue.Reset();
+    m_swapChain.Reset();
+    m_d3d12Device.Reset();
+}
+
+// Tears down D3D resources and reinitializes them.
+void D3D12SM6WaveIntrinsics::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
+    {
+        WaitForGpu();
+    }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
 }
 
 void D3D12SM6WaveIntrinsics::OnDestroy()
@@ -795,17 +838,17 @@ void D3D12SM6WaveIntrinsics::OnSizeChanged(UINT width, UINT height, bool minimiz
 
 void D3D12SM6WaveIntrinsics::OnMouseMove(UINT x, UINT y)
 {
-    // Only update the zoom-in area while mouse left button is pressed.
-    if(m_mouseLeftButtonDown)
-    {
-        m_mousePosition[0] = static_cast<float>(x);
-        m_mousePosition[1] = static_cast<float>(y);        
-    }
+	// Only update the zoom-in area while mouse left button is pressed.
+	if(m_mouseLeftButtonDown)
+	{
+		m_mousePosition[0] = static_cast<float>(x);
+		m_mousePosition[1] = static_cast<float>(y);		
+	}
 }
 
 void D3D12SM6WaveIntrinsics::OnLeftButtonDown(UINT /*x*/, UINT /*y*/)
 {
-    m_mouseLeftButtonDown = true;
+	m_mouseLeftButtonDown = true;
 }
 
 void D3D12SM6WaveIntrinsics::OnLeftButtonUp(UINT /*x*/, UINT /*y*/)

--- a/Samples/Desktop/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.h
+++ b/Samples/Desktop/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.h
@@ -37,8 +37,8 @@ public:
     virtual void OnDestroy();
     virtual void OnKeyDown(UINT8 key);
     virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
-    virtual void OnMouseMove(UINT x, UINT y);
-    virtual void OnLeftButtonDown(UINT x, UINT y);
+	virtual void OnMouseMove(UINT x, UINT y);
+	virtual void OnLeftButtonDown(UINT x, UINT y);
     virtual void OnLeftButtonUp(UINT x, UINT y);
     virtual IDXGISwapChain* GetSwapchain() { return m_swapChain.Get(); }
 
@@ -105,7 +105,7 @@ private:
     SceneConstantBuffer m_constantBufferData;
     UINT8* m_pCbSrvDataBegin;
     float m_mousePosition[2];
-    bool m_mouseLeftButtonDown;
+	bool m_mouseLeftButtonDown;
 
     // Synchronization objects.
     UINT m_frameIndex;
@@ -120,9 +120,11 @@ private:
     // UILayer
     std::shared_ptr<UILayer> m_uiLayer;
 
-    void CreateDevice(const ComPtr<IDXGIFactory4>& factory);
+	void CreateDevice(const ComPtr<IDXGIFactory4>& factory);
     void LoadPipeline();
     void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
     void LoadSizeDependentResources();
     void MoveToNextFrame();
     void WaitForGpu();

--- a/Samples/Desktop/D3D12SM6WaveIntrinsics/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12SM6WaveIntrinsics/src/DXSample.cpp
@@ -52,33 +52,78 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
+
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+            }
+#if !defined(_XBOX_ONE)
+        }
+#endif
 
     *ppAdapter = adapter.Detach();
-}
+    }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)

--- a/Samples/Desktop/D3D12SM6WaveIntrinsics/src/DXSample.h
+++ b/Samples/Desktop/D3D12SM6WaveIntrinsics/src/DXSample.h
@@ -49,7 +49,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/Desktop/D3D12SM6WaveIntrinsics/src/Main.cpp
+++ b/Samples/Desktop/D3D12SM6WaveIntrinsics/src/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12SM6WaveIntrinsics sample(1280, 720, L"D3D12 Shader Model 6 WaveIntrinsics Sample");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12SM6WaveIntrinsics sample(1280, 720, L"D3D12 Shader Model 6 WaveIntrinsics Sample");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12SM6WaveIntrinsics/src/d3dx12.h
+++ b/Samples/Desktop/D3D12SM6WaveIntrinsics/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12SM6WaveIntrinsics/src/wave.hlsl
+++ b/Samples/Desktop/D3D12SM6WaveIntrinsics/src/wave.hlsl
@@ -19,18 +19,18 @@ cbuffer SceneConstantBuffer : register(b0)
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VSMain(float4 position : POSITION, float4 color : COLOR)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = mul(position, orthProjMatrix);
-    result.color = color;
+	result.position = mul(position, orthProjMatrix);
+	result.color = color;
 
-    return result;
+	return result;
 }
 
 

--- a/Samples/Desktop/D3D12SmallResources/src/D3D12SmallResources.cpp
+++ b/Samples/Desktop/D3D12SmallResources/src/D3D12SmallResources.cpp
@@ -13,499 +13,499 @@
 #include "D3D12SmallResources.h"
 
 D3D12SmallResources::D3D12SmallResources(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_fenceValues{},
-    m_rtvDescriptorSize(0),
-    m_srvDescriptorSize(0),
-    m_usePlacedResources(true)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_fenceValues{},
+	m_rtvDescriptorSize(0),
+	m_srvDescriptorSize(0),
+	m_usePlacedResources(true)
 {
 }
 
 void D3D12SmallResources::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12SmallResources::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&m_adapter)));
+	if (m_useWarpDevice)
+	{
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&m_adapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            m_adapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			m_adapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(hardwareAdapter.As(&m_adapter));
+		ThrowIfFailed(hardwareAdapter.As(&m_adapter));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            m_adapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			m_adapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
-    NAME_D3D12_OBJECT(m_commandQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	NAME_D3D12_OBJECT(m_commandQueue);
 
-    // Describe and create the copy queue.
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_COPY;
+	// Describe and create the copy queue.
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_COPY;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_copyQueue)));
-    NAME_D3D12_OBJECT(m_copyQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_copyQueue)));
+	NAME_D3D12_OBJECT(m_copyQueue);
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    // This sample does not support fullscreen transitions.
-    ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
+	// This sample does not support fullscreen transitions.
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a constant buffer view (CBV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
-        cbvHeapDesc.NumDescriptors = TextureCount;
-        cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
-        NAME_D3D12_OBJECT(m_srvHeap);
+		// Describe and create a constant buffer view (CBV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
+		cbvHeapDesc.NumDescriptors = TextureCount;
+		cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
+		NAME_D3D12_OBJECT(m_srvHeap);
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-        m_srvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_srvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV and a command allocator for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
+		// Create a RTV and a command allocator for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-            NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
+			NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
 
-            ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
-        }
-    }
+			ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
+		}
+	}
 
-    // Create copy queue resources.
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_COPY, IID_PPV_ARGS(&m_copyCommandAllocator)));
+	// Create copy queue resources.
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_COPY, IID_PPV_ARGS(&m_copyCommandAllocator)));
 }
 
 // Load the sample assets.
 void D3D12SmallResources::LoadAssets()
 {
-    // Create a root signature consisting of a single CBV parameter.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create a root signature consisting of a single CBV parameter.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
-        CD3DX12_ROOT_PARAMETER1 rootParameters[1];
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
+		CD3DX12_ROOT_PARAMETER1 rootParameters[1];
 
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
 
-        // Allow input layout and deny uneccessary access to certain pipeline stages.
-        D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
-            D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_VERTEX_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS;
+		// Allow input layout and deny uneccessary access to certain pipeline stages.
+		D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
+			D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_VERTEX_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS;
 
-        CD3DX12_STATIC_SAMPLER_DESC samplerDesc(0, D3D12_FILTER_MIN_MAG_MIP_LINEAR);
+		CD3DX12_STATIC_SAMPLER_DESC samplerDesc(0, D3D12_FILTER_MIN_MAG_MIP_LINEAR);
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &samplerDesc, rootSignatureFlags);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &samplerDesc, rootSignatureFlags);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-        NAME_D3D12_OBJECT(m_rootSignature);
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+		NAME_D3D12_OBJECT(m_rootSignature);
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Describe and create the graphics pipeline state objects (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state objects (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-        NAME_D3D12_OBJECT(m_pipelineState);
-    }
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+		NAME_D3D12_OBJECT(m_pipelineState);
+	}
 
-    // Create the command lists.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
-    NAME_D3D12_OBJECT(m_commandList);
+	// Create the command lists.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	NAME_D3D12_OBJECT(m_commandList);
 
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_COPY, m_copyCommandAllocator.Get(), nullptr, IID_PPV_ARGS(&m_copyCommandList)));
-    ThrowIfFailed(m_copyCommandList->Close());
-    NAME_D3D12_OBJECT(m_copyCommandList);
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_COPY, m_copyCommandAllocator.Get(), nullptr, IID_PPV_ARGS(&m_copyCommandList)));
+	ThrowIfFailed(m_copyCommandList->Close());
+	NAME_D3D12_OBJECT(m_copyCommandList);
 
-    // Note: ComPtr's are CPU objects but this resource needs to stay in scope until
-    // the command list that references it has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resource is not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> vertexBufferUpload;
+	// Note: ComPtr's are CPU objects but this resource needs to stay in scope until
+	// the command list that references it has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resource is not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> vertexBufferUpload;
 
-    // Create the vertex buffer.
-    {
-        // Create quads for all of the images that will be generated and drawn to the screen.
-        Vertex quadVertices[TextureCount * 4];
-        UINT index = 0;
-        float offsetX = 0.15f;
-        float marginX = offsetX / 10.0f;;
-        float startX = (GridWidth / 2.0f) * -(offsetX + marginX) + marginX / 2.0f;
-        float offsetY = offsetX * m_aspectRatio;
-        float marginY = offsetY / 10.0f;
-        float y = (GridHeight / 2.0f) * (offsetY + marginY) - marginY / 2.0f;
-        for (UINT row = 0; row < GridHeight; row++)
-        {
-            float x = startX;
-            for (UINT column = 0; column < GridWidth; column++)
-            {
-                quadVertices[index++] = { { x, y - offsetY, 0.0f }, { 0.0f, 0.0f } };
-                quadVertices[index++] = { { x, y, 0.0f }, { 0.0f, 1.0f } };
-                quadVertices[index++] = { { x + offsetX, y - offsetY, 0.0f }, { 1.0f, 0.0f } };
-                quadVertices[index++] = { { x + offsetX, y, 0.0f }, { 1.0f, 1.0f } };
-                x += offsetX + marginX;
-            }
-            y -= offsetY + marginY;
-        }
-        const UINT vertexBufferSize = sizeof(quadVertices);
+	// Create the vertex buffer.
+	{
+		// Create quads for all of the images that will be generated and drawn to the screen.
+		Vertex quadVertices[TextureCount * 4];
+		UINT index = 0;
+		float offsetX = 0.15f;
+		float marginX = offsetX / 10.0f;;
+		float startX = (GridWidth / 2.0f) * -(offsetX + marginX) + marginX / 2.0f;
+		float offsetY = offsetX * m_aspectRatio;
+		float marginY = offsetY / 10.0f;
+		float y = (GridHeight / 2.0f) * (offsetY + marginY) - marginY / 2.0f;
+		for (UINT row = 0; row < GridHeight; row++)
+		{
+			float x = startX;
+			for (UINT column = 0; column < GridWidth; column++)
+			{
+				quadVertices[index++] = { { x, y - offsetY, 0.0f }, { 0.0f, 0.0f } };
+				quadVertices[index++] = { { x, y, 0.0f }, { 0.0f, 1.0f } };
+				quadVertices[index++] = { { x + offsetX, y - offsetY, 0.0f }, { 1.0f, 0.0f } };
+				quadVertices[index++] = { { x + offsetX, y, 0.0f }, { 1.0f, 1.0f } };
+				x += offsetX + marginX;
+			}
+			y -= offsetY + marginY;
+		}
+		const UINT vertexBufferSize = sizeof(quadVertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&vertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&vertexBufferUpload)));
 
-        NAME_D3D12_OBJECT(m_vertexBuffer);
+		NAME_D3D12_OBJECT(m_vertexBuffer);
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(quadVertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(quadVertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = sizeof(quadVertices);
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = sizeof(quadVertices);
+	}
 
-    // Close the command list and execute it to begin the vertex buffer copy into
-    // the default heap.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the vertex buffer copy into
+	// the default heap.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValues[m_frameIndex]++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValues[m_frameIndex]++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForGpu();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForGpu();
+	}
 
-    CreateTextures();
+	CreateTextures();
 }
 
 void D3D12SmallResources::CreateTextures()
 {
-    m_textures.clear();
-    m_textures.resize(TextureCount);
-    m_textureHeap.Reset();
+	m_textures.clear();
+	m_textures.resize(TextureCount);
+	m_textureHeap.Reset();
 
-    ThrowIfFailed(m_copyCommandAllocator->Reset());
-    ThrowIfFailed(m_copyCommandList->Reset(m_copyCommandAllocator.Get(), nullptr));
+	ThrowIfFailed(m_copyCommandAllocator->Reset());
+	ThrowIfFailed(m_copyCommandList->Reset(m_copyCommandAllocator.Get(), nullptr));
 
-    CD3DX12_RESOURCE_DESC textureDesc = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R8G8B8A8_UNORM, TextureWidth, TextureHeight, 1, 1);
+	CD3DX12_RESOURCE_DESC textureDesc = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R8G8B8A8_UNORM, TextureWidth, TextureHeight, 1, 1);
 
-    if (m_usePlacedResources)
-    {
-        // Since we are using small resources we can take advantage of 4KB
-        // resource alignments. As long as the most detailed mip can fit in an
-        // allocation less than 64KB, 4KB alignments can be used.
-        //
-        // When dealing with MSAA textures the rules are similar, but the minimum
-        // alignment is 64KB for a texture whose most detailed mip can fit in an
-        // allocation less than 4MB.
-        textureDesc.Alignment = D3D12_SMALL_RESOURCE_PLACEMENT_ALIGNMENT;
-        D3D12_RESOURCE_ALLOCATION_INFO info = m_device->GetResourceAllocationInfo(0, 1, &textureDesc);
+	if (m_usePlacedResources)
+	{
+		// Since we are using small resources we can take advantage of 4KB
+		// resource alignments. As long as the most detailed mip can fit in an
+		// allocation less than 64KB, 4KB alignments can be used.
+		//
+		// When dealing with MSAA textures the rules are similar, but the minimum
+		// alignment is 64KB for a texture whose most detailed mip can fit in an
+		// allocation less than 4MB.
+		textureDesc.Alignment = D3D12_SMALL_RESOURCE_PLACEMENT_ALIGNMENT;
+		D3D12_RESOURCE_ALLOCATION_INFO info = m_device->GetResourceAllocationInfo(0, 1, &textureDesc);
 
-        if (info.Alignment != D3D12_SMALL_RESOURCE_PLACEMENT_ALIGNMENT)
-        {
-            // If the alignment requested is not granted, then let D3D tell us
-            // the alignment that needs to be used for these resources.
-            textureDesc.Alignment = 0;
-            info = m_device->GetResourceAllocationInfo(0, 1, &textureDesc);
-        }
+		if (info.Alignment != D3D12_SMALL_RESOURCE_PLACEMENT_ALIGNMENT)
+		{
+			// If the alignment requested is not granted, then let D3D tell us
+			// the alignment that needs to be used for these resources.
+			textureDesc.Alignment = 0;
+			info = m_device->GetResourceAllocationInfo(0, 1, &textureDesc);
+		}
 
-        const UINT64 heapSize = TextureCount * info.SizeInBytes;
-        CD3DX12_HEAP_DESC heapDesc(heapSize, D3D12_HEAP_TYPE_DEFAULT, 0, D3D12_HEAP_FLAG_DENY_BUFFERS | D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES);
-        ThrowIfFailed(m_device->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_textureHeap)));
+		const UINT64 heapSize = TextureCount * info.SizeInBytes;
+		CD3DX12_HEAP_DESC heapDesc(heapSize, D3D12_HEAP_TYPE_DEFAULT, 0, D3D12_HEAP_FLAG_DENY_BUFFERS | D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES);
+		ThrowIfFailed(m_device->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_textureHeap)));
 
-        std::vector<D3D12_RESOURCE_BARRIER> barriers;
-        barriers.resize(TextureCount);
-        for (UINT n = 0; n < TextureCount; n++)
-        {
-            ThrowIfFailed(m_device->CreatePlacedResource(
-                m_textureHeap.Get(),
-                n * info.SizeInBytes,
-                &textureDesc,
-                D3D12_RESOURCE_STATE_COMMON,
-                nullptr,
-                IID_PPV_ARGS(&m_textures[n])));
+		std::vector<D3D12_RESOURCE_BARRIER> barriers;
+		barriers.resize(TextureCount);
+		for (UINT n = 0; n < TextureCount; n++)
+		{
+			ThrowIfFailed(m_device->CreatePlacedResource(
+				m_textureHeap.Get(),
+				n * info.SizeInBytes,
+				&textureDesc,
+				D3D12_RESOURCE_STATE_COMMON,
+				nullptr,
+				IID_PPV_ARGS(&m_textures[n])));
 
-            barriers[n] = CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, m_textures[n].Get());
-        }
+			barriers[n] = CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, m_textures[n].Get());
+		}
 
-        m_copyCommandList->ResourceBarrier(static_cast<UINT>(barriers.size()), barriers.data());
-    }
-    else
-    {
-        for (UINT n = 0; n < TextureCount; n++)
-        {
-            ThrowIfFailed(m_device->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-                D3D12_HEAP_FLAG_NONE,
-                &textureDesc,
-                D3D12_RESOURCE_STATE_COMMON,
-                nullptr,
-                IID_PPV_ARGS(&m_textures[n])));
-        }
-    }
+		m_copyCommandList->ResourceBarrier(static_cast<UINT>(barriers.size()), barriers.data());
+	}
+	else
+	{
+		for (UINT n = 0; n < TextureCount; n++)
+		{
+			ThrowIfFailed(m_device->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+				D3D12_HEAP_FLAG_NONE,
+				&textureDesc,
+				D3D12_RESOURCE_STATE_COMMON,
+				nullptr,
+				IID_PPV_ARGS(&m_textures[n])));
+		}
+	}
 
-    // Note: ComPtr's are CPU objects but these resources need to stay in scope until
-    // the command list that references them has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resources are not
-    // prematurely destroyed.
-    std::vector<ComPtr<ID3D12Resource>> uploadResources;
-    uploadResources.resize(TextureCount);
+	// Note: ComPtr's are CPU objects but these resources need to stay in scope until
+	// the command list that references them has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resources are not
+	// prematurely destroyed.
+	std::vector<ComPtr<ID3D12Resource>> uploadResources;
+	uploadResources.resize(TextureCount);
 
-    // Colors for textures are randomly generated. Reset the seed so that the colors
-    // don't change when the resource type changes.
-    srand(100);
+	// Colors for textures are randomly generated. Reset the seed so that the colors
+	// don't change when the resource type changes.
+	srand(100);
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_srvHeap->GetCPUDescriptorHandleForHeapStart());
-    for (UINT n = 0; n < TextureCount; n++)
-    {
-        const UINT64 uploadBufferSize = GetRequiredIntermediateSize(m_textures[n].Get(), 0, 1) + D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
+	CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_srvHeap->GetCPUDescriptorHandleForHeapStart());
+	for (UINT n = 0; n < TextureCount; n++)
+	{
+		const UINT64 uploadBufferSize = GetRequiredIntermediateSize(m_textures[n].Get(), 0, 1) + D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&uploadResources[n])));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&uploadResources[n])));
 
-        auto texture = GenerateTexture();
+		auto texture = GenerateTexture();
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the texture.
-        D3D12_SUBRESOURCE_DATA textureData = {};
-        textureData.pData = reinterpret_cast<UINT8*>(texture.data());
-        textureData.RowPitch = TextureWidth * TexturePixelSizeInBytes;
-        textureData.SlicePitch = textureData.RowPitch * TextureHeight;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the texture.
+		D3D12_SUBRESOURCE_DATA textureData = {};
+		textureData.pData = reinterpret_cast<UINT8*>(texture.data());
+		textureData.RowPitch = TextureWidth * TexturePixelSizeInBytes;
+		textureData.SlicePitch = textureData.RowPitch * TextureHeight;
 
-        UpdateSubresources<1>(m_copyCommandList.Get(), m_textures[n].Get(), uploadResources[n].Get(), 0, 0, 1, &textureData);
+		UpdateSubresources<1>(m_copyCommandList.Get(), m_textures[n].Get(), uploadResources[n].Get(), 0, 0, 1, &textureData);
 
-        NAME_D3D12_OBJECT_INDEXED(m_textures, n);
+		NAME_D3D12_OBJECT_INDEXED(m_textures, n);
 
-        // Describe and create a SRV for the texture.
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Format = textureDesc.Format;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = textureDesc.MipLevels;
+		// Describe and create a SRV for the texture.
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Format = textureDesc.Format;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = textureDesc.MipLevels;
 
-        m_device->CreateShaderResourceView(m_textures[n].Get(), &srvDesc, cpuHandle);
-        cpuHandle.Offset(m_srvDescriptorSize);
-    }
+		m_device->CreateShaderResourceView(m_textures[n].Get(), &srvDesc, cpuHandle);
+		cpuHandle.Offset(m_srvDescriptorSize);
+	}
 
-    ThrowIfFailed(m_copyCommandList->Close());
+	ThrowIfFailed(m_copyCommandList->Close());
 
-    ID3D12CommandList* ppCommandLists[] = { m_copyCommandList.Get() };
-    m_copyQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	ID3D12CommandList* ppCommandLists[] = { m_copyCommandList.Get() };
+	m_copyQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Wait for the copy queue to complete execution of the command list.
-    m_copyQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]);
-    ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-    WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-    m_fenceValues[m_frameIndex]++;
+	// Wait for the copy queue to complete execution of the command list.
+	m_copyQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]);
+	ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+	WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	m_fenceValues[m_frameIndex]++;
 }
 
 // Generate a simple checkerboard texture.
 std::vector<UINT8> D3D12SmallResources::GenerateTexture()
 {
-    const UINT rowPitch = TextureWidth * TexturePixelSizeInBytes;
-    const UINT cellPitch = rowPitch >> 3;        // The width of a cell in the checkboard texture.
-    const UINT cellHeight = TextureWidth >> 3;    // The height of a cell in the checkerboard texture.
-    const UINT textureSize = rowPitch * TextureHeight;
+	const UINT rowPitch = TextureWidth * TexturePixelSizeInBytes;
+	const UINT cellPitch = rowPitch >> 3;		// The width of a cell in the checkboard texture.
+	const UINT cellHeight = TextureWidth >> 3;	// The height of a cell in the checkerboard texture.
+	const UINT textureSize = rowPitch * TextureHeight;
 
-    std::vector<UINT8> data(textureSize);
-    UINT8* pData = &data[0];
-    UINT8 r = rand() & 0xff;
-    UINT8 g = rand() & 0xff;
-    UINT8 b = rand() & 0xff;
+	std::vector<UINT8> data(textureSize);
+	UINT8* pData = &data[0];
+	UINT8 r = rand() & 0xff;
+	UINT8 g = rand() & 0xff;
+	UINT8 b = rand() & 0xff;
 
-    for (UINT n = 0; n < textureSize; n += TexturePixelSizeInBytes)
-    {
-        UINT x = n % rowPitch;
-        UINT y = n / rowPitch;
-        UINT i = x / cellPitch;
-        UINT j = y / cellHeight;
+	for (UINT n = 0; n < textureSize; n += TexturePixelSizeInBytes)
+	{
+		UINT x = n % rowPitch;
+		UINT y = n / rowPitch;
+		UINT i = x / cellPitch;
+		UINT j = y / cellHeight;
 
-        if (i % 2 == j % 2)
-        {
-            pData[n] = 0x00;        // R
-            pData[n + 1] = 0x00;    // G
-            pData[n + 2] = 0x00;    // B
-            pData[n + 3] = 0xff;    // A
-        }
-        else
-        {
-            pData[n] = r;            // R
-            pData[n + 1] = g;        // G
-            pData[n + 2] = b;        // B
-            pData[n + 3] = 0xff;    // A
-        }
-    }
+		if (i % 2 == j % 2)
+		{
+			pData[n] = 0x00;		// R
+			pData[n + 1] = 0x00;	// G
+			pData[n + 2] = 0x00;	// B
+			pData[n + 3] = 0xff;	// A
+		}
+		else
+		{
+			pData[n] = r;			// R
+			pData[n + 1] = g;		// G
+			pData[n + 2] = b;		// B
+			pData[n + 3] = 0xff;	// A
+		}
+	}
 
-    return data;
+	return data;
 }
 
 // Update frame-based values.
@@ -516,164 +516,164 @@ void D3D12SmallResources::OnUpdate()
 template <UINT _Size>
 LPWSTR FormatMemoryUsage(UINT64 usage, WCHAR (&result)[_Size])
 {
-    const UINT64 mb = 1 << 20;
-    const UINT64 kb = 1 << 10;
-    if (usage > mb)
-    {
-        swprintf_s(result, L"%.1f MB", static_cast<float>(usage) / mb);
-    }
-    else if (usage > kb)
-    {
-        swprintf_s(result, L"%.1f KB", static_cast<float>(usage) / kb);
-    }
-    else
-    {
-        swprintf_s(result, L"%I64d B", usage);
-    }
-    return result;
+	const UINT64 mb = 1 << 20;
+	const UINT64 kb = 1 << 10;
+	if (usage > mb)
+	{
+		swprintf_s(result, L"%.1f MB", static_cast<float>(usage) / mb);
+	}
+	else if (usage > kb)
+	{
+		swprintf_s(result, L"%.1f KB", static_cast<float>(usage) / kb);
+	}
+	else
+	{
+		swprintf_s(result, L"%I64d B", usage);
+	}
+	return result;
 }
 
 // Render the scene.
 void D3D12SmallResources::OnRender()
 {
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+	PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
 
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    PIXEndEvent(m_commandQueue.Get());
+	PIXEndEvent(m_commandQueue.Get());
 
-    DXGI_QUERY_VIDEO_MEMORY_INFO memoryInfo;
-    m_adapter->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &memoryInfo);
+	DXGI_QUERY_VIDEO_MEMORY_INFO memoryInfo;
+	m_adapter->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &memoryInfo);
 
-    WCHAR text[100];
-    WCHAR usageString[20];
-    swprintf_s(text, L"[ResourceType: %s] - Memory Used: %s", m_usePlacedResources ? L"Placed" : L"Committed", FormatMemoryUsage(memoryInfo.CurrentUsage, usageString));
-    SetCustomWindowText(text);
+	WCHAR text[100];
+	WCHAR usageString[20];
+	swprintf_s(text, L"[ResourceType: %s] - Memory Used: %s", m_usePlacedResources ? L"Placed" : L"Committed", FormatMemoryUsage(memoryInfo.CurrentUsage, usageString));
+	SetCustomWindowText(text);
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+	// Present the frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    MoveToNextFrame();
+	MoveToNextFrame();
 }
 
 void D3D12SmallResources::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForGpu();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForGpu();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12SmallResources::OnKeyDown(UINT8 key)
 {
-    switch (key)
-    {
-    case VK_SPACE:
-        m_usePlacedResources = !m_usePlacedResources;
+	switch (key)
+	{
+	case VK_SPACE:
+		m_usePlacedResources = !m_usePlacedResources;
 
-        // Flush the GPU to ensure that the resources we are about to destroy are
-        // no longer in use.
-        WaitForGpu();
+		// Flush the GPU to ensure that the resources we are about to destroy are
+		// no longer in use.
+		WaitForGpu();
 
-        CreateTextures();
-        break;
-    }
+		CreateTextures();
+		break;
+	}
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12SmallResources::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
-    m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
+	m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Record drawing commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	// Record drawing commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
 
-    // Draw the grid.
-    {
-        m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-        m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+	// Draw the grid.
+	{
+		m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+		m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
 
-        // Draw the far quad conditionally based on the result of the occlusion query
-        // from the previous frame.
-        PIXBeginEvent(m_commandList.Get(), 0, L"Draw grid");
+		// Draw the far quad conditionally based on the result of the occlusion query
+		// from the previous frame.
+		PIXBeginEvent(m_commandList.Get(), 0, L"Draw grid");
 
-        CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_srvHeap->GetGPUDescriptorHandleForHeapStart());
-        for (UINT n = 0; n < TextureCount; n++)
-        {
-            m_commandList->SetGraphicsRootDescriptorTable(0, srvHandle);
-            m_commandList->DrawInstanced(4, 1, n * 4, 0);
-            srvHandle.Offset(m_srvDescriptorSize);
-        }
-        PIXEndEvent(m_commandList.Get());
-    }
+		CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_srvHeap->GetGPUDescriptorHandleForHeapStart());
+		for (UINT n = 0; n < TextureCount; n++)
+		{
+			m_commandList->SetGraphicsRootDescriptorTable(0, srvHandle);
+			m_commandList->DrawInstanced(4, 1, n * 4, 0);
+			srvHandle.Offset(m_srvDescriptorSize);
+		}
+		PIXEndEvent(m_commandList.Get());
+	}
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 // Wait for pending GPU work to complete.
 void D3D12SmallResources::WaitForGpu()
 {
-    // Schedule a Signal command in the queue.
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
+	// Schedule a Signal command in the queue.
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
 
-    // Wait until the fence has been processed.
-    ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-    WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	// Wait until the fence has been processed.
+	ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+	WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
 
-    // Increment the fence value for the current frame.
-    m_fenceValues[m_frameIndex]++;
+	// Increment the fence value for the current frame.
+	m_fenceValues[m_frameIndex]++;
 }
 
 // Prepare to render the next frame.
 void D3D12SmallResources::MoveToNextFrame()
 {
-    // Schedule a Signal command in the queue.
-    const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
+	// Schedule a Signal command in the queue.
+	const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
 
-    // Update the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Update the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-        WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+		WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	}
 
-    // Set the fence value for the next frame.
-    m_fenceValues[m_frameIndex] = currentFenceValue + 1;
+	// Set the fence value for the next frame.
+	m_fenceValues[m_frameIndex] = currentFenceValue + 1;
 }

--- a/Samples/Desktop/D3D12SmallResources/src/D3D12SmallResources.h
+++ b/Samples/Desktop/D3D12SmallResources/src/D3D12SmallResources.h
@@ -27,68 +27,68 @@ using Microsoft::WRL::ComPtr;
 class D3D12SmallResources : public DXSample
 {
 public:
-    D3D12SmallResources(UINT width, UINT height, std::wstring name);
+	D3D12SmallResources(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
-    virtual void OnKeyDown(UINT8 key);
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
+	virtual void OnKeyDown(UINT8 key);
 
 private:
-    static const UINT FrameCount = 2;
-    static const UINT GridWidth = 11;
-    static const UINT GridHeight = 7;
-    static const UINT TextureCount = GridWidth * GridHeight;
-    static const UINT TextureWidth = 32;
-    static const UINT TextureHeight = 32;
-    static const UINT TexturePixelSizeInBytes = 4;
+	static const UINT FrameCount = 2;
+	static const UINT GridWidth = 11;
+	static const UINT GridHeight = 7;
+	static const UINT TextureCount = GridWidth * GridHeight;
+	static const UINT TextureWidth = 32;
+	static const UINT TextureHeight = 32;
+	static const UINT TexturePixelSizeInBytes = 4;
 
-    // Vertex definition.
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT2 uv;
-    };
+	// Vertex definition.
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT2 uv;
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<IDXGIAdapter3> m_adapter;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_copyCommandAllocator;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12CommandQueue> m_copyQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_srvHeap;
-    UINT m_rtvDescriptorSize;
-    UINT m_srvDescriptorSize;
-    UINT m_frameIndex;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<IDXGIAdapter3> m_adapter;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_copyCommandAllocator;
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12CommandQueue> m_copyQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_srvHeap;
+	UINT m_rtvDescriptorSize;
+	UINT m_srvDescriptorSize;
+	UINT m_frameIndex;
 
-    // Synchronization objects.
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValues[FrameCount];
-    HANDLE m_fenceEvent;
+	// Synchronization objects.
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValues[FrameCount];
+	HANDLE m_fenceEvent;
 
-    // Asset objects.
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    ComPtr<ID3D12GraphicsCommandList> m_copyCommandList;
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    std::vector<ComPtr<ID3D12Resource>> m_textures;
-    ComPtr<ID3D12Heap> m_textureHeap;        // Only used when the resources being drawn are placed resources.
-    bool m_usePlacedResources;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	// Asset objects.
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	ComPtr<ID3D12GraphicsCommandList> m_copyCommandList;
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	std::vector<ComPtr<ID3D12Resource>> m_textures;
+	ComPtr<ID3D12Heap> m_textureHeap;		// Only used when the resources being drawn are placed resources.
+	bool m_usePlacedResources;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
 
-    void LoadPipeline();
-    void LoadAssets();
-    std::vector<UINT8> GenerateTexture();
-    void CreateTextures();
-    void PopulateCommandList();
-    void WaitForGpu();
-    void MoveToNextFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	std::vector<UINT8> GenerateTexture();
+	void CreateTextures();
+	void PopulateCommandList();
+	void WaitForGpu();
+	void MoveToNextFrame();
 };

--- a/Samples/Desktop/D3D12SmallResources/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12SmallResources/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,58 +34,103 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title + L": " + text;
-    SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
+	std::wstring windowText = m_title + L": " + text;
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/Desktop/D3D12SmallResources/src/DXSample.h
+++ b/Samples/Desktop/D3D12SmallResources/src/DXSample.h
@@ -17,42 +17,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/Desktop/D3D12SmallResources/src/Main.cpp
+++ b/Samples/Desktop/D3D12SmallResources/src/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12SmallResources sample(1280, 720, L"D3D12 Small Resources Sample");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12SmallResources sample(1280, 720, L"D3D12 Small Resources Sample");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12SmallResources/src/Win32Application.cpp
+++ b/Samples/Desktop/D3D12SmallResources/src/Win32Application.cpp
@@ -16,104 +16,104 @@ HWND Win32Application::m_hwnd = nullptr;
 
 int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
 {
-    // Parse the command line parameters
-    int argc;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    pSample->ParseCommandLineArgs(argv, argc);
-    LocalFree(argv);
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
 
-    // Initialize the window class.
-    WNDCLASSEX windowClass = { 0 };
-    windowClass.cbSize = sizeof(WNDCLASSEX);
-    windowClass.style = CS_HREDRAW | CS_VREDRAW;
-    windowClass.lpfnWndProc = WindowProc;
-    windowClass.hInstance = hInstance;
-    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-    windowClass.lpszClassName = L"DXSampleClass";
-    RegisterClassEx(&windowClass);
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
 
-    RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
-    AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
 
-    // Create the window and store a handle to it.
-    m_hwnd = CreateWindow(
-        windowClass.lpszClassName,
-        pSample->GetTitle(),
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        windowRect.right - windowRect.left,
-        windowRect.bottom - windowRect.top,
-        nullptr,        // We have no parent window.
-        nullptr,        // We aren't using menus.
-        hInstance,
-        pSample);
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
 
-    // Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-    pSample->OnInit();
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
 
-    ShowWindow(m_hwnd, nCmdShow);
+	ShowWindow(m_hwnd, nCmdShow);
 
-    // Main sample loop.
-    MSG msg = {};
-    while (msg.message != WM_QUIT)
-    {
-        // Process any messages in the queue.
-        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
-    }
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
 
-    pSample->OnDestroy();
+	pSample->OnDestroy();
 
-    // Return this part of the WM_QUIT message to Windows.
-    return static_cast<char>(msg.wParam);
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
 }
 
 // Main message handler for the sample.
 LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
-    switch (message)
-    {
-    case WM_CREATE:
-        {
-            // Save the DXSample* passed in to CreateWindow.
-            LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
-            SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
-        }
-        return 0;
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
 
-    case WM_KEYDOWN:
-        if (pSample)
-        {
-            pSample->OnKeyDown(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_KEYUP:
-        if (pSample)
-        {
-            pSample->OnKeyUp(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_PAINT:
-        if (pSample)
-        {
-            pSample->OnUpdate();
-            pSample->OnRender();
-        }
-        return 0;
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
 
-    case WM_DESTROY:
-        PostQuitMessage(0);
-        return 0;
-    }
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
 
-    // Handle any messages the switch statement didn't.
-    return DefWindowProc(hWnd, message, wParam, lParam);
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/Desktop/D3D12SmallResources/src/Win32Application.h
+++ b/Samples/Desktop/D3D12SmallResources/src/Win32Application.h
@@ -18,12 +18,12 @@ class DXSample;
 class Win32Application
 {
 public:
-    static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
-    static HWND GetHwnd() { return m_hwnd; }
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
 
 protected:
-    static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
-    static HWND m_hwnd;
+	static HWND m_hwnd;
 };

--- a/Samples/Desktop/D3D12SmallResources/src/d3dx12.h
+++ b/Samples/Desktop/D3D12SmallResources/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12SmallResources/src/shaders.hlsl
+++ b/Samples/Desktop/D3D12SmallResources/src/shaders.hlsl
@@ -11,8 +11,8 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 Texture2D g_texture : register(t0);
@@ -20,15 +20,15 @@ SamplerState g_sampler : register(s0);
 
 PSInput VSMain(float4 position : POSITION, float2 uv : TEXCOORD)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.uv = uv;
+	result.position = position;
+	result.uv = uv;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return g_texture.Sample(g_sampler, input.uv);
+	return g_texture.Sample(g_sampler, input.uv);
 }

--- a/Samples/Desktop/D3D12nBodyGravity/src/D3D12nBodyGravity.cpp
+++ b/Samples/Desktop/D3D12nBodyGravity/src/D3D12nBodyGravity.cpp
@@ -20,832 +20,888 @@
 const float D3D12nBodyGravity::ParticleSpread = 400.0f;
 
 D3D12nBodyGravity::D3D12nBodyGravity(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0),
-    m_srvUavDescriptorSize(0),
-    m_pConstantBufferGSData(nullptr),
-    m_renderContextFenceValue(0),
-    m_terminating(0),
-    m_srvIndex{},
-    m_frameFenceValues{}
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0),
+	m_srvUavDescriptorSize(0),
+	m_pConstantBufferGSData(nullptr),
+	m_renderContextFenceValue(0),
+	m_terminating(0),
+	m_srvIndex{},
+	m_frameFenceValues{}
 {
-    for (int n = 0; n < ThreadCount; n++)
-    {
-        m_renderContextFenceValues[n] = 0;
-        m_threadFenceValues[n] = 0;
-    }
+	for (int n = 0; n < ThreadCount; n++)
+	{
+		m_renderContextFenceValues[n] = 0;
+		m_threadFenceValues[n] = 0;
+	}
 
-    float sqRootNumAsyncContexts = sqrt(static_cast<float>(ThreadCount));
-    m_heightInstances = static_cast<UINT>(ceil(sqRootNumAsyncContexts));
-    m_widthInstances = static_cast<UINT>(ceil(sqRootNumAsyncContexts));
+	float sqRootNumAsyncContexts = sqrt(static_cast<float>(ThreadCount));
+	m_heightInstances = static_cast<UINT>(ceil(sqRootNumAsyncContexts));
+	m_widthInstances = static_cast<UINT>(ceil(sqRootNumAsyncContexts));
 
-    if (m_widthInstances * (m_heightInstances - 1) >= ThreadCount)
-    {
-        m_heightInstances--;
-    }
+	if (m_widthInstances * (m_heightInstances - 1) >= ThreadCount)
+	{
+		m_heightInstances--;
+	}
+
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
 }
 
 void D3D12nBodyGravity::OnInit()
 {
-    m_camera.Init({ 0.0f, 0.0f, 1500.0f });
-    m_camera.SetMoveSpeed(250.0f);
+	m_camera.Init({ 0.0f, 0.0f, 1500.0f });
+	m_camera.SetMoveSpeed(250.0f);
 
-    LoadPipeline();
-    LoadAssets();
-    CreateAsyncContexts();
+	LoadPipeline();
+	LoadAssets();
+	CreateAsyncContexts();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12nBodyGravity::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter, true);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
-    NAME_D3D12_OBJECT(m_commandQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	NAME_D3D12_OBJECT(m_commandQueue);
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
-    swapChainDesc.Flags = DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
+	swapChainDesc.Flags = DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForHwnd(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        Win32Application::GetHwnd(),
-        &swapChainDesc,
-        nullptr,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForHwnd(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		Win32Application::GetHwnd(),
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&swapChain
+		));
 
-    // This sample does not support fullscreen transitions.
-    ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
+	// This sample does not support fullscreen transitions.
+	ThrowIfFailed(factory->MakeWindowAssociation(Win32Application::GetHwnd(), DXGI_MWA_NO_ALT_ENTER));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
-    m_swapChainEvent = m_swapChain->GetFrameLatencyWaitableObject();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	m_swapChainEvent = m_swapChain->GetFrameLatencyWaitableObject();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a shader resource view (SRV) and unordered
-        // access view (UAV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC srvUavHeapDesc = {};
-        srvUavHeapDesc.NumDescriptors = DescriptorCount;
-        srvUavHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        srvUavHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&srvUavHeapDesc, IID_PPV_ARGS(&m_srvUavHeap)));
-        NAME_D3D12_OBJECT(m_srvUavHeap);
+		// Describe and create a shader resource view (SRV) and unordered
+		// access view (UAV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC srvUavHeapDesc = {};
+		srvUavHeapDesc.NumDescriptors = DescriptorCount;
+		srvUavHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		srvUavHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&srvUavHeapDesc, IID_PPV_ARGS(&m_srvUavHeap)));
+		NAME_D3D12_OBJECT(m_srvUavHeap);
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-        m_srvUavDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_srvUavDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV and a command allocator for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
+		// Create a RTV and a command allocator for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-            NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
+			NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
 
-            ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
-        }
-    }
+			ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
+		}
+	}
 }
 
 // Load the sample assets.
 void D3D12nBodyGravity::LoadAssets()
 {
-    // Create the root signatures.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signatures.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        // Graphics root signature.
-        {
-            CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
-            ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		// Graphics root signature.
+		{
+			CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
+			ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
 
-            CD3DX12_ROOT_PARAMETER1 rootParameters[GraphicsRootParametersCount];
-            rootParameters[GraphicsRootCBV].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_ALL);
-            rootParameters[GraphicsRootSRVTable].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_VERTEX);
+			CD3DX12_ROOT_PARAMETER1 rootParameters[GraphicsRootParametersCount];
+			rootParameters[GraphicsRootCBV].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_ALL);
+			rootParameters[GraphicsRootSRVTable].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_VERTEX);
 
-            CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-            rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+			CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+			rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-            ComPtr<ID3DBlob> signature;
-            ComPtr<ID3DBlob> error;
-            ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-            ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-            NAME_D3D12_OBJECT(m_rootSignature);
-        }
+			ComPtr<ID3DBlob> signature;
+			ComPtr<ID3DBlob> error;
+			ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+			ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+			NAME_D3D12_OBJECT(m_rootSignature);
+		}
 
-        // Compute root signature.
-        {
-            CD3DX12_DESCRIPTOR_RANGE1 ranges[2];
-            ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DESCRIPTORS_VOLATILE);
-            ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_VOLATILE);
+		// Compute root signature.
+		{
+			CD3DX12_DESCRIPTOR_RANGE1 ranges[2];
+			ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DESCRIPTORS_VOLATILE);
+			ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_VOLATILE);
 
-            CD3DX12_ROOT_PARAMETER1 rootParameters[ComputeRootParametersCount];
-            rootParameters[ComputeRootCBV].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_ALL);
-            rootParameters[ComputeRootSRVTable].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_ALL);
-            rootParameters[ComputeRootUAVTable].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_ALL);
+			CD3DX12_ROOT_PARAMETER1 rootParameters[ComputeRootParametersCount];
+			rootParameters[ComputeRootCBV].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_ALL);
+			rootParameters[ComputeRootSRVTable].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_ALL);
+			rootParameters[ComputeRootUAVTable].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_ALL);
 
-            CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC computeRootSignatureDesc;
-            computeRootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr);
+			CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC computeRootSignatureDesc;
+			computeRootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr);
 
-            ComPtr<ID3DBlob> signature;
-            ComPtr<ID3DBlob> error;
-            ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&computeRootSignatureDesc, featureData.HighestVersion, &signature, &error));
-            ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_computeRootSignature)));
-            NAME_D3D12_OBJECT(m_computeRootSignature);
-        }
-    }
+			ComPtr<ID3DBlob> signature;
+			ComPtr<ID3DBlob> error;
+			ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&computeRootSignatureDesc, featureData.HighestVersion, &signature, &error));
+			ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_computeRootSignature)));
+			NAME_D3D12_OBJECT(m_computeRootSignature);
+		}
+	}
 
-    // Create the pipeline states, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> geometryShader;
-        ComPtr<ID3DBlob> pixelShader;
-        ComPtr<ID3DBlob> computeShader;
+	// Create the pipeline states, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> geometryShader;
+		ComPtr<ID3DBlob> pixelShader;
+		ComPtr<ID3DBlob> computeShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        // Load and compile shaders.
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"ParticleDraw.hlsl").c_str(), nullptr, nullptr, "VSParticleDraw", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"ParticleDraw.hlsl").c_str(), nullptr, nullptr, "GSParticleDraw", "gs_5_0", compileFlags, 0, &geometryShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"ParticleDraw.hlsl").c_str(), nullptr, nullptr, "PSParticleDraw", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"NBodyGravityCS.hlsl").c_str(), nullptr, nullptr, "CSMain", "cs_5_0", compileFlags, 0, &computeShader, nullptr));
+		// Load and compile shaders.
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"ParticleDraw.hlsl").c_str(), nullptr, nullptr, "VSParticleDraw", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"ParticleDraw.hlsl").c_str(), nullptr, nullptr, "GSParticleDraw", "gs_5_0", compileFlags, 0, &geometryShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"ParticleDraw.hlsl").c_str(), nullptr, nullptr, "PSParticleDraw", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"NBodyGravityCS.hlsl").c_str(), nullptr, nullptr, "CSMain", "cs_5_0", compileFlags, 0, &computeShader, nullptr));
 
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        // Describe the blend and depth states.
-        CD3DX12_BLEND_DESC blendDesc(D3D12_DEFAULT);
-        blendDesc.RenderTarget[0].BlendEnable = TRUE;
-        blendDesc.RenderTarget[0].SrcBlend = D3D12_BLEND_SRC_ALPHA;
-        blendDesc.RenderTarget[0].DestBlend = D3D12_BLEND_ONE;
-        blendDesc.RenderTarget[0].SrcBlendAlpha = D3D12_BLEND_ZERO;
-        blendDesc.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_ZERO;
+		// Describe the blend and depth states.
+		CD3DX12_BLEND_DESC blendDesc(D3D12_DEFAULT);
+		blendDesc.RenderTarget[0].BlendEnable = TRUE;
+		blendDesc.RenderTarget[0].SrcBlend = D3D12_BLEND_SRC_ALPHA;
+		blendDesc.RenderTarget[0].DestBlend = D3D12_BLEND_ONE;
+		blendDesc.RenderTarget[0].SrcBlendAlpha = D3D12_BLEND_ZERO;
+		blendDesc.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_ZERO;
 
-        CD3DX12_DEPTH_STENCIL_DESC depthStencilDesc(D3D12_DEFAULT);
-        depthStencilDesc.DepthEnable = FALSE;
-        depthStencilDesc.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ZERO;
+		CD3DX12_DEPTH_STENCIL_DESC depthStencilDesc(D3D12_DEFAULT);
+		depthStencilDesc.DepthEnable = FALSE;
+		depthStencilDesc.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ZERO;
 
-        // Describe and create the graphics pipeline state object (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.GS = CD3DX12_SHADER_BYTECODE(geometryShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = blendDesc;
-        psoDesc.DepthStencilState = depthStencilDesc;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_POINT;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.DSVFormat = DXGI_FORMAT_D24_UNORM_S8_UINT;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state object (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.GS = CD3DX12_SHADER_BYTECODE(geometryShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = blendDesc;
+		psoDesc.DepthStencilState = depthStencilDesc;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_POINT;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.DSVFormat = DXGI_FORMAT_D24_UNORM_S8_UINT;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-        NAME_D3D12_OBJECT(m_pipelineState);
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+		NAME_D3D12_OBJECT(m_pipelineState);
 
-        // Describe and create the compute pipeline state object (PSO).
-        D3D12_COMPUTE_PIPELINE_STATE_DESC computePsoDesc = {};
-        computePsoDesc.pRootSignature = m_computeRootSignature.Get();
-        computePsoDesc.CS = CD3DX12_SHADER_BYTECODE(computeShader.Get());
+		// Describe and create the compute pipeline state object (PSO).
+		D3D12_COMPUTE_PIPELINE_STATE_DESC computePsoDesc = {};
+		computePsoDesc.pRootSignature = m_computeRootSignature.Get();
+		computePsoDesc.CS = CD3DX12_SHADER_BYTECODE(computeShader.Get());
 
-        ThrowIfFailed(m_device->CreateComputePipelineState(&computePsoDesc, IID_PPV_ARGS(&m_computeState)));
-        NAME_D3D12_OBJECT(m_computeState);
-    }
+		ThrowIfFailed(m_device->CreateComputePipelineState(&computePsoDesc, IID_PPV_ARGS(&m_computeState)));
+		NAME_D3D12_OBJECT(m_computeState);
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
-    NAME_D3D12_OBJECT(m_commandList);
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	NAME_D3D12_OBJECT(m_commandList);
 
-    CreateVertexBuffer();
-    CreateParticleBuffers();
+	CreateVertexBuffer();
+	CreateParticleBuffers();
 
-    // Note: ComPtr's are CPU objects but this resource needs to stay in scope until
-    // the command list that references it has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resource is not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> constantBufferCSUpload;
+	// Note: ComPtr's are CPU objects but this resource needs to stay in scope until
+	// the command list that references it has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resource is not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> constantBufferCSUpload;
 
-    // Create the compute shader's constant buffer.
-    {
-        const UINT bufferSize = sizeof(ConstantBufferCS);
+	// Create the compute shader's constant buffer.
+	{
+		const UINT bufferSize = sizeof(ConstantBufferCS);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(bufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_constantBufferCS)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(bufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_constantBufferCS)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(bufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&constantBufferCSUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(bufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&constantBufferCSUpload)));
 
-        NAME_D3D12_OBJECT(m_constantBufferCS);
+		NAME_D3D12_OBJECT(m_constantBufferCS);
 
-        ConstantBufferCS constantBufferCS = {};
-        constantBufferCS.param[0] = ParticleCount;
-        constantBufferCS.param[1] = int(ceil(ParticleCount / 128.0f));
-        constantBufferCS.paramf[0] = 0.1f;
-        constantBufferCS.paramf[1] = 1.0f;
+		ConstantBufferCS constantBufferCS = {};
+		constantBufferCS.param[0] = ParticleCount;
+		constantBufferCS.param[1] = int(ceil(ParticleCount / 128.0f));
+		constantBufferCS.paramf[0] = 0.1f;
+		constantBufferCS.paramf[1] = 1.0f;
 
-        D3D12_SUBRESOURCE_DATA computeCBData = {};
-        computeCBData.pData = reinterpret_cast<UINT8*>(&constantBufferCS);
-        computeCBData.RowPitch = bufferSize;
-        computeCBData.SlicePitch = computeCBData.RowPitch;
+		D3D12_SUBRESOURCE_DATA computeCBData = {};
+		computeCBData.pData = reinterpret_cast<UINT8*>(&constantBufferCS);
+		computeCBData.RowPitch = bufferSize;
+		computeCBData.SlicePitch = computeCBData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_constantBufferCS.Get(), constantBufferCSUpload.Get(), 0, 0, 1, &computeCBData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_constantBufferCS.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
-    }
+		UpdateSubresources<1>(m_commandList.Get(), m_constantBufferCS.Get(), constantBufferCSUpload.Get(), 0, 0, 1, &computeCBData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_constantBufferCS.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+	}
 
-    // Create the geometry shader's constant buffer.
-    {
-        const UINT constantBufferGSSize = sizeof(ConstantBufferGS) * FrameCount;
+	// Create the geometry shader's constant buffer.
+	{
+		const UINT constantBufferGSSize = sizeof(ConstantBufferGS) * FrameCount;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(constantBufferGSSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_constantBufferGS)
-            ));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(constantBufferGSSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_constantBufferGS)
+			));
 
-        NAME_D3D12_OBJECT(m_constantBufferGS);
+		NAME_D3D12_OBJECT(m_constantBufferGS);
 
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_constantBufferGS->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBufferGSData)));
-        ZeroMemory(m_pConstantBufferGSData, constantBufferGSSize);
-    }
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_constantBufferGS->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBufferGSData)));
+		ZeroMemory(m_pConstantBufferGSData, constantBufferGSSize);
+	}
 
-    // Close the command list and execute it to begin the initial GPU setup.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the initial GPU setup.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_renderContextFenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_renderContextFence)));
-        m_renderContextFenceValue++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_renderContextFenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_renderContextFence)));
+		m_renderContextFenceValue++;
 
-        m_renderContextFenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_renderContextFenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		m_renderContextFenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_renderContextFenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        WaitForRenderContext();
-    }
+		WaitForRenderContext();
+	}
 }
 
 // Create the particle vertex buffer.
 void D3D12nBodyGravity::CreateVertexBuffer()
 {
-    std::vector<ParticleVertex> vertices;
-    vertices.resize(ParticleCount);
-    for (UINT i = 0; i < ParticleCount; i++)
-    {
-        vertices[i].color = XMFLOAT4(1.0f, 1.0f, 0.2f, 1.0f);
-    }
-    const UINT bufferSize = ParticleCount * sizeof(ParticleVertex);
+	std::vector<ParticleVertex> vertices;
+	vertices.resize(ParticleCount);
+	for (UINT i = 0; i < ParticleCount; i++)
+	{
+		vertices[i].color = XMFLOAT4(1.0f, 1.0f, 0.2f, 1.0f);
+	}
+	const UINT bufferSize = ParticleCount * sizeof(ParticleVertex);
 
-    ThrowIfFailed(m_device->CreateCommittedResource(
-        &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-        D3D12_HEAP_FLAG_NONE,
-        &CD3DX12_RESOURCE_DESC::Buffer(bufferSize),
-        D3D12_RESOURCE_STATE_COPY_DEST,
-        nullptr,
-        IID_PPV_ARGS(&m_vertexBuffer)));
+	ThrowIfFailed(m_device->CreateCommittedResource(
+		&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+		D3D12_HEAP_FLAG_NONE,
+		&CD3DX12_RESOURCE_DESC::Buffer(bufferSize),
+		D3D12_RESOURCE_STATE_COPY_DEST,
+		nullptr,
+		IID_PPV_ARGS(&m_vertexBuffer)));
 
-    ThrowIfFailed(m_device->CreateCommittedResource(
-        &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-        D3D12_HEAP_FLAG_NONE,
-        &CD3DX12_RESOURCE_DESC::Buffer(bufferSize),
-        D3D12_RESOURCE_STATE_GENERIC_READ,
-        nullptr,
-        IID_PPV_ARGS(&m_vertexBufferUpload)));
+	ThrowIfFailed(m_device->CreateCommittedResource(
+		&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+		D3D12_HEAP_FLAG_NONE,
+		&CD3DX12_RESOURCE_DESC::Buffer(bufferSize),
+		D3D12_RESOURCE_STATE_GENERIC_READ,
+		nullptr,
+		IID_PPV_ARGS(&m_vertexBufferUpload)));
 
-    NAME_D3D12_OBJECT(m_vertexBuffer);
+	NAME_D3D12_OBJECT(m_vertexBuffer);
 
-    D3D12_SUBRESOURCE_DATA vertexData = {};
-    vertexData.pData = reinterpret_cast<UINT8*>(&vertices[0]);
-    vertexData.RowPitch = bufferSize;
-    vertexData.SlicePitch = vertexData.RowPitch;
+	D3D12_SUBRESOURCE_DATA vertexData = {};
+	vertexData.pData = reinterpret_cast<UINT8*>(&vertices[0]);
+	vertexData.RowPitch = bufferSize;
+	vertexData.SlicePitch = vertexData.RowPitch;
 
-    UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), m_vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+	UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), m_vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-    m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-    m_vertexBufferView.SizeInBytes = static_cast<UINT>(bufferSize);
-    m_vertexBufferView.StrideInBytes = sizeof(ParticleVertex);
+	m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+	m_vertexBufferView.SizeInBytes = static_cast<UINT>(bufferSize);
+	m_vertexBufferView.StrideInBytes = sizeof(ParticleVertex);
 }
 
 // Random percent value, from -1 to 1.
 float D3D12nBodyGravity::RandomPercent()
 {
-    float ret = static_cast<float>((rand() % 10000) - 5000);
-    return ret / 5000.0f;
+	float ret = static_cast<float>((rand() % 10000) - 5000);
+	return ret / 5000.0f;
 }
 
 void D3D12nBodyGravity::LoadParticles(_Out_writes_(numParticles) Particle* pParticles, const XMFLOAT3& center, const XMFLOAT4& velocity, float spread, UINT numParticles)
 {
-    srand(0);
-    for (UINT i = 0; i < numParticles; i++)
-    {
-        XMFLOAT3 delta(spread, spread, spread);
+	srand(0);
+	for (UINT i = 0; i < numParticles; i++)
+	{
+		XMFLOAT3 delta(spread, spread, spread);
 
-        while (XMVectorGetX(XMVector3LengthSq(XMLoadFloat3(&delta))) > spread * spread)
-        {
-            delta.x = RandomPercent() * spread;
-            delta.y = RandomPercent() * spread;
-            delta.z = RandomPercent() * spread;
-        }
+		while (XMVectorGetX(XMVector3LengthSq(XMLoadFloat3(&delta))) > spread * spread)
+		{
+			delta.x = RandomPercent() * spread;
+			delta.y = RandomPercent() * spread;
+			delta.z = RandomPercent() * spread;
+		}
 
-        pParticles[i].position.x = center.x + delta.x;
-        pParticles[i].position.y = center.y + delta.y;
-        pParticles[i].position.z = center.z + delta.z;
-        pParticles[i].position.w = 10000.0f * 10000.0f;
+		pParticles[i].position.x = center.x + delta.x;
+		pParticles[i].position.y = center.y + delta.y;
+		pParticles[i].position.z = center.z + delta.z;
+		pParticles[i].position.w = 10000.0f * 10000.0f;
 
-        pParticles[i].velocity = velocity;
-    }
+		pParticles[i].velocity = velocity;
+	}
 }
 
 // Create the position and velocity buffer shader resources.
 void D3D12nBodyGravity::CreateParticleBuffers()
 {
-    // Initialize the data in the buffers.
-    std::vector<Particle> data;
-    data.resize(ParticleCount);
-    const UINT dataSize = ParticleCount * sizeof(Particle);
+	// Initialize the data in the buffers.
+	std::vector<Particle> data;
+	data.resize(ParticleCount);
+	const UINT dataSize = ParticleCount * sizeof(Particle);
 
-    // Split the particles into two groups.
-    float centerSpread = ParticleSpread * 0.50f;
-    LoadParticles(&data[0], XMFLOAT3(centerSpread, 0, 0), XMFLOAT4(0, 0, -20, 1 / 100000000.0f), ParticleSpread, ParticleCount / 2);
-    LoadParticles(&data[ParticleCount / 2], XMFLOAT3(-centerSpread, 0, 0), XMFLOAT4(0, 0, 20, 1 / 100000000.0f), ParticleSpread, ParticleCount / 2);
+	// Split the particles into two groups.
+	float centerSpread = ParticleSpread * 0.50f;
+	LoadParticles(&data[0], XMFLOAT3(centerSpread, 0, 0), XMFLOAT4(0, 0, -20, 1 / 100000000.0f), ParticleSpread, ParticleCount / 2);
+	LoadParticles(&data[ParticleCount / 2], XMFLOAT3(-centerSpread, 0, 0), XMFLOAT4(0, 0, 20, 1 / 100000000.0f), ParticleSpread, ParticleCount / 2);
 
-    D3D12_HEAP_PROPERTIES defaultHeapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
-    D3D12_HEAP_PROPERTIES uploadHeapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
-    D3D12_RESOURCE_DESC bufferDesc = CD3DX12_RESOURCE_DESC::Buffer(dataSize, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
-    D3D12_RESOURCE_DESC uploadBufferDesc = CD3DX12_RESOURCE_DESC::Buffer(dataSize);
+	D3D12_HEAP_PROPERTIES defaultHeapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+	D3D12_HEAP_PROPERTIES uploadHeapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+	D3D12_RESOURCE_DESC bufferDesc = CD3DX12_RESOURCE_DESC::Buffer(dataSize, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+	D3D12_RESOURCE_DESC uploadBufferDesc = CD3DX12_RESOURCE_DESC::Buffer(dataSize);
 
-    for (UINT index = 0; index < ThreadCount; index++)
-    {
-        // Create two buffers in the GPU, each with a copy of the particles data.
-        // The compute shader will update one of them while the rendering thread 
-        // renders the other. When rendering completes, the threads will swap 
-        // which buffer they work on.
+	for (UINT index = 0; index < ThreadCount; index++)
+	{
+		// Create two buffers in the GPU, each with a copy of the particles data.
+		// The compute shader will update one of them while the rendering thread 
+		// renders the other. When rendering completes, the threads will swap 
+		// which buffer they work on.
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &defaultHeapProperties,
-            D3D12_HEAP_FLAG_NONE,
-            &bufferDesc,
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_particleBuffer0[index])));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&defaultHeapProperties,
+			D3D12_HEAP_FLAG_NONE,
+			&bufferDesc,
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_particleBuffer0[index])));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &defaultHeapProperties,
-            D3D12_HEAP_FLAG_NONE,
-            &bufferDesc,
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_particleBuffer1[index])));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&defaultHeapProperties,
+			D3D12_HEAP_FLAG_NONE,
+			&bufferDesc,
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_particleBuffer1[index])));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &uploadHeapProperties,
-            D3D12_HEAP_FLAG_NONE,
-            &uploadBufferDesc,
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_particleBuffer0Upload[index])));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&uploadHeapProperties,
+			D3D12_HEAP_FLAG_NONE,
+			&uploadBufferDesc,
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_particleBuffer0Upload[index])));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &uploadHeapProperties,
-            D3D12_HEAP_FLAG_NONE,
-            &uploadBufferDesc,
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_particleBuffer1Upload[index])));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&uploadHeapProperties,
+			D3D12_HEAP_FLAG_NONE,
+			&uploadBufferDesc,
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_particleBuffer1Upload[index])));
 
-        NAME_D3D12_OBJECT_INDEXED(m_particleBuffer0, index);
-        NAME_D3D12_OBJECT_INDEXED(m_particleBuffer1, index);
+		NAME_D3D12_OBJECT_INDEXED(m_particleBuffer0, index);
+		NAME_D3D12_OBJECT_INDEXED(m_particleBuffer1, index);
 
-        D3D12_SUBRESOURCE_DATA particleData = {};
-        particleData.pData = reinterpret_cast<UINT8*>(&data[0]);
-        particleData.RowPitch = dataSize;
-        particleData.SlicePitch = particleData.RowPitch;
+		D3D12_SUBRESOURCE_DATA particleData = {};
+		particleData.pData = reinterpret_cast<UINT8*>(&data[0]);
+		particleData.RowPitch = dataSize;
+		particleData.SlicePitch = particleData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_particleBuffer0[index].Get(), m_particleBuffer0Upload[index].Get(), 0, 0, 1, &particleData);
-        UpdateSubresources<1>(m_commandList.Get(), m_particleBuffer1[index].Get(), m_particleBuffer1Upload[index].Get(), 0, 0, 1, &particleData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_particleBuffer0[index].Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE));
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_particleBuffer1[index].Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE));
+		UpdateSubresources<1>(m_commandList.Get(), m_particleBuffer0[index].Get(), m_particleBuffer0Upload[index].Get(), 0, 0, 1, &particleData);
+		UpdateSubresources<1>(m_commandList.Get(), m_particleBuffer1[index].Get(), m_particleBuffer1Upload[index].Get(), 0, 0, 1, &particleData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_particleBuffer0[index].Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE));
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_particleBuffer1[index].Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE));
 
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Format = DXGI_FORMAT_UNKNOWN;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
-        srvDesc.Buffer.FirstElement = 0;
-        srvDesc.Buffer.NumElements = ParticleCount;
-        srvDesc.Buffer.StructureByteStride = sizeof(Particle);
-        srvDesc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_NONE;
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Format = DXGI_FORMAT_UNKNOWN;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
+		srvDesc.Buffer.FirstElement = 0;
+		srvDesc.Buffer.NumElements = ParticleCount;
+		srvDesc.Buffer.StructureByteStride = sizeof(Particle);
+		srvDesc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_NONE;
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle0(m_srvUavHeap->GetCPUDescriptorHandleForHeapStart(), SrvParticlePosVelo0 + index, m_srvUavDescriptorSize);
-        CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle1(m_srvUavHeap->GetCPUDescriptorHandleForHeapStart(), SrvParticlePosVelo1 + index, m_srvUavDescriptorSize);
-        m_device->CreateShaderResourceView(m_particleBuffer0[index].Get(), &srvDesc, srvHandle0);
-        m_device->CreateShaderResourceView(m_particleBuffer1[index].Get(), &srvDesc, srvHandle1);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle0(m_srvUavHeap->GetCPUDescriptorHandleForHeapStart(), SrvParticlePosVelo0 + index, m_srvUavDescriptorSize);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle1(m_srvUavHeap->GetCPUDescriptorHandleForHeapStart(), SrvParticlePosVelo1 + index, m_srvUavDescriptorSize);
+		m_device->CreateShaderResourceView(m_particleBuffer0[index].Get(), &srvDesc, srvHandle0);
+		m_device->CreateShaderResourceView(m_particleBuffer1[index].Get(), &srvDesc, srvHandle1);
 
-        D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
-        uavDesc.Format = DXGI_FORMAT_UNKNOWN;
-        uavDesc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
-        uavDesc.Buffer.FirstElement = 0;
-        uavDesc.Buffer.NumElements = ParticleCount;
-        uavDesc.Buffer.StructureByteStride = sizeof(Particle);
-        uavDesc.Buffer.CounterOffsetInBytes = 0;
-        uavDesc.Buffer.Flags = D3D12_BUFFER_UAV_FLAG_NONE;
+		D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
+		uavDesc.Format = DXGI_FORMAT_UNKNOWN;
+		uavDesc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
+		uavDesc.Buffer.FirstElement = 0;
+		uavDesc.Buffer.NumElements = ParticleCount;
+		uavDesc.Buffer.StructureByteStride = sizeof(Particle);
+		uavDesc.Buffer.CounterOffsetInBytes = 0;
+		uavDesc.Buffer.Flags = D3D12_BUFFER_UAV_FLAG_NONE;
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE uavHandle0(m_srvUavHeap->GetCPUDescriptorHandleForHeapStart(), UavParticlePosVelo0 + index, m_srvUavDescriptorSize);
-        CD3DX12_CPU_DESCRIPTOR_HANDLE uavHandle1(m_srvUavHeap->GetCPUDescriptorHandleForHeapStart(), UavParticlePosVelo1 + index, m_srvUavDescriptorSize);
-        m_device->CreateUnorderedAccessView(m_particleBuffer0[index].Get(), nullptr, &uavDesc, uavHandle0);
-        m_device->CreateUnorderedAccessView(m_particleBuffer1[index].Get(), nullptr, &uavDesc, uavHandle1);
-    }
+		CD3DX12_CPU_DESCRIPTOR_HANDLE uavHandle0(m_srvUavHeap->GetCPUDescriptorHandleForHeapStart(), UavParticlePosVelo0 + index, m_srvUavDescriptorSize);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE uavHandle1(m_srvUavHeap->GetCPUDescriptorHandleForHeapStart(), UavParticlePosVelo1 + index, m_srvUavDescriptorSize);
+		m_device->CreateUnorderedAccessView(m_particleBuffer0[index].Get(), nullptr, &uavDesc, uavHandle0);
+		m_device->CreateUnorderedAccessView(m_particleBuffer1[index].Get(), nullptr, &uavDesc, uavHandle1);
+	}
 }
 
 void D3D12nBodyGravity::CreateAsyncContexts()
 {
-    for (UINT threadIndex = 0; threadIndex < ThreadCount; ++threadIndex)
-    {
-        // Create compute resources.
-        D3D12_COMMAND_QUEUE_DESC queueDesc = { D3D12_COMMAND_LIST_TYPE_COMPUTE, 0, D3D12_COMMAND_QUEUE_FLAG_NONE };
-        ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_computeCommandQueue[threadIndex])));
-        ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_COMPUTE, IID_PPV_ARGS(&m_computeAllocator[threadIndex])));
-        ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_COMPUTE, m_computeAllocator[threadIndex].Get(), nullptr, IID_PPV_ARGS(&m_computeCommandList[threadIndex])));
-        ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_SHARED, IID_PPV_ARGS(&m_threadFences[threadIndex])));
+	for (UINT threadIndex = 0; threadIndex < ThreadCount; ++threadIndex)
+	{
+		// Create compute resources.
+		D3D12_COMMAND_QUEUE_DESC queueDesc = { D3D12_COMMAND_LIST_TYPE_COMPUTE, 0, D3D12_COMMAND_QUEUE_FLAG_NONE };
+		ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_computeCommandQueue[threadIndex])));
+		ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_COMPUTE, IID_PPV_ARGS(&m_computeAllocator[threadIndex])));
+		ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_COMPUTE, m_computeAllocator[threadIndex].Get(), nullptr, IID_PPV_ARGS(&m_computeCommandList[threadIndex])));
+		ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_SHARED, IID_PPV_ARGS(&m_threadFences[threadIndex])));
 
-        m_threadFenceEvents[threadIndex] = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_threadFenceEvents[threadIndex] == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		m_threadFenceEvents[threadIndex] = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_threadFenceEvents[threadIndex] == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        m_threadData[threadIndex].pContext = this;
-        m_threadData[threadIndex].threadIndex = threadIndex;
+		m_threadData[threadIndex].pContext = this;
+		m_threadData[threadIndex].threadIndex = threadIndex;
 
-        m_threadHandles[threadIndex] = CreateThread(
-            nullptr,
-            0,
-            reinterpret_cast<LPTHREAD_START_ROUTINE>(ThreadProc),
-            reinterpret_cast<void*>(&m_threadData[threadIndex]),
-            CREATE_SUSPENDED,
-            nullptr);
+		m_threadHandles[threadIndex] = CreateThread(
+			nullptr,
+			0,
+			reinterpret_cast<LPTHREAD_START_ROUTINE>(ThreadProc),
+			reinterpret_cast<void*>(&m_threadData[threadIndex]),
+			CREATE_SUSPENDED,
+			nullptr);
 
-        ResumeThread(m_threadHandles[threadIndex]);
-    }
+		ResumeThread(m_threadHandles[threadIndex]);
+	}
 }
 
 // Update frame-based values.
 void D3D12nBodyGravity::OnUpdate()
 {
-    // Wait for the previous Present to complete.
-    WaitForSingleObjectEx(m_swapChainEvent, 100, FALSE);
+	// Wait for the previous Present to complete.
+	WaitForSingleObjectEx(m_swapChainEvent, 100, FALSE);
 
-    m_timer.Tick(NULL);
-    m_camera.Update(static_cast<float>(m_timer.GetElapsedSeconds()));
+	m_timer.Tick(NULL);
+	m_camera.Update(static_cast<float>(m_timer.GetElapsedSeconds()));
 
-    ConstantBufferGS constantBufferGS = {};
-    XMStoreFloat4x4(&constantBufferGS.worldViewProjection, XMMatrixMultiply(m_camera.GetViewMatrix(), m_camera.GetProjectionMatrix(0.8f, m_aspectRatio, 1.0f, 5000.0f)));
-    XMStoreFloat4x4(&constantBufferGS.inverseView, XMMatrixInverse(nullptr, m_camera.GetViewMatrix()));
+	ConstantBufferGS constantBufferGS = {};
+	XMStoreFloat4x4(&constantBufferGS.worldViewProjection, XMMatrixMultiply(m_camera.GetViewMatrix(), m_camera.GetProjectionMatrix(0.8f, m_aspectRatio, 1.0f, 5000.0f)));
+	XMStoreFloat4x4(&constantBufferGS.inverseView, XMMatrixInverse(nullptr, m_camera.GetViewMatrix()));
 
-    UINT8* destination = m_pConstantBufferGSData + sizeof(ConstantBufferGS) * m_frameIndex;
-    memcpy(destination, &constantBufferGS, sizeof(ConstantBufferGS));
+	UINT8* destination = m_pConstantBufferGSData + sizeof(ConstantBufferGS) * m_frameIndex;
+	memcpy(destination, &constantBufferGS, sizeof(ConstantBufferGS));
 }
 
 // Render the scene.
 void D3D12nBodyGravity::OnRender()
 {
-    // Let the compute thread know that a new frame is being rendered.
-    for (int n = 0; n < ThreadCount; n++)
+    try
     {
-        InterlockedExchange(&m_renderContextFenceValues[n], m_renderContextFenceValue);
-    }
-
-    // Compute work must be completed before the frame can render or else the SRV 
-    // will be in the wrong state.
-    for (UINT n = 0; n < ThreadCount; n++)
-    {
-        UINT64 threadFenceValue = InterlockedGetValue(&m_threadFenceValues[n]);
-        if (m_threadFences[n]->GetCompletedValue() < threadFenceValue)
+        // Let the compute thread know that a new frame is being rendered.
+        for (int n = 0; n < ThreadCount; n++)
         {
-            // Instruct the rendering command queue to wait for the current 
-            // compute work to complete.
-            ThrowIfFailed(m_commandQueue->Wait(m_threadFences[n].Get(), threadFenceValue));
+            InterlockedExchange(&m_renderContextFenceValues[n], m_renderContextFenceValue);
+        }
+
+        // Compute work must be completed before the frame can render or else the SRV 
+        // will be in the wrong state.
+        for (UINT n = 0; n < ThreadCount; n++)
+        {
+            UINT64 threadFenceValue = InterlockedGetValue(&m_threadFenceValues[n]);
+            if (m_threadFences[n]->GetCompletedValue() < threadFenceValue)
+            {
+                // Instruct the rendering command queue to wait for the current 
+                // compute work to complete.
+                ThrowIfFailed(m_commandQueue->Wait(m_threadFences[n].Get(), threadFenceValue));
+            }
+        }
+
+        PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+
+        // Record all the commands we need to render the scene into the command list.
+        PopulateCommandList();
+
+        // Execute the command list.
+        ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+        m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+
+        PIXEndEvent(m_commandQueue.Get());
+
+        // Present the frame.
+        ThrowIfFailed(m_swapChain->Present(1, 0));
+
+        MoveToNextFrame();
+    }
+    catch (HrException& e)
+    {
+        if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
+        {
+            RestoreD3DResources();
+        }
+        else
+        {
+            throw;
         }
     }
+}
 
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+// Release sample's D3D objects.
+void D3D12nBodyGravity::ReleaseD3DResources()
+{
+    m_renderContextFence.Reset();
+    ResetComPtrArray(&m_renderTargets);
+    m_commandQueue.Reset();
+    m_swapChain.Reset();
+    m_device.Reset();
+}
 
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+// Tears down D3D resources and reinitializes them.
+void D3D12nBodyGravity::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
+    {
+        WaitForGpu();
+    }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
+}
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+// Wait for pending GPU work to complete.
+void D3D12nBodyGravity::WaitForGpu()
+{
+    // Schedule a Signal command in the queue.
+    ThrowIfFailed(m_commandQueue->Signal(m_renderContextFence.Get(), m_renderContextFenceValues[m_frameIndex]));
 
-    PIXEndEvent(m_commandQueue.Get());
+    // Wait until the fence has been processed.
+    ThrowIfFailed(m_renderContextFence->SetEventOnCompletion(m_renderContextFenceValues[m_frameIndex], m_renderContextFenceEvent));
+    WaitForSingleObjectEx(m_renderContextFenceEvent, INFINITE, FALSE);
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
-
-    MoveToNextFrame();
+    // Increment the fence value for the current frame.
+    m_renderContextFenceValues[m_frameIndex]++;
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12nBodyGravity::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated
-    // command lists have finished execution on the GPU; apps should use
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
+	// Command list allocators can only be reset when the associated
+	// command lists have finished execution on the GPU; apps should use
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command
-    // list, that command list can then be reset at any time and must be before
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command
+	// list, that command list can then be reset at any time and must be before
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetPipelineState(m_pipelineState.Get());
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	m_commandList->SetPipelineState(m_pipelineState.Get());
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    m_commandList->SetGraphicsRootConstantBufferView(GraphicsRootCBV, m_constantBufferGS->GetGPUVirtualAddress() + m_frameIndex * sizeof(ConstantBufferGS));
+	m_commandList->SetGraphicsRootConstantBufferView(GraphicsRootCBV, m_constantBufferGS->GetGPUVirtualAddress() + m_frameIndex * sizeof(ConstantBufferGS));
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_srvUavHeap.Get() };
-    m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_srvUavHeap.Get() };
+	m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_POINTLIST);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_POINTLIST);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.0f, 0.1f, 0.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.0f, 0.1f, 0.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
 
-    // Render the particles.
-    float viewportHeight = static_cast<float>(static_cast<UINT>(m_viewport.Height) / m_heightInstances);
-    float viewportWidth = static_cast<float>(static_cast<UINT>(m_viewport.Width) / m_widthInstances);
-    for (UINT n = 0; n < ThreadCount; n++)
-    {
-        const UINT srvIndex = n + (m_srvIndex[n] == 0 ? SrvParticlePosVelo0 : SrvParticlePosVelo1);
+	// Render the particles.
+	float viewportHeight = static_cast<float>(static_cast<UINT>(m_viewport.Height) / m_heightInstances);
+	float viewportWidth = static_cast<float>(static_cast<UINT>(m_viewport.Width) / m_widthInstances);
+	for (UINT n = 0; n < ThreadCount; n++)
+	{
+		const UINT srvIndex = n + (m_srvIndex[n] == 0 ? SrvParticlePosVelo0 : SrvParticlePosVelo1);
 
-        CD3DX12_VIEWPORT viewport(
-            (n % m_widthInstances) * viewportWidth,
-            (n / m_widthInstances) * viewportHeight,
-            viewportWidth,
-            viewportHeight);
+		CD3DX12_VIEWPORT viewport(
+			(n % m_widthInstances) * viewportWidth,
+			(n / m_widthInstances) * viewportHeight,
+			viewportWidth,
+			viewportHeight);
 
-        m_commandList->RSSetViewports(1, &viewport);
+		m_commandList->RSSetViewports(1, &viewport);
 
-        CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_srvUavHeap->GetGPUDescriptorHandleForHeapStart(), srvIndex, m_srvUavDescriptorSize);
-        m_commandList->SetGraphicsRootDescriptorTable(GraphicsRootSRVTable, srvHandle);
+		CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_srvUavHeap->GetGPUDescriptorHandleForHeapStart(), srvIndex, m_srvUavDescriptorSize);
+		m_commandList->SetGraphicsRootDescriptorTable(GraphicsRootSRVTable, srvHandle);
 
-        PIXBeginEvent(m_commandList.Get(), 0, L"Draw particles for thread %u", n);
-        m_commandList->DrawInstanced(ParticleCount, 1, 0, 0);
-        PIXEndEvent(m_commandList.Get());
-    }
+		PIXBeginEvent(m_commandList.Get(), 0, L"Draw particles for thread %u", n);
+		m_commandList->DrawInstanced(ParticleCount, 1, 0, 0);
+		PIXEndEvent(m_commandList.Get());
+	}
 
-    m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetViewports(1, &m_viewport);
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 DWORD D3D12nBodyGravity::AsyncComputeThreadProc(int threadIndex)
 {
-    ID3D12CommandQueue* pCommandQueue = m_computeCommandQueue[threadIndex].Get();
-    ID3D12CommandAllocator* pCommandAllocator = m_computeAllocator[threadIndex].Get();
-    ID3D12GraphicsCommandList* pCommandList = m_computeCommandList[threadIndex].Get();
-    ID3D12Fence* pFence = m_threadFences[threadIndex].Get();
+	ID3D12CommandQueue* pCommandQueue = m_computeCommandQueue[threadIndex].Get();
+	ID3D12CommandAllocator* pCommandAllocator = m_computeAllocator[threadIndex].Get();
+	ID3D12GraphicsCommandList* pCommandList = m_computeCommandList[threadIndex].Get();
+	ID3D12Fence* pFence = m_threadFences[threadIndex].Get();
 
-    while (0 == InterlockedGetValue(&m_terminating))
-    {
-        // Run the particle simulation.
-        Simulate(threadIndex);
+	while (0 == InterlockedGetValue(&m_terminating))
+	{
+		// Run the particle simulation.
+		Simulate(threadIndex);
 
-        // Close and execute the command list.
-        ThrowIfFailed(pCommandList->Close());
-        ID3D12CommandList* ppCommandLists[] = { pCommandList };
+		// Close and execute the command list.
+		ThrowIfFailed(pCommandList->Close());
+		ID3D12CommandList* ppCommandLists[] = { pCommandList };
 
-        PIXBeginEvent(pCommandQueue, 0, L"Thread %d: Iterate on the particle simulation", threadIndex);
-        pCommandQueue->ExecuteCommandLists(1, ppCommandLists);
-        PIXEndEvent(pCommandQueue);
+		PIXBeginEvent(pCommandQueue, 0, L"Thread %d: Iterate on the particle simulation", threadIndex);
+		pCommandQueue->ExecuteCommandLists(1, ppCommandLists);
+		PIXEndEvent(pCommandQueue);
 
-        // Wait for the compute shader to complete the simulation.
-        UINT64 threadFenceValue = InterlockedIncrement(&m_threadFenceValues[threadIndex]);
-        ThrowIfFailed(pCommandQueue->Signal(pFence, threadFenceValue));
-        ThrowIfFailed(pFence->SetEventOnCompletion(threadFenceValue, m_threadFenceEvents[threadIndex]));
-        WaitForSingleObject(m_threadFenceEvents[threadIndex], INFINITE);
+		// Wait for the compute shader to complete the simulation.
+		UINT64 threadFenceValue = InterlockedIncrement(&m_threadFenceValues[threadIndex]);
+		ThrowIfFailed(pCommandQueue->Signal(pFence, threadFenceValue));
+		ThrowIfFailed(pFence->SetEventOnCompletion(threadFenceValue, m_threadFenceEvents[threadIndex]));
+		WaitForSingleObject(m_threadFenceEvents[threadIndex], INFINITE);
 
-        // Wait for the render thread to be done with the SRV so that
-        // the next frame in the simulation can run.
-        UINT64 renderContextFenceValue = InterlockedGetValue(&m_renderContextFenceValues[threadIndex]);
-        if (m_renderContextFence->GetCompletedValue() < renderContextFenceValue)
-        {
-            ThrowIfFailed(pCommandQueue->Wait(m_renderContextFence.Get(), renderContextFenceValue));
-            InterlockedExchange(&m_renderContextFenceValues[threadIndex], 0);
-        }
+		// Wait for the render thread to be done with the SRV so that
+		// the next frame in the simulation can run.
+		UINT64 renderContextFenceValue = InterlockedGetValue(&m_renderContextFenceValues[threadIndex]);
+		if (m_renderContextFence->GetCompletedValue() < renderContextFenceValue)
+		{
+			ThrowIfFailed(pCommandQueue->Wait(m_renderContextFence.Get(), renderContextFenceValue));
+			InterlockedExchange(&m_renderContextFenceValues[threadIndex], 0);
+		}
 
-        // Swap the indices to the SRV and UAV.
-        m_srvIndex[threadIndex] = 1 - m_srvIndex[threadIndex];
+		// Swap the indices to the SRV and UAV.
+		m_srvIndex[threadIndex] = 1 - m_srvIndex[threadIndex];
 
-        // Prepare for the next frame.
-        ThrowIfFailed(pCommandAllocator->Reset());
-        ThrowIfFailed(pCommandList->Reset(pCommandAllocator, m_computeState.Get()));
-    }
+		// Prepare for the next frame.
+		ThrowIfFailed(pCommandAllocator->Reset());
+		ThrowIfFailed(pCommandList->Reset(pCommandAllocator, m_computeState.Get()));
+	}
 
-    return 0;
+	return 0;
 }
 
 // Run the particle simulation using the compute shader.
 void D3D12nBodyGravity::Simulate(UINT threadIndex)
 {
-    ID3D12GraphicsCommandList* pCommandList = m_computeCommandList[threadIndex].Get();
+	ID3D12GraphicsCommandList* pCommandList = m_computeCommandList[threadIndex].Get();
 
-    UINT srvIndex;
-    UINT uavIndex;
-    ID3D12Resource *pUavResource;
-    if (m_srvIndex[threadIndex] == 0)
-    {
-        srvIndex = SrvParticlePosVelo0;
-        uavIndex = UavParticlePosVelo1;
-        pUavResource = m_particleBuffer1[threadIndex].Get();
-    }
-    else
-    {
-        srvIndex = SrvParticlePosVelo1;
-        uavIndex = UavParticlePosVelo0;
-        pUavResource = m_particleBuffer0[threadIndex].Get();
-    }
+	UINT srvIndex;
+	UINT uavIndex;
+	ID3D12Resource *pUavResource;
+	if (m_srvIndex[threadIndex] == 0)
+	{
+		srvIndex = SrvParticlePosVelo0;
+		uavIndex = UavParticlePosVelo1;
+		pUavResource = m_particleBuffer1[threadIndex].Get();
+	}
+	else
+	{
+		srvIndex = SrvParticlePosVelo1;
+		uavIndex = UavParticlePosVelo0;
+		pUavResource = m_particleBuffer0[threadIndex].Get();
+	}
 
-    pCommandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(pUavResource, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS));
+	pCommandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(pUavResource, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS));
 
-    pCommandList->SetPipelineState(m_computeState.Get());
-    pCommandList->SetComputeRootSignature(m_computeRootSignature.Get());
+	pCommandList->SetPipelineState(m_computeState.Get());
+	pCommandList->SetComputeRootSignature(m_computeRootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_srvUavHeap.Get() };
-    pCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_srvUavHeap.Get() };
+	pCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_srvUavHeap->GetGPUDescriptorHandleForHeapStart(), srvIndex + threadIndex, m_srvUavDescriptorSize);
-    CD3DX12_GPU_DESCRIPTOR_HANDLE uavHandle(m_srvUavHeap->GetGPUDescriptorHandleForHeapStart(), uavIndex + threadIndex, m_srvUavDescriptorSize);
+	CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_srvUavHeap->GetGPUDescriptorHandleForHeapStart(), srvIndex + threadIndex, m_srvUavDescriptorSize);
+	CD3DX12_GPU_DESCRIPTOR_HANDLE uavHandle(m_srvUavHeap->GetGPUDescriptorHandleForHeapStart(), uavIndex + threadIndex, m_srvUavDescriptorSize);
 
-    pCommandList->SetComputeRootConstantBufferView(ComputeRootCBV, m_constantBufferCS->GetGPUVirtualAddress());
-    pCommandList->SetComputeRootDescriptorTable(ComputeRootSRVTable, srvHandle);
-    pCommandList->SetComputeRootDescriptorTable(ComputeRootUAVTable, uavHandle);
+	pCommandList->SetComputeRootConstantBufferView(ComputeRootCBV, m_constantBufferCS->GetGPUVirtualAddress());
+	pCommandList->SetComputeRootDescriptorTable(ComputeRootSRVTable, srvHandle);
+	pCommandList->SetComputeRootDescriptorTable(ComputeRootUAVTable, uavHandle);
 
-    pCommandList->Dispatch(static_cast<int>(ceil(ParticleCount / 128.0f)), 1, 1);
+	pCommandList->Dispatch(static_cast<int>(ceil(ParticleCount / 128.0f)), 1, 1);
 
-    pCommandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(pUavResource, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE));
+	pCommandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(pUavResource, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE));
 }
 
 void D3D12nBodyGravity::OnDestroy()
 {
-    // Notify the compute threads that the app is shutting down.
-    InterlockedExchange(&m_terminating, 1);
-    WaitForMultipleObjects(ThreadCount, m_threadHandles, TRUE, INFINITE);
+	// Notify the compute threads that the app is shutting down.
+	InterlockedExchange(&m_terminating, 1);
+	WaitForMultipleObjects(ThreadCount, m_threadHandles, TRUE, INFINITE);
 
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForRenderContext();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForRenderContext();
 
-    // Close handles to fence events and threads.
-    CloseHandle(m_renderContextFenceEvent);
-    for (int n = 0; n < ThreadCount; n++)
-    {
-        CloseHandle(m_threadHandles[n]);
-        CloseHandle(m_threadFenceEvents[n]);
-    }
+	// Close handles to fence events and threads.
+	CloseHandle(m_renderContextFenceEvent);
+	for (int n = 0; n < ThreadCount; n++)
+	{
+		CloseHandle(m_threadHandles[n]);
+		CloseHandle(m_threadFenceEvents[n]);
+	}
 }
 
 void D3D12nBodyGravity::OnKeyDown(UINT8 key)
 {
-    m_camera.OnKeyDown(key);
+	m_camera.OnKeyDown(key);
 }
 
 void D3D12nBodyGravity::OnKeyUp(UINT8 key)
 {
-    m_camera.OnKeyUp(key);
+	m_camera.OnKeyUp(key);
 }
 
 void D3D12nBodyGravity::WaitForRenderContext()
 {
-    // Add a signal command to the queue.
-    ThrowIfFailed(m_commandQueue->Signal(m_renderContextFence.Get(), m_renderContextFenceValue));
+	// Add a signal command to the queue.
+	ThrowIfFailed(m_commandQueue->Signal(m_renderContextFence.Get(), m_renderContextFenceValue));
 
-    // Instruct the fence to set the event object when the signal command completes.
-    ThrowIfFailed(m_renderContextFence->SetEventOnCompletion(m_renderContextFenceValue, m_renderContextFenceEvent));
-    m_renderContextFenceValue++;
+	// Instruct the fence to set the event object when the signal command completes.
+	ThrowIfFailed(m_renderContextFence->SetEventOnCompletion(m_renderContextFenceValue, m_renderContextFenceEvent));
+	m_renderContextFenceValue++;
 
-    // Wait until the signal command has been processed.
-    WaitForSingleObject(m_renderContextFenceEvent, INFINITE);
+	// Wait until the signal command has been processed.
+	WaitForSingleObject(m_renderContextFenceEvent, INFINITE);
 }
 
 // Cycle through the frame resources. This method blocks execution if the 
@@ -853,20 +909,20 @@ void D3D12nBodyGravity::WaitForRenderContext()
 // processed by the GPU.
 void D3D12nBodyGravity::MoveToNextFrame()
 {
-    // Assign the current fence value to the current frame.
-    m_frameFenceValues[m_frameIndex] = m_renderContextFenceValue;
+	// Assign the current fence value to the current frame.
+	m_frameFenceValues[m_frameIndex] = m_renderContextFenceValue;
 
-    // Signal and increment the fence value.
-    ThrowIfFailed(m_commandQueue->Signal(m_renderContextFence.Get(), m_renderContextFenceValue));
-    m_renderContextFenceValue++;
+	// Signal and increment the fence value.
+	ThrowIfFailed(m_commandQueue->Signal(m_renderContextFence.Get(), m_renderContextFenceValue));
+	m_renderContextFenceValue++;
 
-    // Update the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Update the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    if (m_renderContextFence->GetCompletedValue() < m_frameFenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_renderContextFence->SetEventOnCompletion(m_frameFenceValues[m_frameIndex], m_renderContextFenceEvent));
-        WaitForSingleObject(m_renderContextFenceEvent, INFINITE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	if (m_renderContextFence->GetCompletedValue() < m_frameFenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_renderContextFence->SetEventOnCompletion(m_frameFenceValues[m_frameIndex], m_renderContextFenceEvent));
+		WaitForSingleObject(m_renderContextFenceEvent, INFINITE);
+	}
 }

--- a/Samples/Desktop/D3D12nBodyGravity/src/D3D12nBodyGravity.h
+++ b/Samples/Desktop/D3D12nBodyGravity/src/D3D12nBodyGravity.h
@@ -27,163 +27,166 @@ using Microsoft::WRL::ComPtr;
 class D3D12nBodyGravity : public DXSample
 {
 public:
-    D3D12nBodyGravity(UINT width, UINT height, std::wstring name);
+	D3D12nBodyGravity(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
-    virtual void OnKeyDown(UINT8 key);
-    virtual void OnKeyUp(UINT8 key);
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
+	virtual void OnKeyDown(UINT8 key);
+	virtual void OnKeyUp(UINT8 key);
 
 private:
-    static const UINT FrameCount = 2;
-    static const UINT ThreadCount = 1;
-    static const float ParticleSpread;
-    static const UINT ParticleCount = 10000;        // The number of particles in the n-body simulation.
+	static const UINT FrameCount = 2;
+	static const UINT ThreadCount = 1;
+	static const float ParticleSpread;
+	static const UINT ParticleCount = 10000;		// The number of particles in the n-body simulation.
 
-    // "Vertex" definition for particles. Triangle vertices are generated 
-    // by the geometry shader. Color data will be assigned to those 
-    // vertices via this struct.
-    struct ParticleVertex
-    {
-        XMFLOAT4 color;
-    };
+	// "Vertex" definition for particles. Triangle vertices are generated 
+	// by the geometry shader. Color data will be assigned to those 
+	// vertices via this struct.
+	struct ParticleVertex
+	{
+		XMFLOAT4 color;
+	};
 
-    // Position and velocity data for the particles in the system.
-    // Two buffers full of Particle data are utilized in this sample.
-    // The compute thread alternates writing to each of them.
-    // The render thread renders using the buffer that is not currently
-    // in use by the compute shader.
-    struct Particle
-    {
-        XMFLOAT4 position;
-        XMFLOAT4 velocity;
-    };
+	// Position and velocity data for the particles in the system.
+	// Two buffers full of Particle data are utilized in this sample.
+	// The compute thread alternates writing to each of them.
+	// The render thread renders using the buffer that is not currently
+	// in use by the compute shader.
+	struct Particle
+	{
+		XMFLOAT4 position;
+		XMFLOAT4 velocity;
+	};
 
-    struct ConstantBufferGS
-    {
-        XMFLOAT4X4 worldViewProjection;
-        XMFLOAT4X4 inverseView;
+	struct ConstantBufferGS
+	{
+		XMFLOAT4X4 worldViewProjection;
+		XMFLOAT4X4 inverseView;
 
-        // Constant buffers are 256-byte aligned in GPU memory. Padding is added
-        // for convenience when computing the struct's size.
-        float padding[32];
-    };
+		// Constant buffers are 256-byte aligned in GPU memory. Padding is added
+		// for convenience when computing the struct's size.
+		float padding[32];
+	};
 
-    struct ConstantBufferCS
-    {
-        UINT param[4];
-        float paramf[4];
-    };
+	struct ConstantBufferCS
+	{
+		UINT param[4];
+		float paramf[4];
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    UINT m_frameIndex;
-    ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12RootSignature> m_computeRootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_srvUavHeap;
-    UINT m_rtvDescriptorSize;
-    UINT m_srvUavDescriptorSize;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	UINT m_frameIndex;
+	ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12RootSignature> m_computeRootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_srvUavHeap;
+	UINT m_rtvDescriptorSize;
+	UINT m_srvUavDescriptorSize;
 
-    // Asset objects.
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12PipelineState> m_computeState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    ComPtr<ID3D12Resource> m_vertexBufferUpload;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
-    ComPtr<ID3D12Resource> m_particleBuffer0[ThreadCount];
-    ComPtr<ID3D12Resource> m_particleBuffer1[ThreadCount];
-    ComPtr<ID3D12Resource> m_particleBuffer0Upload[ThreadCount];
-    ComPtr<ID3D12Resource> m_particleBuffer1Upload[ThreadCount];
-    ComPtr<ID3D12Resource> m_constantBufferGS;
-    UINT8* m_pConstantBufferGSData;
-    ComPtr<ID3D12Resource> m_constantBufferCS;
+	// Asset objects.
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12PipelineState> m_computeState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	ComPtr<ID3D12Resource> m_vertexBufferUpload;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	ComPtr<ID3D12Resource> m_particleBuffer0[ThreadCount];
+	ComPtr<ID3D12Resource> m_particleBuffer1[ThreadCount];
+	ComPtr<ID3D12Resource> m_particleBuffer0Upload[ThreadCount];
+	ComPtr<ID3D12Resource> m_particleBuffer1Upload[ThreadCount];
+	ComPtr<ID3D12Resource> m_constantBufferGS;
+	UINT8* m_pConstantBufferGSData;
+	ComPtr<ID3D12Resource> m_constantBufferCS;
 
-    UINT m_srvIndex[ThreadCount];        // Denotes which of the particle buffer resource views is the SRV (0 or 1). The UAV is 1 - srvIndex.
-    UINT m_heightInstances;
-    UINT m_widthInstances;
-    SimpleCamera m_camera;
-    StepTimer m_timer;
+	UINT m_srvIndex[ThreadCount];		// Denotes which of the particle buffer resource views is the SRV (0 or 1). The UAV is 1 - srvIndex.
+	UINT m_heightInstances;
+	UINT m_widthInstances;
+	SimpleCamera m_camera;
+	StepTimer m_timer;
 
-    // Compute objects.
-    ComPtr<ID3D12CommandAllocator> m_computeAllocator[ThreadCount];
-    ComPtr<ID3D12CommandQueue> m_computeCommandQueue[ThreadCount];
-    ComPtr<ID3D12GraphicsCommandList> m_computeCommandList[ThreadCount];
+	// Compute objects.
+	ComPtr<ID3D12CommandAllocator> m_computeAllocator[ThreadCount];
+	ComPtr<ID3D12CommandQueue> m_computeCommandQueue[ThreadCount];
+	ComPtr<ID3D12GraphicsCommandList> m_computeCommandList[ThreadCount];
 
-    // Synchronization objects.
-    HANDLE m_swapChainEvent;
-    ComPtr<ID3D12Fence> m_renderContextFence;
-    UINT64 m_renderContextFenceValue;
-    HANDLE m_renderContextFenceEvent;
-    UINT64 m_frameFenceValues[FrameCount];
+	// Synchronization objects.
+	HANDLE m_swapChainEvent;
+	ComPtr<ID3D12Fence> m_renderContextFence;
+	UINT64 m_renderContextFenceValue;
+	HANDLE m_renderContextFenceEvent;
+	UINT64 m_frameFenceValues[FrameCount];
 
-    ComPtr<ID3D12Fence> m_threadFences[ThreadCount];
-    volatile HANDLE m_threadFenceEvents[ThreadCount];
+	ComPtr<ID3D12Fence> m_threadFences[ThreadCount];
+	volatile HANDLE m_threadFenceEvents[ThreadCount];
 
-    // Thread state.
-    LONG volatile m_terminating;
-    UINT64 volatile m_renderContextFenceValues[ThreadCount];
-    UINT64 volatile m_threadFenceValues[ThreadCount];
+	// Thread state.
+	LONG volatile m_terminating;
+	UINT64 volatile m_renderContextFenceValues[ThreadCount];
+	UINT64 volatile m_threadFenceValues[ThreadCount];
 
-    struct ThreadData
-    {
-        D3D12nBodyGravity* pContext;
-        UINT threadIndex;
-    };
-    ThreadData m_threadData[ThreadCount];
-    HANDLE m_threadHandles[ThreadCount];
+	struct ThreadData
+	{
+		D3D12nBodyGravity* pContext;
+		UINT threadIndex;
+	};
+	ThreadData m_threadData[ThreadCount];
+	HANDLE m_threadHandles[ThreadCount];
 
-    // Indices of the root signature parameters.
-    enum GraphicsRootParameters : UINT32
-    {
-        GraphicsRootCBV = 0,
-        GraphicsRootSRVTable,
-        GraphicsRootParametersCount
-    };
+	// Indices of the root signature parameters.
+	enum GraphicsRootParameters : UINT32
+	{
+		GraphicsRootCBV = 0,
+		GraphicsRootSRVTable,
+		GraphicsRootParametersCount
+	};
 
-    enum ComputeRootParameters : UINT32
-    {
-        ComputeRootCBV = 0,
-        ComputeRootSRVTable,
-        ComputeRootUAVTable,
-        ComputeRootParametersCount
-    };
+	enum ComputeRootParameters : UINT32
+	{
+		ComputeRootCBV = 0,
+		ComputeRootSRVTable,
+		ComputeRootUAVTable,
+		ComputeRootParametersCount
+	};
 
-    // Indices of shader resources in the descriptor heap.
-    enum DescriptorHeapIndex : UINT32
-    {
-        UavParticlePosVelo0 = 0,
-        UavParticlePosVelo1 = UavParticlePosVelo0 + ThreadCount,
-        SrvParticlePosVelo0 = UavParticlePosVelo1 + ThreadCount,
-        SrvParticlePosVelo1 = SrvParticlePosVelo0 + ThreadCount,
-        DescriptorCount = SrvParticlePosVelo1 + ThreadCount
-    };
+	// Indices of shader resources in the descriptor heap.
+	enum DescriptorHeapIndex : UINT32
+	{
+		UavParticlePosVelo0 = 0,
+		UavParticlePosVelo1 = UavParticlePosVelo0 + ThreadCount,
+		SrvParticlePosVelo0 = UavParticlePosVelo1 + ThreadCount,
+		SrvParticlePosVelo1 = SrvParticlePosVelo0 + ThreadCount,
+		DescriptorCount = SrvParticlePosVelo1 + ThreadCount
+	};
 
-    void LoadPipeline();
-    void LoadAssets();
-    void CreateAsyncContexts();
-    void CreateVertexBuffer();
-    float RandomPercent();
-    void LoadParticles(_Out_writes_(numParticles) Particle* pParticles, const XMFLOAT3 &center, const XMFLOAT4 &velocity, float spread, UINT numParticles);
-    void CreateParticleBuffers();
-    void PopulateCommandList();
+	void LoadPipeline();
+	void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
+    void WaitForGpu();
+	void CreateAsyncContexts();
+	void CreateVertexBuffer();
+	float RandomPercent();
+	void LoadParticles(_Out_writes_(numParticles) Particle* pParticles, const XMFLOAT3 &center, const XMFLOAT4 &velocity, float spread, UINT numParticles);
+	void CreateParticleBuffers();
+	void PopulateCommandList();
 
-    static DWORD WINAPI ThreadProc(ThreadData* pData)
-    {
-        return pData->pContext->AsyncComputeThreadProc(pData->threadIndex);
-    }
-    DWORD AsyncComputeThreadProc(int threadIndex);
-    void Simulate(UINT threadIndex);
+	static DWORD WINAPI ThreadProc(ThreadData* pData)
+	{
+		return pData->pContext->AsyncComputeThreadProc(pData->threadIndex);
+	}
+	DWORD AsyncComputeThreadProc(int threadIndex);
+	void Simulate(UINT threadIndex);
 
-    void WaitForRenderContext();
-    void MoveToNextFrame();
+	void WaitForRenderContext();
+	void MoveToNextFrame();
 };

--- a/Samples/Desktop/D3D12nBodyGravity/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12nBodyGravity/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,58 +34,103 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title + L": " + text;
-    SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
+	std::wstring windowText = m_title + L": " + text;
+	SetWindowText(Win32Application::GetHwnd(), windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/Desktop/D3D12nBodyGravity/src/DXSample.h
+++ b/Samples/Desktop/D3D12nBodyGravity/src/DXSample.h
@@ -17,42 +17,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/Desktop/D3D12nBodyGravity/src/Main.cpp
+++ b/Samples/Desktop/D3D12nBodyGravity/src/Main.cpp
@@ -15,6 +15,6 @@
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {
-    D3D12nBodyGravity sample(1280, 720, L"D3D12 n-Body Gravity Simulation");
-    return Win32Application::Run(&sample, hInstance, nCmdShow);
+	D3D12nBodyGravity sample(1280, 720, L"D3D12 n-Body Gravity Simulation");
+	return Win32Application::Run(&sample, hInstance, nCmdShow);
 }

--- a/Samples/Desktop/D3D12nBodyGravity/src/ParticleDraw.hlsl
+++ b/Samples/Desktop/D3D12nBodyGravity/src/ParticleDraw.hlsl
@@ -11,65 +11,65 @@
 
 struct VSParticleIn
 {
-    float4 color    : COLOR;
-    uint id            : SV_VERTEXID;
+	float4 color	: COLOR;
+	uint id			: SV_VERTEXID;
 };
 
 struct VSParticleDrawOut
 {
-    float3 pos            : POSITION;
-    float4 color        : COLOR;
+	float3 pos			: POSITION;
+	float4 color		: COLOR;
 };
 
 struct GSParticleDrawOut
 {
-    float2 tex            : TEXCOORD0;
-    float4 color        : COLOR;
-    float4 pos            : SV_POSITION;
+	float2 tex			: TEXCOORD0;
+	float4 color		: COLOR;
+	float4 pos			: SV_POSITION;
 };
 
 struct PSParticleDrawIn
 {
-    float2 tex            : TEXCOORD0;
-    float4 color        : COLOR;
+	float2 tex			: TEXCOORD0;
+	float4 color		: COLOR;
 };
 
 struct PosVelo
 {
-    float4 pos;
-    float4 velo;
+	float4 pos;
+	float4 velo;
 };
 
 StructuredBuffer<PosVelo> g_bufPosVelo;
 
 cbuffer cb0
 {
-    row_major float4x4 g_mWorldViewProj;
-    row_major float4x4 g_mInvView;
+	row_major float4x4 g_mWorldViewProj;
+	row_major float4x4 g_mInvView;
 };
 
 cbuffer cb1
 {
-    static float g_fParticleRad = 10.0f;
+	static float g_fParticleRad = 10.0f;
 };
 
 cbuffer cbImmutable
 {
-    static float3 g_positions[4] =
-    {
-        float3(-1, 1, 0),
-        float3(1, 1, 0),
-        float3(-1, -1, 0),
-        float3(1, -1, 0),
-    };
-    
-    static float2 g_texcoords[4] =
-    { 
-        float2(0, 0), 
-        float2(1, 0),
-        float2(0, 1),
-        float2(1, 1),
-    };
+	static float3 g_positions[4] =
+	{
+		float3(-1, 1, 0),
+		float3(1, 1, 0),
+		float3(-1, -1, 0),
+		float3(1, -1, 0),
+	};
+	
+	static float2 g_texcoords[4] =
+	{ 
+		float2(0, 0), 
+		float2(1, 0),
+		float2(0, 1),
+		float2(1, 1),
+	};
 };
 
 //
@@ -77,14 +77,14 @@ cbuffer cbImmutable
 //
 VSParticleDrawOut VSParticleDraw(VSParticleIn input)
 {
-    VSParticleDrawOut output;
-    
-    output.pos = g_bufPosVelo[input.id].pos.xyz;
-    
-    float mag = g_bufPosVelo[input.id].velo.w / 9;
-    output.color = lerp(float4(1.0f, 0.1f, 0.1f, 1.0f), input.color, mag);
-    
-    return output;
+	VSParticleDrawOut output;
+	
+	output.pos = g_bufPosVelo[input.id].pos.xyz;
+	
+	float mag = g_bufPosVelo[input.id].velo.w / 9;
+	output.color = lerp(float4(1.0f, 0.1f, 0.1f, 1.0f), input.color, mag);
+	
+	return output;
 }
 
 //
@@ -94,20 +94,20 @@ VSParticleDrawOut VSParticleDraw(VSParticleIn input)
 [maxvertexcount(4)]
 void GSParticleDraw(point VSParticleDrawOut input[1], inout TriangleStream<GSParticleDrawOut> SpriteStream)
 {
-    GSParticleDrawOut output;
-    
-    // Emit two new triangles.
-    for (int i = 0; i < 4; i++)
-    {
-        float3 position = g_positions[i] * g_fParticleRad;
-        position = mul(position, (float3x3)g_mInvView) + input[0].pos;
-        output.pos = mul(float4(position,1.0), g_mWorldViewProj);
+	GSParticleDrawOut output;
+	
+	// Emit two new triangles.
+	for (int i = 0; i < 4; i++)
+	{
+		float3 position = g_positions[i] * g_fParticleRad;
+		position = mul(position, (float3x3)g_mInvView) + input[0].pos;
+		output.pos = mul(float4(position,1.0), g_mWorldViewProj);
 
-        output.color = input[0].color;
-        output.tex = g_texcoords[i];
-        SpriteStream.Append(output);
-    }
-    SpriteStream.RestartStrip();
+		output.color = input[0].color;
+		output.tex = g_texcoords[i];
+		SpriteStream.Append(output);
+	}
+	SpriteStream.RestartStrip();
 }
 
 //
@@ -116,7 +116,7 @@ void GSParticleDraw(point VSParticleDrawOut input[1], inout TriangleStream<GSPar
 //
 float4 PSParticleDraw(PSParticleDrawIn input) : SV_Target
 {
-    float intensity = 0.5f - length(float2(0.5f, 0.5f) - input.tex);
-    intensity = clamp(intensity, 0.0f, 0.5f) * 2.0f;
-    return float4(input.color.xyz, intensity);
+	float intensity = 0.5f - length(float2(0.5f, 0.5f) - input.tex);
+	intensity = clamp(intensity, 0.0f, 0.5f) * 2.0f;
+	return float4(input.color.xyz, intensity);
 }

--- a/Samples/Desktop/D3D12nBodyGravity/src/SimpleCamera.cpp
+++ b/Samples/Desktop/D3D12nBodyGravity/src/SimpleCamera.cpp
@@ -13,163 +13,163 @@
 #include "SimpleCamera.h"
 
 SimpleCamera::SimpleCamera():
-    m_initialPosition(0, 0, 0),
-    m_position(m_initialPosition),
-    m_yaw(XM_PI),
-    m_pitch(0.0f),
-    m_lookDirection(0, 0, -1),
-    m_upDirection(0, 1, 0),
-    m_moveSpeed(20.0f),
-    m_turnSpeed(XM_PIDIV2),
-    m_keysPressed{}
+	m_initialPosition(0, 0, 0),
+	m_position(m_initialPosition),
+	m_yaw(XM_PI),
+	m_pitch(0.0f),
+	m_lookDirection(0, 0, -1),
+	m_upDirection(0, 1, 0),
+	m_moveSpeed(20.0f),
+	m_turnSpeed(XM_PIDIV2),
+	m_keysPressed{}
 {
 }
 
 void SimpleCamera::Init(XMFLOAT3 position)
 {
-    m_initialPosition = position;
-    Reset();
+	m_initialPosition = position;
+	Reset();
 }
 
 void SimpleCamera::SetMoveSpeed(float unitsPerSecond)
 {
-    m_moveSpeed = unitsPerSecond;
+	m_moveSpeed = unitsPerSecond;
 }
 
 void SimpleCamera::SetTurnSpeed(float radiansPerSecond)
 {
-    m_turnSpeed = radiansPerSecond;
+	m_turnSpeed = radiansPerSecond;
 }
 
 void SimpleCamera::Reset()
 {
-    m_position = m_initialPosition;
-    m_yaw = XM_PI;
-    m_pitch = 0.0f;
-    m_lookDirection = { 0, 0, -1 };
+	m_position = m_initialPosition;
+	m_yaw = XM_PI;
+	m_pitch = 0.0f;
+	m_lookDirection = { 0, 0, -1 };
 }
 
 void SimpleCamera::Update(float elapsedSeconds)
 {
-    // Calculate the move vector in camera space.
-    XMFLOAT3 move(0, 0, 0);
+	// Calculate the move vector in camera space.
+	XMFLOAT3 move(0, 0, 0);
 
-    if (m_keysPressed.a)
-        move.x -= 1.0f;
-    if (m_keysPressed.d)
-        move.x += 1.0f;
-    if (m_keysPressed.w)
-        move.z -= 1.0f;
-    if (m_keysPressed.s)
-        move.z += 1.0f;
+	if (m_keysPressed.a)
+		move.x -= 1.0f;
+	if (m_keysPressed.d)
+		move.x += 1.0f;
+	if (m_keysPressed.w)
+		move.z -= 1.0f;
+	if (m_keysPressed.s)
+		move.z += 1.0f;
 
-    if (fabs(move.x) > 0.1f && fabs(move.z) > 0.1f)
-    {
-        XMVECTOR vector = XMVector3Normalize(XMLoadFloat3(&move));
-        move.x = XMVectorGetX(vector);
-        move.z = XMVectorGetZ(vector);
-    }
+	if (fabs(move.x) > 0.1f && fabs(move.z) > 0.1f)
+	{
+		XMVECTOR vector = XMVector3Normalize(XMLoadFloat3(&move));
+		move.x = XMVectorGetX(vector);
+		move.z = XMVectorGetZ(vector);
+	}
 
-    float moveInterval = m_moveSpeed * elapsedSeconds;
-    float rotateInterval = m_turnSpeed * elapsedSeconds;
+	float moveInterval = m_moveSpeed * elapsedSeconds;
+	float rotateInterval = m_turnSpeed * elapsedSeconds;
 
-    if (m_keysPressed.left)
-        m_yaw += rotateInterval;
-    if (m_keysPressed.right)
-        m_yaw -= rotateInterval;
-    if (m_keysPressed.up)
-        m_pitch += rotateInterval;
-    if (m_keysPressed.down)
-        m_pitch -= rotateInterval;
+	if (m_keysPressed.left)
+		m_yaw += rotateInterval;
+	if (m_keysPressed.right)
+		m_yaw -= rotateInterval;
+	if (m_keysPressed.up)
+		m_pitch += rotateInterval;
+	if (m_keysPressed.down)
+		m_pitch -= rotateInterval;
 
-    // Prevent looking too far up or down.
-    m_pitch = min(m_pitch, XM_PIDIV4);
-    m_pitch = max(-XM_PIDIV4, m_pitch);
+	// Prevent looking too far up or down.
+	m_pitch = min(m_pitch, XM_PIDIV4);
+	m_pitch = max(-XM_PIDIV4, m_pitch);
 
-    // Move the camera in model space.
-    float x = move.x * -cosf(m_yaw) - move.z * sinf(m_yaw);
-    float z = move.x * sinf(m_yaw) - move.z * cosf(m_yaw);
-    m_position.x += x * moveInterval;
-    m_position.z += z * moveInterval;
+	// Move the camera in model space.
+	float x = move.x * -cosf(m_yaw) - move.z * sinf(m_yaw);
+	float z = move.x * sinf(m_yaw) - move.z * cosf(m_yaw);
+	m_position.x += x * moveInterval;
+	m_position.z += z * moveInterval;
 
-    // Determine the look direction.
-    float r = cosf(m_pitch);
-    m_lookDirection.x = r * sinf(m_yaw);
-    m_lookDirection.y = sinf(m_pitch);
-    m_lookDirection.z = r * cosf(m_yaw);
+	// Determine the look direction.
+	float r = cosf(m_pitch);
+	m_lookDirection.x = r * sinf(m_yaw);
+	m_lookDirection.y = sinf(m_pitch);
+	m_lookDirection.z = r * cosf(m_yaw);
 }
 
 XMMATRIX SimpleCamera::GetViewMatrix()
 {
-    return XMMatrixLookToRH(XMLoadFloat3(&m_position), XMLoadFloat3(&m_lookDirection), XMLoadFloat3(&m_upDirection));
+	return XMMatrixLookToRH(XMLoadFloat3(&m_position), XMLoadFloat3(&m_lookDirection), XMLoadFloat3(&m_upDirection));
 }
 
 XMMATRIX SimpleCamera::GetProjectionMatrix(float fov, float aspectRatio, float nearPlane, float farPlane)
 {
-    return XMMatrixPerspectiveFovRH(fov, aspectRatio, nearPlane, farPlane);
+	return XMMatrixPerspectiveFovRH(fov, aspectRatio, nearPlane, farPlane);
 }
 
 void SimpleCamera::OnKeyDown(WPARAM key)
 {
-    switch (key)
-    {
-    case 'W':
-        m_keysPressed.w = true;
-        break;
-    case 'A':
-        m_keysPressed.a = true;
-        break;
-    case 'S':
-        m_keysPressed.s = true;
-        break;
-    case 'D':
-        m_keysPressed.d = true;
-        break;
-    case VK_LEFT:
-        m_keysPressed.left = true;
-        break;
-    case VK_RIGHT:
-        m_keysPressed.right = true;
-        break;
-    case VK_UP:
-        m_keysPressed.up = true;
-        break;
-    case VK_DOWN:
-        m_keysPressed.down = true;
-        break;
-    case VK_ESCAPE:
-        Reset();
-        break;
-    }
+	switch (key)
+	{
+	case 'W':
+		m_keysPressed.w = true;
+		break;
+	case 'A':
+		m_keysPressed.a = true;
+		break;
+	case 'S':
+		m_keysPressed.s = true;
+		break;
+	case 'D':
+		m_keysPressed.d = true;
+		break;
+	case VK_LEFT:
+		m_keysPressed.left = true;
+		break;
+	case VK_RIGHT:
+		m_keysPressed.right = true;
+		break;
+	case VK_UP:
+		m_keysPressed.up = true;
+		break;
+	case VK_DOWN:
+		m_keysPressed.down = true;
+		break;
+	case VK_ESCAPE:
+		Reset();
+		break;
+	}
 }
 
 void SimpleCamera::OnKeyUp(WPARAM key)
 {
-    switch (key)
-    {
-    case 'W':
-        m_keysPressed.w = false;
-        break;
-    case 'A':
-        m_keysPressed.a = false;
-        break;
-    case 'S':
-        m_keysPressed.s = false;
-        break;
-    case 'D':
-        m_keysPressed.d = false;
-        break;
-    case VK_LEFT:
-        m_keysPressed.left = false;
-        break;
-    case VK_RIGHT:
-        m_keysPressed.right = false;
-        break;
-    case VK_UP:
-        m_keysPressed.up = false;
-        break;
-    case VK_DOWN:
-        m_keysPressed.down = false;
-        break;
-    }
+	switch (key)
+	{
+	case 'W':
+		m_keysPressed.w = false;
+		break;
+	case 'A':
+		m_keysPressed.a = false;
+		break;
+	case 'S':
+		m_keysPressed.s = false;
+		break;
+	case 'D':
+		m_keysPressed.d = false;
+		break;
+	case VK_LEFT:
+		m_keysPressed.left = false;
+		break;
+	case VK_RIGHT:
+		m_keysPressed.right = false;
+		break;
+	case VK_UP:
+		m_keysPressed.up = false;
+		break;
+	case VK_DOWN:
+		m_keysPressed.down = false;
+		break;
+	}
 }

--- a/Samples/Desktop/D3D12nBodyGravity/src/SimpleCamera.h
+++ b/Samples/Desktop/D3D12nBodyGravity/src/SimpleCamera.h
@@ -16,42 +16,42 @@ using namespace DirectX;
 class SimpleCamera
 {
 public:
-    SimpleCamera();
+	SimpleCamera();
 
-    void Init(XMFLOAT3 position);
-    void Update(float elapsedSeconds);
-    XMMATRIX GetViewMatrix();
-    XMMATRIX GetProjectionMatrix(float fov, float aspectRatio, float nearPlane = 1.0f, float farPlane = 1000.0f);
-    void SetMoveSpeed(float unitsPerSecond);
-    void SetTurnSpeed(float radiansPerSecond);
+	void Init(XMFLOAT3 position);
+	void Update(float elapsedSeconds);
+	XMMATRIX GetViewMatrix();
+	XMMATRIX GetProjectionMatrix(float fov, float aspectRatio, float nearPlane = 1.0f, float farPlane = 1000.0f);
+	void SetMoveSpeed(float unitsPerSecond);
+	void SetTurnSpeed(float radiansPerSecond);
 
-    void OnKeyDown(WPARAM key);
-    void OnKeyUp(WPARAM key);
+	void OnKeyDown(WPARAM key);
+	void OnKeyUp(WPARAM key);
 
 private:
-    void Reset();
+	void Reset();
 
-    struct KeysPressed
-    {
-        bool w;
-        bool a;
-        bool s;
-        bool d;
+	struct KeysPressed
+	{
+		bool w;
+		bool a;
+		bool s;
+		bool d;
 
-        bool left;
-        bool right;
-        bool up;
-        bool down;
-    };
+		bool left;
+		bool right;
+		bool up;
+		bool down;
+	};
 
-    XMFLOAT3 m_initialPosition;
-    XMFLOAT3 m_position;
-    float m_yaw;                // Relative to the +z axis.
-    float m_pitch;                // Relative to the xz plane.
-    XMFLOAT3 m_lookDirection;
-    XMFLOAT3 m_upDirection;
-    float m_moveSpeed;            // Speed at which the camera moves, in units per second.
-    float m_turnSpeed;            // Speed at which the camera turns, in radians per second.
+	XMFLOAT3 m_initialPosition;
+	XMFLOAT3 m_position;
+	float m_yaw;				// Relative to the +z axis.
+	float m_pitch;				// Relative to the xz plane.
+	XMFLOAT3 m_lookDirection;
+	XMFLOAT3 m_upDirection;
+	float m_moveSpeed;			// Speed at which the camera moves, in units per second.
+	float m_turnSpeed;			// Speed at which the camera turns, in radians per second.
 
-    KeysPressed m_keysPressed;
+	KeysPressed m_keysPressed;
 };

--- a/Samples/Desktop/D3D12nBodyGravity/src/Win32Application.cpp
+++ b/Samples/Desktop/D3D12nBodyGravity/src/Win32Application.cpp
@@ -16,104 +16,104 @@ HWND Win32Application::m_hwnd = nullptr;
 
 int Win32Application::Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow)
 {
-    // Parse the command line parameters
-    int argc;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    pSample->ParseCommandLineArgs(argv, argc);
-    LocalFree(argv);
+	// Parse the command line parameters
+	int argc;
+	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	pSample->ParseCommandLineArgs(argv, argc);
+	LocalFree(argv);
 
-    // Initialize the window class.
-    WNDCLASSEX windowClass = { 0 };
-    windowClass.cbSize = sizeof(WNDCLASSEX);
-    windowClass.style = CS_HREDRAW | CS_VREDRAW;
-    windowClass.lpfnWndProc = WindowProc;
-    windowClass.hInstance = hInstance;
-    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-    windowClass.lpszClassName = L"DXSampleClass";
-    RegisterClassEx(&windowClass);
+	// Initialize the window class.
+	WNDCLASSEX windowClass = { 0 };
+	windowClass.cbSize = sizeof(WNDCLASSEX);
+	windowClass.style = CS_HREDRAW | CS_VREDRAW;
+	windowClass.lpfnWndProc = WindowProc;
+	windowClass.hInstance = hInstance;
+	windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+	windowClass.lpszClassName = L"DXSampleClass";
+	RegisterClassEx(&windowClass);
 
-    RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
-    AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
+	RECT windowRect = { 0, 0, static_cast<LONG>(pSample->GetWidth()), static_cast<LONG>(pSample->GetHeight()) };
+	AdjustWindowRect(&windowRect, WS_OVERLAPPEDWINDOW, FALSE);
 
-    // Create the window and store a handle to it.
-    m_hwnd = CreateWindow(
-        windowClass.lpszClassName,
-        pSample->GetTitle(),
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        windowRect.right - windowRect.left,
-        windowRect.bottom - windowRect.top,
-        nullptr,        // We have no parent window.
-        nullptr,        // We aren't using menus.
-        hInstance,
-        pSample);
+	// Create the window and store a handle to it.
+	m_hwnd = CreateWindow(
+		windowClass.lpszClassName,
+		pSample->GetTitle(),
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		windowRect.right - windowRect.left,
+		windowRect.bottom - windowRect.top,
+		nullptr,		// We have no parent window.
+		nullptr,		// We aren't using menus.
+		hInstance,
+		pSample);
 
-    // Initialize the sample. OnInit is defined in each child-implementation of DXSample.
-    pSample->OnInit();
+	// Initialize the sample. OnInit is defined in each child-implementation of DXSample.
+	pSample->OnInit();
 
-    ShowWindow(m_hwnd, nCmdShow);
+	ShowWindow(m_hwnd, nCmdShow);
 
-    // Main sample loop.
-    MSG msg = {};
-    while (msg.message != WM_QUIT)
-    {
-        // Process any messages in the queue.
-        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
-    }
+	// Main sample loop.
+	MSG msg = {};
+	while (msg.message != WM_QUIT)
+	{
+		// Process any messages in the queue.
+		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
 
-    pSample->OnDestroy();
+	pSample->OnDestroy();
 
-    // Return this part of the WM_QUIT message to Windows.
-    return static_cast<char>(msg.wParam);
+	// Return this part of the WM_QUIT message to Windows.
+	return static_cast<char>(msg.wParam);
 }
 
 // Main message handler for the sample.
 LRESULT CALLBACK Win32Application::WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+	DXSample* pSample = reinterpret_cast<DXSample*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
-    switch (message)
-    {
-    case WM_CREATE:
-        {
-            // Save the DXSample* passed in to CreateWindow.
-            LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
-            SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
-        }
-        return 0;
+	switch (message)
+	{
+	case WM_CREATE:
+		{
+			// Save the DXSample* passed in to CreateWindow.
+			LPCREATESTRUCT pCreateStruct = reinterpret_cast<LPCREATESTRUCT>(lParam);
+			SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pCreateStruct->lpCreateParams));
+		}
+		return 0;
 
-    case WM_KEYDOWN:
-        if (pSample)
-        {
-            pSample->OnKeyDown(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYDOWN:
+		if (pSample)
+		{
+			pSample->OnKeyDown(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_KEYUP:
-        if (pSample)
-        {
-            pSample->OnKeyUp(static_cast<UINT8>(wParam));
-        }
-        return 0;
+	case WM_KEYUP:
+		if (pSample)
+		{
+			pSample->OnKeyUp(static_cast<UINT8>(wParam));
+		}
+		return 0;
 
-    case WM_PAINT:
-        if (pSample)
-        {
-            pSample->OnUpdate();
-            pSample->OnRender();
-        }
-        return 0;
+	case WM_PAINT:
+		if (pSample)
+		{
+			pSample->OnUpdate();
+			pSample->OnRender();
+		}
+		return 0;
 
-    case WM_DESTROY:
-        PostQuitMessage(0);
-        return 0;
-    }
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		return 0;
+	}
 
-    // Handle any messages the switch statement didn't.
-    return DefWindowProc(hWnd, message, wParam, lParam);
+	// Handle any messages the switch statement didn't.
+	return DefWindowProc(hWnd, message, wParam, lParam);
 }

--- a/Samples/Desktop/D3D12nBodyGravity/src/Win32Application.h
+++ b/Samples/Desktop/D3D12nBodyGravity/src/Win32Application.h
@@ -18,12 +18,12 @@ class DXSample;
 class Win32Application
 {
 public:
-    static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
-    static HWND GetHwnd() { return m_hwnd; }
+	static int Run(DXSample* pSample, HINSTANCE hInstance, int nCmdShow);
+	static HWND GetHwnd() { return m_hwnd; }
 
 protected:
-    static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
-    static HWND m_hwnd;
+	static HWND m_hwnd;
 };

--- a/Samples/Desktop/D3D12nBodyGravity/src/d3dx12.h
+++ b/Samples/Desktop/D3D12nBodyGravity/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12nBodyGravity/src/nBodyGravityCS.hlsl
+++ b/Samples/Desktop/D3D12nBodyGravity/src/nBodyGravityCS.hlsl
@@ -9,9 +9,9 @@
 //
 //*********************************************************
 
-static float softeningSquared    = 0.0012500000f * 0.0012500000f;
-static float g_fG                = 6.67300e-11f * 10000.0f;
-static float g_fParticleMass    = g_fG * 10000.0f * 10000.0f;
+static float softeningSquared	= 0.0012500000f * 0.0012500000f;
+static float g_fG				= 6.67300e-11f * 10000.0f;
+static float g_fParticleMass	= g_fG * 10000.0f * 10000.0f;
 
 #define blocksize 128
 groupshared float4 sharedPos[blocksize];
@@ -22,87 +22,87 @@ groupshared float4 sharedPos[blocksize];
 //
 void bodyBodyInteraction(inout float3 ai, float4 bj, float4 bi, float mass, int particles) 
 {
-    float3 r = bj.xyz - bi.xyz;
+	float3 r = bj.xyz - bi.xyz;
 
-    float distSqr = dot(r, r);
-    distSqr += softeningSquared;
+	float distSqr = dot(r, r);
+	distSqr += softeningSquared;
 
-    float invDist = 1.0f / sqrt(distSqr);
-    float invDistCube =  invDist * invDist * invDist;
-    
-    float s = mass * invDistCube * particles;
+	float invDist = 1.0f / sqrt(distSqr);
+	float invDistCube =  invDist * invDist * invDist;
+	
+	float s = mass * invDistCube * particles;
 
-    ai += r * s;
+	ai += r * s;
 }
 
 cbuffer cbCS : register(b0)
 {
-    uint4   g_param;    // param[0] = MAX_PARTICLES;
-                        // param[1] = dimx;
-    float4  g_paramf;    // paramf[0] = 0.1f;
-                        // paramf[1] = 1; 
+	uint4   g_param;	// param[0] = MAX_PARTICLES;
+						// param[1] = dimx;
+	float4  g_paramf;	// paramf[0] = 0.1f;
+						// paramf[1] = 1; 
 };
 
 struct PosVelo
 {
-    float4 pos;
-    float4 velo;
+	float4 pos;
+	float4 velo;
 };
 
-StructuredBuffer<PosVelo> oldPosVelo    : register(t0);    // SRV
-RWStructuredBuffer<PosVelo> newPosVelo    : register(u0);    // UAV
+StructuredBuffer<PosVelo> oldPosVelo	: register(t0);	// SRV
+RWStructuredBuffer<PosVelo> newPosVelo	: register(u0);	// UAV
 
 [numthreads(blocksize, 1, 1)]
 void CSMain(uint3 Gid : SV_GroupID, uint3 DTid : SV_DispatchThreadID, uint3 GTid : SV_GroupThreadID, uint GI : SV_GroupIndex)
 {
-    // Each thread of the CS updates one of the particles.
-    float4 pos = oldPosVelo[DTid.x].pos;
-    float4 vel = oldPosVelo[DTid.x].velo;
-    float3 accel = 0;
-    float mass = g_fParticleMass;
+	// Each thread of the CS updates one of the particles.
+	float4 pos = oldPosVelo[DTid.x].pos;
+	float4 vel = oldPosVelo[DTid.x].velo;
+	float3 accel = 0;
+	float mass = g_fParticleMass;
 
-    // Update current particle using all other particles.
-    [loop]
-    for (uint tile = 0; tile < g_param.y; tile++)
-    {
-        // Cache a tile of particles unto shared memory to increase IO efficiency.
-        sharedPos[GI] = oldPosVelo[tile * blocksize + GI].pos;
-       
-        GroupMemoryBarrierWithGroupSync();
+	// Update current particle using all other particles.
+	[loop]
+	for (uint tile = 0; tile < g_param.y; tile++)
+	{
+		// Cache a tile of particles unto shared memory to increase IO efficiency.
+		sharedPos[GI] = oldPosVelo[tile * blocksize + GI].pos;
+	   
+		GroupMemoryBarrierWithGroupSync();
 
-        [unroll]
-        for (uint counter = 0; counter < blocksize; counter += 8 ) 
-        {
-            bodyBodyInteraction(accel, sharedPos[counter], pos, mass, 1);
-            bodyBodyInteraction(accel, sharedPos[counter+1], pos, mass, 1);
-            bodyBodyInteraction(accel, sharedPos[counter+2], pos, mass, 1);
-            bodyBodyInteraction(accel, sharedPos[counter+3], pos, mass, 1);
-            bodyBodyInteraction(accel, sharedPos[counter+4], pos, mass, 1);
-            bodyBodyInteraction(accel, sharedPos[counter+5], pos, mass, 1);
-            bodyBodyInteraction(accel, sharedPos[counter+6], pos, mass, 1);
-            bodyBodyInteraction(accel, sharedPos[counter+7], pos, mass, 1);
-        }
-        
-        GroupMemoryBarrierWithGroupSync();
-    }  
+		[unroll]
+		for (uint counter = 0; counter < blocksize; counter += 8 ) 
+		{
+			bodyBodyInteraction(accel, sharedPos[counter], pos, mass, 1);
+			bodyBodyInteraction(accel, sharedPos[counter+1], pos, mass, 1);
+			bodyBodyInteraction(accel, sharedPos[counter+2], pos, mass, 1);
+			bodyBodyInteraction(accel, sharedPos[counter+3], pos, mass, 1);
+			bodyBodyInteraction(accel, sharedPos[counter+4], pos, mass, 1);
+			bodyBodyInteraction(accel, sharedPos[counter+5], pos, mass, 1);
+			bodyBodyInteraction(accel, sharedPos[counter+6], pos, mass, 1);
+			bodyBodyInteraction(accel, sharedPos[counter+7], pos, mass, 1);
+		}
+		
+		GroupMemoryBarrierWithGroupSync();
+	}  
 
-    // g_param.x is the number of our particles, however this number might not 
-    // be an exact multiple of the tile size. In such cases, out of bound reads 
-    // occur in the process above, which means there will be tooManyParticles 
-    // "phantom" particles generating false gravity at position (0, 0, 0), so 
-    // we have to subtract them here. NOTE, out of bound reads always return 0 in CS.
-    const int tooManyParticles = g_param.y * blocksize - g_param.x;
-    bodyBodyInteraction(accel, float4(0, 0, 0, 0), pos, mass, -tooManyParticles);
+	// g_param.x is the number of our particles, however this number might not 
+	// be an exact multiple of the tile size. In such cases, out of bound reads 
+	// occur in the process above, which means there will be tooManyParticles 
+	// "phantom" particles generating false gravity at position (0, 0, 0), so 
+	// we have to subtract them here. NOTE, out of bound reads always return 0 in CS.
+	const int tooManyParticles = g_param.y * blocksize - g_param.x;
+	bodyBodyInteraction(accel, float4(0, 0, 0, 0), pos, mass, -tooManyParticles);
 
-    // Update the velocity and position of current particle using the 
-    // acceleration computed above.
-    vel.xyz += accel.xyz * g_paramf.x;        //deltaTime;
-    vel.xyz *= g_paramf.y;                    //damping;
-    pos.xyz += vel.xyz * g_paramf.x;        //deltaTime;
+	// Update the velocity and position of current particle using the 
+	// acceleration computed above.
+	vel.xyz += accel.xyz * g_paramf.x;		//deltaTime;
+	vel.xyz *= g_paramf.y;					//damping;
+	pos.xyz += vel.xyz * g_paramf.x;		//deltaTime;
 
-    if (DTid.x < g_param.x)
-    {
-        newPosVelo[DTid.x].pos = pos;
-        newPosVelo[DTid.x].velo = float4(vel.xyz, length(accel));
-    }
+	if (DTid.x < g_param.x)
+	{
+		newPosVelo[DTid.x].pos = pos;
+		newPosVelo[DTid.x].velo = float4(vel.xyz, length(accel));
+	}
 }

--- a/Samples/Desktop/D3D12nBodyGravity/src/stdafx.h
+++ b/Samples/Desktop/D3D12nBodyGravity/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>

--- a/Samples/Desktop/D3D12xGPU/readme.md
+++ b/Samples/Desktop/D3D12xGPU/readme.md
@@ -14,5 +14,5 @@ As the sample is able to survive an adapter removal event, it declares that it s
 * [1-9] - adapter selection, when manual override is enabled.
 
 ## Requirements
-* Windows 10 October 2018 Update or higher
-* [Visual Studio 2017](https://www.visualstudio.com/) with the [Windows 10 October 2018 Update SDK (17763)](https://developer.microsoft.com/en-US/windows/downloads/windows-10-sdk)
+* Windows 10 17655 or higher (available via [Windows Insider Program](https://insider.windows.com/en-us/))
+* [Visual Studio 2017](https://www.visualstudio.com/) with the Windows 10 17655 SDK

--- a/Samples/Desktop/D3D12xGPU/src/Camera.cpp
+++ b/Samples/Desktop/D3D12xGPU/src/Camera.cpp
@@ -16,18 +16,18 @@ Camera* Camera::mCamera = nullptr;
 
 Camera::Camera()
 {
-    Reset();
-    mCamera = this;
+	Reset();
+	mCamera = this;
 }
 
 Camera::~Camera()
 {
-    mCamera = nullptr;
+	mCamera = nullptr;
 }
 
 Camera* Camera::get()
 {
-    return mCamera;
+	return mCamera;
 }
 
 void Camera::Get3DViewProjMatricesLH(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float fovInDegrees, float screenWidth, float screenHeight)
@@ -47,23 +47,23 @@ void Camera::Get3DViewProjMatricesLH(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float f
 
 void Camera::Get3DViewProjMatrices(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float fovInDegrees, float screenWidth, float screenHeight)
 {
-    
-    float aspectRatio = (float)screenWidth / (float)screenHeight;
-    float fovAngleY = fovInDegrees * XM_PI / 180.0f;
+	
+	float aspectRatio = (float)screenWidth / (float)screenHeight;
+	float fovAngleY = fovInDegrees * XM_PI / 180.0f;
 
-    if (aspectRatio < 1.0f)
-    {
-        fovAngleY /= aspectRatio;
-    }
+	if (aspectRatio < 1.0f)
+	{
+		fovAngleY /= aspectRatio;
+	}
 
-    XMStoreFloat4x4(view, XMMatrixTranspose(XMMatrixLookAtRH(mEye, mAt, mUp)));
-    XMStoreFloat4x4(proj, XMMatrixTranspose(XMMatrixPerspectiveFovRH(fovAngleY, aspectRatio, 0.01f, 125.0f)));
+	XMStoreFloat4x4(view, XMMatrixTranspose(XMMatrixLookAtRH(mEye, mAt, mUp)));
+	XMStoreFloat4x4(proj, XMMatrixTranspose(XMMatrixPerspectiveFovRH(fovAngleY, aspectRatio, 0.01f, 125.0f)));
 }
 
 void Camera::GetOrthoProjMatrices(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float width, float height)
 {
-    XMStoreFloat4x4(view, XMMatrixTranspose(XMMatrixLookAtRH(mEye, mAt, mUp)));
-    XMStoreFloat4x4(proj, XMMatrixTranspose(XMMatrixOrthographicRH(width, height, 0.01f, 125.0f)));
+	XMStoreFloat4x4(view, XMMatrixTranspose(XMMatrixLookAtRH(mEye, mAt, mUp)));
+	XMStoreFloat4x4(proj, XMMatrixTranspose(XMMatrixOrthographicRH(width, height, 0.01f, 125.0f)));
 }
 
 void Camera::RotateAroundYAxis(float angleRad)
@@ -76,30 +76,30 @@ void Camera::RotateAroundYAxis(float angleRad)
 
 void Camera::RotateYaw(float angleRad)
 {
-    XMMATRIX rotation = XMMatrixRotationAxis(mUp, angleRad);
+	XMMATRIX rotation = XMMatrixRotationAxis(mUp, angleRad);
 
-    mEye = mAt + XMVector3TransformCoord(mEye - mAt, rotation);
+	mEye = mAt + XMVector3TransformCoord(mEye - mAt, rotation);
 }
 
 void Camera::RotatePitch(float angleRad)
 {
-    XMVECTOR right = XMVector3Normalize(XMVector3Cross(mAt - mEye, mUp));
-    XMMATRIX rotation = XMMatrixRotationAxis(right, angleRad);
+	XMVECTOR right = XMVector3Normalize(XMVector3Cross(mAt - mEye, mUp));
+	XMMATRIX rotation = XMMatrixRotationAxis(right, angleRad);
 
-    mEye = mAt + XMVector3TransformCoord(mEye - mAt, rotation);
+	mEye = mAt + XMVector3TransformCoord(mEye - mAt, rotation);
     mUp = XMVector3TransformCoord(mUp, rotation);
 }
 
 void Camera::Reset()
 {
     mEye = XMVectorSet(0.0f, 8.0f, -30.0f, 0.0f);
-    mAt = XMVectorSet(0.0f, 8.0f, 0.0f, 0.0f);
-    mUp = XMVectorSet(0.0f, 1.0f, 0.0f, 0.0f);
+	mAt = XMVectorSet(0.0f, 8.0f, 0.0f, 0.0f);
+	mUp = XMVectorSet(0.0f, 1.0f, 0.0f, 0.0f);
 }
 
 void Camera::Set(XMVECTOR eye, XMVECTOR at, XMVECTOR up)
 {
-    mEye = eye;
-    mAt = at;
-    mUp = up;
+	mEye = eye;
+	mAt = at;
+	mUp = up;
 }

--- a/Samples/Desktop/D3D12xGPU/src/Camera.h
+++ b/Samples/Desktop/D3D12xGPU/src/Camera.h
@@ -17,22 +17,22 @@ using namespace DirectX;
 class Camera
 {
 public:
-    Camera();
-    ~Camera();
+	Camera();
+	~Camera();
 
 
     void Get3DViewProjMatricesLH(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float fovInDegrees, float screenWidth, float screenHeight);
-    void Get3DViewProjMatrices(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float fovInDegrees, float screenWidth, float screenHeight);
-    void Reset();
-    void Set(XMVECTOR eye, XMVECTOR at, XMVECTOR up);
-    static Camera *get();
+	void Get3DViewProjMatrices(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float fovInDegrees, float screenWidth, float screenHeight);
+	void Reset();
+	void Set(XMVECTOR eye, XMVECTOR at, XMVECTOR up);
+	static Camera *get();
     void RotateAroundYAxis(float angleRad);
-    void RotateYaw(float angleRad);
-    void RotatePitch(float angleRad);
-    void GetOrthoProjMatrices(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float width, float height);
-    XMVECTOR mEye; // Where the camera is in world space. Z increases into of the screen when using LH coord system (which we are and DX uses)
-    XMVECTOR mAt; // What the camera is looking at (world origin)
-    XMVECTOR mUp; // Which way is up
+	void RotateYaw(float angleRad);
+	void RotatePitch(float angleRad);
+	void GetOrthoProjMatrices(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float width, float height);
+	XMVECTOR mEye; // Where the camera is in world space. Z increases into of the screen when using LH coord system (which we are and DX uses)
+	XMVECTOR mAt; // What the camera is looking at (world origin)
+	XMVECTOR mUp; // Which way is up
 private:
-    static Camera* mCamera;
+	static Camera* mCamera;
 };

--- a/Samples/Desktop/D3D12xGPU/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12xGPU/src/DXSample.cpp
@@ -52,33 +52,78 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
+
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+            }
+#if !defined(_XBOX_ONE)
+        }
+#endif
 
     *ppAdapter = adapter.Detach();
-}
+    }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)

--- a/Samples/Desktop/D3D12xGPU/src/DXSample.h
+++ b/Samples/Desktop/D3D12xGPU/src/DXSample.h
@@ -49,7 +49,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/Desktop/D3D12xGPU/src/FrameResource.cpp
+++ b/Samples/Desktop/D3D12xGPU/src/FrameResource.cpp
@@ -17,47 +17,47 @@
 using namespace SceneEnums;
 
 FrameResource::FrameResource(ID3D12Device* pDevice, ComPtr<ID3D12PipelineState> pPipelineStates[RenderPass::Count], ID3D12DescriptorHeap* pDsvHeap, ID3D12DescriptorHeap* pCbvSrvHeap, UINT frameIndex) :
-    m_frameResourceIndex(frameIndex)
+	m_frameResourceIndex(frameIndex)
 {
     for (UINT i = 0; i < RenderPass::Count; i++)
     {
         m_pipelineStates[i] = pPipelineStates[i];
     }
 
-    for (UINT i = 0; i < CommandListCount; i++)
-    {
-        ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[i])));
-        ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[i].Get(), m_pipelineStates[i].Get(), IID_PPV_ARGS(&m_commandLists[i])));
-        NAME_D3D12_OBJECT_INDEXED(m_commandLists, i);
+	for (UINT i = 0; i < CommandListCount; i++)
+	{
+		ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[i])));
+		ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[i].Get(), m_pipelineStates[i].Get(), IID_PPV_ARGS(&m_commandLists[i])));
+		NAME_D3D12_OBJECT_INDEXED(m_commandLists, i);
 
-        // Close these command lists; don't record into them for now.
-        ThrowIfFailed(m_commandLists[i]->Close());
-    }
+		// Close these command lists; don't record into them for now.
+		ThrowIfFailed(m_commandLists[i]->Close());
+	}
 
-    for (UINT i = 0; i < NumContexts; i++)
-    {
-        // Create command list allocators for worker threads. One alloc is 
-        // for the shadow pass command list, and one is for the scene pass.
-        ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_shadowCommandAllocators[i])));
-        ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[i])));
+	for (UINT i = 0; i < NumContexts; i++)
+	{
+		// Create command list allocators for worker threads. One alloc is 
+		// for the shadow pass command list, and one is for the scene pass.
+		ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_shadowCommandAllocators[i])));
+		ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[i])));
 
-        ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_shadowCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Shadow].Get(), IID_PPV_ARGS(&m_shadowCommandLists[i])));
-        ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_sceneCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Scene].Get(), IID_PPV_ARGS(&m_sceneCommandLists[i])));
+		ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_shadowCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Shadow].Get(), IID_PPV_ARGS(&m_shadowCommandLists[i])));
+		ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_sceneCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Scene].Get(), IID_PPV_ARGS(&m_sceneCommandLists[i])));
 
-        NAME_D3D12_OBJECT_INDEXED(m_shadowCommandLists, i);
-        NAME_D3D12_OBJECT_INDEXED(m_sceneCommandLists, i);
+		NAME_D3D12_OBJECT_INDEXED(m_shadowCommandLists, i);
+		NAME_D3D12_OBJECT_INDEXED(m_sceneCommandLists, i);
 
-        // Close these command lists; don't record into them for now. We will 
-        // reset them to a recording state when we start the render loop.
-        ThrowIfFailed(m_shadowCommandLists[i]->Close());
-        ThrowIfFailed(m_sceneCommandLists[i]->Close());
-    }
+		// Close these command lists; don't record into them for now. We will 
+		// reset them to a recording state when we start the render loop.
+		ThrowIfFailed(m_shadowCommandLists[i]->Close());
+		ThrowIfFailed(m_sceneCommandLists[i]->Close());
+	}
     ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_postprocessCommandAllocator)));
     ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_postprocessCommandAllocator.Get(), m_pipelineStates[RenderPass::Postprocess].Get(), IID_PPV_ARGS(&m_postprocessCommandList)));
     NAME_D3D12_OBJECT(m_postprocessCommandList);
     ThrowIfFailed(m_postprocessCommandList->Close());
 
-    const UINT textureCount = _countof(SampleAssets::Textures);    // Diffuse + normal textures near the start of the heap.  Ideally, track descriptor heap contents/offsets at a higher level.
+    const UINT textureCount = _countof(SampleAssets::Textures);	// Diffuse + normal textures near the start of the heap.  Ideally, track descriptor heap contents/offsets at a higher level.
     const UINT cbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
     const UINT dsvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_DSV);
     CD3DX12_CPU_DESCRIPTOR_HANDLE cbvSrvCpuHandle(pCbvSrvHeap->GetCPUDescriptorHandleForHeapStart());
@@ -84,8 +84,8 @@ FrameResource::FrameResource(ID3D12Device* pDevice, ComPtr<ID3D12PipelineState> 
         m_depthSRVs[DepthGenPass::Scene] = cbvSrvCpuHandle;
         m_depthSrvHandles[DepthGenPass::Scene] = cbvSrvGpuHandle;
     }
-        
-    // Create constant buffers.
+    	
+	// Create constant buffers.
     {
         // Shadow generation constant buffer.
         cbvSrvCpuHandle.Offset(cbvSrvDescriptorSize);
@@ -110,41 +110,41 @@ FrameResource::FrameResource(ID3D12Device* pDevice, ComPtr<ID3D12PipelineState> 
 
         // Map the constant buffers and cache their heap pointers.
         // We don't unmap this until the app closes. Keeping buffer mapped for the lifetime of the resource is okay.
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
+        CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
         ThrowIfFailed(m_constantBuffers[RenderPass::Shadow]->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBuffersWO[RenderPass::Shadow])));
         ThrowIfFailed(m_constantBuffers[RenderPass::Scene]->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBuffersWO[RenderPass::Scene])));
         ThrowIfFailed(m_constantBuffers[RenderPass::Postprocess]->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBuffersWO[RenderPass::Postprocess])));
         
     }
 
-    // Batch up command lists for execution later.
-    const UINT batchSize = _countof(m_sceneCommandLists) + _countof(m_shadowCommandLists) + CommandListCount;
-    m_batchSubmit[0] = m_commandLists[CommandListPre].Get();
-    memcpy(m_batchSubmit + 1, m_shadowCommandLists, _countof(m_shadowCommandLists) * sizeof(ID3D12CommandList*));
-    m_batchSubmit[_countof(m_shadowCommandLists) + 1] = m_commandLists[CommandListMid].Get();
-    memcpy(m_batchSubmit + _countof(m_shadowCommandLists) + 2, m_sceneCommandLists, _countof(m_sceneCommandLists) * sizeof(ID3D12CommandList*));
-    m_batchSubmit[batchSize - 1] = m_commandLists[CommandListPost].Get();
+	// Batch up command lists for execution later.
+	const UINT batchSize = _countof(m_sceneCommandLists) + _countof(m_shadowCommandLists) + CommandListCount;
+	m_batchSubmit[0] = m_commandLists[CommandListPre].Get();
+	memcpy(m_batchSubmit + 1, m_shadowCommandLists, _countof(m_shadowCommandLists) * sizeof(ID3D12CommandList*));
+	m_batchSubmit[_countof(m_shadowCommandLists) + 1] = m_commandLists[CommandListMid].Get();
+	memcpy(m_batchSubmit + _countof(m_shadowCommandLists) + 2, m_sceneCommandLists, _countof(m_sceneCommandLists) * sizeof(ID3D12CommandList*));
+	m_batchSubmit[batchSize - 1] = m_commandLists[CommandListPost].Get();
 }
 
 FrameResource::~FrameResource()
 {
-    for (int i = 0; i < CommandListCount; i++)
-    {
-        m_commandAllocators[i] = nullptr;
-        m_commandLists[i] = nullptr;
-    }
+	for (int i = 0; i < CommandListCount; i++)
+	{
+		m_commandAllocators[i] = nullptr;
+		m_commandLists[i] = nullptr;
+	}
 
-    m_constantBuffers[RenderPass::Shadow] = nullptr;
-    m_constantBuffers[RenderPass::Scene] = nullptr;
+	m_constantBuffers[RenderPass::Shadow] = nullptr;
+	m_constantBuffers[RenderPass::Scene] = nullptr;
 
-    for (int i = 0; i < NumContexts; i++)
-    {
-        m_shadowCommandLists[i] = nullptr;
-        m_shadowCommandAllocators[i] = nullptr;
+	for (int i = 0; i < NumContexts; i++)
+	{
+		m_shadowCommandLists[i] = nullptr;
+		m_shadowCommandAllocators[i] = nullptr;
 
-        m_sceneCommandLists[i] = nullptr;
-        m_sceneCommandAllocators[i] = nullptr;
-    }
+		m_sceneCommandLists[i] = nullptr;
+		m_sceneCommandAllocators[i] = nullptr;
+	}
     m_postprocessCommandAllocator = nullptr;
     m_postprocessCommandList = nullptr;
 
@@ -180,33 +180,33 @@ void FrameResource::ClearDepthStencilViews(ID3D12GraphicsCommandList* pCommandLi
 // this frame resource.
 void FrameResource::WriteConstantBuffers(D3D12_VIEWPORT* pViewport, Camera* pSceneCamera, Camera lightCams[NumLights], LightState lights[NumLights])
 {
-    SceneConstantBuffer sceneConsts = {}; 
-    SceneConstantBuffer shadowConsts = {};
+	SceneConstantBuffer sceneConsts = {}; 
+	SceneConstantBuffer shadowConsts = {};
     PostprocessConstantBuffer postprocessConsts = {};
-    
-    // Scale down the world a bit.
-    ::XMStoreFloat4x4(&sceneConsts.model, XMMatrixScaling(0.1f, 0.1f, 0.1f));
-    ::XMStoreFloat4x4(&shadowConsts.model, XMMatrixScaling(0.1f, 0.1f, 0.1f));
+	
+	// Scale down the world a bit.
+	::XMStoreFloat4x4(&sceneConsts.model, XMMatrixScaling(0.1f, 0.1f, 0.1f));
+	::XMStoreFloat4x4(&shadowConsts.model, XMMatrixScaling(0.1f, 0.1f, 0.1f));
 
-    // The scene pass is drawn from the camera.
-    pSceneCamera->Get3DViewProjMatrices(&sceneConsts.view, &sceneConsts.projection, 90.0f, pViewport->Width, pViewport->Height);
+	// The scene pass is drawn from the camera.
+	pSceneCamera->Get3DViewProjMatrices(&sceneConsts.view, &sceneConsts.projection, 90.0f, pViewport->Width, pViewport->Height);
 
-    // The light pass is drawn from the first light.
-    lightCams[0].Get3DViewProjMatrices(&shadowConsts.view, &shadowConsts.projection, 90.0f, pViewport->Width, pViewport->Height);
+	// The light pass is drawn from the first light.
+	lightCams[0].Get3DViewProjMatrices(&shadowConsts.view, &shadowConsts.projection, 90.0f, pViewport->Width, pViewport->Height);
 
-    for (int i = 0; i < NumLights; i++)
-    {
-        memcpy(&sceneConsts.lights[i], &lights[i], sizeof(LightState));
-        memcpy(&shadowConsts.lights[i], &lights[i], sizeof(LightState));
-    }
+	for (int i = 0; i < NumLights; i++)
+	{
+		memcpy(&sceneConsts.lights[i], &lights[i], sizeof(LightState));
+		memcpy(&shadowConsts.lights[i], &lights[i], sizeof(LightState));
+	}
 
-    // The shadow pass won't sample the shadow map, but rather write to it.
-    shadowConsts.sampleShadowMap = FALSE;
+	// The shadow pass won't sample the shadow map, but rather write to it.
+	shadowConsts.sampleShadowMap = FALSE;
 
-    // The scene pass samples the shadow map.
-    sceneConsts.sampleShadowMap = TRUE;
+	// The scene pass samples the shadow map.
+	sceneConsts.sampleShadowMap = TRUE;
 
-    shadowConsts.ambientColor = sceneConsts.ambientColor = { 0.1f, 0.2f, 0.3f, 1.0f };
+	shadowConsts.ambientColor = sceneConsts.ambientColor = { 0.1f, 0.2f, 0.3f, 1.0f };
 
     postprocessConsts.lightPosition = lights[0].position;
     XMStoreFloat4(&postprocessConsts.cameraPosition, pSceneCamera->mEye);
@@ -231,29 +231,29 @@ void FrameResource::WriteConstantBuffers(D3D12_VIEWPORT* pViewport, Camera* pSce
     XMStoreFloat4x4(&postprocessConsts.projInverse, XMMatrixTranspose(projInverse));
     XMStoreFloat4x4(&postprocessConsts.viewProjInverseAtNearZ1, XMMatrixTranspose(viewProjInverseAtNearZ1));
 
-    memcpy(m_pConstantBuffersWO[RenderPass::Scene], &sceneConsts, sizeof(sceneConsts));
-    memcpy(m_pConstantBuffersWO[RenderPass::Shadow], &shadowConsts, sizeof(shadowConsts));
+	memcpy(m_pConstantBuffersWO[RenderPass::Scene], &sceneConsts, sizeof(sceneConsts));
+	memcpy(m_pConstantBuffersWO[RenderPass::Shadow], &shadowConsts, sizeof(shadowConsts));
     memcpy(m_pConstantBuffersWO[RenderPass::Postprocess], &postprocessConsts, sizeof(postprocessConsts));
 }
 
 void FrameResource::Init()
 {
-    // Reset the command allocators and lists for the main thread.
-    for (int i = 0; i < CommandListCount; i++)
-    {
-        ThrowIfFailed(m_commandAllocators[i]->Reset());
-        ThrowIfFailed(m_commandLists[i]->Reset(m_commandAllocators[i].Get(), m_pipelineStates[RenderPass::Scene].Get()));
-    }
+	// Reset the command allocators and lists for the main thread.
+	for (int i = 0; i < CommandListCount; i++)
+	{
+		ThrowIfFailed(m_commandAllocators[i]->Reset());
+		ThrowIfFailed(m_commandLists[i]->Reset(m_commandAllocators[i].Get(), m_pipelineStates[RenderPass::Scene].Get()));
+	}
     
-    // Reset the worker command allocators and lists.
-    for (int i = 0; i < NumContexts; i++)
-    {
-        ThrowIfFailed(m_shadowCommandAllocators[i]->Reset());
-        ThrowIfFailed(m_shadowCommandLists[i]->Reset(m_shadowCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Shadow].Get()));
+	// Reset the worker command allocators and lists.
+	for (int i = 0; i < NumContexts; i++)
+	{
+		ThrowIfFailed(m_shadowCommandAllocators[i]->Reset());
+		ThrowIfFailed(m_shadowCommandLists[i]->Reset(m_shadowCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Shadow].Get()));
 
-        ThrowIfFailed(m_sceneCommandAllocators[i]->Reset());
-        ThrowIfFailed(m_sceneCommandLists[i]->Reset(m_sceneCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Scene].Get()));
-    }
+		ThrowIfFailed(m_sceneCommandAllocators[i]->Reset());
+		ThrowIfFailed(m_sceneCommandLists[i]->Reset(m_sceneCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Scene].Get()));
+	}
 
     ThrowIfFailed(m_postprocessCommandAllocator->Reset());
     ThrowIfFailed(m_postprocessCommandList->Reset(m_postprocessCommandAllocator.Get(), m_pipelineStates[RenderPass::Postprocess].Get()));
@@ -261,14 +261,14 @@ void FrameResource::Init()
 
 void FrameResource::SwapBarriers()
 {
-    // Transition the shadow map from writeable to readable.
-    m_commandLists[CommandListMid]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_depthTextures[DepthGenPass::Shadow].Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
+	// Transition the shadow map from writeable to readable.
+	m_commandLists[CommandListMid]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_depthTextures[DepthGenPass::Shadow].Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
 }
 
 
 void FrameResource::Finish()
 {
-    m_commandLists[CommandListPost]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_depthTextures[DepthGenPass::Shadow].Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE));
+	m_commandLists[CommandListPost]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_depthTextures[DepthGenPass::Shadow].Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE));
 }
 
 // Sets up the descriptor tables for the worker command list to use 
@@ -280,15 +280,15 @@ void FrameResource::Bind(ID3D12GraphicsCommandList* pCommandList, RenderPass::Va
     case RenderPass::Shadow:
     {
         pCommandList->SetGraphicsRootDescriptorTable(1, m_cbvHandles[RenderPass::Shadow]);
-        pCommandList->SetGraphicsRootDescriptorTable(2, m_nullSrvHandle);                                // Set a null SRV for the shadow texture.
+        pCommandList->SetGraphicsRootDescriptorTable(2, m_nullSrvHandle);			                    // Set a null SRV for the shadow texture.
 
-        pCommandList->OMSetRenderTargets(0, nullptr, FALSE, &m_depthDSVs[DepthGenPass::Shadow]);        // No render target needed for the shadow pass.
+        pCommandList->OMSetRenderTargets(0, nullptr, FALSE, &m_depthDSVs[DepthGenPass::Shadow]);	    // No render target needed for the shadow pass.
         break;
     }
     case RenderPass::Scene:
     {
         pCommandList->SetGraphicsRootDescriptorTable(1, m_cbvHandles[RenderPass::Scene]);
-        pCommandList->SetGraphicsRootDescriptorTable(2, m_depthSrvHandles[DepthGenPass::Shadow]);        // Set the shadow texture as an SRV.
+        pCommandList->SetGraphicsRootDescriptorTable(2, m_depthSrvHandles[DepthGenPass::Shadow]);		// Set the shadow texture as an SRV.
 
         pCommandList->OMSetRenderTargets(1, pRtvHandle, FALSE, &m_depthDSVs[DepthGenPass::Scene]);
         break;
@@ -298,7 +298,7 @@ void FrameResource::Bind(ID3D12GraphicsCommandList* pCommandList, RenderPass::Va
         pCommandList->SetGraphicsRootDescriptorTable(0, m_depthSrvHandles[DepthGenPass::Scene]);
         pCommandList->SetGraphicsRootDescriptorTable(1, m_cbvHandles[RenderPass::Postprocess]);
 
-        pCommandList->OMSetRenderTargets(1, pRtvHandle, FALSE, nullptr);                                // No depth stencil needed for the postprocess pass.
+        pCommandList->OMSetRenderTargets(1, pRtvHandle, FALSE, nullptr);	                            // No depth stencil needed for the postprocess pass.
         break;
     }
     }

--- a/Samples/Desktop/D3D12xGPU/src/FrameResource.h
+++ b/Samples/Desktop/D3D12xGPU/src/FrameResource.h
@@ -36,12 +36,12 @@ public:
     ComPtr<ID3D12Resource> m_renderTarget;
     D3D12_CPU_DESCRIPTOR_HANDLE m_renderTargetView;
     ComPtr<ID3D12PipelineState> m_pipelineStates[SceneEnums::RenderPass::Count];
-    D3D12_GPU_DESCRIPTOR_HANDLE m_nullSrvHandle;                        // Null SRV for out of bounds behavior.
+    D3D12_GPU_DESCRIPTOR_HANDLE m_nullSrvHandle;                	    // Null SRV for out of bounds behavior.
 
     ComPtr<ID3D12Resource> m_constantBuffers[SceneEnums::RenderPass::Count];
-    SceneConstantBuffer* m_pConstantBuffersWO[SceneEnums::RenderPass::Count];        // WRITE-ONLY pointers to the constant buffers
+	SceneConstantBuffer* m_pConstantBuffersWO[SceneEnums::RenderPass::Count];		// WRITE-ONLY pointers to the constant buffers
     D3D12_GPU_DESCRIPTOR_HANDLE m_cbvHandles[SceneEnums::RenderPass::Count];
-    
+	
     ComPtr<ID3D12Resource> m_depthTextures[SceneEnums::DepthGenPass::Count];
     D3D12_CPU_DESCRIPTOR_HANDLE m_depthDSVs[SceneEnums::DepthGenPass::Count];
     D3D12_CPU_DESCRIPTOR_HANDLE m_depthSRVs[SceneEnums::DepthGenPass::Count];
@@ -50,18 +50,18 @@ public:
     UINT m_frameResourceIndex;
 
 public:
-    FrameResource(ID3D12Device* pDevice, ComPtr<ID3D12PipelineState> pPipelineStates[SceneEnums::RenderPass::Count], ID3D12DescriptorHeap* pDsvHeap, ID3D12DescriptorHeap* pCbvSrvHeap, UINT frameResourceIndex);
-    ~FrameResource();
+	FrameResource(ID3D12Device* pDevice, ComPtr<ID3D12PipelineState> pPipelineStates[SceneEnums::RenderPass::Count], ID3D12DescriptorHeap* pDsvHeap, ID3D12DescriptorHeap* pCbvSrvHeap, UINT frameResourceIndex);
+	~FrameResource();
 
     void LoadSizeDependentResources(ID3D12Device* pDevice, UINT width, UINT height);
     void ReleaseSizeDependentResources();
    
     void ClearDepthStencilViews(ID3D12GraphicsCommandList* pCommandList);
     void Bind(ID3D12GraphicsCommandList* pCommandList, SceneEnums::RenderPass::Value renderPass, D3D12_CPU_DESCRIPTOR_HANDLE* pRtvHandle);
-    void Init();
-    void SwapBarriers();
-    void Finish();
-    void WriteConstantBuffers(D3D12_VIEWPORT* pViewport, Camera* pSceneCamera, Camera lightCams[NumLights], LightState lights[NumLights]);
+	void Init();
+	void SwapBarriers();
+	void Finish();
+	void WriteConstantBuffers(D3D12_VIEWPORT* pViewport, Camera* pSceneCamera, Camera lightCams[NumLights], LightState lights[NumLights]);
 };
 
 
@@ -96,7 +96,7 @@ inline HRESULT CreateDepthStencilTexture2D(
             D3D12_TEXTURE_LAYOUT_UNKNOWN,
             D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
 
-        D3D12_CLEAR_VALUE clearValue;        // Performance tip: Tell the runtime at resource creation the desired clear value.
+        D3D12_CLEAR_VALUE clearValue;		// Performance tip: Tell the runtime at resource creation the desired clear value.
         clearValue.Format = dsvFormat;
         clearValue.DepthStencil.Depth = initDepthValue;
         clearValue.DepthStencil.Stencil = initStencilValue;

--- a/Samples/Desktop/D3D12xGPU/src/ShadowsFogScatteringSquidScene.cpp
+++ b/Samples/Desktop/D3D12xGPU/src/ShadowsFogScatteringSquidScene.cpp
@@ -46,9 +46,9 @@ ShadowsFogScatteringSquidScene::~ShadowsFogScatteringSquidScene()
 
 void ShadowsFogScatteringSquidScene::InitializeCameraAndLights()
 {
-    XMVECTOR eye = { 0.0f, 17.1954231f, -28.555980f, 1.0f };
-    XMVECTOR at = { 0.0f, 8.0f, 0.0f, 0.0f };  
-    XMVECTOR up = { 0.0f, 0.951865792f, 0.306514263f, 1.0f };
+    XMVECTOR eye = XMVectorSet(0.0f, 17.1954231f, -28.555980f, 1.0f);
+    XMVECTOR at = XMVectorSet(0.0f, 8.0f, 0.0f, 0.0f);
+    XMVECTOR up = XMVectorSet(0.0f, 0.951865792f, 0.306514263f, 1.0f);
     m_camera.Set(eye, at, up);
 
     // Create lights.
@@ -72,11 +72,11 @@ void ShadowsFogScatteringSquidScene::InitializeCameraAndLights()
 
             XMVECTOR eye = XMLoadFloat4(&m_lights[i].position);
             XMVECTOR at = XMVectorAdd(eye, XMLoadFloat4(&m_lights[i].direction));
-            XMVECTOR up = { 0, 1, 0 };
+            XMVECTOR up = XMVectorSet(0.0f, 1.0f, 0.0f, 0.0f);
             switch (i)
             {
-            case 4: up = { 0, 0, -1 }; break;
-            case 5: up = { 0, 0, 1 }; break;
+            case 4: up = XMVectorSet(0.0f, 0.0f, -1.0f, 0.0f); break;
+            case 5: up = XMVectorSet(0.0f, 0.0f, 1.0f, 0.0f); break;
             }
 
             m_lightCameras[i].Set(eye, at, up);
@@ -133,7 +133,7 @@ void ShadowsFogScatteringSquidScene::CreateDescriptorHeaps(ID3D12Device* pDevice
     // 1) null views, 
     // 2) object diffuse + normal textures views, 
     // 3) per frame views: 2x depth buffers (shadow, scene pass), 3x constant buffers (shadow, scene, postprocess pass)
-    const UINT NumNullSrvs = 2;        // Null descriptors are needed for out of bounds behavior reads.
+    const UINT NumNullSrvs = 2;		// Null descriptors are needed for out of bounds behavior reads.
     const UINT cbvCount = m_frameCount * NumConstantBuffers;
     const UINT srvCount = _countof(SampleAssets::Textures) + m_frameCount * NumDepthBuffers;
     D3D12_DESCRIPTOR_HEAP_DESC cbvSrvHeapDesc = {};
@@ -145,7 +145,7 @@ void ShadowsFogScatteringSquidScene::CreateDescriptorHeaps(ID3D12Device* pDevice
 
     // Describe and create a sampler descriptor heap.
     D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
-    samplerHeapDesc.NumDescriptors = 2;        // One clamp and one wrap sampler.
+    samplerHeapDesc.NumDescriptors = 2;		// One clamp and one wrap sampler.
     samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
     samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
     ThrowIfFailed(pDevice->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_samplerHeap)));
@@ -171,10 +171,10 @@ void ShadowsFogScatteringSquidScene::CreateRootSignatures(ID3D12Device* pDevice)
     // Create a root signature for shadow and scene render pass.
     {
         CD3DX12_DESCRIPTOR_RANGE1 ranges[4]; // Perfomance TIP: Order from most frequent to least frequent.
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 1, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);    // 2 frequently changed diffuse + normal textures - using registers t1 and t2.
-        ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);    // 1 frequently changed constant buffer.
-        ranges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);                                                // 1 infrequently changed shadow texture - starting in register t0.
-        ranges[3].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 2, 0);                                            // 2 static samplers.
+        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 1, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);	// 2 frequently changed diffuse + normal textures - using registers t1 and t2.
+        ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);	// 1 frequently changed constant buffer.
+        ranges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);												// 1 infrequently changed shadow texture - starting in register t0.
+        ranges[3].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 2, 0);											// 2 static samplers.
 
         CD3DX12_ROOT_PARAMETER1 rootParameters[4];
         rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
@@ -197,7 +197,7 @@ void ShadowsFogScatteringSquidScene::CreateRootSignatures(ID3D12Device* pDevice)
         CD3DX12_DESCRIPTOR_RANGE1 ranges[3];
         CD3DX12_ROOT_PARAMETER1 rootParameters[3];
 
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);    // depth texture - using register t0.
+        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);	// depth texture - using register t0.
         ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0);
         ranges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
         rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
@@ -758,12 +758,12 @@ void ShadowsFogScatteringSquidScene::Update(double elapsedTime)
         {
             XMStoreFloat4(&m_lights[i].position, XMVector4Transform(XMLoadFloat4(&m_lights[i].position), XMMatrixRotationY(angleChange)));
             XMVECTOR eye = XMLoadFloat4(&m_lights[i].position);
-            XMVECTOR at = XMVectorSet(0.0f, 15.0f, 0.0f,0.0f);
-            XMVECTOR up = { 0, 1, 0 };
+            XMVECTOR at = XMVectorSet(0.0f, 15.0f, 0.0f, 0.0f);
+            XMVECTOR up = XMVectorSet(0.0f, 1.0f, 0.0f, 0.0f);
             switch (i)
             {
-            case 4: up = { 0, 0, -1 }; break;
-            case 5: up = { 0, 0, 1 }; break;
+            case 4: up = XMVectorSet(0.0f, 0.0f, -1.0f, 0.0f); break;
+            case 5: up = XMVectorSet(0.0f, 0.0f, 1.0f, 0.0f); break;
             }
             m_lightCameras[i].Set(eye, at, up);
 

--- a/Samples/Desktop/D3D12xGPU/src/ShadowsFogScatteringSquidScene.h
+++ b/Samples/Desktop/D3D12xGPU/src/ShadowsFogScatteringSquidScene.h
@@ -29,11 +29,11 @@ class DXSample;
 
 #define SINGLETHREADED FALSE
 
-static const UINT NumNullSrvs = 2;        // Null descriptors at the start of the heap.
+static const UINT NumNullSrvs = 2;		// Null descriptors at the start of the heap.
 static const UINT NumContexts = 3;
 
 // Currently the rendering code can only handle a single point light.
-static const UINT NumLights = 1;        // Keep this in sync with "ShadowsAndScenePass.hlsl".
+static const UINT NumLights = 1;		// Keep this in sync with "ShadowsAndScenePass.hlsl".
             
 
 static const UINT NumDepthBuffers = 2;      // Shadow + Scene pass
@@ -82,7 +82,7 @@ struct SceneConstantBuffer
     XMFLOAT4X4 projection;
     XMFLOAT4 ambientColor;
     BOOL sampleShadowMap;
-    BOOL padding[3];        // Must be aligned to be made up of N float4s.
+    BOOL padding[3];		// Must be aligned to be made up of N float4s.
     LightState lights[NumLights];
 };
 

--- a/Samples/Desktop/D3D12xGPU/src/SquidRoom.h
+++ b/Samples/Desktop/D3D12xGPU/src/SquidRoom.h
@@ -15,1153 +15,1153 @@
 
 namespace SampleAssets
 {
-    const wchar_t DataFileName[] = L"SquidRoom.bin";
+	const wchar_t DataFileName[] = L"SquidRoom.bin";
 
-    const D3D12_INPUT_ELEMENT_DESC StandardVertexDescription[] =
-    {
-        { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,  D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "NORMAL",   0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,    0, 24, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "TANGENT",  0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 32, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-    };
+	const D3D12_INPUT_ELEMENT_DESC StandardVertexDescription[] =
+	{
+		{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,  D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		{ "NORMAL",   0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,    0, 24, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		{ "TANGENT",  0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 32, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+	};
 
-    const UINT StandardVertexStride = 44;
+	const UINT StandardVertexStride = 44;
 
-    const DXGI_FORMAT StandardIndexFormat = DXGI_FORMAT_R32_UINT;
+	const DXGI_FORMAT StandardIndexFormat = DXGI_FORMAT_R32_UINT;
 
-    struct TextureResource
-    {
-        UINT Width;
-        UINT Height;
-        UINT MipLevels;
-        DXGI_FORMAT Format;
-        struct DataProperties
-        {
-            UINT Offset;
-            UINT Size;
-            UINT Pitch;
-        } Data[D3D12_REQ_MIP_LEVELS];
-    };
+	struct TextureResource
+	{
+		UINT Width;
+		UINT Height;
+		UINT MipLevels;
+		DXGI_FORMAT Format;
+		struct DataProperties
+		{
+			UINT Offset;
+			UINT Size;
+			UINT Pitch;
+		} Data[D3D12_REQ_MIP_LEVELS];
+	};
 
-    struct DrawParameters
-    {
-        INT DiffuseTextureIndex;
-        INT NormalTextureIndex;
-        INT SpecularTextureIndex;
-        UINT IndexStart;
-        UINT IndexCount;
-        UINT VertexBase;
-    };
+	struct DrawParameters
+	{
+		INT DiffuseTextureIndex;
+		INT NormalTextureIndex;
+		INT SpecularTextureIndex;
+		UINT IndexStart;
+		UINT IndexCount;
+		UINT VertexBase;
+	};
 
-    const UINT VertexDataOffset = 30277640;
-    const UINT VertexDataSize = 9685808;
-    const UINT IndexDataOffset = 39963448;
-    const UINT IndexDataSize = 3056844;
+	const UINT VertexDataOffset = 30277640;
+	const UINT VertexDataSize = 9685808;
+	const UINT IndexDataOffset = 39963448;
+	const UINT IndexDataSize = 3056844;
 
-    const TextureResource Textures[] =
-    {
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 0, 131072, 1024 }, } }, // squard room platform_3_diff_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 131072, 131072, 1024 }, } }, // squard room platform_3_norm_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 262144, 524288, 2048 }, } }, // squard room platform_2_diff_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 786432, 524288, 2048 }, } }, // squard room platform_2_norm_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 1310720, 524288, 2048 }, } }, // squard room platform_1_diff_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 1835008, 524288, 2048 }, } }, // squard room platform_1_norm_1024.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 2359296, 131072, 1024 }, } }, // shelves2_diff1_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 2490368, 131072, 1024 }, } }, // shelves2_nm1_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 2621440, 524288, 2048 }, } }, // Misc_Boss_2 1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 3145728, 524288, 2048 }, } }, // Misc_Boss_2_normal1024.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 3670016, 131072, 1024 }, } }, // Hanging_bundle_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 3801088, 131072, 1024 }, } }, // Catwalk_03_Normal_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 3932160, 524288, 2048 }, } }, // Stack_ Boxes_Diff02_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 4456448, 524288, 2048 }, } }, // Stack_ Boxes_Nm02_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 4980736, 524288, 2048 }, } }, // Stack_ Boxes_Diff03_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 5505024, 524288, 2048 }, } }, // Stack_ Boxes_Nm03_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 6029312, 524288, 2048 }, } }, // Stack_ Boxes_Diff01_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 6553600, 524288, 2048 }, } }, // Stack_ Boxes_Nm01_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 7077888, 524288, 2048 }, } }, // Back_Alley_box_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 7602176, 524288, 2048 }, } }, // Back_Alley_box _norm_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 8126464, 524288, 2048 }, } }, // gameCrates_01_Diff_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 8650752, 524288, 2048 }, } }, // gameCrates_01_Nor_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 9175040, 524288, 2048 }, } }, // RaceCar_Strorage_Diff512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 9699328, 524288, 2048 }, } }, // RaceCar_Strorage_Norm512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10223616, 131072, 1024 }, } }, // hats_02_diff_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10354688, 131072, 1024 }, } }, // hats_02_norm_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10485760, 131072, 1024 }, } }, // hats_01_diff_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10616832, 131072, 1024 }, } }, // hats_01_norm_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 10747904, 524288, 2048 }, } }, // Misc_Boss_1_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 11272192, 524288, 2048 }, } }, // Misc_Boss_1_normal_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 11796480, 524288, 2048 }, } }, // gameCrates_03_Diff_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 12320768, 524288, 2048 }, } }, // gameCrates_03_Nor_1024.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 12845056, 131072, 1024 }, } }, // gameCrates_02_Diff_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 12976128, 524288, 2048 }, } }, // Back_Alley_Drum.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13500416, 131072, 1024 }, } }, // Back_Alley_Drum _norm_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13631488, 131072, 1024 }, } }, // shelves2_diff_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13762560, 131072, 1024 }, } }, // shelves2_nor_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13893632, 131072, 1024 }, } }, // shelves2_diff2_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 14024704, 131072, 1024 }, } }, // shelves2_nm2_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 14155776, 524288, 2048 }, } }, // marbel drum texture_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 14680064, 524288, 2048 }, } }, // marbel drum texture _Nrml_1024.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15204352, 131072, 1024 }, } }, // Catwalk_02_Diffuse512.dds
-        {     1,     1,   1,  DXGI_FORMAT_R8G8B8A8_UNORM, { { 15335424, 4, 4 }, } }, // default-normalmap.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15335428, 131072, 1024 }, } }, // Catwalk_03_Diffuse_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15466500, 131072, 1024 }, } }, // shelves3_diff_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15597572, 131072, 1024 }, } }, // shelves3_nor_512.dds
-        {  2048,  2048,   1,       DXGI_FORMAT_BC1_UNORM, { { 15728644, 2097152, 4096 }, } }, // Misc_Boss_3_2048.dds
-        {  2048,  2048,   1,       DXGI_FORMAT_BC1_UNORM, { { 17825796, 2097152, 4096 }, } }, // Misc_Boss_3_normal2048R.dds
-        {     1,     1,   1,  DXGI_FORMAT_R8G8B8A8_UNORM, { { 19922948, 4, 4 }, } }, // default.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 19922952, 131072, 1024 }, } }, // Hanghing Light_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20054024, 131072, 1024 }, } }, // Hanghing Light_normal_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20185096, 131072, 1024 }, } }, // Hanging_bundle_normal_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20316168, 131072, 1024 }, } }, // Hanging_bundle_marble_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20447240, 131072, 1024 }, } }, // Hanging_bundle_marble_normal_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20578312, 131072, 1024 }, } }, // window_Diff512.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 20709384, 262144, 1024 }, } }, // Sliding Steel Door_Diff_512.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 20971528, 262144, 1024 }, } }, // Sliding Steel Door_Norm_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 21233672, 131072, 1024 }, } }, // window_Norm512.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 21364744, 262144, 1024 }, } }, // Door_Diff_512.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 21626888, 262144, 1024 }, } }, // Door_Norm_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 21889032, 524288, 2048 }, } }, // floor_Diff_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 22413320, 524288, 2048 }, } }, // floor_Normal_1024.dds
-        {  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 22937608, 1048576, 4096 }, } }, // wall03_Diff_2048.dds
-        {  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 23986184, 1048576, 4096 }, } }, // wall03_Normal_2048.dds
-        {  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 25034760, 1048576, 4096 }, } }, // wall01_Diff_2048.dds
-        {  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 26083336, 1048576, 4096 }, } }, // wall01_Normal_2048.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 27131912, 524288, 2048 }, } }, // Roof_Diff1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 27656200, 524288, 2048 }, } }, // Roof_Normal1024.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28180488, 262144, 1024 }, } }, // pillar_Diff_512.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28442632, 262144, 1024 }, } }, // pillar_Norm_512.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28704776, 262144, 1024 }, } }, // Broken_Pillar_Diff_512.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28966920, 262144, 1024 }, } }, // Broken_Pillar_Norm_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 29229064, 524288, 2048 }, } }, // Golfclub_dm_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 29753352, 524288, 2048 }, } }, // Golfclub_nm_1024.dds
-    };
+	const TextureResource Textures[] =
+	{
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 0, 131072, 1024 }, } }, // squard room platform_3_diff_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 131072, 131072, 1024 }, } }, // squard room platform_3_norm_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 262144, 524288, 2048 }, } }, // squard room platform_2_diff_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 786432, 524288, 2048 }, } }, // squard room platform_2_norm_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 1310720, 524288, 2048 }, } }, // squard room platform_1_diff_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 1835008, 524288, 2048 }, } }, // squard room platform_1_norm_1024.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 2359296, 131072, 1024 }, } }, // shelves2_diff1_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 2490368, 131072, 1024 }, } }, // shelves2_nm1_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 2621440, 524288, 2048 }, } }, // Misc_Boss_2 1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 3145728, 524288, 2048 }, } }, // Misc_Boss_2_normal1024.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 3670016, 131072, 1024 }, } }, // Hanging_bundle_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 3801088, 131072, 1024 }, } }, // Catwalk_03_Normal_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 3932160, 524288, 2048 }, } }, // Stack_ Boxes_Diff02_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 4456448, 524288, 2048 }, } }, // Stack_ Boxes_Nm02_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 4980736, 524288, 2048 }, } }, // Stack_ Boxes_Diff03_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 5505024, 524288, 2048 }, } }, // Stack_ Boxes_Nm03_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 6029312, 524288, 2048 }, } }, // Stack_ Boxes_Diff01_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 6553600, 524288, 2048 }, } }, // Stack_ Boxes_Nm01_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 7077888, 524288, 2048 }, } }, // Back_Alley_box_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 7602176, 524288, 2048 }, } }, // Back_Alley_box _norm_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 8126464, 524288, 2048 }, } }, // gameCrates_01_Diff_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 8650752, 524288, 2048 }, } }, // gameCrates_01_Nor_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 9175040, 524288, 2048 }, } }, // RaceCar_Strorage_Diff512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 9699328, 524288, 2048 }, } }, // RaceCar_Strorage_Norm512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10223616, 131072, 1024 }, } }, // hats_02_diff_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10354688, 131072, 1024 }, } }, // hats_02_norm_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10485760, 131072, 1024 }, } }, // hats_01_diff_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10616832, 131072, 1024 }, } }, // hats_01_norm_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 10747904, 524288, 2048 }, } }, // Misc_Boss_1_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 11272192, 524288, 2048 }, } }, // Misc_Boss_1_normal_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 11796480, 524288, 2048 }, } }, // gameCrates_03_Diff_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 12320768, 524288, 2048 }, } }, // gameCrates_03_Nor_1024.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 12845056, 131072, 1024 }, } }, // gameCrates_02_Diff_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 12976128, 524288, 2048 }, } }, // Back_Alley_Drum.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13500416, 131072, 1024 }, } }, // Back_Alley_Drum _norm_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13631488, 131072, 1024 }, } }, // shelves2_diff_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13762560, 131072, 1024 }, } }, // shelves2_nor_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13893632, 131072, 1024 }, } }, // shelves2_diff2_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 14024704, 131072, 1024 }, } }, // shelves2_nm2_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 14155776, 524288, 2048 }, } }, // marbel drum texture_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 14680064, 524288, 2048 }, } }, // marbel drum texture _Nrml_1024.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15204352, 131072, 1024 }, } }, // Catwalk_02_Diffuse512.dds
+		{     1,     1,   1,  DXGI_FORMAT_R8G8B8A8_UNORM, { { 15335424, 4, 4 }, } }, // default-normalmap.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15335428, 131072, 1024 }, } }, // Catwalk_03_Diffuse_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15466500, 131072, 1024 }, } }, // shelves3_diff_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15597572, 131072, 1024 }, } }, // shelves3_nor_512.dds
+		{  2048,  2048,   1,       DXGI_FORMAT_BC1_UNORM, { { 15728644, 2097152, 4096 }, } }, // Misc_Boss_3_2048.dds
+		{  2048,  2048,   1,       DXGI_FORMAT_BC1_UNORM, { { 17825796, 2097152, 4096 }, } }, // Misc_Boss_3_normal2048R.dds
+		{     1,     1,   1,  DXGI_FORMAT_R8G8B8A8_UNORM, { { 19922948, 4, 4 }, } }, // default.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 19922952, 131072, 1024 }, } }, // Hanghing Light_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20054024, 131072, 1024 }, } }, // Hanghing Light_normal_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20185096, 131072, 1024 }, } }, // Hanging_bundle_normal_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20316168, 131072, 1024 }, } }, // Hanging_bundle_marble_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20447240, 131072, 1024 }, } }, // Hanging_bundle_marble_normal_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20578312, 131072, 1024 }, } }, // window_Diff512.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 20709384, 262144, 1024 }, } }, // Sliding Steel Door_Diff_512.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 20971528, 262144, 1024 }, } }, // Sliding Steel Door_Norm_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 21233672, 131072, 1024 }, } }, // window_Norm512.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 21364744, 262144, 1024 }, } }, // Door_Diff_512.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 21626888, 262144, 1024 }, } }, // Door_Norm_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 21889032, 524288, 2048 }, } }, // floor_Diff_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 22413320, 524288, 2048 }, } }, // floor_Normal_1024.dds
+		{  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 22937608, 1048576, 4096 }, } }, // wall03_Diff_2048.dds
+		{  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 23986184, 1048576, 4096 }, } }, // wall03_Normal_2048.dds
+		{  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 25034760, 1048576, 4096 }, } }, // wall01_Diff_2048.dds
+		{  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 26083336, 1048576, 4096 }, } }, // wall01_Normal_2048.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 27131912, 524288, 2048 }, } }, // Roof_Diff1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 27656200, 524288, 2048 }, } }, // Roof_Normal1024.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28180488, 262144, 1024 }, } }, // pillar_Diff_512.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28442632, 262144, 1024 }, } }, // pillar_Norm_512.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28704776, 262144, 1024 }, } }, // Broken_Pillar_Diff_512.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28966920, 262144, 1024 }, } }, // Broken_Pillar_Norm_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 29229064, 524288, 2048 }, } }, // Golfclub_dm_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 29753352, 524288, 2048 }, } }, // Golfclub_nm_1024.dds
+	};
 
-    const DrawParameters Draws[] =
-    {
-        {   0,   1,  -1,        0,    15198,        0 }, // subset0_squard_room_platform_3_dif1
-        {   2,   3,  -1,    15198,      438,     6051 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    15636,      300,     6164 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    15936,      300,     6225 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    16236,      438,     6286 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    16674,      300,     6399 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    16974,      438,     6460 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    17412,      300,     6573 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    17712,      450,     6634 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    18162,      300,     6756 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    18462,      438,     6817 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    18900,      300,     6930 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    19200,      300,     6991 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    19500,      438,     7052 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    19938,      300,     7165 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    20238,      438,     7226 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    20676,      300,     7339 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    20976,      300,     7400 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    21276,      438,     7461 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    21714,      300,     7574 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    22014,      438,     7635 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    22452,      300,     7748 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    22752,      450,     7809 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    23202,      300,     7931 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    23502,      438,     7992 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    23940,      300,     8105 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    24240,      300,     8166 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    24540,      438,     8227 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    24978,      300,     8340 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    25278,      438,     8401 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    25716,      300,     8514 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    26016,      300,     8575 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    26316,      438,     8636 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    26754,      300,     8749 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    27054,      438,     8810 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    27492,      300,     8923 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    27792,      300,     8984 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    28092,      438,     9045 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    28530,      300,     9158 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    28830,      438,     9219 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    29268,      300,     9332 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    29568,      450,     9393 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    30018,      300,     9515 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    30318,      438,     9576 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    30756,      300,     9689 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    31056,      300,     9750 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    31356,      438,     9811 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    31794,      300,     9924 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    32094,      438,     9985 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    32532,      300,    10098 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    32832,      450,    10159 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    33282,      300,    10281 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    33582,      438,    10342 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    34020,      300,    10455 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    34320,      300,    10516 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    34620,      438,    10577 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    35058,      300,    10690 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    35358,      900,    10751 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    36258,      282,    11016 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    36540,      282,    11142 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    36822,      222,    11228 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    37044,      282,    11304 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    37326,      282,    11396 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    37608,      282,    11485 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    37890,      243,    11577 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    38133,      222,    11665 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    38355,      282,    11743 }, // subset0_squard_room_platform_2_dif
-        {   4,   5,  -1,    38637,     2700,    11834 }, // subset0_squard_room_platform_1_diff
-        {   6,   7,  -1,    41337,     1788,    12560 }, // subset0_shelves1_diff
-        {   8,   9,  -1,    43125,      180,    13101 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43305,      180,    13138 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43485,       96,    13175 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43581,       96,    13202 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43677,       96,    13229 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43773,       96,    13256 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43869,       96,    13283 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43965,       30,    13310 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43995,       24,    13322 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44019,       24,    13332 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44043,       24,    13342 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44067,       24,    13351 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44091,       54,    13360 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44145,       12,    13380 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44157,       72,    13386 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44229,       84,    13424 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44313,       30,    13448 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44343,        6,    13460 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44349,       36,    13464 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44385,       60,    13478 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44445,       72,    13496 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44517,       48,    13534 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44565,       24,    13549 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44589,       24,    13559 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44613,       24,    13569 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44637,       42,    13579 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44679,       12,    13595 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44691,       48,    13603 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44739,        6,    13625 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44745,       48,    13629 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44793,        6,    13644 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44799,       60,    13648 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44859,        6,    13666 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44865,       60,    13670 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44925,       72,    13688 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44997,       48,    13709 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45045,       36,    13727 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45081,       72,    13741 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45153,       12,    13779 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45165,       12,    13785 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45177,       30,    13791 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45207,       36,    13803 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45243,        6,    13817 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45249,        6,    13821 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45255,       24,    13825 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45279,       24,    13835 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45303,       24,    13845 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45327,       96,    13855 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45423,       30,    13882 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45453,       96,    13894 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45549,       96,    13921 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45645,       72,    13948 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45717,       72,    13969 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45789,       42,    13990 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45831,       42,    14006 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45873,       54,    14022 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45927,       54,    14042 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45981,       60,    14062 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46041,       60,    14080 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46101,       36,    14098 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46137,       12,    14112 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46149,       12,    14118 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46161,       12,    14124 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46173,       24,    14130 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46197,       24,    14140 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46221,       24,    14150 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46245,       24,    14160 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46269,       24,    14170 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46293,       48,    14180 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46341,       48,    14195 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46389,       48,    14210 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46437,       48,    14225 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46485,       48,    14240 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46533,       36,    14255 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46569,       36,    14269 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46605,       36,    14283 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46641,       36,    14297 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46677,       36,    14311 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46713,       72,    14325 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46785,       72,    14363 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46857,        6,    14401 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46863,        6,    14405 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46869,        6,    14409 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46875,       24,    14413 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46899,       24,    14422 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46923,       48,    14431 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46971,       48,    14449 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47019,       12,    14464 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47031,       12,    14470 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47043,       12,    14476 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47055,       12,    14482 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47067,       12,    14488 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47079,       12,    14494 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47091,       12,    14500 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47103,       12,    14506 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47115,       24,    14512 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47139,       24,    14521 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47163,       60,    14530 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47223,       60,    14548 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47283,       60,    14566 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47343,       60,    14584 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47403,       60,    14602 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47463,       48,    14620 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47511,       48,    14642 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47559,       36,    14664 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47595,       36,    14678 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47631,       24,    14692 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47655,       12,    14701 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47667,       12,    14707 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47679,       12,    14713 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47691,       12,    14719 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47703,       12,    14725 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47715,       12,    14731 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47727,       12,    14737 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47739,        6,    14743 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47745,        6,    14747 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47751,        6,    14751 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47757,        6,    14755 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47763,       12,    14759 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47775,       12,    14765 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47787,       12,    14771 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47799,       12,    14777 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47811,       60,    14783 }, // subset0_blinnMisc_Boss_2
-        {  10,  11,  -1,    47871,      762,    14801 }, // subset0_lambert1
-        {   8,   9,  -1,    48633,       66,    14801 }, // subset1_blinnMisc_Boss_2_0
-        {   8,   9,  -1,    48699,      144,    15136 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    48843,      144,    15171 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    48987,      144,    15206 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    49131,      144,    15241 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    49275,      180,    15276 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    49455,      144,    15318 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    49599,      144,    15353 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    49743,      144,    15388 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    49887,      180,    15423 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    50067,      180,    15465 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    50247,      144,    15507 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    50391,      180,    15542 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    50571,      144,    15584 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    50715,      108,    15619 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    50823,     4416,    15647 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    55239,      273,    16657 }, // subset0_blinnMisc_Boss_2
-        {  12,  13,  -1,    55512,     4143,    16754 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    59655,      360,    19212 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    60015,      300,    19293 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    60315,      360,    19359 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    60675,      240,    19436 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    60915,     1566,    19491 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62481,       48,    19889 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62529,       48,    19907 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62577,       48,    19925 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62625,       48,    19943 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62673,       48,    19961 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62721,       48,    19979 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62769,       96,    19997 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62865,       36,    20024 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62901,       36,    20038 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62937,       36,    20052 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62973,       36,    20066 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63009,       36,    20080 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63045,       36,    20094 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63081,       36,    20108 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63117,       36,    20122 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63153,       36,    20136 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63189,       36,    20150 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63225,       36,    20164 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63261,      108,    20178 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63369,       36,    20206 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63405,       36,    20220 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63441,       36,    20234 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63477,       36,    20248 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63513,       36,    20262 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63549,       36,    20276 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63585,       36,    20290 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63621,       72,    20304 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63693,       72,    20325 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63765,      144,    20346 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63909,       72,    20381 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63981,       36,    20402 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64017,       36,    20416 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64053,      144,    20430 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64197,      144,    20465 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64341,       36,    20500 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64377,       36,    20514 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64413,       36,    20528 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64449,       36,    20542 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64485,       36,    20556 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64521,       36,    20570 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64557,       36,    20584 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64593,       36,    20598 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64629,       36,    20612 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64665,       36,    20626 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64701,      252,    20640 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64953,      276,    20816 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    65229,      276,    21014 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    65505,      276,    21200 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    65781,      294,    21394 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    66075,      279,    21582 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    66354,      264,    21732 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    66618,      288,    21898 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    66906,      468,    22065 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    67374,     1296,    22222 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    68670,       18,    22988 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    68688,       36,    22996 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    68724,       42,    23022 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    68766,       36,    23054 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    68802,       42,    23076 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    68844,      336,    23104 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    69180,      144,    23104 }, // subset1_lambert1_0
-        {  12,  13,  -1,    69324,      240,    23250 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    69564,      240,    23334 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    69804,      246,    23427 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    70050,      120,    23543 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    70170,      630,    23600 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    70800,     1080,    23743 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    71880,      720,    23991 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    72600,      204,    24154 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    72804,      336,    24198 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    73140,      144,    24198 }, // subset1_lambert1_0
-        {  12,  13,  -1,    73284,      225,    24344 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    73509,       15,    24344 }, // subset1_lambert1_0
-        {  12,  13,  -1,    73524,      225,    24458 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    73749,       15,    24458 }, // subset1_lambert1_0
-        {  12,  13,  -1,    73764,      225,    24572 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    73989,       15,    24572 }, // subset1_lambert1_0
-        {  12,  13,  -1,    74004,      225,    24686 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    74229,       15,    24686 }, // subset1_lambert1_0
-        {  12,  13,  -1,    74244,      225,    24800 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    74469,       15,    24800 }, // subset1_lambert1_0
-        {  12,  13,  -1,    74484,      225,    24914 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    74709,       15,    24914 }, // subset1_lambert1_0
-        {  14,  15,  -1,    74724,     2208,    25028 }, // subset0_Stack__Boxes_Diff03
-        {  16,  17,  -1,    76932,     9381,    25553 }, // subset0_Stack__Boxes_Diff01
-        {  18,  19,  -1,    86313,      948,    29643 }, // subset0_Back_Alley_box
-        {  20,  21,  -1,    87261,     1488,    29946 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,    88749,     1998,    30265 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,    90747,     1872,    30649 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,    92619,     1692,    31034 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,    94311,     1638,    31387 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,    95949,     1872,    31702 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,    97821,     1662,    32056 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,    99483,     1902,    32409 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   101385,      720,    32807 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   102105,     1296,    32957 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   103401,      432,    33232 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   103833,     1152,    33332 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   104985,     1152,    33557 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   106137,     1380,    33782 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   107517,     1470,    34080 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   108987,     1308,    34364 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   110295,     1662,    34622 }, // subset0_gameCrates_01_Diff
-        {  22,  23,  -1,   111957,      636,    34941 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   112593,     1728,    35137 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   114321,      336,    35500 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   114657,     2304,    35577 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   116961,      246,    36138 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   117207,     1260,    36270 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   118467,     1866,    36512 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   120333,     2070,    36976 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   122403,     1050,    37421 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   123453,      450,    37624 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   123903,      450,    37760 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   124353,      390,    37896 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   124743,      390,    38021 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   125133,      390,    38148 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   125523,      330,    38273 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   125853,      390,    38387 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   126243,      330,    38512 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   126573,      420,    38626 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   126993,      390,    38763 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   127383,      300,    38888 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   127683,      300,    38961 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   127983,      300,    39045 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   128283,      300,    39131 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   128583,      300,    39215 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   128883,      300,    39286 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   129183,      300,    39410 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   129483,      300,    39483 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   129783,      300,    39567 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   130083,      300,    39653 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   130383,      300,    39737 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   130683,      300,    39808 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   130983,      300,    39968 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   131283,      300,    40041 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   131583,      300,    40125 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   131883,      300,    40211 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   132183,      300,    40295 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   132483,      300,    40366 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   132783,      300,    40490 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   133083,      300,    40561 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   133383,      300,    40721 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   133683,      300,    40794 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   133983,      300,    40878 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   134283,      300,    40964 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   134583,      300,    41048 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   134883,      300,    41119 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   135183,      300,    41243 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   135483,      300,    41314 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   135783,      300,    41474 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   136083,      300,    41547 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   136383,      300,    41631 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   136683,      300,    41717 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   136983,      300,    41801 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   137283,      300,    41872 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   137583,      300,    41996 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   137883,      300,    42069 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   138183,      300,    42153 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   138483,      300,    42239 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   138783,      300,    42323 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   139083,      300,    42394 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   139383,      300,    42554 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   139683,      300,    42627 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   139983,      300,    42711 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   140283,      300,    42797 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   140583,      300,    42881 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   140883,      300,    42952 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   141183,      300,    43076 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   141483,      300,    43149 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   141783,      300,    43349 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   142083,      300,    43551 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   142383,      300,    43751 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   142683,      300,    43951 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   142983,      300,    44151 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   143283,      300,    44351 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   143583,      300,    44551 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   143883,      300,    44751 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   144183,      300,    44951 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   144483,      300,    45153 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   144783,      300,    45353 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   145083,      300,    45553 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   145383,      300,    45753 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   145683,      300,    45953 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   145983,      300,    46153 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   146283,      300,    46353 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   146583,      300,    46553 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   146883,      300,    46755 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   147183,      300,    46955 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   147483,      300,    47155 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   147783,      300,    47355 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   148083,      300,    47555 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   148383,      300,    47755 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   148683,      300,    47955 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   148983,      300,    48155 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   149283,      300,    48355 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   149583,      300,    48557 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   149883,      300,    48757 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   150183,      300,    48957 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   150483,      300,    49157 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   150783,      216,    49357 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   150999,      216,    49455 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   151215,      216,    49553 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   151431,     1014,    49651 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   152445,      216,    49929 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   152661,     1014,    50029 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   153675,     1014,    50324 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   154689,     1014,    50614 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   155703,      588,    50894 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   156291,     5574,    51104 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   161865,      588,    52700 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   162453,      588,    52910 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   163041,      588,    53120 }, // subset0_RaceCar_Strorage_Diff
-        {  24,  25,  -1,   163629,       48,    53330 }, // subset0_hats_2
-        {  24,  25,  -1,   163677,      501,    53362 }, // subset0_hats_2
-        {  24,  25,  -1,   164178,      252,    53471 }, // subset0_hats_2
-        {  24,  25,  -1,   164430,       48,    53520 }, // subset0_hats_2
-        {  24,  25,  -1,   164478,     1620,    53552 }, // subset0_hats_2
-        {  24,  25,  -1,   166098,     3978,    53850 }, // subset0_hats_2
-        {  24,  25,  -1,   170076,      765,    54754 }, // subset0_hats_2
-        {  24,  25,  -1,   170841,      900,    54906 }, // subset0_hats_2
-        {  24,  25,  -1,   171741,     1260,    55154 }, // subset0_hats_2
-        {  24,  25,  -1,   173001,      408,    55431 }, // subset0_hats_2
-        {  24,  25,  -1,   173409,      765,    55546 }, // subset0_hats_2
-        {  24,  25,  -1,   174174,      720,    55694 }, // subset0_hats_2
-        {  24,  25,  -1,   174894,      252,    55894 }, // subset0_hats_2
-        {  24,  25,  -1,   175146,      252,    55943 }, // subset0_hats_2
-        {  24,  25,  -1,   175398,      252,    55992 }, // subset0_hats_2
-        {  24,  25,  -1,   175650,      252,    56041 }, // subset0_hats_2
-        {  24,  25,  -1,   175902,      252,    56090 }, // subset0_hats_2
-        {  24,  25,  -1,   176154,      252,    56139 }, // subset0_hats_2
-        {  24,  25,  -1,   176406,      252,    56188 }, // subset0_hats_2
-        {  24,  25,  -1,   176658,      252,    56237 }, // subset0_hats_2
-        {  26,  27,  -1,   176910,       48,    56286 }, // subset0_Hats_1
-        {  24,  25,  -1,   176958,     6792,    56318 }, // subset0_hats_2
-        {  24,  25,  -1,   183750,     2124,    57790 }, // subset0_hats_2
-        {  24,  25,  -1,   185874,     2268,    58361 }, // subset0_hats_2
-        {  24,  25,  -1,   188142,       66,    58938 }, // subset0_hats_2
-        {  24,  25,  -1,   188208,      270,    58973 }, // subset0_hats_2
-        {  24,  25,  -1,   188478,       48,    59080 }, // subset0_hats_2
-        {  24,  25,  -1,   188526,       66,    59111 }, // subset0_hats_2
-        {  24,  25,  -1,   188592,       60,    59148 }, // subset0_hats_2
-        {  24,  25,  -1,   188652,       66,    59178 }, // subset0_hats_2
-        {  24,  25,  -1,   188718,      168,    59215 }, // subset0_hats_2
-        {  24,  25,  -1,   188886,      168,    59275 }, // subset0_hats_2
-        {  24,  25,  -1,   189054,      174,    59333 }, // subset0_hats_2
-        {  24,  25,  -1,   189228,     1650,    59418 }, // subset0_hats_2
-        {  24,  25,  -1,   190878,      918,    59867 }, // subset0_hats_2
-        {  24,  25,  -1,   191796,      426,    60089 }, // subset0_hats_2
-        {  26,  27,  -1,   192222,     1209,    60211 }, // subset0_Hats_1
-        {  24,  25,  -1,   193431,      180,    60506 }, // subset0_hats_2
-        {  26,  27,  -1,   193611,      714,    60571 }, // subset0_Hats_1
-        {  26,  27,  -1,   194325,      426,    60759 }, // subset0_Hats_1
-        {  26,  27,  -1,   194751,      426,    60888 }, // subset0_Hats_1
-        {  26,  27,  -1,   195177,      432,    61010 }, // subset0_Hats_1
-        {  26,  27,  -1,   195609,      432,    61147 }, // subset0_Hats_1
-        {  26,  27,  -1,   196041,     1608,    61268 }, // subset0_Hats_1
-        {  28,  29,  -1,   197649,    18219,    61783 }, // subset0_Misc_Boss_1
-        {  16,  17,  -1,   215868,     2484,    69708 }, // subset0_Stack__Boxes_Diff01
-        {  16,  17,  -1,   218352,     2409,    71274 }, // subset0_Stack__Boxes_Diff01
-        {  16,  17,  -1,   220761,     2409,    72652 }, // subset0_Stack__Boxes_Diff01
-        {  16,  17,  -1,   223170,     2409,    74026 }, // subset0_Stack__Boxes_Diff01
-        {  16,  17,  -1,   225579,     1833,    75404 }, // subset0_Stack__Boxes_Diff01
-        {  30,  31,  -1,   227412,     3867,    76541 }, // subset0_gameCrates_03_Diff
-        {  30,  31,  -1,   231279,     3750,    78113 }, // subset0_gameCrates_03_Diff
-        {  16,  17,  -1,   235029,     2409,    79856 }, // subset0_Stack__Boxes_Diff01
-        {  16,  17,  -1,   237438,     2409,    81222 }, // subset0_Stack__Boxes_Diff01
-        {  30,  31,  -1,   239847,    12468,    82594 }, // subset0_gameCrates_03_Diff
-        {  30,  31,  -1,   252315,     3441,    88547 }, // subset0_gameCrates_03_Diff
-        {  32,  32,  -1,   255756,     1932,    89479 }, // subset0_gameCrates_02_Diff
-        {  14,  15,  -1,   257688,      984,    89905 }, // subset0_Stack__Boxes_Diff03
-        {  14,  15,  -1,   258672,      741,    90403 }, // subset0_Stack__Boxes_Diff03
-        {  14,  15,  -1,   259413,      426,    90727 }, // subset0_Stack__Boxes_Diff03
-        {  32,  32,  -1,   259839,     1419,    90932 }, // subset0_gameCrates_02_Diff
-        {  18,  19,  -1,   261258,     3090,    91251 }, // subset0_Back_Alley_box
-        {  14,  15,  -1,   264348,      573,    92286 }, // subset0_Stack__Boxes_Diff03
-        {  32,  32,  -1,   264921,     1176,    92524 }, // subset0_gameCrates_02_Diff
-        {  32,  32,  -1,   266097,      792,    92809 }, // subset0_gameCrates_02_Diff
-        {  14,  15,  -1,   266889,      573,    93047 }, // subset0_Stack__Boxes_Diff03
-        {  14,  15,  -1,   267462,      741,    93285 }, // subset0_Stack__Boxes_Diff03
-        {  18,  19,  -1,   268203,     1620,    93609 }, // subset0_Back_Alley_box
-        {  14,  15,  -1,   269823,      396,    94126 }, // subset0_Stack__Boxes_Diff03
-        {  14,  15,  -1,   270219,      396,    94281 }, // subset0_Stack__Boxes_Diff03
-        {  14,  15,  -1,   270615,      396,    94436 }, // subset0_Stack__Boxes_Diff03
-        {  32,  32,  -1,   271011,     1008,    94591 }, // subset0_gameCrates_02_Diff
-        {  32,  32,  -1,   272019,     2040,    94830 }, // subset0_gameCrates_02_Diff
-        {  14,  15,  -1,   274059,      468,    95269 }, // subset0_Stack__Boxes_Diff03
-        {  32,  32,  -1,   274527,     1236,    95437 }, // subset0_gameCrates_02_Diff
-        {  32,  32,  -1,   275763,      903,    95726 }, // subset0_gameCrates_02_Diff
-        {  32,  32,  -1,   276666,     1884,    95942 }, // subset0_gameCrates_02_Diff
-        {  32,  32,  -1,   278550,     2088,    96353 }, // subset0_gameCrates_02_Diff
-        {  32,  32,  -1,   280638,     1008,    96827 }, // subset0_gameCrates_02_Diff
-        {  33,  34,  -1,   281646,     1920,    97063 }, // subset0_Back_Alley_Drum
-        {  35,  36,  -1,   283566,     7809,    97728 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   291375,     8172,    99390 }, // subset0_shelves2_diff
-        {  37,  38,  -1,   299547,       12,   101144 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   299559,      132,   101150 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   299691,      132,   101218 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   299823,      228,   101286 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   300051,      228,   101382 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   300279,      228,   101485 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   300507,      228,   101581 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   300735,      228,   101689 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   300963,      228,   101785 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   301191,      852,   101881 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   302043,      702,   102217 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   302745,      372,   102461 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   303117,      564,   102637 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   303681,      324,   102857 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   304005,      324,   102977 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   304329,      588,   103097 }, // subset0_shelves2_diff1
-        {   6,   7,  -1,   304917,     1122,   103337 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   306039,      888,   103622 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   306927,       96,   103854 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   307023,       96,   103902 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   307119,      102,   103947 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   307221,       96,   103987 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   307317,       96,   104032 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   307413,      576,   104078 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   307989,       78,   104208 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   308067,      102,   104240 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   308169,       72,   104284 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   308241,      336,   104315 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   308577,      144,   104450 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   308721,      120,   104490 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   308841,      144,   104518 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   308985,      120,   104558 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   309105,      126,   104586 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   309231,      120,   104624 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   309351,      144,   104652 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   309495,      117,   104692 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   309612,     1572,   104720 }, // subset0_shelves1_diff2
-        {  39,  40,  -1,   311184,      540,   105150 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   311724,     2136,   105282 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   313860,       24,   105899 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   313884,       24,   105911 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   313908,       27,   105923 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   313935,     2964,   105936 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   316899,     2964,   106458 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   319863,      702,   106980 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   320565,      702,   107117 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   321267,      702,   107249 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   321969,      702,   107379 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   322671,     2964,   107511 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   325635,        6,   108033 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   325641,      432,   108037 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   326073,      429,   108130 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   326502,     2964,   108216 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   329466,     2106,   108738 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   331572,     2106,   109129 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   333678,      429,   109515 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   334107,     1794,   109614 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   335901,     2262,   109948 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   338163,     2964,   110365 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   341127,     2964,   110880 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   344091,     2964,   111402 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   347055,     2730,   111919 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   349785,     2964,   112407 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   352749,     2964,   112929 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   355713,     2964,   113444 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   358677,     3276,   113961 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   361953,      780,   114605 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   362733,      936,   114773 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   363669,      936,   114969 }, // subset0_marbel_drum_blinn
-        {  41,  42,  -1,   364605,      108,   115165 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   364713,       81,   115185 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   364794,       81,   115225 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   364875,       81,   115255 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   364956,       81,   115287 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365037,      108,   115328 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365145,       81,   115348 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365226,       81,   115388 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365307,       81,   115418 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365388,      108,   115450 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365496,       81,   115470 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365577,      108,   115510 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365685,       81,   115530 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365766,       81,   115570 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365847,       81,   115602 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365928,      108,   115641 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366036,       81,   115669 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366117,       81,   115709 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366198,       81,   115741 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366279,      108,   115780 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366387,       81,   115808 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366468,       81,   115847 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366549,       81,   115879 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366630,       81,   115909 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366711,      108,   115948 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366819,       81,   115976 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366900,       81,   116006 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366981,      108,   116038 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367089,       81,   116066 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367170,       81,   116105 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367251,      108,   116137 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367359,       81,   116165 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367440,       81,   116204 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367521,      237,   116234 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367758,      216,   116293 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367974,      216,   116348 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   368190,      240,   116398 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   368430,      216,   116453 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   368646,      216,   116503 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   368862,      324,   116558 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   369186,      108,   116650 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   369294,      324,   116688 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   369618,      108,   116780 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   369726,      324,   116818 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   370050,      108,   116910 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   370158,      324,   116948 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   370482,      108,   117040 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   370590,      324,   117078 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   370914,      108,   117170 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371022,      324,   117208 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371346,      108,   117300 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371454,       54,   117338 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371508,       54,   117357 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371562,       54,   117376 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371616,       54,   117395 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371670,       54,   117414 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371724,       54,   117433 }, // subset0_blinnCatwalk
-        {  43,  11,  -1,   371778,      120,   117452 }, // subset0_Catwalk_03_Diffuse
-        {  43,  11,  -1,   371898,     3078,   117532 }, // subset0_Catwalk_03_Diffuse
-        {  43,  11,  -1,   374976,     4356,   118172 }, // subset0_Catwalk_03_Diffuse
-        {  43,  11,  -1,   379332,     4356,   119043 }, // subset0_Catwalk_03_Diffuse
-        {  43,  11,  -1,   383688,     4356,   119896 }, // subset0_Catwalk_03_Diffuse
-        {  43,  11,  -1,   388044,     3636,   120749 }, // subset0_Catwalk_03_Diffuse
-        {  41,  42,  -1,   391680,       72,   121481 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   391752,      162,   121513 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   391914,      324,   121553 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   392238,      144,   121630 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   392382,      144,   121665 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   392526,      162,   121705 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   392688,      324,   121745 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   393012,      144,   121822 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   393156,      144,   121857 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   393300,      162,   121897 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   393462,      360,   121937 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   393822,      144,   122014 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   393966,      144,   122049 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   394110,      162,   122084 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   394272,      324,   122124 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   394596,      153,   122194 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   394749,      144,   122234 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   394893,      162,   122269 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   395055,      324,   122309 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   395379,      144,   122379 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   395523,      144,   122419 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   395667,      162,   122459 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   395829,      324,   122503 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   396153,      150,   122573 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   396303,      144,   122621 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   396447,      162,   122661 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   396609,      324,   122701 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   396933,      144,   122778 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   397077,      144,   122818 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   397221,      162,   122853 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   397383,      324,   122897 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   397707,      141,   122967 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   397848,      144,   123006 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   397992,      162,   123041 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   398154,    19506,   123085 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   417660,    19506,   129867 }, // subset0_blinnCatwalk
-        {  43,  11,  -1,   437166,      120,   136640 }, // subset0_Catwalk_03_Diffuse
-        {  41,  42,  -1,   437286,       72,   136720 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437358,       24,   136752 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437382,       24,   136768 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437406,       24,   136784 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437430,       24,   136800 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437454,       24,   136816 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437478,       24,   136832 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437502,       24,   136848 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437526,       24,   136864 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437550,       24,   136880 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437574,       24,   136896 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437598,       24,   136912 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437622,       24,   136928 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437646,       24,   136944 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437670,       24,   136960 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437694,       24,   136976 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437718,       24,   136992 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437742,       24,   137008 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437766,       24,   137024 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437790,       24,   137040 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437814,       24,   137056 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437838,       24,   137072 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437862,       24,   137088 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437886,       24,   137104 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437910,       24,   137120 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437934,       24,   137136 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437958,       24,   137152 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437982,       24,   137168 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438006,       24,   137184 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438030,       24,   137200 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438054,       24,   137216 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438078,       24,   137232 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438102,       24,   137248 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438126,       24,   137264 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438150,       24,   137280 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438174,       24,   137296 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438198,       24,   137312 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438222,       24,   137328 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438246,       24,   137344 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438270,       24,   137360 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438294,       24,   137376 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438318,       24,   137392 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438342,       24,   137408 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438366,       24,   137424 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438390,       24,   137440 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438414,       24,   137456 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438438,       24,   137472 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438462,       24,   137488 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438486,       24,   137504 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438510,       24,   137520 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438534,       24,   137536 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438558,       24,   137552 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438582,       24,   137568 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438606,       24,   137584 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438630,       24,   137600 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438654,       24,   137616 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438678,       24,   137632 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438702,       24,   137648 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438726,       24,   137664 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438750,       24,   137680 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438774,       24,   137696 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438798,       24,   137712 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438822,       24,   137728 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438846,       24,   137744 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438870,       24,   137760 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438894,       24,   137776 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438918,       24,   137792 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438942,       24,   137808 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438966,       24,   137824 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438990,       24,   137840 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439014,       24,   137856 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439038,       24,   137872 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439062,       24,   137888 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439086,       24,   137904 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439110,       24,   137920 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439134,       24,   137936 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439158,       24,   137952 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439182,       24,   137968 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439206,       24,   137984 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439230,       24,   138000 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439254,       24,   138016 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439278,       24,   138032 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439302,       24,   138048 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439326,       24,   138064 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439350,       24,   138080 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439374,       24,   138096 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439398,       24,   138112 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439422,       24,   138128 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439446,       24,   138144 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439470,       24,   138160 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439494,       24,   138176 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439518,       24,   138192 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439542,       24,   138208 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439566,       24,   138224 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439590,       24,   138240 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439614,       24,   138256 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439638,       24,   138272 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439662,       24,   138288 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439686,       24,   138304 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439710,       24,   138320 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439734,       24,   138336 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439758,       24,   138352 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439782,       24,   138368 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439806,       24,   138384 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439830,       24,   138400 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439854,       24,   138416 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439878,       24,   138432 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439902,       24,   138448 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439926,       24,   138464 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439950,       24,   138480 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439974,       24,   138496 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439998,       24,   138512 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440022,       24,   138528 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440046,       24,   138544 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440070,       24,   138560 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440094,       24,   138576 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440118,       24,   138592 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440142,       24,   138608 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440166,       24,   138624 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440190,       24,   138640 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440214,       24,   138656 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440238,       24,   138672 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440262,       24,   138688 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440286,       24,   138704 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440310,       24,   138720 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440334,       24,   138736 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440358,       24,   138752 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440382,       24,   138768 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440406,       24,   138784 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440430,       24,   138800 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440454,       24,   138816 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440478,       24,   138832 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440502,       24,   138848 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440526,       24,   138864 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440550,       24,   138880 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440574,       24,   138896 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440598,       24,   138912 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440622,       24,   138928 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440646,       24,   138944 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440670,       24,   138960 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440694,       24,   138976 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440718,       24,   138992 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440742,       24,   139008 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440766,       24,   139024 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440790,       24,   139040 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440814,       24,   139056 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440838,       24,   139072 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440862,       24,   139088 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440886,       24,   139104 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440910,       24,   139120 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440934,       24,   139136 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440958,       24,   139152 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440982,       24,   139168 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441006,       24,   139184 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441030,       24,   139200 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441054,       24,   139216 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441078,       24,   139232 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441102,       24,   139248 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441126,       24,   139264 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441150,       24,   139280 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441174,       24,   139296 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441198,       24,   139312 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441222,       24,   139328 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441246,       24,   139344 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441270,       24,   139360 }, // subset0_blinnCatwalk
-        {  44,  45,  -1,   441294,     2826,   139376 }, // subset0_shelves3_diff
-        {  35,  36,  -1,   444120,     2637,   139376 }, // subset1_shelves2_diff_0
-        {  14,  15,  -1,   446757,      636,   139376 }, // subset2_Stack__Boxes_Diff03_0
-        {  46,  47,  -1,   447393,       24,   141190 }, // subset0_blinn46
-        {  46,  47,  -1,   447417,      306,   141206 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   447723,      306,   141325 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   448029,      306,   141443 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   448335,      306,   141561 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   448641,      216,   141677 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   448857,     1812,   141759 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   450669,      306,   142479 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   450975,      222,   142604 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   451197,      132,   142704 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   451329,      222,   142754 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   451551,      306,   142854 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   451857,      132,   142975 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   451989,      222,   143025 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   452211,      306,   143125 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   452517,      306,   143247 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   452823,      132,   143370 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   452955,      222,   143420 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   453177,      132,   143520 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   453309,     1368,   143570 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   454677,     2484,   143914 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   457161,     5790,   144731 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   462951,     1836,   147045 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   464787,     3816,   147679 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   468603,    54240,   149038 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   522843,      792,   158991 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   523635,      792,   159136 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   524427,      216,   159281 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   524643,      216,   159363 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   524859,      216,   159445 }, // subset0_phongMisc_Boss_3_2048
-        {  48,  42,  -1,   525075,     1050,   159527 }, // subset0_LightBulbsColor
-        {  49,  50,  -1,   526125,     1128,   159773 }, // subset0_Hanghing_Light
-        {  10,  11,  -1,   527253,      540,   160003 }, // subset0_lambert1
-        {  10,  11,  -1,   527793,      225,   160123 }, // subset0_lambert1
-        {  49,  50,  -1,   528018,     2160,   160202 }, // subset0_Hanghing_Light
-        {  48,  42,  -1,   530178,     1050,   160707 }, // subset0_LightBulbsColor
-        {  49,  50,  -1,   531228,     1128,   160966 }, // subset0_Hanghing_Light
-        {  10,  11,  -1,   532356,      540,   161197 }, // subset0_lambert1
-        {  10,  11,  -1,   532896,      225,   161317 }, // subset0_lambert1
-        {  49,  50,  -1,   533121,     2160,   161391 }, // subset0_Hanghing_Light
-        {  48,  42,  -1,   535281,     1134,   161896 }, // subset0_LightBulbsColor
-        {  49,  50,  -1,   536415,     1128,   162168 }, // subset0_Hanghing_Light
-        {  49,  50,  -1,   537543,      600,   162399 }, // subset0_Hanghing_Light
-        {  49,  50,  -1,   538143,      225,   162531 }, // subset0_Hanghing_Light
-        {  49,  50,  -1,   538368,     2160,   162610 }, // subset0_Hanghing_Light
-        {  10,  51,  -1,   540528,      498,   163115 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   541026,      300,   163321 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   541326,      300,   163400 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   541626,      600,   163479 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   542226,      681,   163604 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   542907,      300,   163755 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   543207,      300,   163834 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   543507,      144,   163913 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   543651,      780,   163949 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   544431,      168,   164135 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   544599,      156,   164197 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   544755,      390,   164255 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   545145,     3702,   164393 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   548847,      468,   165239 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   549315,     1128,   165324 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   550443,      810,   165562 }, // subset0_Hanging_bundle
-        {  52,  53,  -1,   551253,      714,   165819 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   551967,      540,   165949 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   552507,     1080,   166048 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   553587,     1080,   166242 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   554667,      540,   166436 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   555207,      540,   166535 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   555747,     1080,   166642 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   556827,      540,   166836 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   557367,     1080,   166935 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   558447,     1080,   167129 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   559527,      540,   167323 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   560067,     1080,   167422 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   561147,     1080,   167616 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   562227,     1080,   167810 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   563307,     1080,   168001 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   564387,      714,   168195 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   565101,     1080,   168325 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   566181,      540,   168519 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   566721,      540,   168618 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   567261,      540,   168719 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   567801,     1080,   168818 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   568881,      540,   169012 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   569421,     1080,   169111 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   570501,      540,   169305 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   571041,      714,   169404 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   571755,     1080,   169534 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   572835,     1080,   169728 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   573915,      540,   169922 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   574455,      540,   170021 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   574995,     1080,   170120 }, // subset0_Hanging_bundle_marble
-        {  10,  51,  -1,   576075,    17184,   170314 }, // subset0_Rope
-        {  10,  51,  -1,   593259,      576,   176140 }, // subset0_Rope
-        {  10,  51,  -1,   593835,     2556,   176293 }, // subset0_Rope
-        {  10,  51,  -1,   596391,     4032,   176950 }, // subset0_Rope
-        {  10,  51,  -1,   600423,     4284,   177857 }, // subset0_Rope
-        {  10,  51,  -1,   604707,     4536,   178939 }, // subset0_Rope
-        {  10,  51,  -1,   609243,     4536,   179837 }, // subset0_Rope
-        {  10,  51,  -1,   613779,      612,   180733 }, // subset0_Rope
-        {  44,  45,  -1,   614391,      396,   180879 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   614787,      600,   181009 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   615387,      600,   181216 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   615987,      744,   181423 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   616731,      729,   181680 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   617460,     1920,   181932 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   619380,      324,   182343 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   619704,     2274,   182475 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   621978,     1860,   182902 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   623838,     2376,   183256 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   626214,     2190,   183705 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   628404,     2280,   184118 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   630684,      840,   184550 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   631524,      840,   184754 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   632364,      840,   184958 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   633204,      840,   185162 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   634044,     1008,   185366 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   635052,     1332,   185608 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   636384,     1617,   185890 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   638001,     1410,   186290 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   639411,      948,   186589 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   640359,       90,   187035 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   640449,      504,   187055 }, // subset0_shelves3_diff
-        {  35,  36,  -1,   640953,      378,   187197 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   641331,      432,   187284 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   641763,      378,   187378 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   642141,     3120,   187462 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   645261,      402,   188387 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   645663,     2580,   188525 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   648243,     3180,   189008 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   651423,     2100,   189678 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   653523,     3180,   190158 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   656703,      180,   190828 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   656883,      276,   190872 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   657159,      180,   190970 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   657339,      180,   191014 }, // subset0_shelves2_diff
-        {  44,  45,  -1,   657519,      228,   191068 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   657747,      108,   191162 }, // subset0_shelves3_diff
-        {  35,  36,  -1,   657855,      192,   191197 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   658047,      192,   191271 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   658239,      192,   191345 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   658431,      168,   191419 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   658599,      168,   191485 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   658767,      168,   191551 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   658935,      192,   191617 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   659127,      192,   191691 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   659319,      168,   191765 }, // subset0_shelves2_diff
-        {  44,  45,  -1,   659487,     1617,   191831 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   661104,     1617,   192226 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   662721,     1617,   192605 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   664338,       90,   192995 }, // subset0_shelves3_diff
-        {  54,  42,  -1,   664428,     1248,   193015 }, // subset0_Window
-        {  55,  56,  -1,   665676,     3312,   193319 }, // subset0_Sliding_Steel_Door
-        {  54,  57,  -1,   668988,      930,   194197 }, // subset0_window_Diff
-        {  58,  59,  -1,   669918,    12912,   194433 }, // subset0_Door2
-        {  60,  61,  -1,   682830,      969,   197161 }, // subset0_Floor
-        {  62,  63,  -1,   683799,     2037,   197482 }, // subset0_wall_4
-        {  62,  63,  -1,   685836,     3000,   198168 }, // subset0_wall_3
-        {  64,  65,  -1,   688836,     2205,   199986 }, // subset0_wall_1
-        {  64,  65,  -1,   691041,     1656,   200663 }, // subset0_wall_2
-        {  66,  67,  -1,   692697,     5424,   201041 }, // subset0_roof
-        {  68,  69,  -1,   698121,      939,   203677 }, // subset0_Pillar
-        {  66,  67,  -1,   699060,     1536,   203892 }, // subset0_roof
-        {  70,  71,  -1,   700596,      609,   204339 }, // subset0_Broken_Pillar_Diff
-        {  33,  34,  -1,   701205,     1920,   204469 }, // subset0_Back_Alley_Drum
-        {  33,  34,  -1,   703125,     1920,   205134 }, // subset0_Back_Alley_Drum
-        {  33,  34,  -1,   705045,     1920,   205799 }, // subset0_Back_Alley_Drum
-        {  35,  36,  -1,   706965,     7809,   206464 }, // subset0_shelves2_diff
-        {  14,  15,  -1,   714774,     1920,   208128 }, // subset0_Stack__Boxes_Diff03
-        {  33,  34,  -1,   716694,     1920,   208629 }, // subset0_Back_Alley_Drum
-        {  33,  34,  -1,   718614,     1920,   209294 }, // subset0_Back_Alley_Drum
-        {  33,  34,  -1,   720534,     1920,   209959 }, // subset0_Back_Alley_Drum
-        {  35,  36,  -1,   722454,     7809,   210624 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   730263,     7809,   212294 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   738072,     7809,   213953 }, // subset0_shelves2_diff
-        {  32,  32,  -1,   745881,      783,   215619 }, // subset0_gameCrates_02_Diff
-        {  72,  73,  -1,   746664,    14451,   215808 }, // subset0_GolfBag:Golfclub
-        {  18,  19,  -1,   761115,     3096,   219093 }, // subset0_Back_Alley_box
-    };
+	const DrawParameters Draws[] =
+	{
+		{   0,   1,  -1,        0,    15198,        0 }, // subset0_squard_room_platform_3_dif1
+		{   2,   3,  -1,    15198,      438,     6051 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    15636,      300,     6164 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    15936,      300,     6225 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    16236,      438,     6286 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    16674,      300,     6399 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    16974,      438,     6460 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    17412,      300,     6573 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    17712,      450,     6634 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    18162,      300,     6756 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    18462,      438,     6817 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    18900,      300,     6930 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    19200,      300,     6991 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    19500,      438,     7052 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    19938,      300,     7165 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    20238,      438,     7226 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    20676,      300,     7339 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    20976,      300,     7400 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    21276,      438,     7461 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    21714,      300,     7574 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    22014,      438,     7635 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    22452,      300,     7748 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    22752,      450,     7809 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    23202,      300,     7931 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    23502,      438,     7992 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    23940,      300,     8105 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    24240,      300,     8166 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    24540,      438,     8227 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    24978,      300,     8340 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    25278,      438,     8401 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    25716,      300,     8514 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    26016,      300,     8575 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    26316,      438,     8636 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    26754,      300,     8749 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    27054,      438,     8810 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    27492,      300,     8923 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    27792,      300,     8984 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    28092,      438,     9045 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    28530,      300,     9158 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    28830,      438,     9219 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    29268,      300,     9332 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    29568,      450,     9393 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    30018,      300,     9515 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    30318,      438,     9576 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    30756,      300,     9689 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    31056,      300,     9750 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    31356,      438,     9811 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    31794,      300,     9924 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    32094,      438,     9985 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    32532,      300,    10098 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    32832,      450,    10159 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    33282,      300,    10281 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    33582,      438,    10342 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    34020,      300,    10455 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    34320,      300,    10516 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    34620,      438,    10577 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    35058,      300,    10690 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    35358,      900,    10751 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    36258,      282,    11016 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    36540,      282,    11142 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    36822,      222,    11228 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    37044,      282,    11304 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    37326,      282,    11396 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    37608,      282,    11485 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    37890,      243,    11577 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    38133,      222,    11665 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    38355,      282,    11743 }, // subset0_squard_room_platform_2_dif
+		{   4,   5,  -1,    38637,     2700,    11834 }, // subset0_squard_room_platform_1_diff
+		{   6,   7,  -1,    41337,     1788,    12560 }, // subset0_shelves1_diff
+		{   8,   9,  -1,    43125,      180,    13101 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43305,      180,    13138 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43485,       96,    13175 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43581,       96,    13202 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43677,       96,    13229 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43773,       96,    13256 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43869,       96,    13283 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43965,       30,    13310 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43995,       24,    13322 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44019,       24,    13332 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44043,       24,    13342 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44067,       24,    13351 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44091,       54,    13360 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44145,       12,    13380 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44157,       72,    13386 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44229,       84,    13424 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44313,       30,    13448 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44343,        6,    13460 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44349,       36,    13464 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44385,       60,    13478 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44445,       72,    13496 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44517,       48,    13534 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44565,       24,    13549 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44589,       24,    13559 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44613,       24,    13569 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44637,       42,    13579 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44679,       12,    13595 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44691,       48,    13603 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44739,        6,    13625 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44745,       48,    13629 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44793,        6,    13644 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44799,       60,    13648 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44859,        6,    13666 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44865,       60,    13670 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44925,       72,    13688 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44997,       48,    13709 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45045,       36,    13727 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45081,       72,    13741 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45153,       12,    13779 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45165,       12,    13785 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45177,       30,    13791 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45207,       36,    13803 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45243,        6,    13817 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45249,        6,    13821 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45255,       24,    13825 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45279,       24,    13835 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45303,       24,    13845 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45327,       96,    13855 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45423,       30,    13882 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45453,       96,    13894 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45549,       96,    13921 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45645,       72,    13948 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45717,       72,    13969 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45789,       42,    13990 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45831,       42,    14006 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45873,       54,    14022 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45927,       54,    14042 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45981,       60,    14062 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46041,       60,    14080 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46101,       36,    14098 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46137,       12,    14112 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46149,       12,    14118 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46161,       12,    14124 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46173,       24,    14130 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46197,       24,    14140 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46221,       24,    14150 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46245,       24,    14160 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46269,       24,    14170 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46293,       48,    14180 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46341,       48,    14195 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46389,       48,    14210 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46437,       48,    14225 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46485,       48,    14240 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46533,       36,    14255 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46569,       36,    14269 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46605,       36,    14283 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46641,       36,    14297 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46677,       36,    14311 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46713,       72,    14325 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46785,       72,    14363 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46857,        6,    14401 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46863,        6,    14405 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46869,        6,    14409 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46875,       24,    14413 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46899,       24,    14422 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46923,       48,    14431 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46971,       48,    14449 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47019,       12,    14464 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47031,       12,    14470 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47043,       12,    14476 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47055,       12,    14482 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47067,       12,    14488 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47079,       12,    14494 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47091,       12,    14500 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47103,       12,    14506 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47115,       24,    14512 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47139,       24,    14521 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47163,       60,    14530 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47223,       60,    14548 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47283,       60,    14566 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47343,       60,    14584 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47403,       60,    14602 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47463,       48,    14620 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47511,       48,    14642 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47559,       36,    14664 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47595,       36,    14678 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47631,       24,    14692 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47655,       12,    14701 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47667,       12,    14707 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47679,       12,    14713 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47691,       12,    14719 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47703,       12,    14725 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47715,       12,    14731 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47727,       12,    14737 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47739,        6,    14743 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47745,        6,    14747 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47751,        6,    14751 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47757,        6,    14755 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47763,       12,    14759 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47775,       12,    14765 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47787,       12,    14771 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47799,       12,    14777 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47811,       60,    14783 }, // subset0_blinnMisc_Boss_2
+		{  10,  11,  -1,    47871,      762,    14801 }, // subset0_lambert1
+		{   8,   9,  -1,    48633,       66,    14801 }, // subset1_blinnMisc_Boss_2_0
+		{   8,   9,  -1,    48699,      144,    15136 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    48843,      144,    15171 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    48987,      144,    15206 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    49131,      144,    15241 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    49275,      180,    15276 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    49455,      144,    15318 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    49599,      144,    15353 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    49743,      144,    15388 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    49887,      180,    15423 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    50067,      180,    15465 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    50247,      144,    15507 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    50391,      180,    15542 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    50571,      144,    15584 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    50715,      108,    15619 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    50823,     4416,    15647 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    55239,      273,    16657 }, // subset0_blinnMisc_Boss_2
+		{  12,  13,  -1,    55512,     4143,    16754 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    59655,      360,    19212 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    60015,      300,    19293 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    60315,      360,    19359 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    60675,      240,    19436 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    60915,     1566,    19491 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62481,       48,    19889 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62529,       48,    19907 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62577,       48,    19925 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62625,       48,    19943 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62673,       48,    19961 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62721,       48,    19979 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62769,       96,    19997 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62865,       36,    20024 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62901,       36,    20038 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62937,       36,    20052 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62973,       36,    20066 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63009,       36,    20080 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63045,       36,    20094 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63081,       36,    20108 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63117,       36,    20122 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63153,       36,    20136 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63189,       36,    20150 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63225,       36,    20164 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63261,      108,    20178 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63369,       36,    20206 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63405,       36,    20220 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63441,       36,    20234 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63477,       36,    20248 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63513,       36,    20262 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63549,       36,    20276 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63585,       36,    20290 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63621,       72,    20304 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63693,       72,    20325 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63765,      144,    20346 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63909,       72,    20381 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63981,       36,    20402 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64017,       36,    20416 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64053,      144,    20430 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64197,      144,    20465 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64341,       36,    20500 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64377,       36,    20514 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64413,       36,    20528 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64449,       36,    20542 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64485,       36,    20556 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64521,       36,    20570 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64557,       36,    20584 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64593,       36,    20598 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64629,       36,    20612 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64665,       36,    20626 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64701,      252,    20640 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64953,      276,    20816 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    65229,      276,    21014 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    65505,      276,    21200 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    65781,      294,    21394 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    66075,      279,    21582 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    66354,      264,    21732 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    66618,      288,    21898 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    66906,      468,    22065 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    67374,     1296,    22222 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    68670,       18,    22988 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    68688,       36,    22996 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    68724,       42,    23022 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    68766,       36,    23054 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    68802,       42,    23076 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    68844,      336,    23104 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    69180,      144,    23104 }, // subset1_lambert1_0
+		{  12,  13,  -1,    69324,      240,    23250 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    69564,      240,    23334 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    69804,      246,    23427 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    70050,      120,    23543 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    70170,      630,    23600 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    70800,     1080,    23743 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    71880,      720,    23991 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    72600,      204,    24154 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    72804,      336,    24198 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    73140,      144,    24198 }, // subset1_lambert1_0
+		{  12,  13,  -1,    73284,      225,    24344 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    73509,       15,    24344 }, // subset1_lambert1_0
+		{  12,  13,  -1,    73524,      225,    24458 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    73749,       15,    24458 }, // subset1_lambert1_0
+		{  12,  13,  -1,    73764,      225,    24572 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    73989,       15,    24572 }, // subset1_lambert1_0
+		{  12,  13,  -1,    74004,      225,    24686 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    74229,       15,    24686 }, // subset1_lambert1_0
+		{  12,  13,  -1,    74244,      225,    24800 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    74469,       15,    24800 }, // subset1_lambert1_0
+		{  12,  13,  -1,    74484,      225,    24914 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    74709,       15,    24914 }, // subset1_lambert1_0
+		{  14,  15,  -1,    74724,     2208,    25028 }, // subset0_Stack__Boxes_Diff03
+		{  16,  17,  -1,    76932,     9381,    25553 }, // subset0_Stack__Boxes_Diff01
+		{  18,  19,  -1,    86313,      948,    29643 }, // subset0_Back_Alley_box
+		{  20,  21,  -1,    87261,     1488,    29946 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,    88749,     1998,    30265 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,    90747,     1872,    30649 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,    92619,     1692,    31034 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,    94311,     1638,    31387 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,    95949,     1872,    31702 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,    97821,     1662,    32056 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,    99483,     1902,    32409 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   101385,      720,    32807 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   102105,     1296,    32957 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   103401,      432,    33232 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   103833,     1152,    33332 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   104985,     1152,    33557 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   106137,     1380,    33782 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   107517,     1470,    34080 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   108987,     1308,    34364 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   110295,     1662,    34622 }, // subset0_gameCrates_01_Diff
+		{  22,  23,  -1,   111957,      636,    34941 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   112593,     1728,    35137 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   114321,      336,    35500 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   114657,     2304,    35577 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   116961,      246,    36138 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   117207,     1260,    36270 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   118467,     1866,    36512 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   120333,     2070,    36976 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   122403,     1050,    37421 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   123453,      450,    37624 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   123903,      450,    37760 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   124353,      390,    37896 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   124743,      390,    38021 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   125133,      390,    38148 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   125523,      330,    38273 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   125853,      390,    38387 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   126243,      330,    38512 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   126573,      420,    38626 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   126993,      390,    38763 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   127383,      300,    38888 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   127683,      300,    38961 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   127983,      300,    39045 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   128283,      300,    39131 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   128583,      300,    39215 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   128883,      300,    39286 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   129183,      300,    39410 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   129483,      300,    39483 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   129783,      300,    39567 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   130083,      300,    39653 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   130383,      300,    39737 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   130683,      300,    39808 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   130983,      300,    39968 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   131283,      300,    40041 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   131583,      300,    40125 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   131883,      300,    40211 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   132183,      300,    40295 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   132483,      300,    40366 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   132783,      300,    40490 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   133083,      300,    40561 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   133383,      300,    40721 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   133683,      300,    40794 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   133983,      300,    40878 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   134283,      300,    40964 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   134583,      300,    41048 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   134883,      300,    41119 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   135183,      300,    41243 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   135483,      300,    41314 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   135783,      300,    41474 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   136083,      300,    41547 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   136383,      300,    41631 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   136683,      300,    41717 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   136983,      300,    41801 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   137283,      300,    41872 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   137583,      300,    41996 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   137883,      300,    42069 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   138183,      300,    42153 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   138483,      300,    42239 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   138783,      300,    42323 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   139083,      300,    42394 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   139383,      300,    42554 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   139683,      300,    42627 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   139983,      300,    42711 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   140283,      300,    42797 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   140583,      300,    42881 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   140883,      300,    42952 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   141183,      300,    43076 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   141483,      300,    43149 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   141783,      300,    43349 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   142083,      300,    43551 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   142383,      300,    43751 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   142683,      300,    43951 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   142983,      300,    44151 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   143283,      300,    44351 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   143583,      300,    44551 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   143883,      300,    44751 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   144183,      300,    44951 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   144483,      300,    45153 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   144783,      300,    45353 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   145083,      300,    45553 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   145383,      300,    45753 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   145683,      300,    45953 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   145983,      300,    46153 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   146283,      300,    46353 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   146583,      300,    46553 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   146883,      300,    46755 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   147183,      300,    46955 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   147483,      300,    47155 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   147783,      300,    47355 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   148083,      300,    47555 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   148383,      300,    47755 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   148683,      300,    47955 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   148983,      300,    48155 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   149283,      300,    48355 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   149583,      300,    48557 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   149883,      300,    48757 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   150183,      300,    48957 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   150483,      300,    49157 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   150783,      216,    49357 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   150999,      216,    49455 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   151215,      216,    49553 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   151431,     1014,    49651 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   152445,      216,    49929 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   152661,     1014,    50029 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   153675,     1014,    50324 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   154689,     1014,    50614 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   155703,      588,    50894 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   156291,     5574,    51104 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   161865,      588,    52700 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   162453,      588,    52910 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   163041,      588,    53120 }, // subset0_RaceCar_Strorage_Diff
+		{  24,  25,  -1,   163629,       48,    53330 }, // subset0_hats_2
+		{  24,  25,  -1,   163677,      501,    53362 }, // subset0_hats_2
+		{  24,  25,  -1,   164178,      252,    53471 }, // subset0_hats_2
+		{  24,  25,  -1,   164430,       48,    53520 }, // subset0_hats_2
+		{  24,  25,  -1,   164478,     1620,    53552 }, // subset0_hats_2
+		{  24,  25,  -1,   166098,     3978,    53850 }, // subset0_hats_2
+		{  24,  25,  -1,   170076,      765,    54754 }, // subset0_hats_2
+		{  24,  25,  -1,   170841,      900,    54906 }, // subset0_hats_2
+		{  24,  25,  -1,   171741,     1260,    55154 }, // subset0_hats_2
+		{  24,  25,  -1,   173001,      408,    55431 }, // subset0_hats_2
+		{  24,  25,  -1,   173409,      765,    55546 }, // subset0_hats_2
+		{  24,  25,  -1,   174174,      720,    55694 }, // subset0_hats_2
+		{  24,  25,  -1,   174894,      252,    55894 }, // subset0_hats_2
+		{  24,  25,  -1,   175146,      252,    55943 }, // subset0_hats_2
+		{  24,  25,  -1,   175398,      252,    55992 }, // subset0_hats_2
+		{  24,  25,  -1,   175650,      252,    56041 }, // subset0_hats_2
+		{  24,  25,  -1,   175902,      252,    56090 }, // subset0_hats_2
+		{  24,  25,  -1,   176154,      252,    56139 }, // subset0_hats_2
+		{  24,  25,  -1,   176406,      252,    56188 }, // subset0_hats_2
+		{  24,  25,  -1,   176658,      252,    56237 }, // subset0_hats_2
+		{  26,  27,  -1,   176910,       48,    56286 }, // subset0_Hats_1
+		{  24,  25,  -1,   176958,     6792,    56318 }, // subset0_hats_2
+		{  24,  25,  -1,   183750,     2124,    57790 }, // subset0_hats_2
+		{  24,  25,  -1,   185874,     2268,    58361 }, // subset0_hats_2
+		{  24,  25,  -1,   188142,       66,    58938 }, // subset0_hats_2
+		{  24,  25,  -1,   188208,      270,    58973 }, // subset0_hats_2
+		{  24,  25,  -1,   188478,       48,    59080 }, // subset0_hats_2
+		{  24,  25,  -1,   188526,       66,    59111 }, // subset0_hats_2
+		{  24,  25,  -1,   188592,       60,    59148 }, // subset0_hats_2
+		{  24,  25,  -1,   188652,       66,    59178 }, // subset0_hats_2
+		{  24,  25,  -1,   188718,      168,    59215 }, // subset0_hats_2
+		{  24,  25,  -1,   188886,      168,    59275 }, // subset0_hats_2
+		{  24,  25,  -1,   189054,      174,    59333 }, // subset0_hats_2
+		{  24,  25,  -1,   189228,     1650,    59418 }, // subset0_hats_2
+		{  24,  25,  -1,   190878,      918,    59867 }, // subset0_hats_2
+		{  24,  25,  -1,   191796,      426,    60089 }, // subset0_hats_2
+		{  26,  27,  -1,   192222,     1209,    60211 }, // subset0_Hats_1
+		{  24,  25,  -1,   193431,      180,    60506 }, // subset0_hats_2
+		{  26,  27,  -1,   193611,      714,    60571 }, // subset0_Hats_1
+		{  26,  27,  -1,   194325,      426,    60759 }, // subset0_Hats_1
+		{  26,  27,  -1,   194751,      426,    60888 }, // subset0_Hats_1
+		{  26,  27,  -1,   195177,      432,    61010 }, // subset0_Hats_1
+		{  26,  27,  -1,   195609,      432,    61147 }, // subset0_Hats_1
+		{  26,  27,  -1,   196041,     1608,    61268 }, // subset0_Hats_1
+		{  28,  29,  -1,   197649,    18219,    61783 }, // subset0_Misc_Boss_1
+		{  16,  17,  -1,   215868,     2484,    69708 }, // subset0_Stack__Boxes_Diff01
+		{  16,  17,  -1,   218352,     2409,    71274 }, // subset0_Stack__Boxes_Diff01
+		{  16,  17,  -1,   220761,     2409,    72652 }, // subset0_Stack__Boxes_Diff01
+		{  16,  17,  -1,   223170,     2409,    74026 }, // subset0_Stack__Boxes_Diff01
+		{  16,  17,  -1,   225579,     1833,    75404 }, // subset0_Stack__Boxes_Diff01
+		{  30,  31,  -1,   227412,     3867,    76541 }, // subset0_gameCrates_03_Diff
+		{  30,  31,  -1,   231279,     3750,    78113 }, // subset0_gameCrates_03_Diff
+		{  16,  17,  -1,   235029,     2409,    79856 }, // subset0_Stack__Boxes_Diff01
+		{  16,  17,  -1,   237438,     2409,    81222 }, // subset0_Stack__Boxes_Diff01
+		{  30,  31,  -1,   239847,    12468,    82594 }, // subset0_gameCrates_03_Diff
+		{  30,  31,  -1,   252315,     3441,    88547 }, // subset0_gameCrates_03_Diff
+		{  32,  32,  -1,   255756,     1932,    89479 }, // subset0_gameCrates_02_Diff
+		{  14,  15,  -1,   257688,      984,    89905 }, // subset0_Stack__Boxes_Diff03
+		{  14,  15,  -1,   258672,      741,    90403 }, // subset0_Stack__Boxes_Diff03
+		{  14,  15,  -1,   259413,      426,    90727 }, // subset0_Stack__Boxes_Diff03
+		{  32,  32,  -1,   259839,     1419,    90932 }, // subset0_gameCrates_02_Diff
+		{  18,  19,  -1,   261258,     3090,    91251 }, // subset0_Back_Alley_box
+		{  14,  15,  -1,   264348,      573,    92286 }, // subset0_Stack__Boxes_Diff03
+		{  32,  32,  -1,   264921,     1176,    92524 }, // subset0_gameCrates_02_Diff
+		{  32,  32,  -1,   266097,      792,    92809 }, // subset0_gameCrates_02_Diff
+		{  14,  15,  -1,   266889,      573,    93047 }, // subset0_Stack__Boxes_Diff03
+		{  14,  15,  -1,   267462,      741,    93285 }, // subset0_Stack__Boxes_Diff03
+		{  18,  19,  -1,   268203,     1620,    93609 }, // subset0_Back_Alley_box
+		{  14,  15,  -1,   269823,      396,    94126 }, // subset0_Stack__Boxes_Diff03
+		{  14,  15,  -1,   270219,      396,    94281 }, // subset0_Stack__Boxes_Diff03
+		{  14,  15,  -1,   270615,      396,    94436 }, // subset0_Stack__Boxes_Diff03
+		{  32,  32,  -1,   271011,     1008,    94591 }, // subset0_gameCrates_02_Diff
+		{  32,  32,  -1,   272019,     2040,    94830 }, // subset0_gameCrates_02_Diff
+		{  14,  15,  -1,   274059,      468,    95269 }, // subset0_Stack__Boxes_Diff03
+		{  32,  32,  -1,   274527,     1236,    95437 }, // subset0_gameCrates_02_Diff
+		{  32,  32,  -1,   275763,      903,    95726 }, // subset0_gameCrates_02_Diff
+		{  32,  32,  -1,   276666,     1884,    95942 }, // subset0_gameCrates_02_Diff
+		{  32,  32,  -1,   278550,     2088,    96353 }, // subset0_gameCrates_02_Diff
+		{  32,  32,  -1,   280638,     1008,    96827 }, // subset0_gameCrates_02_Diff
+		{  33,  34,  -1,   281646,     1920,    97063 }, // subset0_Back_Alley_Drum
+		{  35,  36,  -1,   283566,     7809,    97728 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   291375,     8172,    99390 }, // subset0_shelves2_diff
+		{  37,  38,  -1,   299547,       12,   101144 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   299559,      132,   101150 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   299691,      132,   101218 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   299823,      228,   101286 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   300051,      228,   101382 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   300279,      228,   101485 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   300507,      228,   101581 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   300735,      228,   101689 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   300963,      228,   101785 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   301191,      852,   101881 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   302043,      702,   102217 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   302745,      372,   102461 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   303117,      564,   102637 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   303681,      324,   102857 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   304005,      324,   102977 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   304329,      588,   103097 }, // subset0_shelves2_diff1
+		{   6,   7,  -1,   304917,     1122,   103337 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   306039,      888,   103622 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   306927,       96,   103854 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   307023,       96,   103902 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   307119,      102,   103947 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   307221,       96,   103987 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   307317,       96,   104032 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   307413,      576,   104078 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   307989,       78,   104208 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   308067,      102,   104240 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   308169,       72,   104284 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   308241,      336,   104315 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   308577,      144,   104450 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   308721,      120,   104490 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   308841,      144,   104518 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   308985,      120,   104558 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   309105,      126,   104586 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   309231,      120,   104624 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   309351,      144,   104652 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   309495,      117,   104692 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   309612,     1572,   104720 }, // subset0_shelves1_diff2
+		{  39,  40,  -1,   311184,      540,   105150 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   311724,     2136,   105282 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   313860,       24,   105899 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   313884,       24,   105911 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   313908,       27,   105923 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   313935,     2964,   105936 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   316899,     2964,   106458 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   319863,      702,   106980 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   320565,      702,   107117 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   321267,      702,   107249 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   321969,      702,   107379 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   322671,     2964,   107511 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   325635,        6,   108033 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   325641,      432,   108037 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   326073,      429,   108130 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   326502,     2964,   108216 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   329466,     2106,   108738 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   331572,     2106,   109129 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   333678,      429,   109515 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   334107,     1794,   109614 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   335901,     2262,   109948 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   338163,     2964,   110365 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   341127,     2964,   110880 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   344091,     2964,   111402 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   347055,     2730,   111919 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   349785,     2964,   112407 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   352749,     2964,   112929 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   355713,     2964,   113444 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   358677,     3276,   113961 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   361953,      780,   114605 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   362733,      936,   114773 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   363669,      936,   114969 }, // subset0_marbel_drum_blinn
+		{  41,  42,  -1,   364605,      108,   115165 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   364713,       81,   115185 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   364794,       81,   115225 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   364875,       81,   115255 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   364956,       81,   115287 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365037,      108,   115328 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365145,       81,   115348 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365226,       81,   115388 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365307,       81,   115418 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365388,      108,   115450 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365496,       81,   115470 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365577,      108,   115510 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365685,       81,   115530 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365766,       81,   115570 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365847,       81,   115602 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365928,      108,   115641 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366036,       81,   115669 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366117,       81,   115709 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366198,       81,   115741 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366279,      108,   115780 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366387,       81,   115808 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366468,       81,   115847 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366549,       81,   115879 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366630,       81,   115909 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366711,      108,   115948 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366819,       81,   115976 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366900,       81,   116006 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366981,      108,   116038 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367089,       81,   116066 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367170,       81,   116105 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367251,      108,   116137 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367359,       81,   116165 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367440,       81,   116204 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367521,      237,   116234 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367758,      216,   116293 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367974,      216,   116348 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   368190,      240,   116398 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   368430,      216,   116453 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   368646,      216,   116503 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   368862,      324,   116558 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   369186,      108,   116650 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   369294,      324,   116688 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   369618,      108,   116780 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   369726,      324,   116818 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   370050,      108,   116910 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   370158,      324,   116948 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   370482,      108,   117040 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   370590,      324,   117078 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   370914,      108,   117170 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371022,      324,   117208 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371346,      108,   117300 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371454,       54,   117338 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371508,       54,   117357 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371562,       54,   117376 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371616,       54,   117395 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371670,       54,   117414 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371724,       54,   117433 }, // subset0_blinnCatwalk
+		{  43,  11,  -1,   371778,      120,   117452 }, // subset0_Catwalk_03_Diffuse
+		{  43,  11,  -1,   371898,     3078,   117532 }, // subset0_Catwalk_03_Diffuse
+		{  43,  11,  -1,   374976,     4356,   118172 }, // subset0_Catwalk_03_Diffuse
+		{  43,  11,  -1,   379332,     4356,   119043 }, // subset0_Catwalk_03_Diffuse
+		{  43,  11,  -1,   383688,     4356,   119896 }, // subset0_Catwalk_03_Diffuse
+		{  43,  11,  -1,   388044,     3636,   120749 }, // subset0_Catwalk_03_Diffuse
+		{  41,  42,  -1,   391680,       72,   121481 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   391752,      162,   121513 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   391914,      324,   121553 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   392238,      144,   121630 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   392382,      144,   121665 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   392526,      162,   121705 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   392688,      324,   121745 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   393012,      144,   121822 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   393156,      144,   121857 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   393300,      162,   121897 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   393462,      360,   121937 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   393822,      144,   122014 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   393966,      144,   122049 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   394110,      162,   122084 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   394272,      324,   122124 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   394596,      153,   122194 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   394749,      144,   122234 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   394893,      162,   122269 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   395055,      324,   122309 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   395379,      144,   122379 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   395523,      144,   122419 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   395667,      162,   122459 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   395829,      324,   122503 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   396153,      150,   122573 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   396303,      144,   122621 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   396447,      162,   122661 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   396609,      324,   122701 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   396933,      144,   122778 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   397077,      144,   122818 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   397221,      162,   122853 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   397383,      324,   122897 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   397707,      141,   122967 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   397848,      144,   123006 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   397992,      162,   123041 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   398154,    19506,   123085 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   417660,    19506,   129867 }, // subset0_blinnCatwalk
+		{  43,  11,  -1,   437166,      120,   136640 }, // subset0_Catwalk_03_Diffuse
+		{  41,  42,  -1,   437286,       72,   136720 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437358,       24,   136752 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437382,       24,   136768 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437406,       24,   136784 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437430,       24,   136800 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437454,       24,   136816 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437478,       24,   136832 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437502,       24,   136848 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437526,       24,   136864 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437550,       24,   136880 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437574,       24,   136896 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437598,       24,   136912 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437622,       24,   136928 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437646,       24,   136944 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437670,       24,   136960 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437694,       24,   136976 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437718,       24,   136992 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437742,       24,   137008 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437766,       24,   137024 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437790,       24,   137040 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437814,       24,   137056 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437838,       24,   137072 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437862,       24,   137088 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437886,       24,   137104 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437910,       24,   137120 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437934,       24,   137136 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437958,       24,   137152 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437982,       24,   137168 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438006,       24,   137184 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438030,       24,   137200 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438054,       24,   137216 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438078,       24,   137232 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438102,       24,   137248 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438126,       24,   137264 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438150,       24,   137280 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438174,       24,   137296 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438198,       24,   137312 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438222,       24,   137328 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438246,       24,   137344 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438270,       24,   137360 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438294,       24,   137376 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438318,       24,   137392 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438342,       24,   137408 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438366,       24,   137424 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438390,       24,   137440 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438414,       24,   137456 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438438,       24,   137472 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438462,       24,   137488 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438486,       24,   137504 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438510,       24,   137520 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438534,       24,   137536 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438558,       24,   137552 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438582,       24,   137568 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438606,       24,   137584 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438630,       24,   137600 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438654,       24,   137616 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438678,       24,   137632 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438702,       24,   137648 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438726,       24,   137664 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438750,       24,   137680 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438774,       24,   137696 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438798,       24,   137712 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438822,       24,   137728 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438846,       24,   137744 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438870,       24,   137760 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438894,       24,   137776 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438918,       24,   137792 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438942,       24,   137808 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438966,       24,   137824 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438990,       24,   137840 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439014,       24,   137856 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439038,       24,   137872 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439062,       24,   137888 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439086,       24,   137904 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439110,       24,   137920 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439134,       24,   137936 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439158,       24,   137952 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439182,       24,   137968 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439206,       24,   137984 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439230,       24,   138000 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439254,       24,   138016 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439278,       24,   138032 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439302,       24,   138048 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439326,       24,   138064 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439350,       24,   138080 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439374,       24,   138096 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439398,       24,   138112 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439422,       24,   138128 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439446,       24,   138144 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439470,       24,   138160 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439494,       24,   138176 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439518,       24,   138192 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439542,       24,   138208 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439566,       24,   138224 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439590,       24,   138240 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439614,       24,   138256 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439638,       24,   138272 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439662,       24,   138288 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439686,       24,   138304 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439710,       24,   138320 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439734,       24,   138336 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439758,       24,   138352 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439782,       24,   138368 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439806,       24,   138384 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439830,       24,   138400 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439854,       24,   138416 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439878,       24,   138432 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439902,       24,   138448 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439926,       24,   138464 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439950,       24,   138480 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439974,       24,   138496 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439998,       24,   138512 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440022,       24,   138528 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440046,       24,   138544 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440070,       24,   138560 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440094,       24,   138576 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440118,       24,   138592 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440142,       24,   138608 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440166,       24,   138624 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440190,       24,   138640 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440214,       24,   138656 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440238,       24,   138672 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440262,       24,   138688 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440286,       24,   138704 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440310,       24,   138720 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440334,       24,   138736 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440358,       24,   138752 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440382,       24,   138768 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440406,       24,   138784 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440430,       24,   138800 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440454,       24,   138816 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440478,       24,   138832 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440502,       24,   138848 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440526,       24,   138864 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440550,       24,   138880 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440574,       24,   138896 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440598,       24,   138912 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440622,       24,   138928 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440646,       24,   138944 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440670,       24,   138960 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440694,       24,   138976 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440718,       24,   138992 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440742,       24,   139008 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440766,       24,   139024 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440790,       24,   139040 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440814,       24,   139056 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440838,       24,   139072 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440862,       24,   139088 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440886,       24,   139104 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440910,       24,   139120 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440934,       24,   139136 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440958,       24,   139152 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440982,       24,   139168 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441006,       24,   139184 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441030,       24,   139200 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441054,       24,   139216 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441078,       24,   139232 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441102,       24,   139248 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441126,       24,   139264 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441150,       24,   139280 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441174,       24,   139296 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441198,       24,   139312 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441222,       24,   139328 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441246,       24,   139344 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441270,       24,   139360 }, // subset0_blinnCatwalk
+		{  44,  45,  -1,   441294,     2826,   139376 }, // subset0_shelves3_diff
+		{  35,  36,  -1,   444120,     2637,   139376 }, // subset1_shelves2_diff_0
+		{  14,  15,  -1,   446757,      636,   139376 }, // subset2_Stack__Boxes_Diff03_0
+		{  46,  47,  -1,   447393,       24,   141190 }, // subset0_blinn46
+		{  46,  47,  -1,   447417,      306,   141206 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   447723,      306,   141325 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   448029,      306,   141443 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   448335,      306,   141561 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   448641,      216,   141677 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   448857,     1812,   141759 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   450669,      306,   142479 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   450975,      222,   142604 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   451197,      132,   142704 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   451329,      222,   142754 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   451551,      306,   142854 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   451857,      132,   142975 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   451989,      222,   143025 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   452211,      306,   143125 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   452517,      306,   143247 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   452823,      132,   143370 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   452955,      222,   143420 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   453177,      132,   143520 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   453309,     1368,   143570 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   454677,     2484,   143914 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   457161,     5790,   144731 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   462951,     1836,   147045 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   464787,     3816,   147679 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   468603,    54240,   149038 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   522843,      792,   158991 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   523635,      792,   159136 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   524427,      216,   159281 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   524643,      216,   159363 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   524859,      216,   159445 }, // subset0_phongMisc_Boss_3_2048
+		{  48,  42,  -1,   525075,     1050,   159527 }, // subset0_LightBulbsColor
+		{  49,  50,  -1,   526125,     1128,   159773 }, // subset0_Hanghing_Light
+		{  10,  11,  -1,   527253,      540,   160003 }, // subset0_lambert1
+		{  10,  11,  -1,   527793,      225,   160123 }, // subset0_lambert1
+		{  49,  50,  -1,   528018,     2160,   160202 }, // subset0_Hanghing_Light
+		{  48,  42,  -1,   530178,     1050,   160707 }, // subset0_LightBulbsColor
+		{  49,  50,  -1,   531228,     1128,   160966 }, // subset0_Hanghing_Light
+		{  10,  11,  -1,   532356,      540,   161197 }, // subset0_lambert1
+		{  10,  11,  -1,   532896,      225,   161317 }, // subset0_lambert1
+		{  49,  50,  -1,   533121,     2160,   161391 }, // subset0_Hanghing_Light
+		{  48,  42,  -1,   535281,     1134,   161896 }, // subset0_LightBulbsColor
+		{  49,  50,  -1,   536415,     1128,   162168 }, // subset0_Hanghing_Light
+		{  49,  50,  -1,   537543,      600,   162399 }, // subset0_Hanghing_Light
+		{  49,  50,  -1,   538143,      225,   162531 }, // subset0_Hanghing_Light
+		{  49,  50,  -1,   538368,     2160,   162610 }, // subset0_Hanghing_Light
+		{  10,  51,  -1,   540528,      498,   163115 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   541026,      300,   163321 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   541326,      300,   163400 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   541626,      600,   163479 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   542226,      681,   163604 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   542907,      300,   163755 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   543207,      300,   163834 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   543507,      144,   163913 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   543651,      780,   163949 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   544431,      168,   164135 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   544599,      156,   164197 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   544755,      390,   164255 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   545145,     3702,   164393 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   548847,      468,   165239 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   549315,     1128,   165324 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   550443,      810,   165562 }, // subset0_Hanging_bundle
+		{  52,  53,  -1,   551253,      714,   165819 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   551967,      540,   165949 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   552507,     1080,   166048 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   553587,     1080,   166242 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   554667,      540,   166436 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   555207,      540,   166535 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   555747,     1080,   166642 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   556827,      540,   166836 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   557367,     1080,   166935 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   558447,     1080,   167129 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   559527,      540,   167323 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   560067,     1080,   167422 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   561147,     1080,   167616 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   562227,     1080,   167810 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   563307,     1080,   168001 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   564387,      714,   168195 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   565101,     1080,   168325 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   566181,      540,   168519 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   566721,      540,   168618 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   567261,      540,   168719 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   567801,     1080,   168818 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   568881,      540,   169012 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   569421,     1080,   169111 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   570501,      540,   169305 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   571041,      714,   169404 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   571755,     1080,   169534 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   572835,     1080,   169728 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   573915,      540,   169922 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   574455,      540,   170021 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   574995,     1080,   170120 }, // subset0_Hanging_bundle_marble
+		{  10,  51,  -1,   576075,    17184,   170314 }, // subset0_Rope
+		{  10,  51,  -1,   593259,      576,   176140 }, // subset0_Rope
+		{  10,  51,  -1,   593835,     2556,   176293 }, // subset0_Rope
+		{  10,  51,  -1,   596391,     4032,   176950 }, // subset0_Rope
+		{  10,  51,  -1,   600423,     4284,   177857 }, // subset0_Rope
+		{  10,  51,  -1,   604707,     4536,   178939 }, // subset0_Rope
+		{  10,  51,  -1,   609243,     4536,   179837 }, // subset0_Rope
+		{  10,  51,  -1,   613779,      612,   180733 }, // subset0_Rope
+		{  44,  45,  -1,   614391,      396,   180879 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   614787,      600,   181009 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   615387,      600,   181216 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   615987,      744,   181423 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   616731,      729,   181680 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   617460,     1920,   181932 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   619380,      324,   182343 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   619704,     2274,   182475 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   621978,     1860,   182902 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   623838,     2376,   183256 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   626214,     2190,   183705 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   628404,     2280,   184118 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   630684,      840,   184550 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   631524,      840,   184754 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   632364,      840,   184958 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   633204,      840,   185162 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   634044,     1008,   185366 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   635052,     1332,   185608 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   636384,     1617,   185890 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   638001,     1410,   186290 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   639411,      948,   186589 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   640359,       90,   187035 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   640449,      504,   187055 }, // subset0_shelves3_diff
+		{  35,  36,  -1,   640953,      378,   187197 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   641331,      432,   187284 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   641763,      378,   187378 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   642141,     3120,   187462 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   645261,      402,   188387 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   645663,     2580,   188525 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   648243,     3180,   189008 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   651423,     2100,   189678 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   653523,     3180,   190158 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   656703,      180,   190828 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   656883,      276,   190872 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   657159,      180,   190970 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   657339,      180,   191014 }, // subset0_shelves2_diff
+		{  44,  45,  -1,   657519,      228,   191068 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   657747,      108,   191162 }, // subset0_shelves3_diff
+		{  35,  36,  -1,   657855,      192,   191197 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   658047,      192,   191271 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   658239,      192,   191345 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   658431,      168,   191419 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   658599,      168,   191485 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   658767,      168,   191551 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   658935,      192,   191617 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   659127,      192,   191691 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   659319,      168,   191765 }, // subset0_shelves2_diff
+		{  44,  45,  -1,   659487,     1617,   191831 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   661104,     1617,   192226 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   662721,     1617,   192605 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   664338,       90,   192995 }, // subset0_shelves3_diff
+		{  54,  42,  -1,   664428,     1248,   193015 }, // subset0_Window
+		{  55,  56,  -1,   665676,     3312,   193319 }, // subset0_Sliding_Steel_Door
+		{  54,  57,  -1,   668988,      930,   194197 }, // subset0_window_Diff
+		{  58,  59,  -1,   669918,    12912,   194433 }, // subset0_Door2
+		{  60,  61,  -1,   682830,      969,   197161 }, // subset0_Floor
+		{  62,  63,  -1,   683799,     2037,   197482 }, // subset0_wall_4
+		{  62,  63,  -1,   685836,     3000,   198168 }, // subset0_wall_3
+		{  64,  65,  -1,   688836,     2205,   199986 }, // subset0_wall_1
+		{  64,  65,  -1,   691041,     1656,   200663 }, // subset0_wall_2
+		{  66,  67,  -1,   692697,     5424,   201041 }, // subset0_roof
+		{  68,  69,  -1,   698121,      939,   203677 }, // subset0_Pillar
+		{  66,  67,  -1,   699060,     1536,   203892 }, // subset0_roof
+		{  70,  71,  -1,   700596,      609,   204339 }, // subset0_Broken_Pillar_Diff
+		{  33,  34,  -1,   701205,     1920,   204469 }, // subset0_Back_Alley_Drum
+		{  33,  34,  -1,   703125,     1920,   205134 }, // subset0_Back_Alley_Drum
+		{  33,  34,  -1,   705045,     1920,   205799 }, // subset0_Back_Alley_Drum
+		{  35,  36,  -1,   706965,     7809,   206464 }, // subset0_shelves2_diff
+		{  14,  15,  -1,   714774,     1920,   208128 }, // subset0_Stack__Boxes_Diff03
+		{  33,  34,  -1,   716694,     1920,   208629 }, // subset0_Back_Alley_Drum
+		{  33,  34,  -1,   718614,     1920,   209294 }, // subset0_Back_Alley_Drum
+		{  33,  34,  -1,   720534,     1920,   209959 }, // subset0_Back_Alley_Drum
+		{  35,  36,  -1,   722454,     7809,   210624 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   730263,     7809,   212294 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   738072,     7809,   213953 }, // subset0_shelves2_diff
+		{  32,  32,  -1,   745881,      783,   215619 }, // subset0_gameCrates_02_Diff
+		{  72,  73,  -1,   746664,    14451,   215808 }, // subset0_GolfBag:Golfclub
+		{  18,  19,  -1,   761115,     3096,   219093 }, // subset0_Back_Alley_box
+	};
 }

--- a/Samples/Desktop/D3D12xGPU/src/d3dx12.h
+++ b/Samples/Desktop/D3D12xGPU/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D1211On12/src/D3D1211On12.cpp
+++ b/Samples/UWP/D3D1211On12/src/D3D1211On12.cpp
@@ -13,384 +13,387 @@
 #include "D3D1211On12.h"
 
 D3D1211on12::D3D1211on12(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0),
-    m_fenceValues{}
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0),
+	m_fenceValues{}
 {
 }
 
 void D3D1211on12::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D1211on12::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
-    UINT d3d11DeviceFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
-    D2D1_FACTORY_OPTIONS d2dFactoryOptions = {};
+	UINT dxgiFactoryFlags = 0;
+	UINT d3d11DeviceFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
+	D2D1_FACTORY_OPTIONS d2dFactoryOptions = {};
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-            d3d11DeviceFlags |= D3D11_CREATE_DEVICE_DEBUG;
-            d2dFactoryOptions.debugLevel = D2D1_DEBUG_LEVEL_INFORMATION;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+			d3d11DeviceFlags |= D3D11_CREATE_DEVICE_DEBUG;
+			d2dFactoryOptions.debugLevel = D2D1_DEBUG_LEVEL_INFORMATION;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_d3d12Device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_d3d12Device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_d3d12Device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_d3d12Device)
+			));
+	}
 
 #if defined(_DEBUG)
-    // Filter a debug error coming from the 11on12 layer.
-    ComPtr<ID3D12InfoQueue> infoQueue;
-    if (SUCCEEDED(m_d3d12Device->QueryInterface(IID_PPV_ARGS(&infoQueue))))
-    {
-        // Suppress whole categories of messages.
-        //D3D12_MESSAGE_CATEGORY categories[] = {};
+	// Filter a debug error coming from the 11on12 layer.
+	ComPtr<ID3D12InfoQueue> infoQueue;
+	if (SUCCEEDED(m_d3d12Device->QueryInterface(IID_PPV_ARGS(&infoQueue))))
+	{
+		// Suppress whole categories of messages.
+		//D3D12_MESSAGE_CATEGORY categories[] = {};
 
-        // Suppress messages based on their severity level.
-        D3D12_MESSAGE_SEVERITY severities[] =
-        {
-            D3D12_MESSAGE_SEVERITY_INFO,
-        };
+		// Suppress messages based on their severity level.
+		D3D12_MESSAGE_SEVERITY severities[] =
+		{
+			D3D12_MESSAGE_SEVERITY_INFO,
+		};
 
-        // Suppress individual messages by their ID.
-        D3D12_MESSAGE_ID denyIds[] =
-        {
-            // This occurs when there are uninitialized descriptors in a descriptor table, even when a
-            // shader does not access the missing descriptors.
-            D3D12_MESSAGE_ID_INVALID_DESCRIPTOR_HANDLE,
-        };
+		// Suppress individual messages by their ID.
+		D3D12_MESSAGE_ID denyIds[] =
+		{
+			// This occurs when there are uninitialized descriptors in a descriptor table, even when a
+			// shader does not access the missing descriptors.
+			D3D12_MESSAGE_ID_INVALID_DESCRIPTOR_HANDLE,
+		};
 
-        D3D12_INFO_QUEUE_FILTER filter = {};
-        //filter.DenyList.NumCategories = _countof(categories);
-        //filter.DenyList.pCategoryList = categories;
-        filter.DenyList.NumSeverities = _countof(severities);
-        filter.DenyList.pSeverityList = severities;
-        filter.DenyList.NumIDs = _countof(denyIds);
-        filter.DenyList.pIDList = denyIds;
+		D3D12_INFO_QUEUE_FILTER filter = {};
+		//filter.DenyList.NumCategories = _countof(categories);
+		//filter.DenyList.pCategoryList = categories;
+		filter.DenyList.NumSeverities = _countof(severities);
+		filter.DenyList.pSeverityList = severities;
+		filter.DenyList.NumIDs = _countof(denyIds);
+		filter.DenyList.pIDList = denyIds;
 
-        ThrowIfFailed(infoQueue->PushStorageFilter(&filter));
-    }
+		ThrowIfFailed(infoQueue->PushStorageFilter(&filter));
+	}
 #endif
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_d3d12Device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
-    NAME_D3D12_OBJECT(m_commandQueue);
+	ThrowIfFailed(m_d3d12Device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	NAME_D3D12_OBJECT(m_commandQueue);
 
-    // Describe the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create an 11 device wrapped around the 12 device and share
-    // 12's command queue.
-    ComPtr<ID3D11Device> d3d11Device;
-    ThrowIfFailed(D3D11On12CreateDevice(
-        m_d3d12Device.Get(),
-        d3d11DeviceFlags,
-        nullptr,
-        0,
-        reinterpret_cast<IUnknown**>(m_commandQueue.GetAddressOf()),
-        1,
-        0,
-        &d3d11Device,
-        &m_d3d11DeviceContext,
-        nullptr
-        ));
+	// Create an 11 device wrapped around the 12 device and share
+	// 12's command queue.
+	ComPtr<ID3D11Device> d3d11Device;
+	ThrowIfFailed(D3D11On12CreateDevice(
+		m_d3d12Device.Get(),
+		d3d11DeviceFlags,
+		nullptr,
+		0,
+		reinterpret_cast<IUnknown**>(m_commandQueue.GetAddressOf()),
+		1,
+		0,
+		&d3d11Device,
+		&m_d3d11DeviceContext,
+		nullptr
+		));
 
-    // Query the 11On12 device from the 11 device.
-    ThrowIfFailed(d3d11Device.As(&m_d3d11On12Device));
+	// Query the 11On12 device from the 11 device.
+	ThrowIfFailed(d3d11Device.As(&m_d3d11On12Device));
 
-    // Create D2D/DWrite components.
-    {
-        D2D1_DEVICE_CONTEXT_OPTIONS deviceOptions = D2D1_DEVICE_CONTEXT_OPTIONS_NONE;
-        ThrowIfFailed(D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, __uuidof(ID2D1Factory3), &d2dFactoryOptions, &m_d2dFactory));
-        ComPtr<IDXGIDevice> dxgiDevice;
-        ThrowIfFailed(m_d3d11On12Device.As(&dxgiDevice));
-        ThrowIfFailed(m_d2dFactory->CreateDevice(dxgiDevice.Get(), &m_d2dDevice));
-        ThrowIfFailed(m_d2dDevice->CreateDeviceContext(deviceOptions, &m_d2dDeviceContext));
-        ThrowIfFailed(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &m_dWriteFactory));
-    }
+	// Create D2D/DWrite components.
+	{
+		D2D1_DEVICE_CONTEXT_OPTIONS deviceOptions = D2D1_DEVICE_CONTEXT_OPTIONS_NONE;
+		ThrowIfFailed(D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, __uuidof(ID2D1Factory3), &d2dFactoryOptions, &m_d2dFactory));
+		ComPtr<IDXGIDevice> dxgiDevice;
+		ThrowIfFailed(m_d3d11On12Device.As(&dxgiDevice));
+		ThrowIfFailed(m_d2dFactory->CreateDevice(dxgiDevice.Get(), &m_d2dDevice));
+		ThrowIfFailed(m_d2dDevice->CreateDeviceContext(deviceOptions, &m_d2dDeviceContext));
+		ThrowIfFailed(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &m_dWriteFactory));
+	}
 
-    // Query the desktop's dpi settings, which will be used to create
-    // D2D's render targets.
-    float dpiX;
-    float dpiY;
-    m_d2dFactory->GetDesktopDpi(&dpiX, &dpiY);
-    D2D1_BITMAP_PROPERTIES1 bitmapProperties = D2D1::BitmapProperties1(
-        D2D1_BITMAP_OPTIONS_TARGET | D2D1_BITMAP_OPTIONS_CANNOT_DRAW,
-        D2D1::PixelFormat(DXGI_FORMAT_UNKNOWN, D2D1_ALPHA_MODE_PREMULTIPLIED),
-        dpiX,
-        dpiY
-        );
+	// Query the desktop's dpi settings, which will be used to create
+	// D2D's render targets.
+	float dpiX;
+	float dpiY;
+#pragma warning(push)
+#pragma warning(disable : 4996) // GetDesktopDpi is deprecated.
+	m_d2dFactory->GetDesktopDpi(&dpiX, &dpiY);
+#pragma warning(pop)
+	D2D1_BITMAP_PROPERTIES1 bitmapProperties = D2D1::BitmapProperties1(
+		D2D1_BITMAP_OPTIONS_TARGET | D2D1_BITMAP_OPTIONS_CANNOT_DRAW,
+		D2D1::PixelFormat(DXGI_FORMAT_UNKNOWN, D2D1_ALPHA_MODE_PREMULTIPLIED),
+		dpiX,
+		dpiY
+		);
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_d3d12Device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_d3d12Device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        m_rtvDescriptorSize = m_d3d12Device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    }
+		m_rtvDescriptorSize = m_d3d12Device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV, D2D render target, and a command allocator for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_d3d12Device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+		// Create a RTV, D2D render target, and a command allocator for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_d3d12Device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
 
-            NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
+			NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
 
-            // Create a wrapped 11On12 resource of this back buffer. Since we are 
-            // rendering all D3D12 content first and then all D2D content, we specify 
-            // the In resource state as RENDER_TARGET - because D3D12 will have last 
-            // used it in this state - and the Out resource state as PRESENT. When 
-            // ReleaseWrappedResources() is called on the 11On12 device, the resource 
-            // will be transitioned to the PRESENT state.
-            D3D11_RESOURCE_FLAGS d3d11Flags = { D3D11_BIND_RENDER_TARGET };
-            ThrowIfFailed(m_d3d11On12Device->CreateWrappedResource(
-                m_renderTargets[n].Get(),
-                &d3d11Flags,
-                D3D12_RESOURCE_STATE_RENDER_TARGET,
-                D3D12_RESOURCE_STATE_PRESENT,
-                IID_PPV_ARGS(&m_wrappedBackBuffers[n])
-                ));
+			// Create a wrapped 11On12 resource of this back buffer. Since we are 
+			// rendering all D3D12 content first and then all D2D content, we specify 
+			// the In resource state as RENDER_TARGET - because D3D12 will have last 
+			// used it in this state - and the Out resource state as PRESENT. When 
+			// ReleaseWrappedResources() is called on the 11On12 device, the resource 
+			// will be transitioned to the PRESENT state.
+			D3D11_RESOURCE_FLAGS d3d11Flags = { D3D11_BIND_RENDER_TARGET };
+			ThrowIfFailed(m_d3d11On12Device->CreateWrappedResource(
+				m_renderTargets[n].Get(),
+				&d3d11Flags,
+				D3D12_RESOURCE_STATE_RENDER_TARGET,
+				D3D12_RESOURCE_STATE_PRESENT,
+				IID_PPV_ARGS(&m_wrappedBackBuffers[n])
+				));
 
-            // Create a render target for D2D to draw directly to this back buffer.
-            ComPtr<IDXGISurface> surface;
-            ThrowIfFailed(m_wrappedBackBuffers[n].As(&surface));
-            ThrowIfFailed(m_d2dDeviceContext->CreateBitmapFromDxgiSurface(
-                surface.Get(),
-                &bitmapProperties,
-                &m_d2dRenderTargets[n]
-                ));
+			// Create a render target for D2D to draw directly to this back buffer.
+			ComPtr<IDXGISurface> surface;
+			ThrowIfFailed(m_wrappedBackBuffers[n].As(&surface));
+			ThrowIfFailed(m_d2dDeviceContext->CreateBitmapFromDxgiSurface(
+				surface.Get(),
+				&bitmapProperties,
+				&m_d2dRenderTargets[n]
+				));
 
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-            ThrowIfFailed(m_d3d12Device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
-        }
-    }
+			ThrowIfFailed(m_d3d12Device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
+		}
+	}
 }
 
 // Load the sample assets.
 void D3D1211on12::LoadAssets()
 {
-    // Create an empty root signature.
-    {
-        CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+	// Create an empty root signature.
+	{
+		CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
-        ThrowIfFailed(m_d3d12Device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-        NAME_D3D12_OBJECT(m_rootSignature);
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
+		ThrowIfFailed(m_d3d12Device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+		NAME_D3D12_OBJECT(m_rootSignature);
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Describe and create the graphics pipeline state object (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state object (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_d3d12Device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-        NAME_D3D12_OBJECT(m_pipelineState);
-    }
+		ThrowIfFailed(m_d3d12Device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+		NAME_D3D12_OBJECT(m_pipelineState);
+	}
 
-    ThrowIfFailed(m_d3d12Device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
-    NAME_D3D12_OBJECT(m_commandList);
+	ThrowIfFailed(m_d3d12Device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	NAME_D3D12_OBJECT(m_commandList);
 
-    // Create D2D/DWrite objects for rendering text.
-    {
-        ThrowIfFailed(m_d2dDeviceContext->CreateSolidColorBrush(D2D1::ColorF(D2D1::ColorF::Black), &m_textBrush));
-        ThrowIfFailed(m_dWriteFactory->CreateTextFormat(
-            L"Verdana",
-            NULL,
-            DWRITE_FONT_WEIGHT_NORMAL,
-            DWRITE_FONT_STYLE_NORMAL,
-            DWRITE_FONT_STRETCH_NORMAL,
-            50,
-            L"en-us",
-            &m_textFormat
-            ));
-        ThrowIfFailed(m_textFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER));
-        ThrowIfFailed(m_textFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER));
-    }
+	// Create D2D/DWrite objects for rendering text.
+	{
+		ThrowIfFailed(m_d2dDeviceContext->CreateSolidColorBrush(D2D1::ColorF(D2D1::ColorF::Black), &m_textBrush));
+		ThrowIfFailed(m_dWriteFactory->CreateTextFormat(
+			L"Verdana",
+			NULL,
+			DWRITE_FONT_WEIGHT_NORMAL,
+			DWRITE_FONT_STYLE_NORMAL,
+			DWRITE_FONT_STRETCH_NORMAL,
+			50,
+			L"en-us",
+			&m_textFormat
+			));
+		ThrowIfFailed(m_textFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER));
+		ThrowIfFailed(m_textFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER));
+	}
 
-    // Note: ComPtr's are CPU objects but this resource needs to stay in scope until
-    // the command list that references it has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resource is not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> vertexBufferUpload;
+	// Note: ComPtr's are CPU objects but this resource needs to stay in scope until
+	// the command list that references it has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resource is not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> vertexBufferUpload;
 
-    // Create the vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        Vertex triangleVertices[] =
-        {
-            { { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
-            { { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
-            { { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
-        };
+	// Create the vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		Vertex triangleVertices[] =
+		{
+			{ { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
+			{ { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
+			{ { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
+		};
 
-        const UINT vertexBufferSize = sizeof(triangleVertices);
+		const UINT vertexBufferSize = sizeof(triangleVertices);
 
-        ThrowIfFailed(m_d3d12Device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		ThrowIfFailed(m_d3d12Device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        ThrowIfFailed(m_d3d12Device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&vertexBufferUpload)));
+		ThrowIfFailed(m_d3d12Device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&vertexBufferUpload)));
 
-        NAME_D3D12_OBJECT(m_vertexBuffer);
+		NAME_D3D12_OBJECT(m_vertexBuffer);
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(triangleVertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(triangleVertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = vertexBufferSize;
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = vertexBufferSize;
+	}
 
-    // Close the command list and execute it to begin the vertex buffer copy into
-    // the default heap.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the vertex buffer copy into
+	// the default heap.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_d3d12Device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(m_fence.GetAddressOf())));
-        m_fenceValues[m_frameIndex]++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_d3d12Device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(m_fence.GetAddressOf())));
+		m_fenceValues[m_frameIndex]++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForGpu();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForGpu();
+	}
 }
 
 // Update frame-based values.
@@ -401,136 +404,136 @@ void D3D1211on12::OnUpdate()
 // Render the scene.
 void D3D1211on12::OnRender()
 {
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render 3D");
+	PIXBeginEvent(m_commandQueue.Get(), 0, L"Render 3D");
 
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    PIXEndEvent(m_commandQueue.Get());
+	PIXEndEvent(m_commandQueue.Get());
 
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render UI");
-    RenderUI();
-    PIXEndEvent(m_commandQueue.Get());
+	PIXBeginEvent(m_commandQueue.Get(), 0, L"Render UI");
+	RenderUI();
+	PIXEndEvent(m_commandQueue.Get());
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+	// Present the frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    MoveToNextFrame();
+	MoveToNextFrame();
 }
 
 void D3D1211on12::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForGpu();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForGpu();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D1211on12::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
-    m_commandList->DrawInstanced(3, 1, 0, 0);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+	m_commandList->DrawInstanced(3, 1, 0, 0);
 
-    // Note: do not transition the render target to present here.
-    // the transition will occur when the wrapped 11On12 render
-    // target resource is released.
+	// Note: do not transition the render target to present here.
+	// the transition will occur when the wrapped 11On12 render
+	// target resource is released.
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 // Render text over D3D12 using D2D via the 11On12 device.
 void D3D1211on12::RenderUI()
 {
-    D2D1_SIZE_F rtSize = m_d2dRenderTargets[m_frameIndex]->GetSize();
-    D2D1_RECT_F textRect = D2D1::RectF(0, 0, rtSize.width, rtSize.height);
-    static const WCHAR text[] = L"11On12";
+	D2D1_SIZE_F rtSize = m_d2dRenderTargets[m_frameIndex]->GetSize();
+	D2D1_RECT_F textRect = D2D1::RectF(0, 0, rtSize.width, rtSize.height);
+	static const WCHAR text[] = L"11On12";
 
-    // Acquire our wrapped render target resource for the current back buffer.
-    m_d3d11On12Device->AcquireWrappedResources(m_wrappedBackBuffers[m_frameIndex].GetAddressOf(), 1);
+	// Acquire our wrapped render target resource for the current back buffer.
+	m_d3d11On12Device->AcquireWrappedResources(m_wrappedBackBuffers[m_frameIndex].GetAddressOf(), 1);
 
-    // Render text directly to the back buffer.
-    m_d2dDeviceContext->SetTarget(m_d2dRenderTargets[m_frameIndex].Get());
-    m_d2dDeviceContext->BeginDraw();
-    m_d2dDeviceContext->SetTransform(D2D1::Matrix3x2F::Identity());
-    m_d2dDeviceContext->DrawText(
-        text,
-        _countof(text) - 1,
-        m_textFormat.Get(),
-        &textRect,
-        m_textBrush.Get()
-        );
-    ThrowIfFailed(m_d2dDeviceContext->EndDraw());
+	// Render text directly to the back buffer.
+	m_d2dDeviceContext->SetTarget(m_d2dRenderTargets[m_frameIndex].Get());
+	m_d2dDeviceContext->BeginDraw();
+	m_d2dDeviceContext->SetTransform(D2D1::Matrix3x2F::Identity());
+	m_d2dDeviceContext->DrawText(
+		text,
+		_countof(text) - 1,
+		m_textFormat.Get(),
+		&textRect,
+		m_textBrush.Get()
+		);
+	ThrowIfFailed(m_d2dDeviceContext->EndDraw());
 
-    // Release our wrapped render target resource. Releasing 
-    // transitions the back buffer resource to the state specified
-    // as the OutState when the wrapped resource was created.
-    m_d3d11On12Device->ReleaseWrappedResources(m_wrappedBackBuffers[m_frameIndex].GetAddressOf(), 1);
+	// Release our wrapped render target resource. Releasing 
+	// transitions the back buffer resource to the state specified
+	// as the OutState when the wrapped resource was created.
+	m_d3d11On12Device->ReleaseWrappedResources(m_wrappedBackBuffers[m_frameIndex].GetAddressOf(), 1);
 
-    // Flush to submit the 11 command list to the shared command queue.
-    m_d3d11DeviceContext->Flush();
+	// Flush to submit the 11 command list to the shared command queue.
+	m_d3d11DeviceContext->Flush();
 }
 
 // Wait for pending GPU work to complete.
 void D3D1211on12::WaitForGpu()
 {
-    // Schedule a Signal command in the queue.
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
+	// Schedule a Signal command in the queue.
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
 
-    // Wait until the fence has been processed.
-    ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-    WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	// Wait until the fence has been processed.
+	ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+	WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
 
-    // Increment the fence value for the current frame.
-    m_fenceValues[m_frameIndex]++;
+	// Increment the fence value for the current frame.
+	m_fenceValues[m_frameIndex]++;
 }
 
 // Prepare to render the next frame.
 void D3D1211on12::MoveToNextFrame()
 {
-    // Schedule a Signal command in the queue.
-    const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
+	// Schedule a Signal command in the queue.
+	const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
 
-    // Update the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Update the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-        WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+		WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	}
 
-    // Set the fence value for the next frame.
-    m_fenceValues[m_frameIndex] = currentFenceValue + 1;
+	// Set the fence value for the next frame.
+	m_fenceValues[m_frameIndex] = currentFenceValue + 1;
 }

--- a/Samples/UWP/D3D1211On12/src/D3D1211On12.h
+++ b/Samples/UWP/D3D1211On12/src/D3D1211On12.h
@@ -25,60 +25,60 @@ using Microsoft::WRL::ComPtr;
 class D3D1211on12 : public DXSample
 {
 public:
-    D3D1211on12(UINT width, UINT height, std::wstring name);
+	D3D1211on12(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    static const UINT FrameCount = 3;
+	static const UINT FrameCount = 3;
 
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT4 color;
-    };
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT4 color;
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D11DeviceContext> m_d3d11DeviceContext;
-    ComPtr<ID3D11On12Device> m_d3d11On12Device;
-    ComPtr<ID3D12Device> m_d3d12Device;
-    ComPtr<IDWriteFactory> m_dWriteFactory;
-    ComPtr<ID2D1Factory3> m_d2dFactory;
-    ComPtr<ID2D1Device2> m_d2dDevice;
-    ComPtr<ID2D1DeviceContext2> m_d2dDeviceContext;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D11Resource> m_wrappedBackBuffers[FrameCount];
-    ComPtr<ID2D1Bitmap1> m_d2dRenderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D11DeviceContext> m_d3d11DeviceContext;
+	ComPtr<ID3D11On12Device> m_d3d11On12Device;
+	ComPtr<ID3D12Device> m_d3d12Device;
+	ComPtr<IDWriteFactory> m_dWriteFactory;
+	ComPtr<ID2D1Factory3> m_d2dFactory;
+	ComPtr<ID2D1Device2> m_d2dDevice;
+	ComPtr<ID2D1DeviceContext2> m_d2dDeviceContext;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D11Resource> m_wrappedBackBuffers[FrameCount];
+	ComPtr<ID2D1Bitmap1> m_d2dRenderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
 
-    // App resources.
-    UINT m_rtvDescriptorSize;
-    ComPtr<ID2D1SolidColorBrush> m_textBrush;
-    ComPtr<IDWriteTextFormat> m_textFormat;
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	// App resources.
+	UINT m_rtvDescriptorSize;
+	ComPtr<ID2D1SolidColorBrush> m_textBrush;
+	ComPtr<IDWriteTextFormat> m_textFormat;
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValues[FrameCount];
+	// Synchronization objects.
+	UINT m_frameIndex;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValues[FrameCount];
 
-    void LoadPipeline();
-    void LoadAssets();
-    void PopulateCommandList();
-    void WaitForGpu();
-    void MoveToNextFrame();
-    void RenderUI();
+	void LoadPipeline();
+	void LoadAssets();
+	void PopulateCommandList();
+	void WaitForGpu();
+	void MoveToNextFrame();
+	void RenderUI();
 };

--- a/Samples/UWP/D3D1211On12/src/DXSample.cpp
+++ b/Samples/UWP/D3D1211On12/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,59 +34,104 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
-    auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(windowText.c_str());
+	std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
+	auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/UWP/D3D1211On12/src/DXSample.h
+++ b/Samples/UWP/D3D1211On12/src/DXSample.h
@@ -16,42 +16,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/UWP/D3D1211On12/src/Main.cpp
+++ b/Samples/UWP/D3D1211On12/src/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D1211on12 sample(1200, 900, L"");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D1211on12 sample(1200, 900, L"");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D1211On12/src/View.cpp
+++ b/Samples/UWP/D3D1211On12/src/View.cpp
@@ -15,27 +15,27 @@
 using namespace Windows::Foundation;
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -44,20 +44,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -66,26 +66,26 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnClosed(CoreWindow^ /*sender*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }

--- a/Samples/UWP/D3D1211On12/src/View.h
+++ b/Samples/UWP/D3D1211On12/src/View.h
@@ -23,20 +23,20 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
+	DXSample* m_pSample;
+	bool m_windowClosed;
 };

--- a/Samples/UWP/D3D1211On12/src/ViewProvider.cpp
+++ b/Samples/UWP/D3D1211On12/src/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D1211On12/src/ViewProvider.h
+++ b/Samples/UWP/D3D1211On12/src/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D1211On12/src/d3dx12.h
+++ b/Samples/UWP/D3D1211On12/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D1211On12/src/shaders.hlsl
+++ b/Samples/UWP/D3D1211On12/src/shaders.hlsl
@@ -11,21 +11,21 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VSMain(float4 position : POSITION, float4 color : COLOR)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.color = color;
+	result.position = position;
+	result.color = color;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/UWP/D3D12Bundles/src/D3D12Bundles.cpp
+++ b/Samples/UWP/D3D12Bundles/src/D3D12Bundles.cpp
@@ -14,630 +14,630 @@
 #include "occcity.h"
 
 D3D12Bundles::D3D12Bundles(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_frameCounter(0),
-    m_fenceValue(0),
-    m_rtvDescriptorSize(0),
-    m_currentFrameResourceIndex(0),
-    m_pCurrentFrameResource(nullptr)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_frameCounter(0),
+	m_fenceValue(0),
+	m_rtvDescriptorSize(0),
+	m_currentFrameResourceIndex(0),
+	m_pCurrentFrameResource(nullptr)
 {
 }
 
 void D3D12Bundles::OnInit()
 {
-    m_camera.Init({ 8, 8, 30 });
+	m_camera.Init({ 8, 8, 30 });
 
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12Bundles::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
-    NAME_D3D12_OBJECT(m_commandQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	NAME_D3D12_OBJECT(m_commandQueue);
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a depth stencil view (DSV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
-        dsvHeapDesc.NumDescriptors = 1;
-        dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-        dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
+		// Describe and create a depth stencil view (DSV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
+		dsvHeapDesc.NumDescriptors = 1;
+		dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+		dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
 
-        // Describe and create a shader resource view (SRV) and constant 
-        // buffer view (CBV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvSrvHeapDesc = {};
-        cbvSrvHeapDesc.NumDescriptors =
-            FrameCount * CityRowCount * CityColumnCount        // FrameCount frames * CityRowCount * CityColumnCount.
-            + 1;                                            // + 1 for the SRV.
-        cbvSrvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        cbvSrvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvSrvHeapDesc, IID_PPV_ARGS(&m_cbvSrvHeap)));
-        NAME_D3D12_OBJECT(m_cbvSrvHeap);
+		// Describe and create a shader resource view (SRV) and constant 
+		// buffer view (CBV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvSrvHeapDesc = {};
+		cbvSrvHeapDesc.NumDescriptors =
+			FrameCount * CityRowCount * CityColumnCount		// FrameCount frames * CityRowCount * CityColumnCount.
+			+ 1;											// + 1 for the SRV.
+		cbvSrvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		cbvSrvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvSrvHeapDesc, IID_PPV_ARGS(&m_cbvSrvHeap)));
+		NAME_D3D12_OBJECT(m_cbvSrvHeap);
 
-        // Describe and create a sampler descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
-        samplerHeapDesc.NumDescriptors = 1;
-        samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
-        samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_samplerHeap)));
+		// Describe and create a sampler descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
+		samplerHeapDesc.NumDescriptors = 1;
+		samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
+		samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_samplerHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-        m_cbvSrvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_cbvSrvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	}
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
 }
 
 // Load the sample assets.
 void D3D12Bundles::LoadAssets()
 {
-    // Note: ComPtr's are CPU objects but these resources need to stay in scope until
-    // the command list that references them has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resources are not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> vertexBufferUploadHeap;
-    ComPtr<ID3D12Resource> indexBufferUploadHeap;
-    ComPtr<ID3D12Resource> textureUploadHeap;
+	// Note: ComPtr's are CPU objects but these resources need to stay in scope until
+	// the command list that references them has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resources are not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> vertexBufferUploadHeap;
+	ComPtr<ID3D12Resource> indexBufferUploadHeap;
+	ComPtr<ID3D12Resource> textureUploadHeap;
 
-    // Create the root signature.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signature.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[3];
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
-        ranges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[3];
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
+		ranges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
 
-        CD3DX12_ROOT_PARAMETER1 rootParameters[3];
-        rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
-        rootParameters[1].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_PIXEL);
-        rootParameters[2].InitAsDescriptorTable(1, &ranges[2], D3D12_SHADER_VISIBILITY_ALL);
+		CD3DX12_ROOT_PARAMETER1 rootParameters[3];
+		rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
+		rootParameters[1].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_PIXEL);
+		rootParameters[2].InitAsDescriptorTable(1, &ranges[2], D3D12_SHADER_VISIBILITY_ALL);
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-        NAME_D3D12_OBJECT(m_rootSignature);
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+		NAME_D3D12_OBJECT(m_rootSignature);
+	}
 
-    // Create the pipeline state, which includes loading shaders.
-    {
-        UINT8* pVertexShaderData;
-        UINT8* pPixelShaderData1;
-        UINT8* pPixelShaderData2;
-        UINT vertexShaderDataLength;
-        UINT pixelShaderDataLength1;
-        UINT pixelShaderDataLength2;
+	// Create the pipeline state, which includes loading shaders.
+	{
+		UINT8* pVertexShaderData;
+		UINT8* pPixelShaderData1;
+		UINT8* pPixelShaderData2;
+		UINT vertexShaderDataLength;
+		UINT pixelShaderDataLength1;
+		UINT pixelShaderDataLength2;
 
-        // Load pre-compiled shaders.
-        ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(L"shader_mesh_simple_vert.cso").c_str(), &pVertexShaderData, &vertexShaderDataLength));
-        ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(L"shader_mesh_simple_pixel.cso").c_str(), &pPixelShaderData1, &pixelShaderDataLength1));
-        ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(L"shader_mesh_alt_pixel.cso").c_str(), &pPixelShaderData2, &pixelShaderDataLength2));
+		// Load pre-compiled shaders.
+		ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(L"shader_mesh_simple_vert.cso").c_str(), &pVertexShaderData, &vertexShaderDataLength));
+		ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(L"shader_mesh_simple_pixel.cso").c_str(), &pPixelShaderData1, &pixelShaderDataLength1));
+		ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(L"shader_mesh_alt_pixel.cso").c_str(), &pPixelShaderData2, &pixelShaderDataLength2));
 
-        CD3DX12_RASTERIZER_DESC rasterizerStateDesc(D3D12_DEFAULT);
-        rasterizerStateDesc.CullMode = D3D12_CULL_MODE_NONE;
+		CD3DX12_RASTERIZER_DESC rasterizerStateDesc(D3D12_DEFAULT);
+		rasterizerStateDesc.CullMode = D3D12_CULL_MODE_NONE;
 
-        // Describe and create the graphics pipeline state objects (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { SampleAssets::StandardVertexDescription, SampleAssets::StandardVertexDescriptionNumElements };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(pVertexShaderData, vertexShaderDataLength);
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pPixelShaderData1, pixelShaderDataLength1);
-        psoDesc.RasterizerState = rasterizerStateDesc;
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state objects (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { SampleAssets::StandardVertexDescription, SampleAssets::StandardVertexDescriptionNumElements };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(pVertexShaderData, vertexShaderDataLength);
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pPixelShaderData1, pixelShaderDataLength1);
+		psoDesc.RasterizerState = rasterizerStateDesc;
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState1)));
-        NAME_D3D12_OBJECT(m_pipelineState1);
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState1)));
+		NAME_D3D12_OBJECT(m_pipelineState1);
 
-        // Modify the description to use an alternate pixel shader and create
-        // a second PSO.
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pPixelShaderData2, pixelShaderDataLength2);
+		// Modify the description to use an alternate pixel shader and create
+		// a second PSO.
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pPixelShaderData2, pixelShaderDataLength2);
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState2)));
-        NAME_D3D12_OBJECT(m_pipelineState2);
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState2)));
+		NAME_D3D12_OBJECT(m_pipelineState2);
 
-        delete pVertexShaderData;
-        delete pPixelShaderData1;
-        delete pPixelShaderData2;
-    }
+		delete pVertexShaderData;
+		delete pPixelShaderData1;
+		delete pPixelShaderData2;
+	}
 
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), nullptr, IID_PPV_ARGS(&m_commandList)));
-    NAME_D3D12_OBJECT(m_commandList);
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), nullptr, IID_PPV_ARGS(&m_commandList)));
+	NAME_D3D12_OBJECT(m_commandList);
 
-    // Create render target views (RTVs).
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
-    for (UINT i = 0; i < FrameCount; i++)
-    {
-        ThrowIfFailed(m_swapChain->GetBuffer(i, IID_PPV_ARGS(&m_renderTargets[i])));
-        m_device->CreateRenderTargetView(m_renderTargets[i].Get(), nullptr, rtvHandle);
-        rtvHandle.Offset(1, m_rtvDescriptorSize);
+	// Create render target views (RTVs).
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	for (UINT i = 0; i < FrameCount; i++)
+	{
+		ThrowIfFailed(m_swapChain->GetBuffer(i, IID_PPV_ARGS(&m_renderTargets[i])));
+		m_device->CreateRenderTargetView(m_renderTargets[i].Get(), nullptr, rtvHandle);
+		rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-        NAME_D3D12_OBJECT_INDEXED(m_renderTargets, i);
-    }
+		NAME_D3D12_OBJECT_INDEXED(m_renderTargets, i);
+	}
 
-    // Read in mesh data for vertex/index buffers.
-    UINT8* pMeshData;
-    UINT meshDataLength;
-    ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(SampleAssets::DataFileName).c_str(), &pMeshData, &meshDataLength));
+	// Read in mesh data for vertex/index buffers.
+	UINT8* pMeshData;
+	UINT meshDataLength;
+	ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(SampleAssets::DataFileName).c_str(), &pMeshData, &meshDataLength));
 
-    // Create the vertex buffer.
-    {
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+	// Create the vertex buffer.
+	{
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&vertexBufferUploadHeap)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&vertexBufferUploadHeap)));
 
-        NAME_D3D12_OBJECT(m_vertexBuffer);
+		NAME_D3D12_OBJECT(m_vertexBuffer);
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = pMeshData + SampleAssets::VertexDataOffset;
-        vertexData.RowPitch = SampleAssets::VertexDataSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = pMeshData + SampleAssets::VertexDataOffset;
+		vertexData.RowPitch = SampleAssets::VertexDataSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUploadHeap.Get(), 0, 0, 1, &vertexData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUploadHeap.Get(), 0, 0, 1, &vertexData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = SampleAssets::StandardVertexStride;
-        m_vertexBufferView.SizeInBytes = SampleAssets::VertexDataSize;
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = SampleAssets::StandardVertexStride;
+		m_vertexBufferView.SizeInBytes = SampleAssets::VertexDataSize;
+	}
 
-    // Create the index buffer.
-    {
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::IndexDataSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_indexBuffer)));
+	// Create the index buffer.
+	{
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::IndexDataSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_indexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::IndexDataSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&indexBufferUploadHeap)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::IndexDataSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&indexBufferUploadHeap)));
 
-        NAME_D3D12_OBJECT(m_indexBuffer);
+		NAME_D3D12_OBJECT(m_indexBuffer);
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the index buffer.
-        D3D12_SUBRESOURCE_DATA indexData = {};
-        indexData.pData = pMeshData + SampleAssets::IndexDataOffset;
-        indexData.RowPitch = SampleAssets::IndexDataSize;
-        indexData.SlicePitch = indexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the index buffer.
+		D3D12_SUBRESOURCE_DATA indexData = {};
+		indexData.pData = pMeshData + SampleAssets::IndexDataOffset;
+		indexData.RowPitch = SampleAssets::IndexDataSize;
+		indexData.SlicePitch = indexData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_indexBuffer.Get(), indexBufferUploadHeap.Get(), 0, 0, 1, &indexData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_indexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_INDEX_BUFFER));
+		UpdateSubresources<1>(m_commandList.Get(), m_indexBuffer.Get(), indexBufferUploadHeap.Get(), 0, 0, 1, &indexData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_indexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_INDEX_BUFFER));
 
-        // Describe the index buffer view.
-        m_indexBufferView.BufferLocation = m_indexBuffer->GetGPUVirtualAddress();
-        m_indexBufferView.Format = SampleAssets::StandardIndexFormat;
-        m_indexBufferView.SizeInBytes = SampleAssets::IndexDataSize;
+		// Describe the index buffer view.
+		m_indexBufferView.BufferLocation = m_indexBuffer->GetGPUVirtualAddress();
+		m_indexBufferView.Format = SampleAssets::StandardIndexFormat;
+		m_indexBufferView.SizeInBytes = SampleAssets::IndexDataSize;
 
-        m_numIndices = SampleAssets::IndexDataSize / 4;    // R32_UINT (SampleAssets::StandardIndexFormat) = 4 bytes each.
-    }
+		m_numIndices = SampleAssets::IndexDataSize / 4;	// R32_UINT (SampleAssets::StandardIndexFormat) = 4 bytes each.
+	}
 
-    // Create the texture and sampler.
-    {
-        // Describe and create a Texture2D.
-        D3D12_RESOURCE_DESC textureDesc = {};
-        textureDesc.MipLevels = SampleAssets::Textures[0].MipLevels;
-        textureDesc.Format = SampleAssets::Textures[0].Format;
-        textureDesc.Width = SampleAssets::Textures[0].Width;
-        textureDesc.Height = SampleAssets::Textures[0].Height;
-        textureDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
-        textureDesc.DepthOrArraySize = 1;
-        textureDesc.SampleDesc.Count = 1;
-        textureDesc.SampleDesc.Quality = 0;
-        textureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+	// Create the texture and sampler.
+	{
+		// Describe and create a Texture2D.
+		D3D12_RESOURCE_DESC textureDesc = {};
+		textureDesc.MipLevels = SampleAssets::Textures[0].MipLevels;
+		textureDesc.Format = SampleAssets::Textures[0].Format;
+		textureDesc.Width = SampleAssets::Textures[0].Width;
+		textureDesc.Height = SampleAssets::Textures[0].Height;
+		textureDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
+		textureDesc.DepthOrArraySize = 1;
+		textureDesc.SampleDesc.Count = 1;
+		textureDesc.SampleDesc.Quality = 0;
+		textureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &textureDesc,
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_texture)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&textureDesc,
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_texture)));
 
-        NAME_D3D12_OBJECT(m_texture);
+		NAME_D3D12_OBJECT(m_texture);
 
-        const UINT subresourceCount = textureDesc.DepthOrArraySize * textureDesc.MipLevels;
-        const UINT64 uploadBufferSize = GetRequiredIntermediateSize(m_texture.Get(), 0, subresourceCount);
+		const UINT subresourceCount = textureDesc.DepthOrArraySize * textureDesc.MipLevels;
+		const UINT64 uploadBufferSize = GetRequiredIntermediateSize(m_texture.Get(), 0, subresourceCount);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&textureUploadHeap)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&textureUploadHeap)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the Texture2D.
-        D3D12_SUBRESOURCE_DATA textureData = {};
-        textureData.pData = pMeshData + SampleAssets::Textures[0].Data[0].Offset;
-        textureData.RowPitch = SampleAssets::Textures[0].Data[0].Pitch;
-        textureData.SlicePitch = SampleAssets::Textures[0].Data[0].Size;
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the Texture2D.
+		D3D12_SUBRESOURCE_DATA textureData = {};
+		textureData.pData = pMeshData + SampleAssets::Textures[0].Data[0].Offset;
+		textureData.RowPitch = SampleAssets::Textures[0].Data[0].Pitch;
+		textureData.SlicePitch = SampleAssets::Textures[0].Data[0].Size;
 
-        UpdateSubresources(m_commandList.Get(), m_texture.Get(), textureUploadHeap.Get(), 0, 0, subresourceCount, &textureData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_texture.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
+		UpdateSubresources(m_commandList.Get(), m_texture.Get(), textureUploadHeap.Get(), 0, 0, subresourceCount, &textureData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_texture.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
 
-        // Describe and create a sampler.
-        D3D12_SAMPLER_DESC samplerDesc = {};
-        samplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-        samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.MinLOD = 0;
-        samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
-        samplerDesc.MipLODBias = 0.0f;
-        samplerDesc.MaxAnisotropy = 1;
-        samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
-        m_device->CreateSampler(&samplerDesc, m_samplerHeap->GetCPUDescriptorHandleForHeapStart());
+		// Describe and create a sampler.
+		D3D12_SAMPLER_DESC samplerDesc = {};
+		samplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.MinLOD = 0;
+		samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
+		samplerDesc.MipLODBias = 0.0f;
+		samplerDesc.MaxAnisotropy = 1;
+		samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
+		m_device->CreateSampler(&samplerDesc, m_samplerHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Describe and create a SRV for the texture.
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Format = SampleAssets::Textures->Format;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = 1;
-        m_device->CreateShaderResourceView(m_texture.Get(), &srvDesc, m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		// Describe and create a SRV for the texture.
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Format = SampleAssets::Textures->Format;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = 1;
+		m_device->CreateShaderResourceView(m_texture.Get(), &srvDesc, m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    delete pMeshData;
+	delete pMeshData;
 
-    // Create the depth stencil view.
-    {
-        D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
-        depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
-        depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
-        depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
+	// Create the depth stencil view.
+	{
+		D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
+		depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
+		depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+		depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
 
-        D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
-        depthOptimizedClearValue.Format = DXGI_FORMAT_D32_FLOAT;
-        depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
-        depthOptimizedClearValue.DepthStencil.Stencil = 0;
+		D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
+		depthOptimizedClearValue.Format = DXGI_FORMAT_D32_FLOAT;
+		depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
+		depthOptimizedClearValue.DepthStencil.Stencil = 0;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
-            D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            &depthOptimizedClearValue,
-            IID_PPV_ARGS(&m_depthStencil)
-            ));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
+			D3D12_RESOURCE_STATE_DEPTH_WRITE,
+			&depthOptimizedClearValue,
+			IID_PPV_ARGS(&m_depthStencil)
+			));
 
-        NAME_D3D12_OBJECT(m_depthStencil);
+		NAME_D3D12_OBJECT(m_depthStencil);
 
-        m_device->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		m_device->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    // Close the command list and execute it to begin the initial GPU setup.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the initial GPU setup.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_fenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValue++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_fenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValue++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
 
-        // Signal and increment the fence value.
-        const UINT64 fenceToWaitFor = m_fenceValue;
-        ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fenceToWaitFor));
-        m_fenceValue++;
+		// Signal and increment the fence value.
+		const UINT64 fenceToWaitFor = m_fenceValue;
+		ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fenceToWaitFor));
+		m_fenceValue++;
 
-        // Wait until the fence is completed.
-        ThrowIfFailed(m_fence->SetEventOnCompletion(fenceToWaitFor, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+		// Wait until the fence is completed.
+		ThrowIfFailed(m_fence->SetEventOnCompletion(fenceToWaitFor, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 
-    CreateFrameResources();
+	CreateFrameResources();
 }
 
 // Update frame-based values.
 void D3D12Bundles::OnUpdate()
 {
-    m_timer.Tick(NULL);
+	m_timer.Tick(NULL);
 
-    if (m_frameCounter == 500)
-    {
-        // Update window text with FPS value.
-        wchar_t fps[64];
-        swprintf_s(fps, L"%ufps", m_timer.GetFramesPerSecond());
-        SetCustomWindowText(fps);
-        m_frameCounter = 0;
-    }
+	if (m_frameCounter == 500)
+	{
+		// Update window text with FPS value.
+		wchar_t fps[64];
+		swprintf_s(fps, L"%ufps", m_timer.GetFramesPerSecond());
+		SetCustomWindowText(fps);
+		m_frameCounter = 0;
+	}
 
-    m_frameCounter++;
+	m_frameCounter++;
 
-    // Get current GPU progress against submitted workload. Resources still scheduled 
-    // for GPU execution cannot be modified or else undefined behavior will result.
-    const UINT64 lastCompletedFence = m_fence->GetCompletedValue();
+	// Get current GPU progress against submitted workload. Resources still scheduled 
+	// for GPU execution cannot be modified or else undefined behavior will result.
+	const UINT64 lastCompletedFence = m_fence->GetCompletedValue();
 
-    // Move to the next frame resource.
-    m_currentFrameResourceIndex = (m_currentFrameResourceIndex + 1) % FrameCount;
-    m_pCurrentFrameResource = m_frameResources[m_currentFrameResourceIndex];
+	// Move to the next frame resource.
+	m_currentFrameResourceIndex = (m_currentFrameResourceIndex + 1) % FrameCount;
+	m_pCurrentFrameResource = m_frameResources[m_currentFrameResourceIndex];
 
-    // Make sure that this frame resource isn't still in use by the GPU.
-    // If it is, wait for it to complete.
-    if (m_pCurrentFrameResource->m_fenceValue != 0 && m_pCurrentFrameResource->m_fenceValue > lastCompletedFence)
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_pCurrentFrameResource->m_fenceValue, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+	// Make sure that this frame resource isn't still in use by the GPU.
+	// If it is, wait for it to complete.
+	if (m_pCurrentFrameResource->m_fenceValue != 0 && m_pCurrentFrameResource->m_fenceValue > lastCompletedFence)
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_pCurrentFrameResource->m_fenceValue, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 
-    m_camera.Update(static_cast<float>(m_timer.GetElapsedSeconds()));
-    m_pCurrentFrameResource->UpdateConstantBuffers(m_camera.GetViewMatrix(), m_camera.GetProjectionMatrix(0.8f, m_aspectRatio));
+	m_camera.Update(static_cast<float>(m_timer.GetElapsedSeconds()));
+	m_pCurrentFrameResource->UpdateConstantBuffers(m_camera.GetViewMatrix(), m_camera.GetProjectionMatrix(0.8f, m_aspectRatio));
 }
 
 // Render the scene.
 void D3D12Bundles::OnRender()
 {
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+	PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
 
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList(m_pCurrentFrameResource);
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList(m_pCurrentFrameResource);
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    PIXEndEvent(m_commandQueue.Get());
+	PIXEndEvent(m_commandQueue.Get());
 
-    // Present and update the frame index for the next frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Present and update the frame index for the next frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Signal and increment the fence value.
-    m_pCurrentFrameResource->m_fenceValue = m_fenceValue;
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValue));
-    m_fenceValue++;
+	// Signal and increment the fence value.
+	m_pCurrentFrameResource->m_fenceValue = m_fenceValue;
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValue));
+	m_fenceValue++;
 }
 
 void D3D12Bundles::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    {
-        const UINT64 fence = m_fenceValue;
-        const UINT64 lastCompletedFence = m_fence->GetCompletedValue();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	{
+		const UINT64 fence = m_fenceValue;
+		const UINT64 lastCompletedFence = m_fence->GetCompletedValue();
 
-        // Signal and increment the fence value.
-        ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValue));
-        m_fenceValue++;
+		// Signal and increment the fence value.
+		ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValue));
+		m_fenceValue++;
 
-        // Wait until the previous frame is finished.
-        if (lastCompletedFence < fence)
-        {
-            ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
-            WaitForSingleObject(m_fenceEvent, INFINITE);
-        }
-    }
+		// Wait until the previous frame is finished.
+		if (lastCompletedFence < fence)
+		{
+			ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
+			WaitForSingleObject(m_fenceEvent, INFINITE);
+		}
+	}
 
-    for (UINT i = 0; i < m_frameResources.size(); i++)
-    {
-        delete m_frameResources.at(i);
-    }
+	for (UINT i = 0; i < m_frameResources.size(); i++)
+	{
+		delete m_frameResources.at(i);
+	}
 }
 
 void D3D12Bundles::OnKeyDown(UINT8 key)
 {
-    m_camera.OnKeyDown(key);
+	m_camera.OnKeyDown(key);
 }
 
 void D3D12Bundles::OnKeyUp(UINT8 key)
 {
-    m_camera.OnKeyUp(key);
+	m_camera.OnKeyUp(key);
 }
 
 // Create the resources that will be used every frame.
 void D3D12Bundles::CreateFrameResources()
 {
-    // Initialize each frame resource.
-    CD3DX12_CPU_DESCRIPTOR_HANDLE cbvSrvHandle(m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart(), 1, m_cbvSrvDescriptorSize);    // Move past the SRV in slot 1.
-    for (UINT i = 0; i < FrameCount; i++)
-    {
-        FrameResource* pFrameResource = new FrameResource(m_device.Get(), CityRowCount, CityColumnCount);
+	// Initialize each frame resource.
+	CD3DX12_CPU_DESCRIPTOR_HANDLE cbvSrvHandle(m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart(), 1, m_cbvSrvDescriptorSize);	// Move past the SRV in slot 1.
+	for (UINT i = 0; i < FrameCount; i++)
+	{
+		FrameResource* pFrameResource = new FrameResource(m_device.Get(), CityRowCount, CityColumnCount);
 
-        UINT64 cbOffset = 0;
-        for (UINT j = 0; j < CityRowCount; j++)
-        {
-            for (UINT k = 0; k < CityColumnCount; k++)
-            {
-                // Describe and create a constant buffer view (CBV).
-                D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
-                cbvDesc.BufferLocation = pFrameResource->m_cbvUploadHeap->GetGPUVirtualAddress() + cbOffset;
-                cbvDesc.SizeInBytes = sizeof(FrameResource::SceneConstantBuffer);
-                cbOffset += cbvDesc.SizeInBytes;
-                m_device->CreateConstantBufferView(&cbvDesc, cbvSrvHandle);
-                cbvSrvHandle.Offset(m_cbvSrvDescriptorSize);
-            }
-        }
+		UINT64 cbOffset = 0;
+		for (UINT j = 0; j < CityRowCount; j++)
+		{
+			for (UINT k = 0; k < CityColumnCount; k++)
+			{
+				// Describe and create a constant buffer view (CBV).
+				D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
+				cbvDesc.BufferLocation = pFrameResource->m_cbvUploadHeap->GetGPUVirtualAddress() + cbOffset;
+				cbvDesc.SizeInBytes = sizeof(FrameResource::SceneConstantBuffer);
+				cbOffset += cbvDesc.SizeInBytes;
+				m_device->CreateConstantBufferView(&cbvDesc, cbvSrvHandle);
+				cbvSrvHandle.Offset(m_cbvSrvDescriptorSize);
+			}
+		}
 
-        pFrameResource->InitBundle(m_device.Get(), m_pipelineState1.Get(), m_pipelineState2.Get(), i, m_numIndices, &m_indexBufferView,
-            &m_vertexBufferView, m_cbvSrvHeap.Get(), m_cbvSrvDescriptorSize, m_samplerHeap.Get(), m_rootSignature.Get());
+		pFrameResource->InitBundle(m_device.Get(), m_pipelineState1.Get(), m_pipelineState2.Get(), i, m_numIndices, &m_indexBufferView,
+			&m_vertexBufferView, m_cbvSrvHeap.Get(), m_cbvSrvDescriptorSize, m_samplerHeap.Get(), m_rootSignature.Get());
 
-        m_frameResources.push_back(pFrameResource);
-    }
+		m_frameResources.push_back(pFrameResource);
+	}
 }
 
 void D3D12Bundles::PopulateCommandList(FrameResource* pFrameResource)
 {
-    // Command list allocators can only be reset when the associated
-    // command lists have finished execution on the GPU; apps should use
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_pCurrentFrameResource->m_commandAllocator->Reset());
+	// Command list allocators can only be reset when the associated
+	// command lists have finished execution on the GPU; apps should use
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_pCurrentFrameResource->m_commandAllocator->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command
-    // list, that command list can then be reset at any time and must be before
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_pCurrentFrameResource->m_commandAllocator.Get(), m_pipelineState1.Get()));
+	// However, when ExecuteCommandList() is called on a particular command
+	// list, that command list can then be reset at any time and must be before
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_pCurrentFrameResource->m_commandAllocator.Get(), m_pipelineState1.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvHeap.Get(), m_samplerHeap.Get() };
-    m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvHeap.Get(), m_samplerHeap.Get() };
+	m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    m_commandList->ClearDepthStencilView(m_dsvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	m_commandList->ClearDepthStencilView(m_dsvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
 
-    if (UseBundles)
-    {
-        // Execute the prebuilt bundle.
-        m_commandList->ExecuteBundle(pFrameResource->m_bundle.Get());
-    }
-    else
-    {
-        // Populate a new command list.
-        pFrameResource->PopulateCommandList(m_commandList.Get(), m_pipelineState1.Get(), m_pipelineState2.Get(), m_currentFrameResourceIndex, m_numIndices, &m_indexBufferView,
-            &m_vertexBufferView, m_cbvSrvHeap.Get(), m_cbvSrvDescriptorSize, m_samplerHeap.Get(), m_rootSignature.Get());
-    }
+	if (UseBundles)
+	{
+		// Execute the prebuilt bundle.
+		m_commandList->ExecuteBundle(pFrameResource->m_bundle.Get());
+	}
+	else
+	{
+		// Populate a new command list.
+		pFrameResource->PopulateCommandList(m_commandList.Get(), m_pipelineState1.Get(), m_pipelineState2.Get(), m_currentFrameResourceIndex, m_numIndices, &m_indexBufferView,
+			&m_vertexBufferView, m_cbvSrvHeap.Get(), m_cbvSrvDescriptorSize, m_samplerHeap.Get(), m_rootSignature.Get());
+	}
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }

--- a/Samples/UWP/D3D12Bundles/src/D3D12Bundles.h
+++ b/Samples/UWP/D3D12Bundles/src/D3D12Bundles.h
@@ -28,65 +28,65 @@ using Microsoft::WRL::ComPtr;
 class D3D12Bundles : public DXSample
 {
 public:
-    D3D12Bundles(UINT width, UINT height, std::wstring name);
+	D3D12Bundles(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
-    virtual void OnKeyDown(UINT8 key);
-    virtual void OnKeyUp(UINT8 key);
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
+	virtual void OnKeyDown(UINT8 key);
+	virtual void OnKeyUp(UINT8 key);
 
 private:
-    static const UINT FrameCount = 3;
-    static const UINT CityRowCount = 10;
-    static const UINT CityColumnCount = 3;
-    static const bool UseBundles = true;
+	static const UINT FrameCount = 3;
+	static const UINT CityRowCount = 10;
+	static const UINT CityColumnCount = 3;
+	static const bool UseBundles = true;
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12Resource> m_depthStencil;
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature >m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_cbvSrvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_samplerHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState1;
-    ComPtr<ID3D12PipelineState> m_pipelineState2;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12Resource> m_depthStencil;
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature >m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_cbvSrvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_samplerHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState1;
+	ComPtr<ID3D12PipelineState> m_pipelineState2;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
 
-    // App resources.
-    UINT m_numIndices;
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    ComPtr<ID3D12Resource> m_indexBuffer;
-    ComPtr<ID3D12Resource> m_texture;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
-    D3D12_INDEX_BUFFER_VIEW m_indexBufferView;
-    StepTimer m_timer;
-    UINT m_cbvSrvDescriptorSize;
-    UINT m_rtvDescriptorSize;
-    SimpleCamera m_camera;
+	// App resources.
+	UINT m_numIndices;
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	ComPtr<ID3D12Resource> m_indexBuffer;
+	ComPtr<ID3D12Resource> m_texture;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	D3D12_INDEX_BUFFER_VIEW m_indexBufferView;
+	StepTimer m_timer;
+	UINT m_cbvSrvDescriptorSize;
+	UINT m_rtvDescriptorSize;
+	SimpleCamera m_camera;
 
-    // Frame resources.
-    std::vector<FrameResource*> m_frameResources;
-    FrameResource* m_pCurrentFrameResource;
-    UINT m_currentFrameResourceIndex;
+	// Frame resources.
+	std::vector<FrameResource*> m_frameResources;
+	FrameResource* m_pCurrentFrameResource;
+	UINT m_currentFrameResourceIndex;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    UINT m_frameCounter;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValue;
+	// Synchronization objects.
+	UINT m_frameIndex;
+	UINT m_frameCounter;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValue;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void CreateFrameResources();
-    void PopulateCommandList(FrameResource* pFrameResource);
+	void LoadPipeline();
+	void LoadAssets();
+	void CreateFrameResources();
+	void PopulateCommandList(FrameResource* pFrameResource);
 };

--- a/Samples/UWP/D3D12Bundles/src/DXSample.cpp
+++ b/Samples/UWP/D3D12Bundles/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,59 +34,104 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
-    auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(windowText.c_str());
+	std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
+	auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/UWP/D3D12Bundles/src/DXSample.h
+++ b/Samples/UWP/D3D12Bundles/src/DXSample.h
@@ -16,42 +16,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/UWP/D3D12Bundles/src/FrameResource.cpp
+++ b/Samples/UWP/D3D12Bundles/src/FrameResource.cpp
@@ -13,134 +13,134 @@
 #include "FrameResource.h"
 
 FrameResource::FrameResource(ID3D12Device* pDevice, UINT cityRowCount, UINT cityColumnCount) : 
-    m_fenceValue(0),
-    m_cityRowCount(cityRowCount),
-    m_cityColumnCount(cityColumnCount)
+	m_fenceValue(0),
+	m_cityRowCount(cityRowCount),
+	m_cityColumnCount(cityColumnCount)
 {
-    m_modelMatrices.resize(m_cityRowCount * m_cityColumnCount);
+	m_modelMatrices.resize(m_cityRowCount * m_cityColumnCount);
 
-    // The command allocator is used by the main sample class when 
-    // resetting the command list in the main update loop. Each frame 
-    // resource needs a command allocator because command allocators 
-    // cannot be reused until the GPU is done executing the commands 
-    // associated with it.
-    ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
-    ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_BUNDLE, IID_PPV_ARGS(&m_bundleAllocator)));
+	// The command allocator is used by the main sample class when 
+	// resetting the command list in the main update loop. Each frame 
+	// resource needs a command allocator because command allocators 
+	// cannot be reused until the GPU is done executing the commands 
+	// associated with it.
+	ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_BUNDLE, IID_PPV_ARGS(&m_bundleAllocator)));
 
-    // Create an upload heap for the constant buffers.
-    ThrowIfFailed(pDevice->CreateCommittedResource(
-        &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-        D3D12_HEAP_FLAG_NONE,
-        &CD3DX12_RESOURCE_DESC::Buffer(sizeof(SceneConstantBuffer) * m_cityRowCount * m_cityColumnCount),
-        D3D12_RESOURCE_STATE_GENERIC_READ,
-        nullptr,
-        IID_PPV_ARGS(&m_cbvUploadHeap)));
+	// Create an upload heap for the constant buffers.
+	ThrowIfFailed(pDevice->CreateCommittedResource(
+		&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+		D3D12_HEAP_FLAG_NONE,
+		&CD3DX12_RESOURCE_DESC::Buffer(sizeof(SceneConstantBuffer) * m_cityRowCount * m_cityColumnCount),
+		D3D12_RESOURCE_STATE_GENERIC_READ,
+		nullptr,
+		IID_PPV_ARGS(&m_cbvUploadHeap)));
 
-    // Map the constant buffers. Note that unlike D3D11, the resource 
-    // does not need to be unmapped for use by the GPU. In this sample, 
-    // the resource stays 'permenantly' mapped to avoid overhead with 
-    // mapping/unmapping each frame.
-    CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-    ThrowIfFailed(m_cbvUploadHeap->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBuffers)));
+	// Map the constant buffers. Note that unlike D3D11, the resource 
+	// does not need to be unmapped for use by the GPU. In this sample, 
+	// the resource stays 'permenantly' mapped to avoid overhead with 
+	// mapping/unmapping each frame.
+	CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+	ThrowIfFailed(m_cbvUploadHeap->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBuffers)));
 
-    // Update all of the model matrices once; our cities don't move so 
-    // we don't need to do this ever again.
-    SetCityPositions(8.0f, -8.0f);
+	// Update all of the model matrices once; our cities don't move so 
+	// we don't need to do this ever again.
+	SetCityPositions(8.0f, -8.0f);
 }
 
 FrameResource::~FrameResource()
 {
-    m_cbvUploadHeap->Unmap(0, nullptr);
-    m_pConstantBuffers = nullptr;
+	m_cbvUploadHeap->Unmap(0, nullptr);
+	m_pConstantBuffers = nullptr;
 }
 
 void FrameResource::InitBundle(ID3D12Device* pDevice, ID3D12PipelineState* pPso1, ID3D12PipelineState* pPso2,
-    UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
-    ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature)
+	UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
+	ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature)
 {
-    ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_BUNDLE, m_bundleAllocator.Get(), pPso1, IID_PPV_ARGS(&m_bundle)));
-    NAME_D3D12_OBJECT(m_bundle);
+	ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_BUNDLE, m_bundleAllocator.Get(), pPso1, IID_PPV_ARGS(&m_bundle)));
+	NAME_D3D12_OBJECT(m_bundle);
 
-    PopulateCommandList(m_bundle.Get(), pPso1, pPso2, frameResourceIndex, numIndices, pIndexBufferViewDesc,
-        pVertexBufferViewDesc, pCbvSrvDescriptorHeap, cbvSrvDescriptorSize, pSamplerDescriptorHeap, pRootSignature);
+	PopulateCommandList(m_bundle.Get(), pPso1, pPso2, frameResourceIndex, numIndices, pIndexBufferViewDesc,
+		pVertexBufferViewDesc, pCbvSrvDescriptorHeap, cbvSrvDescriptorSize, pSamplerDescriptorHeap, pRootSignature);
 
-    ThrowIfFailed(m_bundle->Close());
+	ThrowIfFailed(m_bundle->Close());
 }
 
 void FrameResource::SetCityPositions(FLOAT intervalX, FLOAT intervalZ)
 {
-    for (UINT i = 0; i < m_cityRowCount; i++)
-    {
-        FLOAT cityOffsetZ = i * intervalZ;
-        for (UINT j = 0; j < m_cityColumnCount; j++)
-        {
-            FLOAT cityOffsetX = j * intervalX;
+	for (UINT i = 0; i < m_cityRowCount; i++)
+	{
+		FLOAT cityOffsetZ = i * intervalZ;
+		for (UINT j = 0; j < m_cityColumnCount; j++)
+		{
+			FLOAT cityOffsetX = j * intervalX;
 
-            // The y position is based off of the city's row and column 
-            // position to prevent z-fighting.
-            XMStoreFloat4x4(&m_modelMatrices[i * m_cityColumnCount + j], XMMatrixTranslation(cityOffsetX, 0.02f * (i * m_cityColumnCount + j), cityOffsetZ));
-        }
-    }
+			// The y position is based off of the city's row and column 
+			// position to prevent z-fighting.
+			XMStoreFloat4x4(&m_modelMatrices[i * m_cityColumnCount + j], XMMatrixTranslation(cityOffsetX, 0.02f * (i * m_cityColumnCount + j), cityOffsetZ));
+		}
+	}
 }
 
 void FrameResource::PopulateCommandList(ID3D12GraphicsCommandList* pCommandList, ID3D12PipelineState* pPso1, ID3D12PipelineState* pPso2,
-    UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
-    ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature)
+	UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
+	ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature)
 {
-    // If the root signature matches the root signature of the caller, then
-    // bindings are inherited, otherwise the bind space is reset.
-    pCommandList->SetGraphicsRootSignature(pRootSignature);
+	// If the root signature matches the root signature of the caller, then
+	// bindings are inherited, otherwise the bind space is reset.
+	pCommandList->SetGraphicsRootSignature(pRootSignature);
 
-    ID3D12DescriptorHeap* ppHeaps[] = { pCbvSrvDescriptorHeap, pSamplerDescriptorHeap };
-    pCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
-    pCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    pCommandList->IASetIndexBuffer(pIndexBufferViewDesc);
-    pCommandList->IASetVertexBuffers(0, 1, pVertexBufferViewDesc);
-    pCommandList->SetGraphicsRootDescriptorTable(0, pCbvSrvDescriptorHeap->GetGPUDescriptorHandleForHeapStart());
-    pCommandList->SetGraphicsRootDescriptorTable(1, pSamplerDescriptorHeap->GetGPUDescriptorHandleForHeapStart());
+	ID3D12DescriptorHeap* ppHeaps[] = { pCbvSrvDescriptorHeap, pSamplerDescriptorHeap };
+	pCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	pCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	pCommandList->IASetIndexBuffer(pIndexBufferViewDesc);
+	pCommandList->IASetVertexBuffers(0, 1, pVertexBufferViewDesc);
+	pCommandList->SetGraphicsRootDescriptorTable(0, pCbvSrvDescriptorHeap->GetGPUDescriptorHandleForHeapStart());
+	pCommandList->SetGraphicsRootDescriptorTable(1, pSamplerDescriptorHeap->GetGPUDescriptorHandleForHeapStart());
 
-    // Calculate the descriptor offset due to multiple frame resources.
-    // 1 SRV + how many CBVs we have currently.
-    UINT frameResourceDescriptorOffset = 1 + (frameResourceIndex * m_cityRowCount * m_cityColumnCount);
-    CD3DX12_GPU_DESCRIPTOR_HANDLE cbvSrvHandle(pCbvSrvDescriptorHeap->GetGPUDescriptorHandleForHeapStart(), frameResourceDescriptorOffset, cbvSrvDescriptorSize);
+	// Calculate the descriptor offset due to multiple frame resources.
+	// 1 SRV + how many CBVs we have currently.
+	UINT frameResourceDescriptorOffset = 1 + (frameResourceIndex * m_cityRowCount * m_cityColumnCount);
+	CD3DX12_GPU_DESCRIPTOR_HANDLE cbvSrvHandle(pCbvSrvDescriptorHeap->GetGPUDescriptorHandleForHeapStart(), frameResourceDescriptorOffset, cbvSrvDescriptorSize);
 
-    PIXBeginEvent(pCommandList, 0, L"Draw cities");
-    BOOL usePso1 = TRUE;
-    for (UINT i = 0; i < m_cityRowCount; i++)
-    {
-        for (UINT j = 0; j < m_cityColumnCount; j++)
-        {
-            // Alternate which PSO to use; the pixel shader is different on 
-            // each just as a PSO setting demonstration.
-            pCommandList->SetPipelineState(usePso1 ? pPso1 : pPso2);
-            usePso1 = !usePso1;
+	PIXBeginEvent(pCommandList, 0, L"Draw cities");
+	BOOL usePso1 = TRUE;
+	for (UINT i = 0; i < m_cityRowCount; i++)
+	{
+		for (UINT j = 0; j < m_cityColumnCount; j++)
+		{
+			// Alternate which PSO to use; the pixel shader is different on 
+			// each just as a PSO setting demonstration.
+			pCommandList->SetPipelineState(usePso1 ? pPso1 : pPso2);
+			usePso1 = !usePso1;
 
-            // Set this city's CBV table and move to the next descriptor.
-            pCommandList->SetGraphicsRootDescriptorTable(2, cbvSrvHandle);
-            cbvSrvHandle.Offset(cbvSrvDescriptorSize);
+			// Set this city's CBV table and move to the next descriptor.
+			pCommandList->SetGraphicsRootDescriptorTable(2, cbvSrvHandle);
+			cbvSrvHandle.Offset(cbvSrvDescriptorSize);
 
-            pCommandList->DrawIndexedInstanced(numIndices, 1, 0, 0, 0);
-        }
-    }
-    PIXEndEvent(pCommandList);
+			pCommandList->DrawIndexedInstanced(numIndices, 1, 0, 0, 0);
+		}
+	}
+	PIXEndEvent(pCommandList);
 }
 
 void XM_CALLCONV FrameResource::UpdateConstantBuffers(FXMMATRIX view, CXMMATRIX projection)
 {
-    XMMATRIX model;
-    XMFLOAT4X4 mvp;
+	XMMATRIX model;
+	XMFLOAT4X4 mvp;
 
-    for (UINT i = 0; i < m_cityRowCount; i++)
-    {
-        for (UINT j = 0; j < m_cityColumnCount; j++)
-        {
-            model = XMLoadFloat4x4(&m_modelMatrices[i * m_cityColumnCount + j]);
+	for (UINT i = 0; i < m_cityRowCount; i++)
+	{
+		for (UINT j = 0; j < m_cityColumnCount; j++)
+		{
+			model = XMLoadFloat4x4(&m_modelMatrices[i * m_cityColumnCount + j]);
 
-            // Compute the model-view-projection matrix.
-            XMStoreFloat4x4(&mvp, XMMatrixTranspose(model * view * projection));
+			// Compute the model-view-projection matrix.
+			XMStoreFloat4x4(&mvp, XMMatrixTranspose(model * view * projection));
 
-            // Copy this matrix into the appropriate location in the upload heap subresource.
-            memcpy(&m_pConstantBuffers[i * m_cityColumnCount + j], &mvp, sizeof(mvp));
-        }
-    }
+			// Copy this matrix into the appropriate location in the upload heap subresource.
+			memcpy(&m_pConstantBuffers[i * m_cityColumnCount + j], &mvp, sizeof(mvp));
+		}
+	}
 }

--- a/Samples/UWP/D3D12Bundles/src/FrameResource.h
+++ b/Samples/UWP/D3D12Bundles/src/FrameResource.h
@@ -19,36 +19,36 @@ using Microsoft::WRL::ComPtr;
 class FrameResource
 {
 private:
-    void SetCityPositions(FLOAT intervalX, FLOAT intervalZ);
+	void SetCityPositions(FLOAT intervalX, FLOAT intervalZ);
 
 public:
-    struct SceneConstantBuffer
-    {
-        XMFLOAT4X4 mvp;        // Model-view-projection (MVP) matrix.
-        FLOAT padding[48];
-    };
+	struct SceneConstantBuffer
+	{
+		XMFLOAT4X4 mvp;		// Model-view-projection (MVP) matrix.
+		FLOAT padding[48];
+	};
 
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandAllocator> m_bundleAllocator;
-    ComPtr<ID3D12GraphicsCommandList> m_bundle;
-    ComPtr<ID3D12Resource> m_cbvUploadHeap;
-    SceneConstantBuffer* m_pConstantBuffers;
-    UINT64 m_fenceValue;
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandAllocator> m_bundleAllocator;
+	ComPtr<ID3D12GraphicsCommandList> m_bundle;
+	ComPtr<ID3D12Resource> m_cbvUploadHeap;
+	SceneConstantBuffer* m_pConstantBuffers;
+	UINT64 m_fenceValue;
 
-    std::vector<XMFLOAT4X4> m_modelMatrices;
-    UINT m_cityRowCount;
-    UINT m_cityColumnCount;
+	std::vector<XMFLOAT4X4> m_modelMatrices;
+	UINT m_cityRowCount;
+	UINT m_cityColumnCount;
 
-    FrameResource(ID3D12Device* pDevice, UINT cityRowCount, UINT cityColumnCount);
-    ~FrameResource();
+	FrameResource(ID3D12Device* pDevice, UINT cityRowCount, UINT cityColumnCount);
+	~FrameResource();
 
-    void InitBundle(ID3D12Device* pDevice, ID3D12PipelineState* pPso1, ID3D12PipelineState* pPso2,
-        UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
-        ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature);
+	void InitBundle(ID3D12Device* pDevice, ID3D12PipelineState* pPso1, ID3D12PipelineState* pPso2,
+		UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
+		ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature);
 
-    void PopulateCommandList(ID3D12GraphicsCommandList* pCommandList, ID3D12PipelineState* pPso1, ID3D12PipelineState* pPso2,
-        UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
-        ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature);
+	void PopulateCommandList(ID3D12GraphicsCommandList* pCommandList, ID3D12PipelineState* pPso1, ID3D12PipelineState* pPso2,
+		UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
+		ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature);
 
-    void XM_CALLCONV UpdateConstantBuffers(FXMMATRIX view, CXMMATRIX projection);
+	void XM_CALLCONV UpdateConstantBuffers(FXMMATRIX view, CXMMATRIX projection);
 };

--- a/Samples/UWP/D3D12Bundles/src/Main.cpp
+++ b/Samples/UWP/D3D12Bundles/src/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12Bundles sample(1200, 900, L"");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12Bundles sample(1200, 900, L"");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12Bundles/src/SimpleCamera.cpp
+++ b/Samples/UWP/D3D12Bundles/src/SimpleCamera.cpp
@@ -13,163 +13,163 @@
 #include "SimpleCamera.h"
 
 SimpleCamera::SimpleCamera():
-    m_initialPosition(0, 0, 0),
-    m_position(m_initialPosition),
-    m_yaw(XM_PI),
-    m_pitch(0.0f),
-    m_lookDirection(0, 0, -1),
-    m_upDirection(0, 1, 0),
-    m_moveSpeed(20.0f),
-    m_turnSpeed(XM_PIDIV2),
-    m_keysPressed{}
+	m_initialPosition(0, 0, 0),
+	m_position(m_initialPosition),
+	m_yaw(XM_PI),
+	m_pitch(0.0f),
+	m_lookDirection(0, 0, -1),
+	m_upDirection(0, 1, 0),
+	m_moveSpeed(20.0f),
+	m_turnSpeed(XM_PIDIV2),
+	m_keysPressed{}
 {
 }
 
 void SimpleCamera::Init(XMFLOAT3 position)
 {
-    m_initialPosition = position;
-    Reset();
+	m_initialPosition = position;
+	Reset();
 }
 
 void SimpleCamera::SetMoveSpeed(float unitsPerSecond)
 {
-    m_moveSpeed = unitsPerSecond;
+	m_moveSpeed = unitsPerSecond;
 }
 
 void SimpleCamera::SetTurnSpeed(float radiansPerSecond)
 {
-    m_turnSpeed = radiansPerSecond;
+	m_turnSpeed = radiansPerSecond;
 }
 
 void SimpleCamera::Reset()
 {
-    m_position = m_initialPosition;
-    m_yaw = XM_PI;
-    m_pitch = 0.0f;
-    m_lookDirection = { 0, 0, -1 };
+	m_position = m_initialPosition;
+	m_yaw = XM_PI;
+	m_pitch = 0.0f;
+	m_lookDirection = { 0, 0, -1 };
 }
 
 void SimpleCamera::Update(float elapsedSeconds)
 {
-    // Calculate the move vector in camera space.
-    XMFLOAT3 move(0, 0, 0);
+	// Calculate the move vector in camera space.
+	XMFLOAT3 move(0, 0, 0);
 
-    if (m_keysPressed.a)
-        move.x -= 1.0f;
-    if (m_keysPressed.d)
-        move.x += 1.0f;
-    if (m_keysPressed.w)
-        move.z -= 1.0f;
-    if (m_keysPressed.s)
-        move.z += 1.0f;
+	if (m_keysPressed.a)
+		move.x -= 1.0f;
+	if (m_keysPressed.d)
+		move.x += 1.0f;
+	if (m_keysPressed.w)
+		move.z -= 1.0f;
+	if (m_keysPressed.s)
+		move.z += 1.0f;
 
-    if (fabs(move.x) > 0.1f && fabs(move.z) > 0.1f)
-    {
-        XMVECTOR vector = XMVector3Normalize(XMLoadFloat3(&move));
-        move.x = XMVectorGetX(vector);
-        move.z = XMVectorGetZ(vector);
-    }
+	if (fabs(move.x) > 0.1f && fabs(move.z) > 0.1f)
+	{
+		XMVECTOR vector = XMVector3Normalize(XMLoadFloat3(&move));
+		move.x = XMVectorGetX(vector);
+		move.z = XMVectorGetZ(vector);
+	}
 
-    float moveInterval = m_moveSpeed * elapsedSeconds;
-    float rotateInterval = m_turnSpeed * elapsedSeconds;
+	float moveInterval = m_moveSpeed * elapsedSeconds;
+	float rotateInterval = m_turnSpeed * elapsedSeconds;
 
-    if (m_keysPressed.left)
-        m_yaw += rotateInterval;
-    if (m_keysPressed.right)
-        m_yaw -= rotateInterval;
-    if (m_keysPressed.up)
-        m_pitch += rotateInterval;
-    if (m_keysPressed.down)
-        m_pitch -= rotateInterval;
+	if (m_keysPressed.left)
+		m_yaw += rotateInterval;
+	if (m_keysPressed.right)
+		m_yaw -= rotateInterval;
+	if (m_keysPressed.up)
+		m_pitch += rotateInterval;
+	if (m_keysPressed.down)
+		m_pitch -= rotateInterval;
 
-    // Prevent looking too far up or down.
-    m_pitch = min(m_pitch, XM_PIDIV4);
-    m_pitch = max(-XM_PIDIV4, m_pitch);
+	// Prevent looking too far up or down.
+	m_pitch = min(m_pitch, XM_PIDIV4);
+	m_pitch = max(-XM_PIDIV4, m_pitch);
 
-    // Move the camera in model space.
-    float x = move.x * -cosf(m_yaw) - move.z * sinf(m_yaw);
-    float z = move.x * sinf(m_yaw) - move.z * cosf(m_yaw);
-    m_position.x += x * moveInterval;
-    m_position.z += z * moveInterval;
+	// Move the camera in model space.
+	float x = move.x * -cosf(m_yaw) - move.z * sinf(m_yaw);
+	float z = move.x * sinf(m_yaw) - move.z * cosf(m_yaw);
+	m_position.x += x * moveInterval;
+	m_position.z += z * moveInterval;
 
-    // Determine the look direction.
-    float r = cosf(m_pitch);
-    m_lookDirection.x = r * sinf(m_yaw);
-    m_lookDirection.y = sinf(m_pitch);
-    m_lookDirection.z = r * cosf(m_yaw);
+	// Determine the look direction.
+	float r = cosf(m_pitch);
+	m_lookDirection.x = r * sinf(m_yaw);
+	m_lookDirection.y = sinf(m_pitch);
+	m_lookDirection.z = r * cosf(m_yaw);
 }
 
 XMMATRIX SimpleCamera::GetViewMatrix()
 {
-    return XMMatrixLookToRH(XMLoadFloat3(&m_position), XMLoadFloat3(&m_lookDirection), XMLoadFloat3(&m_upDirection));
+	return XMMatrixLookToRH(XMLoadFloat3(&m_position), XMLoadFloat3(&m_lookDirection), XMLoadFloat3(&m_upDirection));
 }
 
 XMMATRIX SimpleCamera::GetProjectionMatrix(float fov, float aspectRatio, float nearPlane, float farPlane)
 {
-    return XMMatrixPerspectiveFovRH(fov, aspectRatio, nearPlane, farPlane);
+	return XMMatrixPerspectiveFovRH(fov, aspectRatio, nearPlane, farPlane);
 }
 
 void SimpleCamera::OnKeyDown(WPARAM key)
 {
-    switch (key)
-    {
-    case 'W':
-        m_keysPressed.w = true;
-        break;
-    case 'A':
-        m_keysPressed.a = true;
-        break;
-    case 'S':
-        m_keysPressed.s = true;
-        break;
-    case 'D':
-        m_keysPressed.d = true;
-        break;
-    case VK_LEFT:
-        m_keysPressed.left = true;
-        break;
-    case VK_RIGHT:
-        m_keysPressed.right = true;
-        break;
-    case VK_UP:
-        m_keysPressed.up = true;
-        break;
-    case VK_DOWN:
-        m_keysPressed.down = true;
-        break;
-    case VK_ESCAPE:
-        Reset();
-        break;
-    }
+	switch (key)
+	{
+	case 'W':
+		m_keysPressed.w = true;
+		break;
+	case 'A':
+		m_keysPressed.a = true;
+		break;
+	case 'S':
+		m_keysPressed.s = true;
+		break;
+	case 'D':
+		m_keysPressed.d = true;
+		break;
+	case VK_LEFT:
+		m_keysPressed.left = true;
+		break;
+	case VK_RIGHT:
+		m_keysPressed.right = true;
+		break;
+	case VK_UP:
+		m_keysPressed.up = true;
+		break;
+	case VK_DOWN:
+		m_keysPressed.down = true;
+		break;
+	case VK_ESCAPE:
+		Reset();
+		break;
+	}
 }
 
 void SimpleCamera::OnKeyUp(WPARAM key)
 {
-    switch (key)
-    {
-    case 'W':
-        m_keysPressed.w = false;
-        break;
-    case 'A':
-        m_keysPressed.a = false;
-        break;
-    case 'S':
-        m_keysPressed.s = false;
-        break;
-    case 'D':
-        m_keysPressed.d = false;
-        break;
-    case VK_LEFT:
-        m_keysPressed.left = false;
-        break;
-    case VK_RIGHT:
-        m_keysPressed.right = false;
-        break;
-    case VK_UP:
-        m_keysPressed.up = false;
-        break;
-    case VK_DOWN:
-        m_keysPressed.down = false;
-        break;
-    }
+	switch (key)
+	{
+	case 'W':
+		m_keysPressed.w = false;
+		break;
+	case 'A':
+		m_keysPressed.a = false;
+		break;
+	case 'S':
+		m_keysPressed.s = false;
+		break;
+	case 'D':
+		m_keysPressed.d = false;
+		break;
+	case VK_LEFT:
+		m_keysPressed.left = false;
+		break;
+	case VK_RIGHT:
+		m_keysPressed.right = false;
+		break;
+	case VK_UP:
+		m_keysPressed.up = false;
+		break;
+	case VK_DOWN:
+		m_keysPressed.down = false;
+		break;
+	}
 }

--- a/Samples/UWP/D3D12Bundles/src/SimpleCamera.h
+++ b/Samples/UWP/D3D12Bundles/src/SimpleCamera.h
@@ -16,42 +16,42 @@ using namespace DirectX;
 class SimpleCamera
 {
 public:
-    SimpleCamera();
+	SimpleCamera();
 
-    void Init(XMFLOAT3 position);
-    void Update(float elapsedSeconds);
-    XMMATRIX GetViewMatrix();
-    XMMATRIX GetProjectionMatrix(float fov, float aspectRatio, float nearPlane = 1.0f, float farPlane = 1000.0f);
-    void SetMoveSpeed(float unitsPerSecond);
-    void SetTurnSpeed(float radiansPerSecond);
+	void Init(XMFLOAT3 position);
+	void Update(float elapsedSeconds);
+	XMMATRIX GetViewMatrix();
+	XMMATRIX GetProjectionMatrix(float fov, float aspectRatio, float nearPlane = 1.0f, float farPlane = 1000.0f);
+	void SetMoveSpeed(float unitsPerSecond);
+	void SetTurnSpeed(float radiansPerSecond);
 
-    void OnKeyDown(WPARAM key);
-    void OnKeyUp(WPARAM key);
+	void OnKeyDown(WPARAM key);
+	void OnKeyUp(WPARAM key);
 
 private:
-    void Reset();
+	void Reset();
 
-    struct KeysPressed
-    {
-        bool w;
-        bool a;
-        bool s;
-        bool d;
+	struct KeysPressed
+	{
+		bool w;
+		bool a;
+		bool s;
+		bool d;
 
-        bool left;
-        bool right;
-        bool up;
-        bool down;
-    };
+		bool left;
+		bool right;
+		bool up;
+		bool down;
+	};
 
-    XMFLOAT3 m_initialPosition;
-    XMFLOAT3 m_position;
-    float m_yaw;                // Relative to the +z axis.
-    float m_pitch;                // Relative to the xz plane.
-    XMFLOAT3 m_lookDirection;
-    XMFLOAT3 m_upDirection;
-    float m_moveSpeed;            // Speed at which the camera moves, in units per second.
-    float m_turnSpeed;            // Speed at which the camera turns, in radians per second.
+	XMFLOAT3 m_initialPosition;
+	XMFLOAT3 m_position;
+	float m_yaw;				// Relative to the +z axis.
+	float m_pitch;				// Relative to the xz plane.
+	XMFLOAT3 m_lookDirection;
+	XMFLOAT3 m_upDirection;
+	float m_moveSpeed;			// Speed at which the camera moves, in units per second.
+	float m_turnSpeed;			// Speed at which the camera turns, in radians per second.
 
-    KeysPressed m_keysPressed;
+	KeysPressed m_keysPressed;
 };

--- a/Samples/UWP/D3D12Bundles/src/View.cpp
+++ b/Samples/UWP/D3D12Bundles/src/View.cpp
@@ -15,27 +15,27 @@
 using namespace Windows::Foundation;
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -44,20 +44,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -66,26 +66,26 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnClosed(CoreWindow^ /*sender*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }

--- a/Samples/UWP/D3D12Bundles/src/View.h
+++ b/Samples/UWP/D3D12Bundles/src/View.h
@@ -23,20 +23,20 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
+	DXSample* m_pSample;
+	bool m_windowClosed;
 };

--- a/Samples/UWP/D3D12Bundles/src/ViewProvider.cpp
+++ b/Samples/UWP/D3D12Bundles/src/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12Bundles/src/ViewProvider.h
+++ b/Samples/UWP/D3D12Bundles/src/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12Bundles/src/d3dx12.h
+++ b/Samples/UWP/D3D12Bundles/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12Bundles/src/occcity.h
+++ b/Samples/UWP/D3D12Bundles/src/occcity.h
@@ -13,57 +13,57 @@
 
 namespace SampleAssets
 {
-    LPCWSTR DataFileName = L"occcity.bin";
+	LPCWSTR DataFileName = L"occcity.bin";
 
-    const D3D12_INPUT_ELEMENT_DESC StandardVertexDescription[] =
-    {
-        { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,  D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "NORMAL",   0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,    0, 24, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "TANGENT",  0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 32, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-    };
-    UINT StandardVertexDescriptionNumElements = _countof(StandardVertexDescription);
+	const D3D12_INPUT_ELEMENT_DESC StandardVertexDescription[] =
+	{
+		{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,  D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		{ "NORMAL",   0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,    0, 24, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		{ "TANGENT",  0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 32, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+	};
+	UINT StandardVertexDescriptionNumElements = _countof(StandardVertexDescription);
 
-    const UINT StandardVertexStride = 44;
+	const UINT StandardVertexStride = 44;
 
-    const DXGI_FORMAT StandardIndexFormat = DXGI_FORMAT_R32_UINT;
+	const DXGI_FORMAT StandardIndexFormat = DXGI_FORMAT_R32_UINT;
 
-    struct TextureResource
-    {
-        UINT Width;
-        UINT Height;
-        UINT16 MipLevels;
-        DXGI_FORMAT Format;
-        struct DataProperties
-        {
-            UINT Offset;
-            UINT Size;
-            UINT Pitch;
-        } Data[D3D12_REQ_MIP_LEVELS];
-    };
+	struct TextureResource
+	{
+		UINT Width;
+		UINT Height;
+		UINT16 MipLevels;
+		DXGI_FORMAT Format;
+		struct DataProperties
+		{
+			UINT Offset;
+			UINT Size;
+			UINT Pitch;
+		} Data[D3D12_REQ_MIP_LEVELS];
+	};
 
-    struct DrawParameters
-    {
-        INT DiffuseTextureIndex;
-        INT NormalTextureIndex;
-        INT SpecularTextureIndex;
-        UINT IndexStart;
-        UINT IndexCount;
-        UINT VertexBase;
-    };
+	struct DrawParameters
+	{
+		INT DiffuseTextureIndex;
+		INT NormalTextureIndex;
+		INT SpecularTextureIndex;
+		UINT IndexStart;
+		UINT IndexCount;
+		UINT VertexBase;
+	};
 
-    const UINT VertexDataOffset = 524288;
-    const UINT VertexDataSize = 820248;
-    const UINT IndexDataOffset = 1344536;
-    const UINT IndexDataSize = 74568;
+	const UINT VertexDataOffset = 524288;
+	const UINT VertexDataSize = 820248;
+	const UINT IndexDataOffset = 1344536;
+	const UINT IndexDataSize = 74568;
 
-    TextureResource Textures[] =
-    {
-        { 1024, 1024, 1, DXGI_FORMAT_BC1_UNORM, { { 0, 524288, 2048 }, } }, // city.dds
-    };
+	TextureResource Textures[] =
+	{
+		{ 1024, 1024, 1, DXGI_FORMAT_BC1_UNORM, { { 0, 524288, 2048 }, } }, // city.dds
+	};
 
-    DrawParameters Draws[] =
-    {
-        { 0, -1, -1, 0, 18642, 0 },
-    };
+	DrawParameters Draws[] =
+	{
+		{ 0, -1, -1, 0, 18642, 0 },
+	};
 }

--- a/Samples/UWP/D3D12Bundles/src/shader_mesh_alt_pixel.hlsl
+++ b/Samples/UWP/D3D12Bundles/src/shader_mesh_alt_pixel.hlsl
@@ -11,19 +11,19 @@
 
 struct PSInput
 {
-    float4 position    : SV_POSITION;
-    float2 uv        : TEXCOORD0;
+	float4 position	: SV_POSITION;
+	float2 uv		: TEXCOORD0;
 };
 
-Texture2D        g_txDiffuse : register(t0);
-SamplerState    g_sampler : register(s0);
+Texture2D		g_txDiffuse : register(t0);
+SamplerState	g_sampler : register(s0);
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    float3 color = g_txDiffuse.Sample(g_sampler, input.uv).rgb;
+	float3 color = g_txDiffuse.Sample(g_sampler, input.uv).rgb;
 
-    // Reduce R and B contributions to the output color.
-    float3 filter = float3(0.25f, 1.0f, 0.25f);
+	// Reduce R and B contributions to the output color.
+	float3 filter = float3(0.25f, 1.0f, 0.25f);
 
-    return float4(color.xyz * filter, 1.0f);
+	return float4(color.xyz * filter, 1.0f);
 }

--- a/Samples/UWP/D3D12Bundles/src/shader_mesh_simple_pixel.hlsl
+++ b/Samples/UWP/D3D12Bundles/src/shader_mesh_simple_pixel.hlsl
@@ -11,14 +11,14 @@
 
 struct PSInput
 {
-    float4 position    : SV_POSITION;
-    float2 uv        : TEXCOORD0;
+	float4 position	: SV_POSITION;
+	float2 uv		: TEXCOORD0;
 };
 
-Texture2D        g_txDiffuse : register(t0);
-SamplerState    g_sampler : register(s0);
+Texture2D		g_txDiffuse : register(t0);
+SamplerState	g_sampler : register(s0);
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return g_txDiffuse.Sample(g_sampler, input.uv);
+	return g_txDiffuse.Sample(g_sampler, input.uv);
 }

--- a/Samples/UWP/D3D12Bundles/src/shader_mesh_simple_vert.hlsl
+++ b/Samples/UWP/D3D12Bundles/src/shader_mesh_simple_vert.hlsl
@@ -11,29 +11,29 @@
 
 struct VSInput
 {
-    float3 position    : POSITION;
-    float3 normal    : NORMAL;
-    float2 uv        : TEXCOORD0;
-    float3 tangent    : TANGENT;
+	float3 position	: POSITION;
+	float3 normal	: NORMAL;
+	float2 uv		: TEXCOORD0;
+	float3 tangent	: TANGENT;
 };
 
 struct PSInput
 {
-    float4 position    : SV_POSITION;
-    float2 uv        : TEXCOORD0;
+	float4 position	: SV_POSITION;
+	float2 uv		: TEXCOORD0;
 };
 
 cbuffer cb0 : register(b0)
 {
-    float4x4 g_mWorldViewProj;
+	float4x4 g_mWorldViewProj;
 };
 
 PSInput VSMain(VSInput input)
 {
-    PSInput result;
-    
-    result.position = mul(float4(input.position, 1.0f), g_mWorldViewProj);
-    result.uv = input.uv;
-    
-    return result;
+	PSInput result;
+	
+	result.position = mul(float4(input.position, 1.0f), g_mWorldViewProj);
+	result.uv = input.uv;
+	
+	return result;
 }

--- a/Samples/UWP/D3D12DepthBoundsTest/src/D3D12DepthBoundsTest.cpp
+++ b/Samples/UWP/D3D12DepthBoundsTest/src/D3D12DepthBoundsTest.cpp
@@ -13,167 +13,167 @@
 #include "D3D12DepthBoundsTest.h"
 
 D3D12DepthBoundsTest::D3D12DepthBoundsTest(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_frameNumber(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_frameNumber(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0)
 {
 }
 
 void D3D12DepthBoundsTest::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12DepthBoundsTest::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-        ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+		));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-        ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+		));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
+	ComPtr<IDXGISwapChain1> swapChain;
 
-    ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-    ));
+	ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+	));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a depth stencil view (DSV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
-        dsvHeapDesc.NumDescriptors = 1;
-        dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-        dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
+		// Describe and create a depth stencil view (DSV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
+		dsvHeapDesc.NumDescriptors = 1;
+		dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+		dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
-        }
-    }
+		// Create a RTV for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
+		}
+	}
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
 }
 
 // Load the sample assets.
 void D3D12DepthBoundsTest::LoadAssets()
 {
-    // Create an empty root signature.
-    {
-        CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+	// Create an empty root signature.
+	{
+		CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
         // To bring up depth bounds feature, DX12 introduces a new concept to create pipeline state, called PSO stream. 
         // It is required to use PSO stream to enable depth bounds test.
@@ -247,208 +247,208 @@ void D3D12DepthBoundsTest::LoadAssets()
 
         const D3D12_PIPELINE_STATE_STREAM_DESC depthOnlyPSOStreamDesc = { sizeof(depthOnlyPSOStream), &depthOnlyPSOStream };
         ThrowIfFailed(m_device->CreatePipelineState(&depthOnlyPSOStreamDesc, IID_PPV_ARGS(&m_depthOnlyPipelineState)));
-    }
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
 
-    // Command lists are created in the recording state, but there is nothing
-    // to record yet. The main loop expects it to be closed, so close it now.
-    ThrowIfFailed(m_commandList->Close());
+	// Command lists are created in the recording state, but there is nothing
+	// to record yet. The main loop expects it to be closed, so close it now.
+	ThrowIfFailed(m_commandList->Close());
 
-    // Create the vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        Vertex triangleVertices[] =
-        {
-            { { 0.00f,  0.25f * m_aspectRatio, 0.1f },    // Top
-            { 1.0f,   0.0f,  0.0f,  1.0f } },        // Red
-            { { 0.25f, -0.25f * m_aspectRatio, 0.9f },    // Right
-            { 0.0f,   1.0f,  0.0f,  1.0f } },        // Green
-            { { -0.25f, -0.25f * m_aspectRatio, 0.5f },    // Left
-            { 0.0f,   0.0f,  1.0f,  1.0f } }         // Blue
-        };
+	// Create the vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		Vertex triangleVertices[] =
+		{
+			{ { 0.00f,  0.25f * m_aspectRatio, 0.1f },	// Top
+			{ 1.0f,   0.0f,  0.0f,  1.0f } },		// Red
+			{ { 0.25f, -0.25f * m_aspectRatio, 0.9f },	// Right
+			{ 0.0f,   1.0f,  0.0f,  1.0f } },		// Green
+			{ { -0.25f, -0.25f * m_aspectRatio, 0.5f },	// Left
+			{ 0.0f,   0.0f,  1.0f,  1.0f } } 		// Blue
+		};
 
-        const UINT vertexBufferSize = sizeof(triangleVertices);
+		const UINT vertexBufferSize = sizeof(triangleVertices);
 
-        // Note: using upload heaps to transfer static data like vert buffers is not 
-        // recommended. Every time the GPU needs it, the upload heap will be marshalled 
-        // over. Please read up on Default Heap usage. An upload heap is used here for 
-        // code simplicity and because there are very few verts to actually transfer.
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		// Note: using upload heaps to transfer static data like vert buffers is not 
+		// recommended. Every time the GPU needs it, the upload heap will be marshalled 
+		// over. Please read up on Default Heap usage. An upload heap is used here for 
+		// code simplicity and because there are very few verts to actually transfer.
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        // Copy the triangle data to the vertex buffer.
-        UINT8* pVertexDataBegin;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
-        memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
-        m_vertexBuffer->Unmap(0, nullptr);
+		// Copy the triangle data to the vertex buffer.
+		UINT8* pVertexDataBegin;
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
+		memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
+		m_vertexBuffer->Unmap(0, nullptr);
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = vertexBufferSize;
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = vertexBufferSize;
+	}
 
-    // Create the depth stencil view.
-    {
-        D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
-        depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
-        depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
-        depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
+	// Create the depth stencil view.
+	{
+		D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
+		depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
+		depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+		depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
 
-        D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
-        depthOptimizedClearValue.Format = DXGI_FORMAT_D32_FLOAT;
-        depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
-        depthOptimizedClearValue.DepthStencil.Stencil = 0;
+		D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
+		depthOptimizedClearValue.Format = DXGI_FORMAT_D32_FLOAT;
+		depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
+		depthOptimizedClearValue.DepthStencil.Stencil = 0;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
-            D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            &depthOptimizedClearValue,
-            IID_PPV_ARGS(&m_depthStencil)
-        ));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
+			D3D12_RESOURCE_STATE_DEPTH_WRITE,
+			&depthOptimizedClearValue,
+			IID_PPV_ARGS(&m_depthStencil)
+		));
 
-        NAME_D3D12_OBJECT(m_depthStencil);
+		NAME_D3D12_OBJECT(m_depthStencil);
 
-        m_device->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		m_device->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValue = 1;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValue = 1;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForPreviousFrame();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForPreviousFrame();
+	}
 }
 
 // Update frame-based values.
 void D3D12DepthBoundsTest::OnUpdate()
 {
-    m_frameNumber++;
+	m_frameNumber++;
 }
 
 // Render the scene.
 void D3D12DepthBoundsTest::OnRender()
 {
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+	// Present the frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    WaitForPreviousFrame();
+	WaitForPreviousFrame();
 }
 
 void D3D12DepthBoundsTest::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForPreviousFrame();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForPreviousFrame();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12DepthBoundsTest::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocator->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocator->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_depthOnlyPipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_depthOnlyPipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
 
-    // Record commands.
-    const float clearColor[] = { 0.392f, 0.584f, 0.929f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    m_commandList->ClearDepthStencilView(m_dsvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+	// Record commands.
+	const float clearColor[] = { 0.392f, 0.584f, 0.929f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	m_commandList->ClearDepthStencilView(m_dsvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
 
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
 
     // Render only the depth stencil view of the triangle to prime the depth value of the triangle
-    m_commandList->DrawInstanced(3, 1, 0, 0);
+	m_commandList->DrawInstanced(3, 1, 0, 0);
 
     // Move depth bounds so we can see they move. Depth bound test will test against DEST depth
-    // that we primed previously
-    const FLOAT f = 0.125f + sinf((m_frameNumber & 0x7F) / 127.f) * 0.125f;      // [0.. 0.25]
-    if (DepthBoundsTestSupported)
-    {
-        m_commandList->OMSetDepthBounds(0.0f + f, 1.0f - f);
-    }
+	// that we primed previously
+	const FLOAT f = 0.125f + sinf((m_frameNumber & 0x7F) / 127.f) * 0.125f;      // [0.. 0.25]
+	if (DepthBoundsTestSupported)
+	{
+		m_commandList->OMSetDepthBounds(0.0f + f, 1.0f - f);
+	}
 
-    // Render the triangle with depth bounds
-    m_commandList->SetPipelineState(m_pipelineState.Get());
-    m_commandList->DrawInstanced(3, 1, 0, 0);
+	// Render the triangle with depth bounds
+	m_commandList->SetPipelineState(m_pipelineState.Get());
+	m_commandList->DrawInstanced(3, 1, 0, 0);
 
-    // Disable depth bounds on Direct3D 12 by resetting back to the default range
-    if (DepthBoundsTestSupported)
-    {
-        m_commandList->OMSetDepthBounds(0.0f, 1.0f);
-    }
+	// Disable depth bounds on Direct3D 12 by resetting back to the default range
+	if (DepthBoundsTestSupported)
+	{
+		m_commandList->OMSetDepthBounds(0.0f, 1.0f);
+	}
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 void D3D12DepthBoundsTest::WaitForPreviousFrame()
 {
-    // WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
-    // This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
-    // sample illustrates how to use fences for efficient resource usage and to
-    // maximize GPU utilization.
+	// WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
+	// This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
+	// sample illustrates how to use fences for efficient resource usage and to
+	// maximize GPU utilization.
 
-    // Signal and increment the fence value.
-    const UINT64 fence = m_fenceValue;
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
-    m_fenceValue++;
+	// Signal and increment the fence value.
+	const UINT64 fence = m_fenceValue;
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
+	m_fenceValue++;
 
-    // Wait until the previous frame is finished.
-    if (m_fence->GetCompletedValue() < fence)
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+	// Wait until the previous frame is finished.
+	if (m_fence->GetCompletedValue() < fence)
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 }

--- a/Samples/UWP/D3D12DepthBoundsTest/src/D3D12DepthBoundsTest.h
+++ b/Samples/UWP/D3D12DepthBoundsTest/src/D3D12DepthBoundsTest.h
@@ -25,53 +25,53 @@ using Microsoft::WRL::ComPtr;
 class D3D12DepthBoundsTest : public DXSample
 {
 public:
-    D3D12DepthBoundsTest(UINT width, UINT height, std::wstring name);
+	D3D12DepthBoundsTest(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    static const UINT FrameCount = 2;
+	static const UINT FrameCount = 2;
 
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT4 color;
-    };
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT4 color;
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device2> m_device;
-    ComPtr<ID3D12Resource> m_depthStencil;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12PipelineState> m_depthOnlyPipelineState;
-    ComPtr<ID3D12GraphicsCommandList1> m_commandList;
-    UINT m_rtvDescriptorSize;
-    bool DepthBoundsTestSupported;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device2> m_device;
+	ComPtr<ID3D12Resource> m_depthStencil;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12PipelineState> m_depthOnlyPipelineState;
+	ComPtr<ID3D12GraphicsCommandList1> m_commandList;
+	UINT m_rtvDescriptorSize;
+	bool DepthBoundsTestSupported;
 
-    // App resources.
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	// App resources.
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    UINT m_frameNumber;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValue;
+	// Synchronization objects.
+	UINT m_frameIndex;
+	UINT m_frameNumber;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValue;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void PopulateCommandList();
-    void WaitForPreviousFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	void PopulateCommandList();
+	void WaitForPreviousFrame();
 };

--- a/Samples/UWP/D3D12DepthBoundsTest/src/DXSample.cpp
+++ b/Samples/UWP/D3D12DepthBoundsTest/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,59 +34,104 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
-    auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(windowText.c_str());
+	std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
+	auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/UWP/D3D12DepthBoundsTest/src/DXSample.h
+++ b/Samples/UWP/D3D12DepthBoundsTest/src/DXSample.h
@@ -16,42 +16,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/UWP/D3D12DepthBoundsTest/src/Main.cpp
+++ b/Samples/UWP/D3D12DepthBoundsTest/src/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12DepthBoundsTest sample(1200, 900, L"");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12DepthBoundsTest sample(1200, 900, L"");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12DepthBoundsTest/src/View.cpp
+++ b/Samples/UWP/D3D12DepthBoundsTest/src/View.cpp
@@ -15,27 +15,27 @@
 using namespace Windows::Foundation;
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -44,20 +44,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -66,26 +66,26 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnClosed(CoreWindow^ /*sender*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }

--- a/Samples/UWP/D3D12DepthBoundsTest/src/View.h
+++ b/Samples/UWP/D3D12DepthBoundsTest/src/View.h
@@ -23,20 +23,20 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
+	DXSample* m_pSample;
+	bool m_windowClosed;
 };

--- a/Samples/UWP/D3D12DepthBoundsTest/src/ViewProvider.cpp
+++ b/Samples/UWP/D3D12DepthBoundsTest/src/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12DepthBoundsTest/src/ViewProvider.h
+++ b/Samples/UWP/D3D12DepthBoundsTest/src/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12DepthBoundsTest/src/d3dx12.h
+++ b/Samples/UWP/D3D12DepthBoundsTest/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12DepthBoundsTest/src/shaders.hlsl
+++ b/Samples/UWP/D3D12DepthBoundsTest/src/shaders.hlsl
@@ -11,21 +11,21 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VSMain(float4 position : POSITION, float4 color : COLOR)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.color = color;
+	result.position = position;
+	result.color = color;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/UWP/D3D12DynamicIndexing/src/D3D12DynamicIndexing.cpp
+++ b/Samples/UWP/D3D12DynamicIndexing/src/D3D12DynamicIndexing.cpp
@@ -16,726 +16,726 @@
 const float D3D12DynamicIndexing::CitySpacingInterval = 16.0f;
 
 D3D12DynamicIndexing::D3D12DynamicIndexing(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_frameCounter(0),
-    m_fenceValue(0),
-    m_rtvDescriptorSize(0),
-    m_cbvSrvDescriptorSize(0),
-    m_currentFrameResourceIndex(0),
-    m_pCurrentFrameResource(nullptr)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_frameCounter(0),
+	m_fenceValue(0),
+	m_rtvDescriptorSize(0),
+	m_cbvSrvDescriptorSize(0),
+	m_currentFrameResourceIndex(0),
+	m_pCurrentFrameResource(nullptr)
 {
 }
 
 void D3D12DynamicIndexing::OnInit()
 {
-    m_camera.Init({ (CityColumnCount / 2.0f) * CitySpacingInterval - (CitySpacingInterval / 2.0f), 15, 50 });
-    m_camera.SetMoveSpeed(CitySpacingInterval * 2.0f);
+	m_camera.Init({ (CityColumnCount / 2.0f) * CitySpacingInterval - (CitySpacingInterval / 2.0f), 15, 50 });
+	m_camera.SetMoveSpeed(CitySpacingInterval * 2.0f);
 
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12DynamicIndexing::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
-    NAME_D3D12_OBJECT(m_commandQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	NAME_D3D12_OBJECT(m_commandQueue);
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a depth stencil view (DSV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
-        dsvHeapDesc.NumDescriptors = 1;
-        dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-        dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
+		// Describe and create a depth stencil view (DSV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
+		dsvHeapDesc.NumDescriptors = 1;
+		dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+		dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
 
-        // Describe and create a shader resource view (SRV) and constant 
-        // buffer view (CBV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvSrvHeapDesc = {};
-        cbvSrvHeapDesc.NumDescriptors =
-            FrameCount * CityRowCount * CityColumnCount +    // FrameCount frames * CityRowCount * CityColumnCount.
-            CityMaterialCount + 1;                            // CityMaterialCount + 1 for the SRVs.
-        cbvSrvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        cbvSrvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvSrvHeapDesc, IID_PPV_ARGS(&m_cbvSrvHeap)));
-        NAME_D3D12_OBJECT(m_cbvSrvHeap);
+		// Describe and create a shader resource view (SRV) and constant 
+		// buffer view (CBV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvSrvHeapDesc = {};
+		cbvSrvHeapDesc.NumDescriptors =
+			FrameCount * CityRowCount * CityColumnCount +	// FrameCount frames * CityRowCount * CityColumnCount.
+			CityMaterialCount + 1;							// CityMaterialCount + 1 for the SRVs.
+		cbvSrvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		cbvSrvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvSrvHeapDesc, IID_PPV_ARGS(&m_cbvSrvHeap)));
+		NAME_D3D12_OBJECT(m_cbvSrvHeap);
 
-        // Describe and create a sampler descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
-        samplerHeapDesc.NumDescriptors = 1;
-        samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
-        samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_samplerHeap)));
+		// Describe and create a sampler descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
+		samplerHeapDesc.NumDescriptors = 1;
+		samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
+		samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_samplerHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-        m_cbvSrvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_cbvSrvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	}
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
 }
 
 // Load the sample assets.
 void D3D12DynamicIndexing::LoadAssets()
 {
-    // Note: ComPtr's are CPU objects but these resources need to stay in scope until
-    // the command list that references them has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resources are not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> vertexBufferUploadHeap;
-    ComPtr<ID3D12Resource> indexBufferUploadHeap;
-    ComPtr<ID3D12Resource> textureUploadHeap;
-    ComPtr<ID3D12Resource> materialsUploadHeap;
+	// Note: ComPtr's are CPU objects but these resources need to stay in scope until
+	// the command list that references them has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resources are not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> vertexBufferUploadHeap;
+	ComPtr<ID3D12Resource> indexBufferUploadHeap;
+	ComPtr<ID3D12Resource> textureUploadHeap;
+	ComPtr<ID3D12Resource> materialsUploadHeap;
 
-    // Create the root signature.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signature.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[3];
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1 + CityMaterialCount, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);    // Diffuse texture + array of materials.
-        ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
-        ranges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[3];
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1 + CityMaterialCount, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);	// Diffuse texture + array of materials.
+		ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
+		ranges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
 
-        CD3DX12_ROOT_PARAMETER1 rootParameters[4];
-        rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
-        rootParameters[1].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_PIXEL);
-        rootParameters[2].InitAsDescriptorTable(1, &ranges[2], D3D12_SHADER_VISIBILITY_VERTEX);
-        rootParameters[3].InitAsConstants(1, 0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
+		CD3DX12_ROOT_PARAMETER1 rootParameters[4];
+		rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
+		rootParameters[1].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_PIXEL);
+		rootParameters[2].InitAsDescriptorTable(1, &ranges[2], D3D12_SHADER_VISIBILITY_VERTEX);
+		rootParameters[3].InitAsConstants(1, 0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-        NAME_D3D12_OBJECT(m_rootSignature);
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+		NAME_D3D12_OBJECT(m_rootSignature);
+	}
 
-    // Create the pipeline state, which includes loading shaders.
-    {
-        UINT8* pVertexShaderData;
-        UINT8* pPixelShaderData;
-        UINT vertexShaderDataLength;
-        UINT pixelShaderDataLength;
+	// Create the pipeline state, which includes loading shaders.
+	{
+		UINT8* pVertexShaderData;
+		UINT8* pPixelShaderData;
+		UINT vertexShaderDataLength;
+		UINT pixelShaderDataLength;
 
-        ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(L"shader_mesh_simple_vert.cso").c_str(), &pVertexShaderData, &vertexShaderDataLength));
-        ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(L"shader_mesh_dynamic_indexing_pixel.cso").c_str(), &pPixelShaderData, &pixelShaderDataLength));
+		ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(L"shader_mesh_simple_vert.cso").c_str(), &pVertexShaderData, &vertexShaderDataLength));
+		ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(L"shader_mesh_dynamic_indexing_pixel.cso").c_str(), &pPixelShaderData, &pixelShaderDataLength));
 
-        CD3DX12_RASTERIZER_DESC rasterizerStateDesc(D3D12_DEFAULT);
-        rasterizerStateDesc.CullMode = D3D12_CULL_MODE_NONE;
+		CD3DX12_RASTERIZER_DESC rasterizerStateDesc(D3D12_DEFAULT);
+		rasterizerStateDesc.CullMode = D3D12_CULL_MODE_NONE;
 
-        // Describe and create the graphics pipeline state object (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { SampleAssets::StandardVertexDescription, SampleAssets::StandardVertexDescriptionNumElements };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(pVertexShaderData, vertexShaderDataLength);
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pPixelShaderData, pixelShaderDataLength);
-        psoDesc.RasterizerState = rasterizerStateDesc;
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state object (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { SampleAssets::StandardVertexDescription, SampleAssets::StandardVertexDescriptionNumElements };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(pVertexShaderData, vertexShaderDataLength);
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pPixelShaderData, pixelShaderDataLength);
+		psoDesc.RasterizerState = rasterizerStateDesc;
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-        NAME_D3D12_OBJECT(m_pipelineState);
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+		NAME_D3D12_OBJECT(m_pipelineState);
 
-        delete pVertexShaderData;
-        delete pPixelShaderData;
-    }
+		delete pVertexShaderData;
+		delete pPixelShaderData;
+	}
 
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), nullptr, IID_PPV_ARGS(&m_commandList)));
-    NAME_D3D12_OBJECT(m_commandList);
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), nullptr, IID_PPV_ARGS(&m_commandList)));
+	NAME_D3D12_OBJECT(m_commandList);
 
-    // Create render target views (RTVs).
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
-    for (UINT i = 0; i < FrameCount; i++)
-    {
-        ThrowIfFailed(m_swapChain->GetBuffer(i, IID_PPV_ARGS(&m_renderTargets[i])));
-        m_device->CreateRenderTargetView(m_renderTargets[i].Get(), nullptr, rtvHandle);
-        rtvHandle.Offset(1, m_rtvDescriptorSize);
+	// Create render target views (RTVs).
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	for (UINT i = 0; i < FrameCount; i++)
+	{
+		ThrowIfFailed(m_swapChain->GetBuffer(i, IID_PPV_ARGS(&m_renderTargets[i])));
+		m_device->CreateRenderTargetView(m_renderTargets[i].Get(), nullptr, rtvHandle);
+		rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-        NAME_D3D12_OBJECT_INDEXED(m_renderTargets, i);
-    }
+		NAME_D3D12_OBJECT_INDEXED(m_renderTargets, i);
+	}
 
-    // Read in mesh data for vertex/index buffers.
-    UINT8* pMeshData;
-    UINT meshDataLength;
-    ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(SampleAssets::DataFileName).c_str(), &pMeshData, &meshDataLength));
+	// Read in mesh data for vertex/index buffers.
+	UINT8* pMeshData;
+	UINT meshDataLength;
+	ThrowIfFailed(ReadDataFromFile(GetAssetFullPath(SampleAssets::DataFileName).c_str(), &pMeshData, &meshDataLength));
 
-    // Create the vertex buffer.
-    {
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+	// Create the vertex buffer.
+	{
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&vertexBufferUploadHeap)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&vertexBufferUploadHeap)));
 
-        NAME_D3D12_OBJECT(m_vertexBuffer);
+		NAME_D3D12_OBJECT(m_vertexBuffer);
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = pMeshData + SampleAssets::VertexDataOffset;
-        vertexData.RowPitch = SampleAssets::VertexDataSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = pMeshData + SampleAssets::VertexDataOffset;
+		vertexData.RowPitch = SampleAssets::VertexDataSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUploadHeap.Get(), 0, 0, 1, &vertexData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUploadHeap.Get(), 0, 0, 1, &vertexData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = SampleAssets::StandardVertexStride;
-        m_vertexBufferView.SizeInBytes = SampleAssets::VertexDataSize;
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = SampleAssets::StandardVertexStride;
+		m_vertexBufferView.SizeInBytes = SampleAssets::VertexDataSize;
+	}
 
-    // Create the index buffer.
-    {
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::IndexDataSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_indexBuffer)));
+	// Create the index buffer.
+	{
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::IndexDataSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_indexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::IndexDataSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&indexBufferUploadHeap)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::IndexDataSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&indexBufferUploadHeap)));
 
-        NAME_D3D12_OBJECT(m_indexBuffer);
+		NAME_D3D12_OBJECT(m_indexBuffer);
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the index buffer.
-        D3D12_SUBRESOURCE_DATA indexData = {};
-        indexData.pData = pMeshData + SampleAssets::IndexDataOffset;
-        indexData.RowPitch = SampleAssets::IndexDataSize;
-        indexData.SlicePitch = indexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the index buffer.
+		D3D12_SUBRESOURCE_DATA indexData = {};
+		indexData.pData = pMeshData + SampleAssets::IndexDataOffset;
+		indexData.RowPitch = SampleAssets::IndexDataSize;
+		indexData.SlicePitch = indexData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_indexBuffer.Get(), indexBufferUploadHeap.Get(), 0, 0, 1, &indexData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_indexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_INDEX_BUFFER));
+		UpdateSubresources<1>(m_commandList.Get(), m_indexBuffer.Get(), indexBufferUploadHeap.Get(), 0, 0, 1, &indexData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_indexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_INDEX_BUFFER));
 
-        // Describe the index buffer view.
-        m_indexBufferView.BufferLocation = m_indexBuffer->GetGPUVirtualAddress();
-        m_indexBufferView.Format = SampleAssets::StandardIndexFormat;
-        m_indexBufferView.SizeInBytes = SampleAssets::IndexDataSize;
+		// Describe the index buffer view.
+		m_indexBufferView.BufferLocation = m_indexBuffer->GetGPUVirtualAddress();
+		m_indexBufferView.Format = SampleAssets::StandardIndexFormat;
+		m_indexBufferView.SizeInBytes = SampleAssets::IndexDataSize;
 
-        m_numIndices = SampleAssets::IndexDataSize / 4;    // R32_UINT (SampleAssets::StandardIndexFormat) = 4 bytes each.
-    }
+		m_numIndices = SampleAssets::IndexDataSize / 4;	// R32_UINT (SampleAssets::StandardIndexFormat) = 4 bytes each.
+	}
 
-    // Create the textures and sampler.
-    {
-        // Procedurally generate an array of textures to use as city materials.
-        {
-            // All of these materials use the same texture desc.
-            D3D12_RESOURCE_DESC textureDesc = {};
-            textureDesc.MipLevels = 1;
-            textureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-            textureDesc.Width = CityMaterialTextureWidth;
-            textureDesc.Height = CityMaterialTextureHeight;
-            textureDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
-            textureDesc.DepthOrArraySize = 1;
-            textureDesc.SampleDesc.Count = 1;
-            textureDesc.SampleDesc.Quality = 0;
-            textureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+	// Create the textures and sampler.
+	{
+		// Procedurally generate an array of textures to use as city materials.
+		{
+			// All of these materials use the same texture desc.
+			D3D12_RESOURCE_DESC textureDesc = {};
+			textureDesc.MipLevels = 1;
+			textureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+			textureDesc.Width = CityMaterialTextureWidth;
+			textureDesc.Height = CityMaterialTextureHeight;
+			textureDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
+			textureDesc.DepthOrArraySize = 1;
+			textureDesc.SampleDesc.Count = 1;
+			textureDesc.SampleDesc.Quality = 0;
+			textureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
 
-            // The textures evenly span the color rainbow so that each city gets
-            // a different material.
-            float materialGradStep = (1.0f / static_cast<float>(CityMaterialCount));
+			// The textures evenly span the color rainbow so that each city gets
+			// a different material.
+			float materialGradStep = (1.0f / static_cast<float>(CityMaterialCount));
 
-            // Generate texture data.
-            std::vector<std::vector<unsigned char>> cityTextureData;
-            cityTextureData.resize(CityMaterialCount);
-            for (UINT i = 0; i < CityMaterialCount; ++i)
-            {
-                ThrowIfFailed(m_device->CreateCommittedResource(
-                    &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-                    D3D12_HEAP_FLAG_NONE,
-                    &textureDesc,
-                    D3D12_RESOURCE_STATE_COPY_DEST,
-                    nullptr,
-                    IID_PPV_ARGS(&m_cityMaterialTextures[i])));
+			// Generate texture data.
+			std::vector<std::vector<unsigned char>> cityTextureData;
+			cityTextureData.resize(CityMaterialCount);
+			for (UINT i = 0; i < CityMaterialCount; ++i)
+			{
+				ThrowIfFailed(m_device->CreateCommittedResource(
+					&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+					D3D12_HEAP_FLAG_NONE,
+					&textureDesc,
+					D3D12_RESOURCE_STATE_COPY_DEST,
+					nullptr,
+					IID_PPV_ARGS(&m_cityMaterialTextures[i])));
 
-                NAME_D3D12_OBJECT_INDEXED(m_cityMaterialTextures, i);
+				NAME_D3D12_OBJECT_INDEXED(m_cityMaterialTextures, i);
 
-                // Fill the texture.
-                float t = i * materialGradStep;
-                cityTextureData[i].resize(CityMaterialTextureWidth * CityMaterialTextureHeight * CityMaterialTextureChannelCount);
-                for (int x = 0; x < CityMaterialTextureWidth; ++x)
-                {
-                    for (int y = 0; y < CityMaterialTextureHeight; ++y)
-                    {
-                        // Compute the appropriate index into the buffer based on the x/y coordinates.
-                        int pixelIndex = (y * CityMaterialTextureChannelCount * CityMaterialTextureWidth) + (x * CityMaterialTextureChannelCount);
+				// Fill the texture.
+				float t = i * materialGradStep;
+				cityTextureData[i].resize(CityMaterialTextureWidth * CityMaterialTextureHeight * CityMaterialTextureChannelCount);
+				for (int x = 0; x < CityMaterialTextureWidth; ++x)
+				{
+					for (int y = 0; y < CityMaterialTextureHeight; ++y)
+					{
+						// Compute the appropriate index into the buffer based on the x/y coordinates.
+						int pixelIndex = (y * CityMaterialTextureChannelCount * CityMaterialTextureWidth) + (x * CityMaterialTextureChannelCount);
 
-                        // Determine this row's position along the rainbow gradient.
-                        float tPrime = t + ((static_cast<float>(y) / static_cast<float>(CityMaterialTextureHeight)) * materialGradStep);
+						// Determine this row's position along the rainbow gradient.
+						float tPrime = t + ((static_cast<float>(y) / static_cast<float>(CityMaterialTextureHeight)) * materialGradStep);
 
-                        // Compute the RGB value for this position along the rainbow
-                        // and pack the pixel value.
-                        XMVECTOR hsl = XMVectorSet(tPrime, 0.5f, 0.5f, 1.0f);
-                        XMVECTOR rgb = XMColorHSLToRGB(hsl);
-                        cityTextureData[i][pixelIndex + 0] = static_cast<unsigned char>((255 * XMVectorGetX(rgb)));
-                        cityTextureData[i][pixelIndex + 1] = static_cast<unsigned char>((255 * XMVectorGetY(rgb)));
-                        cityTextureData[i][pixelIndex + 2] = static_cast<unsigned char>((255 * XMVectorGetZ(rgb)));
-                        cityTextureData[i][pixelIndex + 3] = 255;
-                    }
-                }
-            }
+						// Compute the RGB value for this position along the rainbow
+						// and pack the pixel value.
+						XMVECTOR hsl = XMVectorSet(tPrime, 0.5f, 0.5f, 1.0f);
+						XMVECTOR rgb = XMColorHSLToRGB(hsl);
+						cityTextureData[i][pixelIndex + 0] = static_cast<unsigned char>((255 * XMVectorGetX(rgb)));
+						cityTextureData[i][pixelIndex + 1] = static_cast<unsigned char>((255 * XMVectorGetY(rgb)));
+						cityTextureData[i][pixelIndex + 2] = static_cast<unsigned char>((255 * XMVectorGetZ(rgb)));
+						cityTextureData[i][pixelIndex + 3] = 255;
+					}
+				}
+			}
 
-            // Upload texture data to the default heap resources.
-            {
-                const UINT subresourceCount = textureDesc.DepthOrArraySize * textureDesc.MipLevels;
-                const UINT64 uploadBufferStep = GetRequiredIntermediateSize(m_cityMaterialTextures[0].Get(), 0, subresourceCount); // All of our textures are the same size in this case.
-                const UINT64 uploadBufferSize = uploadBufferStep * CityMaterialCount;
-                ThrowIfFailed(m_device->CreateCommittedResource(
-                    &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-                    D3D12_HEAP_FLAG_NONE,
-                    &CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
-                    D3D12_RESOURCE_STATE_GENERIC_READ,
-                    nullptr,
-                    IID_PPV_ARGS(&materialsUploadHeap)));
+			// Upload texture data to the default heap resources.
+			{
+				const UINT subresourceCount = textureDesc.DepthOrArraySize * textureDesc.MipLevels;
+				const UINT64 uploadBufferStep = GetRequiredIntermediateSize(m_cityMaterialTextures[0].Get(), 0, subresourceCount); // All of our textures are the same size in this case.
+				const UINT64 uploadBufferSize = uploadBufferStep * CityMaterialCount;
+				ThrowIfFailed(m_device->CreateCommittedResource(
+					&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+					D3D12_HEAP_FLAG_NONE,
+					&CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
+					D3D12_RESOURCE_STATE_GENERIC_READ,
+					nullptr,
+					IID_PPV_ARGS(&materialsUploadHeap)));
 
-                for (int i = 0; i < CityMaterialCount; ++i)
-                {
-                    // Copy data to the intermediate upload heap and then schedule 
-                    // a copy from the upload heap to the appropriate texture.
-                    D3D12_SUBRESOURCE_DATA textureData = {};
-                    textureData.pData = &cityTextureData[i][0];
-                    textureData.RowPitch = static_cast<LONG_PTR>((CityMaterialTextureChannelCount * textureDesc.Width));
-                    textureData.SlicePitch = textureData.RowPitch * textureDesc.Height;
+				for (int i = 0; i < CityMaterialCount; ++i)
+				{
+					// Copy data to the intermediate upload heap and then schedule 
+					// a copy from the upload heap to the appropriate texture.
+					D3D12_SUBRESOURCE_DATA textureData = {};
+					textureData.pData = &cityTextureData[i][0];
+					textureData.RowPitch = static_cast<LONG_PTR>((CityMaterialTextureChannelCount * textureDesc.Width));
+					textureData.SlicePitch = textureData.RowPitch * textureDesc.Height;
 
-                    UpdateSubresources(m_commandList.Get(), m_cityMaterialTextures[i].Get(), materialsUploadHeap.Get(), i * uploadBufferStep, 0, subresourceCount, &textureData);
-                    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_cityMaterialTextures[i].Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
-                }
-            }
-        }
+					UpdateSubresources(m_commandList.Get(), m_cityMaterialTextures[i].Get(), materialsUploadHeap.Get(), i * uploadBufferStep, 0, subresourceCount, &textureData);
+					m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_cityMaterialTextures[i].Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
+				}
+			}
+		}
 
-        // Load the occcity diffuse texture with baked-in ambient lighting.
-        // This texture will be blended with a texture from the materials
-        // array in the pixel shader.
-        {
-            D3D12_RESOURCE_DESC textureDesc = {};
-            textureDesc.MipLevels = SampleAssets::Textures[0].MipLevels;
-            textureDesc.Format = SampleAssets::Textures[0].Format;
-            textureDesc.Width = SampleAssets::Textures[0].Width;
-            textureDesc.Height = SampleAssets::Textures[0].Height;
-            textureDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
-            textureDesc.DepthOrArraySize = 1;
-            textureDesc.SampleDesc.Count = 1;
-            textureDesc.SampleDesc.Quality = 0;
-            textureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+		// Load the occcity diffuse texture with baked-in ambient lighting.
+		// This texture will be blended with a texture from the materials
+		// array in the pixel shader.
+		{
+			D3D12_RESOURCE_DESC textureDesc = {};
+			textureDesc.MipLevels = SampleAssets::Textures[0].MipLevels;
+			textureDesc.Format = SampleAssets::Textures[0].Format;
+			textureDesc.Width = SampleAssets::Textures[0].Width;
+			textureDesc.Height = SampleAssets::Textures[0].Height;
+			textureDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
+			textureDesc.DepthOrArraySize = 1;
+			textureDesc.SampleDesc.Count = 1;
+			textureDesc.SampleDesc.Quality = 0;
+			textureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
 
-            ThrowIfFailed(m_device->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-                D3D12_HEAP_FLAG_NONE,
-                &textureDesc,
-                D3D12_RESOURCE_STATE_COPY_DEST,
-                nullptr,
-                IID_PPV_ARGS(&m_cityDiffuseTexture)));
+			ThrowIfFailed(m_device->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+				D3D12_HEAP_FLAG_NONE,
+				&textureDesc,
+				D3D12_RESOURCE_STATE_COPY_DEST,
+				nullptr,
+				IID_PPV_ARGS(&m_cityDiffuseTexture)));
 
-            const UINT subresourceCount = textureDesc.DepthOrArraySize * textureDesc.MipLevels;
-            const UINT64 uploadBufferSize = GetRequiredIntermediateSize(m_cityDiffuseTexture.Get(), 0, subresourceCount);
-            ThrowIfFailed(m_device->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-                D3D12_HEAP_FLAG_NONE,
-                &CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
-                D3D12_RESOURCE_STATE_GENERIC_READ,
-                nullptr,
-                IID_PPV_ARGS(&textureUploadHeap)));
+			const UINT subresourceCount = textureDesc.DepthOrArraySize * textureDesc.MipLevels;
+			const UINT64 uploadBufferSize = GetRequiredIntermediateSize(m_cityDiffuseTexture.Get(), 0, subresourceCount);
+			ThrowIfFailed(m_device->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+				D3D12_HEAP_FLAG_NONE,
+				&CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
+				D3D12_RESOURCE_STATE_GENERIC_READ,
+				nullptr,
+				IID_PPV_ARGS(&textureUploadHeap)));
 
-            NAME_D3D12_OBJECT(m_cityDiffuseTexture);
+			NAME_D3D12_OBJECT(m_cityDiffuseTexture);
 
-            // Copy data to the intermediate upload heap and then schedule 
-            // a copy from the upload heap to the diffuse texture.
-            D3D12_SUBRESOURCE_DATA textureData = {};
-            textureData.pData = pMeshData + SampleAssets::Textures[0].Data[0].Offset;
-            textureData.RowPitch = SampleAssets::Textures[0].Data[0].Pitch;
-            textureData.SlicePitch = SampleAssets::Textures[0].Data[0].Size;
+			// Copy data to the intermediate upload heap and then schedule 
+			// a copy from the upload heap to the diffuse texture.
+			D3D12_SUBRESOURCE_DATA textureData = {};
+			textureData.pData = pMeshData + SampleAssets::Textures[0].Data[0].Offset;
+			textureData.RowPitch = SampleAssets::Textures[0].Data[0].Pitch;
+			textureData.SlicePitch = SampleAssets::Textures[0].Data[0].Size;
 
-            UpdateSubresources(m_commandList.Get(), m_cityDiffuseTexture.Get(), textureUploadHeap.Get(), 0, 0, subresourceCount, &textureData);
-            m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_cityDiffuseTexture.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
-        }
+			UpdateSubresources(m_commandList.Get(), m_cityDiffuseTexture.Get(), textureUploadHeap.Get(), 0, 0, subresourceCount, &textureData);
+			m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_cityDiffuseTexture.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
+		}
 
-        // Describe and create a sampler.
-        D3D12_SAMPLER_DESC samplerDesc = {};
-        samplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-        samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.MinLOD = 0;
-        samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
-        samplerDesc.MipLODBias = 0.0f;
-        samplerDesc.MaxAnisotropy = 1;
-        samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
-        m_device->CreateSampler(&samplerDesc, m_samplerHeap->GetCPUDescriptorHandleForHeapStart());
+		// Describe and create a sampler.
+		D3D12_SAMPLER_DESC samplerDesc = {};
+		samplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.MinLOD = 0;
+		samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
+		samplerDesc.MipLODBias = 0.0f;
+		samplerDesc.MaxAnisotropy = 1;
+		samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
+		m_device->CreateSampler(&samplerDesc, m_samplerHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create SRV for the city's diffuse texture.
-        CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart(), 0, m_cbvSrvDescriptorSize);
-        D3D12_SHADER_RESOURCE_VIEW_DESC diffuseSrvDesc = {};
-        diffuseSrvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        diffuseSrvDesc.Format = SampleAssets::Textures->Format;
-        diffuseSrvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        diffuseSrvDesc.Texture2D.MipLevels = 1;
-        m_device->CreateShaderResourceView(m_cityDiffuseTexture.Get(), &diffuseSrvDesc, srvHandle);
-        srvHandle.Offset(m_cbvSrvDescriptorSize);
+		// Create SRV for the city's diffuse texture.
+		CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart(), 0, m_cbvSrvDescriptorSize);
+		D3D12_SHADER_RESOURCE_VIEW_DESC diffuseSrvDesc = {};
+		diffuseSrvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		diffuseSrvDesc.Format = SampleAssets::Textures->Format;
+		diffuseSrvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		diffuseSrvDesc.Texture2D.MipLevels = 1;
+		m_device->CreateShaderResourceView(m_cityDiffuseTexture.Get(), &diffuseSrvDesc, srvHandle);
+		srvHandle.Offset(m_cbvSrvDescriptorSize);
 
-        // Create SRVs for each city material.
-        for (int i = 0; i < CityMaterialCount; ++i)
-        {
-            D3D12_SHADER_RESOURCE_VIEW_DESC materialSrvDesc = {};
-            materialSrvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-            materialSrvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-            materialSrvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-            materialSrvDesc.Texture2D.MipLevels = 1;
-            m_device->CreateShaderResourceView(m_cityMaterialTextures[i].Get(), &materialSrvDesc, srvHandle);
+		// Create SRVs for each city material.
+		for (int i = 0; i < CityMaterialCount; ++i)
+		{
+			D3D12_SHADER_RESOURCE_VIEW_DESC materialSrvDesc = {};
+			materialSrvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+			materialSrvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+			materialSrvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+			materialSrvDesc.Texture2D.MipLevels = 1;
+			m_device->CreateShaderResourceView(m_cityMaterialTextures[i].Get(), &materialSrvDesc, srvHandle);
 
-            srvHandle.Offset(m_cbvSrvDescriptorSize);
-        }
-    }
+			srvHandle.Offset(m_cbvSrvDescriptorSize);
+		}
+	}
 
-    delete pMeshData;
+	delete pMeshData;
 
-    // Create the depth stencil view.
-    {
-        D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
-        depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
-        depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
-        depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
+	// Create the depth stencil view.
+	{
+		D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
+		depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
+		depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+		depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
 
-        D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
-        depthOptimizedClearValue.Format = DXGI_FORMAT_D32_FLOAT;
-        depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
-        depthOptimizedClearValue.DepthStencil.Stencil = 0;
+		D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
+		depthOptimizedClearValue.Format = DXGI_FORMAT_D32_FLOAT;
+		depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
+		depthOptimizedClearValue.DepthStencil.Stencil = 0;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
-            D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            &depthOptimizedClearValue,
-            IID_PPV_ARGS(&m_depthStencil)
-            ));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
+			D3D12_RESOURCE_STATE_DEPTH_WRITE,
+			&depthOptimizedClearValue,
+			IID_PPV_ARGS(&m_depthStencil)
+			));
 
-        NAME_D3D12_OBJECT(m_depthStencil);
+		NAME_D3D12_OBJECT(m_depthStencil);
 
-        m_device->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		m_device->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    // Close the command list and execute it to begin the initial GPU setup.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the initial GPU setup.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_fenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValue++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_fenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValue++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
 
-        // Signal and increment the fence value.
-        const UINT64 fenceToWaitFor = m_fenceValue;
-        ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fenceToWaitFor));
-        m_fenceValue++;
+		// Signal and increment the fence value.
+		const UINT64 fenceToWaitFor = m_fenceValue;
+		ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fenceToWaitFor));
+		m_fenceValue++;
 
-        // Wait until the fence is completed.
-        ThrowIfFailed(m_fence->SetEventOnCompletion(fenceToWaitFor, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+		// Wait until the fence is completed.
+		ThrowIfFailed(m_fence->SetEventOnCompletion(fenceToWaitFor, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 
-    CreateFrameResources();
+	CreateFrameResources();
 }
 
 // Update frame-based values.
 void D3D12DynamicIndexing::OnUpdate()
 {
-    m_timer.Tick(NULL);
+	m_timer.Tick(NULL);
 
-    if (m_frameCounter == 500)
-    {
-        // Update window text with FPS value.
-        wchar_t fps[64];
-        swprintf_s(fps, L"%ufps", m_timer.GetFramesPerSecond());
-        SetCustomWindowText(fps);
-        m_frameCounter = 0;
-    }
+	if (m_frameCounter == 500)
+	{
+		// Update window text with FPS value.
+		wchar_t fps[64];
+		swprintf_s(fps, L"%ufps", m_timer.GetFramesPerSecond());
+		SetCustomWindowText(fps);
+		m_frameCounter = 0;
+	}
 
-    m_frameCounter++;
+	m_frameCounter++;
 
-    // Get current GPU progress against submitted workload. Resources still scheduled 
-    // for GPU execution cannot be modified or else undefined behavior will result.
-    const UINT64 lastCompletedFence = m_fence->GetCompletedValue();
+	// Get current GPU progress against submitted workload. Resources still scheduled 
+	// for GPU execution cannot be modified or else undefined behavior will result.
+	const UINT64 lastCompletedFence = m_fence->GetCompletedValue();
 
-    // Move to the next frame resource.
-    m_currentFrameResourceIndex = (m_currentFrameResourceIndex + 1) % FrameCount;
-    m_pCurrentFrameResource = m_frameResources[m_currentFrameResourceIndex];
+	// Move to the next frame resource.
+	m_currentFrameResourceIndex = (m_currentFrameResourceIndex + 1) % FrameCount;
+	m_pCurrentFrameResource = m_frameResources[m_currentFrameResourceIndex];
 
-    // Make sure that this frame resource isn't still in use by the GPU.
-    // If it is, wait for it to complete.
-    if (m_pCurrentFrameResource->m_fenceValue != 0 && m_pCurrentFrameResource->m_fenceValue > lastCompletedFence)
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_pCurrentFrameResource->m_fenceValue, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+	// Make sure that this frame resource isn't still in use by the GPU.
+	// If it is, wait for it to complete.
+	if (m_pCurrentFrameResource->m_fenceValue != 0 && m_pCurrentFrameResource->m_fenceValue > lastCompletedFence)
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_pCurrentFrameResource->m_fenceValue, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 
-    m_camera.Update(static_cast<float>(m_timer.GetElapsedSeconds()));
-    m_pCurrentFrameResource->UpdateConstantBuffers(m_camera.GetViewMatrix(), m_camera.GetProjectionMatrix(0.8f, m_aspectRatio));
+	m_camera.Update(static_cast<float>(m_timer.GetElapsedSeconds()));
+	m_pCurrentFrameResource->UpdateConstantBuffers(m_camera.GetViewMatrix(), m_camera.GetProjectionMatrix(0.8f, m_aspectRatio));
 }
 
 // Render the scene.
 void D3D12DynamicIndexing::OnRender()
 {
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+	PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
 
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList(m_pCurrentFrameResource);
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList(m_pCurrentFrameResource);
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    PIXEndEvent(m_commandQueue.Get());
+	PIXEndEvent(m_commandQueue.Get());
 
-    // Present and update the frame index for the next frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Present and update the frame index for the next frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Signal and increment the fence value.
-    m_pCurrentFrameResource->m_fenceValue = m_fenceValue;
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValue));
-    m_fenceValue++;
+	// Signal and increment the fence value.
+	m_pCurrentFrameResource->m_fenceValue = m_fenceValue;
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValue));
+	m_fenceValue++;
 }
 
 void D3D12DynamicIndexing::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    {
-        const UINT64 fence = m_fenceValue;
-        const UINT64 lastCompletedFence = m_fence->GetCompletedValue();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	{
+		const UINT64 fence = m_fenceValue;
+		const UINT64 lastCompletedFence = m_fence->GetCompletedValue();
 
-        // Signal and increment the fence value.
-        ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValue));
-        m_fenceValue++;
+		// Signal and increment the fence value.
+		ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValue));
+		m_fenceValue++;
 
-        // Wait until the previous frame is finished.
-        if (lastCompletedFence < fence)
-        {
-            ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
-            WaitForSingleObject(m_fenceEvent, INFINITE);
-        }
-    }
+		// Wait until the previous frame is finished.
+		if (lastCompletedFence < fence)
+		{
+			ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
+			WaitForSingleObject(m_fenceEvent, INFINITE);
+		}
+	}
 
-    for (UINT i = 0; i < m_frameResources.size(); i++)
-    {
-        delete m_frameResources.at(i);
-    }
+	for (UINT i = 0; i < m_frameResources.size(); i++)
+	{
+		delete m_frameResources.at(i);
+	}
 }
 
 void D3D12DynamicIndexing::OnKeyDown(UINT8 key)
 {
-    m_camera.OnKeyDown(key);
+	m_camera.OnKeyDown(key);
 }
 
 void D3D12DynamicIndexing::OnKeyUp(UINT8 key)
 {
-    m_camera.OnKeyUp(key);
+	m_camera.OnKeyUp(key);
 }
 
 // Create the resources that will be used every frame.
 void D3D12DynamicIndexing::CreateFrameResources()
 {
-    // Initialize each frame resource.
-    CD3DX12_CPU_DESCRIPTOR_HANDLE cbvSrvHandle(m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart(), CityMaterialCount + 1, m_cbvSrvDescriptorSize);    // Move past the SRVs.
-    for (UINT i = 0; i < FrameCount; i++)
-    {
-        FrameResource* pFrameResource = new FrameResource(m_device.Get(), CityRowCount, CityColumnCount, CityMaterialCount, CitySpacingInterval);
+	// Initialize each frame resource.
+	CD3DX12_CPU_DESCRIPTOR_HANDLE cbvSrvHandle(m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart(), CityMaterialCount + 1, m_cbvSrvDescriptorSize);	// Move past the SRVs.
+	for (UINT i = 0; i < FrameCount; i++)
+	{
+		FrameResource* pFrameResource = new FrameResource(m_device.Get(), CityRowCount, CityColumnCount, CityMaterialCount, CitySpacingInterval);
 
-        UINT64 cbOffset = 0;
-        for (UINT j = 0; j < CityRowCount; j++)
-        {
-            for (UINT k = 0; k < CityColumnCount; k++)
-            {
-                // Describe and create a constant buffer view (CBV).
-                D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
-                cbvDesc.BufferLocation = pFrameResource->m_cbvUploadHeap->GetGPUVirtualAddress() + cbOffset;
-                cbvDesc.SizeInBytes = sizeof(FrameResource::SceneConstantBuffer);
-                cbOffset += cbvDesc.SizeInBytes;
-                m_device->CreateConstantBufferView(&cbvDesc, cbvSrvHandle);
-                cbvSrvHandle.Offset(m_cbvSrvDescriptorSize);
-            }
-        }
+		UINT64 cbOffset = 0;
+		for (UINT j = 0; j < CityRowCount; j++)
+		{
+			for (UINT k = 0; k < CityColumnCount; k++)
+			{
+				// Describe and create a constant buffer view (CBV).
+				D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
+				cbvDesc.BufferLocation = pFrameResource->m_cbvUploadHeap->GetGPUVirtualAddress() + cbOffset;
+				cbvDesc.SizeInBytes = sizeof(FrameResource::SceneConstantBuffer);
+				cbOffset += cbvDesc.SizeInBytes;
+				m_device->CreateConstantBufferView(&cbvDesc, cbvSrvHandle);
+				cbvSrvHandle.Offset(m_cbvSrvDescriptorSize);
+			}
+		}
 
-        pFrameResource->InitBundle(m_device.Get(), m_pipelineState.Get(), i, m_numIndices, &m_indexBufferView,
-            &m_vertexBufferView, m_cbvSrvHeap.Get(), m_cbvSrvDescriptorSize, m_samplerHeap.Get(), m_rootSignature.Get());
+		pFrameResource->InitBundle(m_device.Get(), m_pipelineState.Get(), i, m_numIndices, &m_indexBufferView,
+			&m_vertexBufferView, m_cbvSrvHeap.Get(), m_cbvSrvDescriptorSize, m_samplerHeap.Get(), m_rootSignature.Get());
 
-        m_frameResources.push_back(pFrameResource);
-    }
+		m_frameResources.push_back(pFrameResource);
+	}
 }
 
 void D3D12DynamicIndexing::PopulateCommandList(FrameResource* pFrameResource)
 {
-    // Command list allocators can only be reset when the associated
-    // command lists have finished execution on the GPU; apps should use
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_pCurrentFrameResource->m_commandAllocator->Reset());
+	// Command list allocators can only be reset when the associated
+	// command lists have finished execution on the GPU; apps should use
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_pCurrentFrameResource->m_commandAllocator->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command
-    // list, that command list can then be reset at any time and must be before
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_pCurrentFrameResource->m_commandAllocator.Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command
+	// list, that command list can then be reset at any time and must be before
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_pCurrentFrameResource->m_commandAllocator.Get(), m_pipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvHeap.Get(), m_samplerHeap.Get() };
-    m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvHeap.Get(), m_samplerHeap.Get() };
+	m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    m_commandList->ClearDepthStencilView(m_dsvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	m_commandList->ClearDepthStencilView(m_dsvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
 
-    if (UseBundles)
-    {
-        // Execute the prebuilt bundle.
-        m_commandList->ExecuteBundle(pFrameResource->m_bundle.Get());
-    }
-    else
-    {
-        // Populate a new command list.
-        pFrameResource->PopulateCommandList(m_commandList.Get(), m_pipelineState.Get(), m_currentFrameResourceIndex, m_numIndices, &m_indexBufferView,
-            &m_vertexBufferView, m_cbvSrvHeap.Get(), m_cbvSrvDescriptorSize, m_samplerHeap.Get(), m_rootSignature.Get());
-    }
+	if (UseBundles)
+	{
+		// Execute the prebuilt bundle.
+		m_commandList->ExecuteBundle(pFrameResource->m_bundle.Get());
+	}
+	else
+	{
+		// Populate a new command list.
+		pFrameResource->PopulateCommandList(m_commandList.Get(), m_pipelineState.Get(), m_currentFrameResourceIndex, m_numIndices, &m_indexBufferView,
+			&m_vertexBufferView, m_cbvSrvHeap.Get(), m_cbvSrvDescriptorSize, m_samplerHeap.Get(), m_rootSignature.Get());
+	}
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }

--- a/Samples/UWP/D3D12DynamicIndexing/src/D3D12DynamicIndexing.h
+++ b/Samples/UWP/D3D12DynamicIndexing/src/D3D12DynamicIndexing.h
@@ -28,70 +28,70 @@ using Microsoft::WRL::ComPtr;
 class D3D12DynamicIndexing : public DXSample
 {
 public:
-    D3D12DynamicIndexing(UINT width, UINT height, std::wstring name);
+	D3D12DynamicIndexing(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
-    virtual void OnKeyDown(UINT8 key);
-    virtual void OnKeyUp(UINT8 key);
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
+	virtual void OnKeyDown(UINT8 key);
+	virtual void OnKeyUp(UINT8 key);
 
 private:
-    static const UINT FrameCount = 3;
-    static const UINT CityRowCount = 15;
-    static const UINT CityColumnCount = 8;
-    static const UINT CityMaterialCount = CityRowCount * CityColumnCount;
-    static const UINT CityMaterialTextureWidth = 64;
-    static const UINT CityMaterialTextureHeight = 64;
-    static const UINT CityMaterialTextureChannelCount = 4;
-    static const bool UseBundles = true;
-    static const float CitySpacingInterval;
+	static const UINT FrameCount = 3;
+	static const UINT CityRowCount = 15;
+	static const UINT CityColumnCount = 8;
+	static const UINT CityMaterialCount = CityRowCount * CityColumnCount;
+	static const UINT CityMaterialTextureWidth = 64;
+	static const UINT CityMaterialTextureHeight = 64;
+	static const UINT CityMaterialTextureChannelCount = 4;
+	static const bool UseBundles = true;
+	static const float CitySpacingInterval;
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12Resource> m_depthStencil;
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_cbvSrvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_samplerHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12Resource> m_depthStencil;
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_cbvSrvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_samplerHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
 
-    // App resources.
-    UINT m_numIndices;
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    ComPtr<ID3D12Resource> m_indexBuffer;
-    ComPtr<ID3D12Resource> m_cityDiffuseTexture;
-    ComPtr<ID3D12Resource> m_cityMaterialTextures[CityMaterialCount];
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
-    D3D12_INDEX_BUFFER_VIEW m_indexBufferView;
-    StepTimer m_timer;
-    UINT m_cbvSrvDescriptorSize;
-    UINT m_rtvDescriptorSize;
-    SimpleCamera m_camera;
+	// App resources.
+	UINT m_numIndices;
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	ComPtr<ID3D12Resource> m_indexBuffer;
+	ComPtr<ID3D12Resource> m_cityDiffuseTexture;
+	ComPtr<ID3D12Resource> m_cityMaterialTextures[CityMaterialCount];
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	D3D12_INDEX_BUFFER_VIEW m_indexBufferView;
+	StepTimer m_timer;
+	UINT m_cbvSrvDescriptorSize;
+	UINT m_rtvDescriptorSize;
+	SimpleCamera m_camera;
 
-    // Frame resources.
-    std::vector<FrameResource*> m_frameResources;
-    FrameResource* m_pCurrentFrameResource;
-    UINT m_currentFrameResourceIndex;
+	// Frame resources.
+	std::vector<FrameResource*> m_frameResources;
+	FrameResource* m_pCurrentFrameResource;
+	UINT m_currentFrameResourceIndex;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    UINT m_frameCounter;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValue;
+	// Synchronization objects.
+	UINT m_frameIndex;
+	UINT m_frameCounter;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValue;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void CreateFrameResources();
-    void PopulateCommandList(FrameResource* pFrameResource);
+	void LoadPipeline();
+	void LoadAssets();
+	void CreateFrameResources();
+	void PopulateCommandList(FrameResource* pFrameResource);
 };

--- a/Samples/UWP/D3D12DynamicIndexing/src/DXSample.cpp
+++ b/Samples/UWP/D3D12DynamicIndexing/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,59 +34,104 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
-    auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(windowText.c_str());
+	std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
+	auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/UWP/D3D12DynamicIndexing/src/DXSample.h
+++ b/Samples/UWP/D3D12DynamicIndexing/src/DXSample.h
@@ -16,42 +16,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/UWP/D3D12DynamicIndexing/src/FrameResource.cpp
+++ b/Samples/UWP/D3D12DynamicIndexing/src/FrameResource.cpp
@@ -13,134 +13,134 @@
 #include "FrameResource.h"
 
 FrameResource::FrameResource(ID3D12Device* pDevice, UINT cityRowCount, UINT cityColumnCount, UINT cityMaterialCount, float citySpacingInterval) :
-    m_fenceValue(0),
-    m_cityRowCount(cityRowCount),
-    m_cityColumnCount(cityColumnCount),
-    m_cityMaterialCount(cityMaterialCount)
+	m_fenceValue(0),
+	m_cityRowCount(cityRowCount),
+	m_cityColumnCount(cityColumnCount),
+	m_cityMaterialCount(cityMaterialCount)
 {
-    m_modelMatrices.resize(m_cityRowCount * m_cityColumnCount);
+	m_modelMatrices.resize(m_cityRowCount * m_cityColumnCount);
 
-    // The command allocator is used by the main sample class when 
-    // resetting the command list in the main update loop. Each frame 
-    // resource needs a command allocator because command allocators 
-    // cannot be reused until the GPU is done executing the commands 
-    // associated with it.
-    ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
-    ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_BUNDLE, IID_PPV_ARGS(&m_bundleAllocator)));
+	// The command allocator is used by the main sample class when 
+	// resetting the command list in the main update loop. Each frame 
+	// resource needs a command allocator because command allocators 
+	// cannot be reused until the GPU is done executing the commands 
+	// associated with it.
+	ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_BUNDLE, IID_PPV_ARGS(&m_bundleAllocator)));
 
-    // Create an upload heap for the constant buffers.
-    ThrowIfFailed(pDevice->CreateCommittedResource(
-        &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-        D3D12_HEAP_FLAG_NONE,
-        &CD3DX12_RESOURCE_DESC::Buffer(sizeof(SceneConstantBuffer) * m_cityRowCount * m_cityColumnCount),
-        D3D12_RESOURCE_STATE_GENERIC_READ,
-        nullptr,
-        IID_PPV_ARGS(&m_cbvUploadHeap)));
+	// Create an upload heap for the constant buffers.
+	ThrowIfFailed(pDevice->CreateCommittedResource(
+		&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+		D3D12_HEAP_FLAG_NONE,
+		&CD3DX12_RESOURCE_DESC::Buffer(sizeof(SceneConstantBuffer) * m_cityRowCount * m_cityColumnCount),
+		D3D12_RESOURCE_STATE_GENERIC_READ,
+		nullptr,
+		IID_PPV_ARGS(&m_cbvUploadHeap)));
 
-    // Map the constant buffers. Note that unlike D3D11, the resource 
-    // does not need to be unmapped for use by the GPU. In this sample, 
-    // the resource stays 'permenantly' mapped to avoid overhead with 
-    // mapping/unmapping each frame.
-    CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-    ThrowIfFailed(m_cbvUploadHeap->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBuffers)));
+	// Map the constant buffers. Note that unlike D3D11, the resource 
+	// does not need to be unmapped for use by the GPU. In this sample, 
+	// the resource stays 'permenantly' mapped to avoid overhead with 
+	// mapping/unmapping each frame.
+	CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+	ThrowIfFailed(m_cbvUploadHeap->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBuffers)));
 
-    // Update all of the model matrices once; our cities don't move so 
-    // we don't need to do this ever again.
-    SetCityPositions(citySpacingInterval, -citySpacingInterval);
+	// Update all of the model matrices once; our cities don't move so 
+	// we don't need to do this ever again.
+	SetCityPositions(citySpacingInterval, -citySpacingInterval);
 }
 
 FrameResource::~FrameResource()
 {
-    m_cbvUploadHeap->Unmap(0, nullptr);
-    m_pConstantBuffers = nullptr;
+	m_cbvUploadHeap->Unmap(0, nullptr);
+	m_pConstantBuffers = nullptr;
 }
 
 void FrameResource::InitBundle(ID3D12Device* pDevice, ID3D12PipelineState* pPso,
-    UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
-    ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature)
+	UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
+	ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature)
 {
-    ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_BUNDLE, m_bundleAllocator.Get(), pPso, IID_PPV_ARGS(&m_bundle)));
-    NAME_D3D12_OBJECT(m_bundle);
+	ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_BUNDLE, m_bundleAllocator.Get(), pPso, IID_PPV_ARGS(&m_bundle)));
+	NAME_D3D12_OBJECT(m_bundle);
 
-    PopulateCommandList(m_bundle.Get(), pPso, frameResourceIndex, numIndices, pIndexBufferViewDesc,
-        pVertexBufferViewDesc, pCbvSrvDescriptorHeap, cbvSrvDescriptorSize, pSamplerDescriptorHeap, pRootSignature);
+	PopulateCommandList(m_bundle.Get(), pPso, frameResourceIndex, numIndices, pIndexBufferViewDesc,
+		pVertexBufferViewDesc, pCbvSrvDescriptorHeap, cbvSrvDescriptorSize, pSamplerDescriptorHeap, pRootSignature);
 
-    ThrowIfFailed(m_bundle->Close());
+	ThrowIfFailed(m_bundle->Close());
 }
 
 void FrameResource::SetCityPositions(FLOAT intervalX, FLOAT intervalZ)
 {
-    for (UINT i = 0; i < m_cityRowCount; i++)
-    {
-        FLOAT cityOffsetZ = i * intervalZ;
-        for (UINT j = 0; j < m_cityColumnCount; j++)
-        {
-            FLOAT cityOffsetX = j * intervalX;
+	for (UINT i = 0; i < m_cityRowCount; i++)
+	{
+		FLOAT cityOffsetZ = i * intervalZ;
+		for (UINT j = 0; j < m_cityColumnCount; j++)
+		{
+			FLOAT cityOffsetX = j * intervalX;
 
-            // The y position is based off of the city's row and column 
-            // position to prevent z-fighting.
-            XMStoreFloat4x4(&m_modelMatrices[i * m_cityColumnCount + j], XMMatrixTranslation(cityOffsetX, 0.02f * (i * m_cityColumnCount + j), cityOffsetZ));
-        }
-    }
+			// The y position is based off of the city's row and column 
+			// position to prevent z-fighting.
+			XMStoreFloat4x4(&m_modelMatrices[i * m_cityColumnCount + j], XMMatrixTranslation(cityOffsetX, 0.02f * (i * m_cityColumnCount + j), cityOffsetZ));
+		}
+	}
 }
 
 void FrameResource::PopulateCommandList(ID3D12GraphicsCommandList* pCommandList, ID3D12PipelineState* pPso,
-    UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
-    ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature)
+	UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
+	ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature)
 {
-    // If the root signature matches the root signature of the caller, then
-    // bindings are inherited, otherwise the bind space is reset.
-    pCommandList->SetGraphicsRootSignature(pRootSignature);
+	// If the root signature matches the root signature of the caller, then
+	// bindings are inherited, otherwise the bind space is reset.
+	pCommandList->SetGraphicsRootSignature(pRootSignature);
 
-    ID3D12DescriptorHeap* ppHeaps[] = { pCbvSrvDescriptorHeap, pSamplerDescriptorHeap };
-    pCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
-    pCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    pCommandList->IASetIndexBuffer(pIndexBufferViewDesc);
-    pCommandList->IASetVertexBuffers(0, 1, pVertexBufferViewDesc);
-    pCommandList->SetGraphicsRootDescriptorTable(0, pCbvSrvDescriptorHeap->GetGPUDescriptorHandleForHeapStart());
-    pCommandList->SetGraphicsRootDescriptorTable(1, pSamplerDescriptorHeap->GetGPUDescriptorHandleForHeapStart());
+	ID3D12DescriptorHeap* ppHeaps[] = { pCbvSrvDescriptorHeap, pSamplerDescriptorHeap };
+	pCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	pCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	pCommandList->IASetIndexBuffer(pIndexBufferViewDesc);
+	pCommandList->IASetVertexBuffers(0, 1, pVertexBufferViewDesc);
+	pCommandList->SetGraphicsRootDescriptorTable(0, pCbvSrvDescriptorHeap->GetGPUDescriptorHandleForHeapStart());
+	pCommandList->SetGraphicsRootDescriptorTable(1, pSamplerDescriptorHeap->GetGPUDescriptorHandleForHeapStart());
 
-    // Calculate the descriptor offset due to multiple frame resources.
-    // (m_cityMaterialCount + 1) SRVs + how many CBVs we have currently.
-    UINT frameResourceDescriptorOffset = (m_cityMaterialCount + 1) + (frameResourceIndex * m_cityRowCount * m_cityColumnCount);
-    CD3DX12_GPU_DESCRIPTOR_HANDLE cbvSrvHandle(pCbvSrvDescriptorHeap->GetGPUDescriptorHandleForHeapStart(), frameResourceDescriptorOffset, cbvSrvDescriptorSize);
+	// Calculate the descriptor offset due to multiple frame resources.
+	// (m_cityMaterialCount + 1) SRVs + how many CBVs we have currently.
+	UINT frameResourceDescriptorOffset = (m_cityMaterialCount + 1) + (frameResourceIndex * m_cityRowCount * m_cityColumnCount);
+	CD3DX12_GPU_DESCRIPTOR_HANDLE cbvSrvHandle(pCbvSrvDescriptorHeap->GetGPUDescriptorHandleForHeapStart(), frameResourceDescriptorOffset, cbvSrvDescriptorSize);
 
-    PIXBeginEvent(pCommandList, 0, L"Draw cities");
-    for (UINT i = 0; i < m_cityRowCount; i++)
-    {
-        for (UINT j = 0; j < m_cityColumnCount; j++)
-        {
-            pCommandList->SetPipelineState(pPso);
+	PIXBeginEvent(pCommandList, 0, L"Draw cities");
+	for (UINT i = 0; i < m_cityRowCount; i++)
+	{
+		for (UINT j = 0; j < m_cityColumnCount; j++)
+		{
+			pCommandList->SetPipelineState(pPso);
 
-            // Set the city's root constant for dynamically indexing into the material array.
-            pCommandList->SetGraphicsRoot32BitConstant(3, (i * m_cityColumnCount) + j, 0);
+			// Set the city's root constant for dynamically indexing into the material array.
+			pCommandList->SetGraphicsRoot32BitConstant(3, (i * m_cityColumnCount) + j, 0);
 
-            // Set this city's CBV table and move to the next descriptor.
-            pCommandList->SetGraphicsRootDescriptorTable(2, cbvSrvHandle);
-            cbvSrvHandle.Offset(cbvSrvDescriptorSize);
+			// Set this city's CBV table and move to the next descriptor.
+			pCommandList->SetGraphicsRootDescriptorTable(2, cbvSrvHandle);
+			cbvSrvHandle.Offset(cbvSrvDescriptorSize);
 
-            pCommandList->DrawIndexedInstanced(numIndices, 1, 0, 0, 0);
-        }
-    }
-    PIXEndEvent(pCommandList);
+			pCommandList->DrawIndexedInstanced(numIndices, 1, 0, 0, 0);
+		}
+	}
+	PIXEndEvent(pCommandList);
 }
 
 void XM_CALLCONV FrameResource::UpdateConstantBuffers(FXMMATRIX view, CXMMATRIX projection)
 {
-    XMMATRIX model;
-    XMFLOAT4X4 mvp;
+	XMMATRIX model;
+	XMFLOAT4X4 mvp;
 
-    for (UINT i = 0; i < m_cityRowCount; i++)
-    {
-        for (UINT j = 0; j < m_cityColumnCount; j++)
-        {
-            model = XMLoadFloat4x4(&m_modelMatrices[i * m_cityColumnCount + j]);
+	for (UINT i = 0; i < m_cityRowCount; i++)
+	{
+		for (UINT j = 0; j < m_cityColumnCount; j++)
+		{
+			model = XMLoadFloat4x4(&m_modelMatrices[i * m_cityColumnCount + j]);
 
-            // Compute the model-view-projection matrix.
-            XMStoreFloat4x4(&mvp, XMMatrixTranspose(model * view * projection));
+			// Compute the model-view-projection matrix.
+			XMStoreFloat4x4(&mvp, XMMatrixTranspose(model * view * projection));
 
-            // Copy this matrix into the appropriate location in the upload heap subresource.
-            memcpy(&m_pConstantBuffers[i * m_cityColumnCount + j], &mvp, sizeof(mvp));
-        }
-    }
+			// Copy this matrix into the appropriate location in the upload heap subresource.
+			memcpy(&m_pConstantBuffers[i * m_cityColumnCount + j], &mvp, sizeof(mvp));
+		}
+	}
 }

--- a/Samples/UWP/D3D12DynamicIndexing/src/FrameResource.h
+++ b/Samples/UWP/D3D12DynamicIndexing/src/FrameResource.h
@@ -19,37 +19,37 @@ using Microsoft::WRL::ComPtr;
 class FrameResource
 {
 private:
-    void SetCityPositions(FLOAT intervalX, FLOAT intervalZ);
+	void SetCityPositions(FLOAT intervalX, FLOAT intervalZ);
 
 public:
-    struct SceneConstantBuffer
-    {
-        XMFLOAT4X4 mvp;        // Model-view-projection (MVP) matrix.
-        FLOAT padding[48];
-    };
+	struct SceneConstantBuffer
+	{
+		XMFLOAT4X4 mvp;		// Model-view-projection (MVP) matrix.
+		FLOAT padding[48];
+	};
 
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandAllocator> m_bundleAllocator;
-    ComPtr<ID3D12GraphicsCommandList> m_bundle;
-    ComPtr<ID3D12Resource> m_cbvUploadHeap;
-    SceneConstantBuffer* m_pConstantBuffers;
-    UINT64 m_fenceValue;
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandAllocator> m_bundleAllocator;
+	ComPtr<ID3D12GraphicsCommandList> m_bundle;
+	ComPtr<ID3D12Resource> m_cbvUploadHeap;
+	SceneConstantBuffer* m_pConstantBuffers;
+	UINT64 m_fenceValue;
 
-    std::vector<XMFLOAT4X4> m_modelMatrices;
-    UINT m_cityRowCount;
-    UINT m_cityColumnCount;
-    UINT m_cityMaterialCount;
+	std::vector<XMFLOAT4X4> m_modelMatrices;
+	UINT m_cityRowCount;
+	UINT m_cityColumnCount;
+	UINT m_cityMaterialCount;
 
-    FrameResource(ID3D12Device* pDevice, UINT cityRowCount, UINT cityColumnCount, UINT cityMaterialCount, float citySpacingInterval);
-    ~FrameResource();
+	FrameResource(ID3D12Device* pDevice, UINT cityRowCount, UINT cityColumnCount, UINT cityMaterialCount, float citySpacingInterval);
+	~FrameResource();
 
-    void InitBundle(ID3D12Device* pDevice, ID3D12PipelineState* pPso,
-        UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
-        ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature);
+	void InitBundle(ID3D12Device* pDevice, ID3D12PipelineState* pPso,
+		UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
+		ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature);
 
-    void PopulateCommandList(ID3D12GraphicsCommandList* pCommandList, ID3D12PipelineState* pPso,
-        UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
-        ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature);
+	void PopulateCommandList(ID3D12GraphicsCommandList* pCommandList, ID3D12PipelineState* pPso,
+		UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
+		ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature);
 
-    void XM_CALLCONV UpdateConstantBuffers(FXMMATRIX view, CXMMATRIX projection);
+	void XM_CALLCONV UpdateConstantBuffers(FXMMATRIX view, CXMMATRIX projection);
 };

--- a/Samples/UWP/D3D12DynamicIndexing/src/Main.cpp
+++ b/Samples/UWP/D3D12DynamicIndexing/src/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12DynamicIndexing sample(1200, 900, L"");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12DynamicIndexing sample(1200, 900, L"");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12DynamicIndexing/src/SimpleCamera.cpp
+++ b/Samples/UWP/D3D12DynamicIndexing/src/SimpleCamera.cpp
@@ -13,163 +13,163 @@
 #include "SimpleCamera.h"
 
 SimpleCamera::SimpleCamera():
-    m_initialPosition(0, 0, 0),
-    m_position(m_initialPosition),
-    m_yaw(XM_PI),
-    m_pitch(0.0f),
-    m_lookDirection(0, 0, -1),
-    m_upDirection(0, 1, 0),
-    m_moveSpeed(20.0f),
-    m_turnSpeed(XM_PIDIV2),
-    m_keysPressed{}
+	m_initialPosition(0, 0, 0),
+	m_position(m_initialPosition),
+	m_yaw(XM_PI),
+	m_pitch(0.0f),
+	m_lookDirection(0, 0, -1),
+	m_upDirection(0, 1, 0),
+	m_moveSpeed(20.0f),
+	m_turnSpeed(XM_PIDIV2),
+	m_keysPressed{}
 {
 }
 
 void SimpleCamera::Init(XMFLOAT3 position)
 {
-    m_initialPosition = position;
-    Reset();
+	m_initialPosition = position;
+	Reset();
 }
 
 void SimpleCamera::SetMoveSpeed(float unitsPerSecond)
 {
-    m_moveSpeed = unitsPerSecond;
+	m_moveSpeed = unitsPerSecond;
 }
 
 void SimpleCamera::SetTurnSpeed(float radiansPerSecond)
 {
-    m_turnSpeed = radiansPerSecond;
+	m_turnSpeed = radiansPerSecond;
 }
 
 void SimpleCamera::Reset()
 {
-    m_position = m_initialPosition;
-    m_yaw = XM_PI;
-    m_pitch = 0.0f;
-    m_lookDirection = { 0, 0, -1 };
+	m_position = m_initialPosition;
+	m_yaw = XM_PI;
+	m_pitch = 0.0f;
+	m_lookDirection = { 0, 0, -1 };
 }
 
 void SimpleCamera::Update(float elapsedSeconds)
 {
-    // Calculate the move vector in camera space.
-    XMFLOAT3 move(0, 0, 0);
+	// Calculate the move vector in camera space.
+	XMFLOAT3 move(0, 0, 0);
 
-    if (m_keysPressed.a)
-        move.x -= 1.0f;
-    if (m_keysPressed.d)
-        move.x += 1.0f;
-    if (m_keysPressed.w)
-        move.z -= 1.0f;
-    if (m_keysPressed.s)
-        move.z += 1.0f;
+	if (m_keysPressed.a)
+		move.x -= 1.0f;
+	if (m_keysPressed.d)
+		move.x += 1.0f;
+	if (m_keysPressed.w)
+		move.z -= 1.0f;
+	if (m_keysPressed.s)
+		move.z += 1.0f;
 
-    if (fabs(move.x) > 0.1f && fabs(move.z) > 0.1f)
-    {
-        XMVECTOR vector = XMVector3Normalize(XMLoadFloat3(&move));
-        move.x = XMVectorGetX(vector);
-        move.z = XMVectorGetZ(vector);
-    }
+	if (fabs(move.x) > 0.1f && fabs(move.z) > 0.1f)
+	{
+		XMVECTOR vector = XMVector3Normalize(XMLoadFloat3(&move));
+		move.x = XMVectorGetX(vector);
+		move.z = XMVectorGetZ(vector);
+	}
 
-    float moveInterval = m_moveSpeed * elapsedSeconds;
-    float rotateInterval = m_turnSpeed * elapsedSeconds;
+	float moveInterval = m_moveSpeed * elapsedSeconds;
+	float rotateInterval = m_turnSpeed * elapsedSeconds;
 
-    if (m_keysPressed.left)
-        m_yaw += rotateInterval;
-    if (m_keysPressed.right)
-        m_yaw -= rotateInterval;
-    if (m_keysPressed.up)
-        m_pitch += rotateInterval;
-    if (m_keysPressed.down)
-        m_pitch -= rotateInterval;
+	if (m_keysPressed.left)
+		m_yaw += rotateInterval;
+	if (m_keysPressed.right)
+		m_yaw -= rotateInterval;
+	if (m_keysPressed.up)
+		m_pitch += rotateInterval;
+	if (m_keysPressed.down)
+		m_pitch -= rotateInterval;
 
-    // Prevent looking too far up or down.
-    m_pitch = min(m_pitch, XM_PIDIV4);
-    m_pitch = max(-XM_PIDIV4, m_pitch);
+	// Prevent looking too far up or down.
+	m_pitch = min(m_pitch, XM_PIDIV4);
+	m_pitch = max(-XM_PIDIV4, m_pitch);
 
-    // Move the camera in model space.
-    float x = move.x * -cosf(m_yaw) - move.z * sinf(m_yaw);
-    float z = move.x * sinf(m_yaw) - move.z * cosf(m_yaw);
-    m_position.x += x * moveInterval;
-    m_position.z += z * moveInterval;
+	// Move the camera in model space.
+	float x = move.x * -cosf(m_yaw) - move.z * sinf(m_yaw);
+	float z = move.x * sinf(m_yaw) - move.z * cosf(m_yaw);
+	m_position.x += x * moveInterval;
+	m_position.z += z * moveInterval;
 
-    // Determine the look direction.
-    float r = cosf(m_pitch);
-    m_lookDirection.x = r * sinf(m_yaw);
-    m_lookDirection.y = sinf(m_pitch);
-    m_lookDirection.z = r * cosf(m_yaw);
+	// Determine the look direction.
+	float r = cosf(m_pitch);
+	m_lookDirection.x = r * sinf(m_yaw);
+	m_lookDirection.y = sinf(m_pitch);
+	m_lookDirection.z = r * cosf(m_yaw);
 }
 
 XMMATRIX SimpleCamera::GetViewMatrix()
 {
-    return XMMatrixLookToRH(XMLoadFloat3(&m_position), XMLoadFloat3(&m_lookDirection), XMLoadFloat3(&m_upDirection));
+	return XMMatrixLookToRH(XMLoadFloat3(&m_position), XMLoadFloat3(&m_lookDirection), XMLoadFloat3(&m_upDirection));
 }
 
 XMMATRIX SimpleCamera::GetProjectionMatrix(float fov, float aspectRatio, float nearPlane, float farPlane)
 {
-    return XMMatrixPerspectiveFovRH(fov, aspectRatio, nearPlane, farPlane);
+	return XMMatrixPerspectiveFovRH(fov, aspectRatio, nearPlane, farPlane);
 }
 
 void SimpleCamera::OnKeyDown(WPARAM key)
 {
-    switch (key)
-    {
-    case 'W':
-        m_keysPressed.w = true;
-        break;
-    case 'A':
-        m_keysPressed.a = true;
-        break;
-    case 'S':
-        m_keysPressed.s = true;
-        break;
-    case 'D':
-        m_keysPressed.d = true;
-        break;
-    case VK_LEFT:
-        m_keysPressed.left = true;
-        break;
-    case VK_RIGHT:
-        m_keysPressed.right = true;
-        break;
-    case VK_UP:
-        m_keysPressed.up = true;
-        break;
-    case VK_DOWN:
-        m_keysPressed.down = true;
-        break;
-    case VK_ESCAPE:
-        Reset();
-        break;
-    }
+	switch (key)
+	{
+	case 'W':
+		m_keysPressed.w = true;
+		break;
+	case 'A':
+		m_keysPressed.a = true;
+		break;
+	case 'S':
+		m_keysPressed.s = true;
+		break;
+	case 'D':
+		m_keysPressed.d = true;
+		break;
+	case VK_LEFT:
+		m_keysPressed.left = true;
+		break;
+	case VK_RIGHT:
+		m_keysPressed.right = true;
+		break;
+	case VK_UP:
+		m_keysPressed.up = true;
+		break;
+	case VK_DOWN:
+		m_keysPressed.down = true;
+		break;
+	case VK_ESCAPE:
+		Reset();
+		break;
+	}
 }
 
 void SimpleCamera::OnKeyUp(WPARAM key)
 {
-    switch (key)
-    {
-    case 'W':
-        m_keysPressed.w = false;
-        break;
-    case 'A':
-        m_keysPressed.a = false;
-        break;
-    case 'S':
-        m_keysPressed.s = false;
-        break;
-    case 'D':
-        m_keysPressed.d = false;
-        break;
-    case VK_LEFT:
-        m_keysPressed.left = false;
-        break;
-    case VK_RIGHT:
-        m_keysPressed.right = false;
-        break;
-    case VK_UP:
-        m_keysPressed.up = false;
-        break;
-    case VK_DOWN:
-        m_keysPressed.down = false;
-        break;
-    }
+	switch (key)
+	{
+	case 'W':
+		m_keysPressed.w = false;
+		break;
+	case 'A':
+		m_keysPressed.a = false;
+		break;
+	case 'S':
+		m_keysPressed.s = false;
+		break;
+	case 'D':
+		m_keysPressed.d = false;
+		break;
+	case VK_LEFT:
+		m_keysPressed.left = false;
+		break;
+	case VK_RIGHT:
+		m_keysPressed.right = false;
+		break;
+	case VK_UP:
+		m_keysPressed.up = false;
+		break;
+	case VK_DOWN:
+		m_keysPressed.down = false;
+		break;
+	}
 }

--- a/Samples/UWP/D3D12DynamicIndexing/src/SimpleCamera.h
+++ b/Samples/UWP/D3D12DynamicIndexing/src/SimpleCamera.h
@@ -16,42 +16,42 @@ using namespace DirectX;
 class SimpleCamera
 {
 public:
-    SimpleCamera();
+	SimpleCamera();
 
-    void Init(XMFLOAT3 position);
-    void Update(float elapsedSeconds);
-    XMMATRIX GetViewMatrix();
-    XMMATRIX GetProjectionMatrix(float fov, float aspectRatio, float nearPlane = 1.0f, float farPlane = 1000.0f);
-    void SetMoveSpeed(float unitsPerSecond);
-    void SetTurnSpeed(float radiansPerSecond);
+	void Init(XMFLOAT3 position);
+	void Update(float elapsedSeconds);
+	XMMATRIX GetViewMatrix();
+	XMMATRIX GetProjectionMatrix(float fov, float aspectRatio, float nearPlane = 1.0f, float farPlane = 1000.0f);
+	void SetMoveSpeed(float unitsPerSecond);
+	void SetTurnSpeed(float radiansPerSecond);
 
-    void OnKeyDown(WPARAM key);
-    void OnKeyUp(WPARAM key);
+	void OnKeyDown(WPARAM key);
+	void OnKeyUp(WPARAM key);
 
 private:
-    void Reset();
+	void Reset();
 
-    struct KeysPressed
-    {
-        bool w;
-        bool a;
-        bool s;
-        bool d;
+	struct KeysPressed
+	{
+		bool w;
+		bool a;
+		bool s;
+		bool d;
 
-        bool left;
-        bool right;
-        bool up;
-        bool down;
-    };
+		bool left;
+		bool right;
+		bool up;
+		bool down;
+	};
 
-    XMFLOAT3 m_initialPosition;
-    XMFLOAT3 m_position;
-    float m_yaw;                // Relative to the +z axis.
-    float m_pitch;                // Relative to the xz plane.
-    XMFLOAT3 m_lookDirection;
-    XMFLOAT3 m_upDirection;
-    float m_moveSpeed;            // Speed at which the camera moves, in units per second.
-    float m_turnSpeed;            // Speed at which the camera turns, in radians per second.
+	XMFLOAT3 m_initialPosition;
+	XMFLOAT3 m_position;
+	float m_yaw;				// Relative to the +z axis.
+	float m_pitch;				// Relative to the xz plane.
+	XMFLOAT3 m_lookDirection;
+	XMFLOAT3 m_upDirection;
+	float m_moveSpeed;			// Speed at which the camera moves, in units per second.
+	float m_turnSpeed;			// Speed at which the camera turns, in radians per second.
 
-    KeysPressed m_keysPressed;
+	KeysPressed m_keysPressed;
 };

--- a/Samples/UWP/D3D12DynamicIndexing/src/View.cpp
+++ b/Samples/UWP/D3D12DynamicIndexing/src/View.cpp
@@ -15,27 +15,27 @@
 using namespace Windows::Foundation;
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -44,20 +44,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -66,26 +66,26 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnClosed(CoreWindow^ /*sender*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }

--- a/Samples/UWP/D3D12DynamicIndexing/src/View.h
+++ b/Samples/UWP/D3D12DynamicIndexing/src/View.h
@@ -23,20 +23,20 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
+	DXSample* m_pSample;
+	bool m_windowClosed;
 };

--- a/Samples/UWP/D3D12DynamicIndexing/src/ViewProvider.cpp
+++ b/Samples/UWP/D3D12DynamicIndexing/src/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12DynamicIndexing/src/ViewProvider.h
+++ b/Samples/UWP/D3D12DynamicIndexing/src/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12DynamicIndexing/src/d3dx12.h
+++ b/Samples/UWP/D3D12DynamicIndexing/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12DynamicIndexing/src/occcity.h
+++ b/Samples/UWP/D3D12DynamicIndexing/src/occcity.h
@@ -13,57 +13,57 @@
 
 namespace SampleAssets
 {
-    LPCWSTR DataFileName = L"occcity.bin";
+	LPCWSTR DataFileName = L"occcity.bin";
 
-    const D3D12_INPUT_ELEMENT_DESC StandardVertexDescription[] =
-    {
-        { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,  D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "NORMAL",   0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,    0, 24, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "TANGENT",  0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 32, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-    };
-    UINT StandardVertexDescriptionNumElements = _countof(StandardVertexDescription);
+	const D3D12_INPUT_ELEMENT_DESC StandardVertexDescription[] =
+	{
+		{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,  D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		{ "NORMAL",   0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,    0, 24, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		{ "TANGENT",  0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 32, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+	};
+	UINT StandardVertexDescriptionNumElements = _countof(StandardVertexDescription);
 
-    const UINT StandardVertexStride = 44;
+	const UINT StandardVertexStride = 44;
 
-    const DXGI_FORMAT StandardIndexFormat = DXGI_FORMAT_R32_UINT;
+	const DXGI_FORMAT StandardIndexFormat = DXGI_FORMAT_R32_UINT;
 
-    struct TextureResource
-    {
-        UINT Width;
-        UINT Height;
-        UINT16 MipLevels;
-        DXGI_FORMAT Format;
-        struct DataProperties
-        {
-            UINT Offset;
-            UINT Size;
-            UINT Pitch;
-        } Data[D3D12_REQ_MIP_LEVELS];
-    };
+	struct TextureResource
+	{
+		UINT Width;
+		UINT Height;
+		UINT16 MipLevels;
+		DXGI_FORMAT Format;
+		struct DataProperties
+		{
+			UINT Offset;
+			UINT Size;
+			UINT Pitch;
+		} Data[D3D12_REQ_MIP_LEVELS];
+	};
 
-    struct DrawParameters
-    {
-        INT DiffuseTextureIndex;
-        INT NormalTextureIndex;
-        INT SpecularTextureIndex;
-        UINT IndexStart;
-        UINT IndexCount;
-        UINT VertexBase;
-    };
+	struct DrawParameters
+	{
+		INT DiffuseTextureIndex;
+		INT NormalTextureIndex;
+		INT SpecularTextureIndex;
+		UINT IndexStart;
+		UINT IndexCount;
+		UINT VertexBase;
+	};
 
-    const UINT VertexDataOffset = 524288;
-    const UINT VertexDataSize = 820248;
-    const UINT IndexDataOffset = 1344536;
-    const UINT IndexDataSize = 74568;
+	const UINT VertexDataOffset = 524288;
+	const UINT VertexDataSize = 820248;
+	const UINT IndexDataOffset = 1344536;
+	const UINT IndexDataSize = 74568;
 
-    TextureResource Textures[] =
-    {
-        { 1024, 1024, 1, DXGI_FORMAT_BC1_UNORM, { { 0, 524288, 2048 }, } }, // city.dds
-    };
+	TextureResource Textures[] =
+	{
+		{ 1024, 1024, 1, DXGI_FORMAT_BC1_UNORM, { { 0, 524288, 2048 }, } }, // city.dds
+	};
 
-    DrawParameters Draws[] =
-    {
-        { 0, -1, -1, 0, 18642, 0 },
-    };
+	DrawParameters Draws[] =
+	{
+		{ 0, -1, -1, 0, 18642, 0 },
+	};
 }

--- a/Samples/UWP/D3D12DynamicIndexing/src/shader_mesh_dynamic_indexing_pixel.hlsl
+++ b/Samples/UWP/D3D12DynamicIndexing/src/shader_mesh_dynamic_indexing_pixel.hlsl
@@ -11,23 +11,23 @@
 
 struct PSInput
 {
-    float4 position    : SV_POSITION;
-    float2 uv        : TEXCOORD0;
+	float4 position	: SV_POSITION;
+	float2 uv		: TEXCOORD0;
 };
 
 struct MaterialConstants
 {
-    uint matIndex;    // Dynamically set index for looking up from g_txMats[].
+	uint matIndex;	// Dynamically set index for looking up from g_txMats[].
 };
 
 ConstantBuffer<MaterialConstants> materialConstants : register(b0, space0);
-Texture2D        g_txDiffuse    : register(t0);
-Texture2D        g_txMats[]    : register(t1);
-SamplerState    g_sampler    : register(s0);
+Texture2D		g_txDiffuse	: register(t0);
+Texture2D		g_txMats[]	: register(t1);
+SamplerState	g_sampler	: register(s0);
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    float3 diffuse = g_txDiffuse.Sample(g_sampler, input.uv).rgb;
-    float3 mat = g_txMats[materialConstants.matIndex].Sample(g_sampler, input.uv).rgb;
-    return float4(diffuse * mat, 1.0f);
+	float3 diffuse = g_txDiffuse.Sample(g_sampler, input.uv).rgb;
+	float3 mat = g_txMats[materialConstants.matIndex].Sample(g_sampler, input.uv).rgb;
+	return float4(diffuse * mat, 1.0f);
 }

--- a/Samples/UWP/D3D12DynamicIndexing/src/shader_mesh_simple_vert.hlsl
+++ b/Samples/UWP/D3D12DynamicIndexing/src/shader_mesh_simple_vert.hlsl
@@ -11,29 +11,29 @@
 
 struct VSInput
 {
-    float3 position    : POSITION;
-    float3 normal    : NORMAL;
-    float2 uv        : TEXCOORD0;
-    float3 tangent    : TANGENT;
+	float3 position	: POSITION;
+	float3 normal	: NORMAL;
+	float2 uv		: TEXCOORD0;
+	float3 tangent	: TANGENT;
 };
 
 struct PSInput
 {
-    float4 position    : SV_POSITION;
-    float2 uv        : TEXCOORD0;
+	float4 position	: SV_POSITION;
+	float2 uv		: TEXCOORD0;
 };
 
 cbuffer cb0 : register(b0)
 {
-    float4x4 g_mWorldViewProj;
+	float4x4 g_mWorldViewProj;
 };
 
 PSInput VSMain(VSInput input)
 {
-    PSInput result;
-    
-    result.position = mul(float4(input.position, 1.0f), g_mWorldViewProj);
-    result.uv = input.uv;
-    
-    return result;
+	PSInput result;
+	
+	result.position = mul(float4(input.position, 1.0f), g_mWorldViewProj);
+	result.uv = input.uv;
+	
+	return result;
 }

--- a/Samples/UWP/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.cpp
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.cpp
@@ -19,797 +19,841 @@ const float D3D12ExecuteIndirect::TriangleDepth = 1.0f;
 const float D3D12ExecuteIndirect::CullingCutoff = 0.5f;
 
 D3D12ExecuteIndirect::D3D12ExecuteIndirect(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_cullingScissorRect(),
-    m_rtvDescriptorSize(0),
-    m_cbvSrvUavDescriptorSize(0),
-    m_csRootConstants(),
-    m_enableCulling(true),
-    m_fenceValues{}
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_cullingScissorRect(),
+	m_rtvDescriptorSize(0),
+	m_cbvSrvUavDescriptorSize(0),
+	m_csRootConstants(),
+	m_enableCulling(true),
+	m_fenceValues{}
 {
-    m_constantBufferData.resize(TriangleCount);
+	m_constantBufferData.resize(TriangleCount);
 
-    m_csRootConstants.xOffset = TriangleHalfWidth;
-    m_csRootConstants.zOffset = TriangleDepth;
-    m_csRootConstants.cullOffset = CullingCutoff;
-    m_csRootConstants.commandCount = TriangleCount;
+	m_csRootConstants.xOffset = TriangleHalfWidth;
+	m_csRootConstants.zOffset = TriangleDepth;
+	m_csRootConstants.cullOffset = CullingCutoff;
+	m_csRootConstants.commandCount = TriangleCount;
 
-    float center = width / 2.0f;
-    m_cullingScissorRect.left = static_cast<LONG>(center - (center * CullingCutoff));
-    m_cullingScissorRect.right = static_cast<LONG>(center + (center * CullingCutoff));
-    m_cullingScissorRect.bottom = static_cast<LONG>(height);
+	float center = width / 2.0f;
+	m_cullingScissorRect.left = static_cast<LONG>(center - (center * CullingCutoff));
+	m_cullingScissorRect.right = static_cast<LONG>(center + (center * CullingCutoff));
+	m_cullingScissorRect.bottom = static_cast<LONG>(height);
+
+#if !defined(_XBOX_ONE)
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
+#endif
 }
 
 void D3D12ExecuteIndirect::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12ExecuteIndirect::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter, true);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queues.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queues.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
-    NAME_D3D12_OBJECT(m_commandQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	NAME_D3D12_OBJECT(m_commandQueue);
 
-    D3D12_COMMAND_QUEUE_DESC computeQueueDesc = {};
-    computeQueueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    computeQueueDesc.Type = D3D12_COMMAND_LIST_TYPE_COMPUTE;
+	D3D12_COMMAND_QUEUE_DESC computeQueueDesc = {};
+	computeQueueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	computeQueueDesc.Type = D3D12_COMMAND_LIST_TYPE_COMPUTE;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&computeQueueDesc, IID_PPV_ARGS(&m_computeCommandQueue)));
-    NAME_D3D12_OBJECT(m_computeCommandQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&computeQueueDesc, IID_PPV_ARGS(&m_computeCommandQueue)));
+	NAME_D3D12_OBJECT(m_computeCommandQueue);
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a depth stencil view (DSV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
-        dsvHeapDesc.NumDescriptors = 1;
-        dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-        dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
+		// Describe and create a depth stencil view (DSV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
+		dsvHeapDesc.NumDescriptors = 1;
+		dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+		dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
 
-        // Describe and create a constant buffer view (CBV), Shader resource
-        // view (SRV), and unordered access view (UAV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvSrvUavHeapDesc = {};
-        cbvSrvUavHeapDesc.NumDescriptors = CbvSrvUavDescriptorCountPerFrame * FrameCount;
-        cbvSrvUavHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        cbvSrvUavHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvSrvUavHeapDesc, IID_PPV_ARGS(&m_cbvSrvUavHeap)));
-        NAME_D3D12_OBJECT(m_cbvSrvUavHeap);
+		// Describe and create a constant buffer view (CBV), Shader resource
+		// view (SRV), and unordered access view (UAV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvSrvUavHeapDesc = {};
+		cbvSrvUavHeapDesc.NumDescriptors = CbvSrvUavDescriptorCountPerFrame * FrameCount;
+		cbvSrvUavHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		cbvSrvUavHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvSrvUavHeapDesc, IID_PPV_ARGS(&m_cbvSrvUavHeap)));
+		NAME_D3D12_OBJECT(m_cbvSrvUavHeap);
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-        m_cbvSrvUavDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_cbvSrvUavDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV and command allocators for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
+		// Create a RTV and command allocators for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-            NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
+			NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
 
-            ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
-            ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_COMPUTE, IID_PPV_ARGS(&m_computeCommandAllocators[n])));
-        }
-    }
+			ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
+			ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_COMPUTE, IID_PPV_ARGS(&m_computeCommandAllocators[n])));
+		}
+	}
 }
 
 // Load the sample assets.
 void D3D12ExecuteIndirect::LoadAssets()
 {
-    // Create the root signatures.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signatures.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        CD3DX12_ROOT_PARAMETER1 rootParameters[GraphicsRootParametersCount];
-        rootParameters[Cbv].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_VERTEX);
+		CD3DX12_ROOT_PARAMETER1 rootParameters[GraphicsRootParametersCount];
+		rootParameters[Cbv].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_VERTEX);
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-        NAME_D3D12_OBJECT(m_rootSignature);
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+		NAME_D3D12_OBJECT(m_rootSignature);
 
-        // Create compute signature.
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[2];
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_VOLATILE);
+		// Create compute signature.
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[2];
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_VOLATILE);
 
-        CD3DX12_ROOT_PARAMETER1 computeRootParameters[ComputeRootParametersCount];
-        computeRootParameters[SrvUavTable].InitAsDescriptorTable(2, ranges);
-        computeRootParameters[RootConstants].InitAsConstants(4, 0);
+		CD3DX12_ROOT_PARAMETER1 computeRootParameters[ComputeRootParametersCount];
+		computeRootParameters[SrvUavTable].InitAsDescriptorTable(2, ranges);
+		computeRootParameters[RootConstants].InitAsConstants(4, 0);
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC computeRootSignatureDesc;
-        computeRootSignatureDesc.Init_1_1(_countof(computeRootParameters), computeRootParameters);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC computeRootSignatureDesc;
+		computeRootSignatureDesc.Init_1_1(_countof(computeRootParameters), computeRootParameters);
 
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&computeRootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_computeRootSignature)));
-        NAME_D3D12_OBJECT(m_computeRootSignature);
-    }
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&computeRootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_computeRootSignature)));
+		NAME_D3D12_OBJECT(m_computeRootSignature);
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
-        ComPtr<ID3DBlob> computeShader;
-        ComPtr<ID3DBlob> error;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
+		ComPtr<ID3DBlob> computeShader;
+		ComPtr<ID3DBlob> error;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, &error));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, &error));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"compute.hlsl").c_str(), nullptr, nullptr, "CSMain", "cs_5_0", compileFlags, 0, &computeShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"compute.hlsl").c_str(), nullptr, nullptr, "CSMain", "cs_5_0", compileFlags, 0, &computeShader, &error));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        // Describe and create the graphics pipeline state objects (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state objects (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-        NAME_D3D12_OBJECT(m_pipelineState);
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+		NAME_D3D12_OBJECT(m_pipelineState);
 
-        // Describe and create the compute pipeline state object (PSO).
-        D3D12_COMPUTE_PIPELINE_STATE_DESC computePsoDesc = {};
-        computePsoDesc.pRootSignature = m_computeRootSignature.Get();
-        computePsoDesc.CS = CD3DX12_SHADER_BYTECODE(computeShader.Get());
+		// Describe and create the compute pipeline state object (PSO).
+		D3D12_COMPUTE_PIPELINE_STATE_DESC computePsoDesc = {};
+		computePsoDesc.pRootSignature = m_computeRootSignature.Get();
+		computePsoDesc.CS = CD3DX12_SHADER_BYTECODE(computeShader.Get());
 
-        ThrowIfFailed(m_device->CreateComputePipelineState(&computePsoDesc, IID_PPV_ARGS(&m_computeState)));
-        NAME_D3D12_OBJECT(m_computeState);
-    }
+		ThrowIfFailed(m_device->CreateComputePipelineState(&computePsoDesc, IID_PPV_ARGS(&m_computeState)));
+		NAME_D3D12_OBJECT(m_computeState);
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_COMPUTE, m_computeCommandAllocators[m_frameIndex].Get(), m_computeState.Get(), IID_PPV_ARGS(&m_computeCommandList)));
-    ThrowIfFailed(m_computeCommandList->Close());
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_COMPUTE, m_computeCommandAllocators[m_frameIndex].Get(), m_computeState.Get(), IID_PPV_ARGS(&m_computeCommandList)));
+	ThrowIfFailed(m_computeCommandList->Close());
 
-    NAME_D3D12_OBJECT(m_commandList);
-    NAME_D3D12_OBJECT(m_computeCommandList);
+	NAME_D3D12_OBJECT(m_commandList);
+	NAME_D3D12_OBJECT(m_computeCommandList);
 
-    // Note: ComPtr's are CPU objects but these resources need to stay in scope until
-    // the command list that references them has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resources are not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> vertexBufferUpload;
-    ComPtr<ID3D12Resource> commandBufferUpload;
+	// Note: ComPtr's are CPU objects but these resources need to stay in scope until
+	// the command list that references them has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resources are not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> vertexBufferUpload;
+	ComPtr<ID3D12Resource> commandBufferUpload;
 
-    // Create the vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        Vertex triangleVertices[] =
-        {
-            { { 0.0f, TriangleHalfWidth, TriangleDepth } },
-            { { TriangleHalfWidth, -TriangleHalfWidth, TriangleDepth } },
-            { { -TriangleHalfWidth, -TriangleHalfWidth, TriangleDepth } }
-        };
+	// Create the vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		Vertex triangleVertices[] =
+		{
+			{ { 0.0f, TriangleHalfWidth, TriangleDepth } },
+			{ { TriangleHalfWidth, -TriangleHalfWidth, TriangleDepth } },
+			{ { -TriangleHalfWidth, -TriangleHalfWidth, TriangleDepth } }
+		};
 
-        const UINT vertexBufferSize = sizeof(triangleVertices);
+		const UINT vertexBufferSize = sizeof(triangleVertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&vertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&vertexBufferUpload)));
 
-        NAME_D3D12_OBJECT(m_vertexBuffer);
+		NAME_D3D12_OBJECT(m_vertexBuffer);
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(triangleVertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(triangleVertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = sizeof(triangleVertices);
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = sizeof(triangleVertices);
+	}
 
-    // Create the depth stencil view.
-    {
-        D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
-        depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
-        depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
-        depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
+	// Create the depth stencil view.
+	{
+		D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
+		depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
+		depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+		depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
 
-        D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
-        depthOptimizedClearValue.Format = DXGI_FORMAT_D32_FLOAT;
-        depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
-        depthOptimizedClearValue.DepthStencil.Stencil = 0;
+		D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
+		depthOptimizedClearValue.Format = DXGI_FORMAT_D32_FLOAT;
+		depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
+		depthOptimizedClearValue.DepthStencil.Stencil = 0;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
-            D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            &depthOptimizedClearValue,
-            IID_PPV_ARGS(&m_depthStencil)
-            ));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
+			D3D12_RESOURCE_STATE_DEPTH_WRITE,
+			&depthOptimizedClearValue,
+			IID_PPV_ARGS(&m_depthStencil)
+			));
 
-        NAME_D3D12_OBJECT(m_depthStencil);
+		NAME_D3D12_OBJECT(m_depthStencil);
 
-        m_device->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		m_device->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    // Create the constant buffers.
-    {
-        const UINT constantBufferDataSize = TriangleResourceCount * sizeof(SceneConstantBuffer);
+	// Create the constant buffers.
+	{
+		const UINT constantBufferDataSize = TriangleResourceCount * sizeof(SceneConstantBuffer);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(constantBufferDataSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_constantBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(constantBufferDataSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_constantBuffer)));
 
-        NAME_D3D12_OBJECT(m_constantBuffer);
+		NAME_D3D12_OBJECT(m_constantBuffer);
 
-        // Initialize the constant buffers for each of the triangles.
-        for (UINT n = 0; n < TriangleCount; n++)
-        {
-            m_constantBufferData[n].velocity = XMFLOAT4(GetRandomFloat(0.01f, 0.02f), 0.0f, 0.0f, 0.0f);
-            m_constantBufferData[n].offset = XMFLOAT4(GetRandomFloat(-5.0f, -1.5f), GetRandomFloat(-1.0f, 1.0f), GetRandomFloat(0.0f, 2.0f), 0.0f);
-            m_constantBufferData[n].color = XMFLOAT4(GetRandomFloat(0.5f, 1.0f), GetRandomFloat(0.5f, 1.0f), GetRandomFloat(0.5f, 1.0f), 1.0f);
-            XMStoreFloat4x4(&m_constantBufferData[n].projection, XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f)));
-        }
+		// Initialize the constant buffers for each of the triangles.
+		for (UINT n = 0; n < TriangleCount; n++)
+		{
+			m_constantBufferData[n].velocity = XMFLOAT4(GetRandomFloat(0.01f, 0.02f), 0.0f, 0.0f, 0.0f);
+			m_constantBufferData[n].offset = XMFLOAT4(GetRandomFloat(-5.0f, -1.5f), GetRandomFloat(-1.0f, 1.0f), GetRandomFloat(0.0f, 2.0f), 0.0f);
+			m_constantBufferData[n].color = XMFLOAT4(GetRandomFloat(0.5f, 1.0f), GetRandomFloat(0.5f, 1.0f), GetRandomFloat(0.5f, 1.0f), 1.0f);
+			XMStoreFloat4x4(&m_constantBufferData[n].projection, XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f)));
+		}
 
-        // Map and initialize the constant buffer. We don't unmap this until the
-        // app closes. Keeping things mapped for the lifetime of the resource is okay.
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbvDataBegin)));
-        memcpy(m_pCbvDataBegin, &m_constantBufferData[0], TriangleCount * sizeof(SceneConstantBuffer));
+		// Map and initialize the constant buffer. We don't unmap this until the
+		// app closes. Keeping things mapped for the lifetime of the resource is okay.
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbvDataBegin)));
+		memcpy(m_pCbvDataBegin, &m_constantBufferData[0], TriangleCount * sizeof(SceneConstantBuffer));
 
-        // Create shader resource views (SRV) of the constant buffers for the
-        // compute shader to read from.
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Format = DXGI_FORMAT_UNKNOWN;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Buffer.NumElements = TriangleCount;
-        srvDesc.Buffer.StructureByteStride = sizeof(SceneConstantBuffer);
-        srvDesc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_NONE;
+		// Create shader resource views (SRV) of the constant buffers for the
+		// compute shader to read from.
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Format = DXGI_FORMAT_UNKNOWN;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Buffer.NumElements = TriangleCount;
+		srvDesc.Buffer.StructureByteStride = sizeof(SceneConstantBuffer);
+		srvDesc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_NONE;
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE cbvSrvHandle(m_cbvSrvUavHeap->GetCPUDescriptorHandleForHeapStart(), CbvSrvOffset, m_cbvSrvUavDescriptorSize);
-        for (UINT frame = 0; frame < FrameCount; frame++)
-        {
-            srvDesc.Buffer.FirstElement = frame * TriangleCount;
-            m_device->CreateShaderResourceView(m_constantBuffer.Get(), &srvDesc, cbvSrvHandle);
-            cbvSrvHandle.Offset(CbvSrvUavDescriptorCountPerFrame, m_cbvSrvUavDescriptorSize);
-        }
-    }
+		CD3DX12_CPU_DESCRIPTOR_HANDLE cbvSrvHandle(m_cbvSrvUavHeap->GetCPUDescriptorHandleForHeapStart(), CbvSrvOffset, m_cbvSrvUavDescriptorSize);
+		for (UINT frame = 0; frame < FrameCount; frame++)
+		{
+			srvDesc.Buffer.FirstElement = frame * TriangleCount;
+			m_device->CreateShaderResourceView(m_constantBuffer.Get(), &srvDesc, cbvSrvHandle);
+			cbvSrvHandle.Offset(CbvSrvUavDescriptorCountPerFrame, m_cbvSrvUavDescriptorSize);
+		}
+	}
 
-    // Create the command signature used for indirect drawing.
-    {
-        // Each command consists of a CBV update and a DrawInstanced call.
-        D3D12_INDIRECT_ARGUMENT_DESC argumentDescs[2] = {};
-        argumentDescs[0].Type = D3D12_INDIRECT_ARGUMENT_TYPE_CONSTANT_BUFFER_VIEW;
-        argumentDescs[0].ConstantBufferView.RootParameterIndex = Cbv;
-        argumentDescs[1].Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW;
+	// Create the command signature used for indirect drawing.
+	{
+		// Each command consists of a CBV update and a DrawInstanced call.
+		D3D12_INDIRECT_ARGUMENT_DESC argumentDescs[2] = {};
+		argumentDescs[0].Type = D3D12_INDIRECT_ARGUMENT_TYPE_CONSTANT_BUFFER_VIEW;
+		argumentDescs[0].ConstantBufferView.RootParameterIndex = Cbv;
+		argumentDescs[1].Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW;
 
-        D3D12_COMMAND_SIGNATURE_DESC commandSignatureDesc = {};
-        commandSignatureDesc.pArgumentDescs = argumentDescs;
-        commandSignatureDesc.NumArgumentDescs = _countof(argumentDescs);
-        commandSignatureDesc.ByteStride = sizeof(IndirectCommand);
+		D3D12_COMMAND_SIGNATURE_DESC commandSignatureDesc = {};
+		commandSignatureDesc.pArgumentDescs = argumentDescs;
+		commandSignatureDesc.NumArgumentDescs = _countof(argumentDescs);
+		commandSignatureDesc.ByteStride = sizeof(IndirectCommand);
 
-        ThrowIfFailed(m_device->CreateCommandSignature(&commandSignatureDesc, m_rootSignature.Get(), IID_PPV_ARGS(&m_commandSignature)));
-        NAME_D3D12_OBJECT(m_commandSignature);
-    }
+		ThrowIfFailed(m_device->CreateCommandSignature(&commandSignatureDesc, m_rootSignature.Get(), IID_PPV_ARGS(&m_commandSignature)));
+		NAME_D3D12_OBJECT(m_commandSignature);
+	}
 
-    // Create the command buffers and UAVs to store the results of the compute work.
-    {
-        std::vector<IndirectCommand> commands;
-        commands.resize(TriangleResourceCount);
-        const UINT commandBufferSize = CommandSizePerFrame * FrameCount;
+	// Create the command buffers and UAVs to store the results of the compute work.
+	{
+		std::vector<IndirectCommand> commands;
+		commands.resize(TriangleResourceCount);
+		const UINT commandBufferSize = CommandSizePerFrame * FrameCount;
 
-        D3D12_RESOURCE_DESC commandBufferDesc = CD3DX12_RESOURCE_DESC::Buffer(commandBufferSize);
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &commandBufferDesc,
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_commandBuffer)));
+		D3D12_RESOURCE_DESC commandBufferDesc = CD3DX12_RESOURCE_DESC::Buffer(commandBufferSize);
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&commandBufferDesc,
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_commandBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(commandBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&commandBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(commandBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&commandBufferUpload)));
 
-        NAME_D3D12_OBJECT(m_commandBuffer);
+		NAME_D3D12_OBJECT(m_commandBuffer);
 
-        D3D12_GPU_VIRTUAL_ADDRESS gpuAddress = m_constantBuffer->GetGPUVirtualAddress();
-        UINT commandIndex = 0;
+		D3D12_GPU_VIRTUAL_ADDRESS gpuAddress = m_constantBuffer->GetGPUVirtualAddress();
+		UINT commandIndex = 0;
 
-        for (UINT frame = 0; frame < FrameCount; frame++)
-        {
-            for (UINT n = 0; n < TriangleCount; n++)
-            {
-                commands[commandIndex].cbv = gpuAddress;
-                commands[commandIndex].drawArguments.VertexCountPerInstance = 3;
-                commands[commandIndex].drawArguments.InstanceCount = 1;
-                commands[commandIndex].drawArguments.StartVertexLocation = 0;
-                commands[commandIndex].drawArguments.StartInstanceLocation = 0;
+		for (UINT frame = 0; frame < FrameCount; frame++)
+		{
+			for (UINT n = 0; n < TriangleCount; n++)
+			{
+				commands[commandIndex].cbv = gpuAddress;
+				commands[commandIndex].drawArguments.VertexCountPerInstance = 3;
+				commands[commandIndex].drawArguments.InstanceCount = 1;
+				commands[commandIndex].drawArguments.StartVertexLocation = 0;
+				commands[commandIndex].drawArguments.StartInstanceLocation = 0;
 
-                commandIndex++;
-                gpuAddress += sizeof(SceneConstantBuffer);
-            }
-        }
+				commandIndex++;
+				gpuAddress += sizeof(SceneConstantBuffer);
+			}
+		}
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the command buffer.
-        D3D12_SUBRESOURCE_DATA commandData = {};
-        commandData.pData = reinterpret_cast<UINT8*>(&commands[0]);
-        commandData.RowPitch = commandBufferSize;
-        commandData.SlicePitch = commandData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the command buffer.
+		D3D12_SUBRESOURCE_DATA commandData = {};
+		commandData.pData = reinterpret_cast<UINT8*>(&commands[0]);
+		commandData.RowPitch = commandBufferSize;
+		commandData.SlicePitch = commandData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_commandBuffer.Get(), commandBufferUpload.Get(), 0, 0, 1, &commandData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_commandBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE));
+		UpdateSubresources<1>(m_commandList.Get(), m_commandBuffer.Get(), commandBufferUpload.Get(), 0, 0, 1, &commandData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_commandBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE));
 
-        // Create SRVs for the command buffers.
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Format = DXGI_FORMAT_UNKNOWN;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Buffer.NumElements = TriangleCount;
-        srvDesc.Buffer.StructureByteStride = sizeof(IndirectCommand);
-        srvDesc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_NONE;
+		// Create SRVs for the command buffers.
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Format = DXGI_FORMAT_UNKNOWN;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Buffer.NumElements = TriangleCount;
+		srvDesc.Buffer.StructureByteStride = sizeof(IndirectCommand);
+		srvDesc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_NONE;
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE commandsHandle(m_cbvSrvUavHeap->GetCPUDescriptorHandleForHeapStart(), CommandsOffset, m_cbvSrvUavDescriptorSize);
-        for (UINT frame = 0; frame < FrameCount; frame++)
-        {
-            srvDesc.Buffer.FirstElement = frame * TriangleCount;
-            m_device->CreateShaderResourceView(m_commandBuffer.Get(), &srvDesc, commandsHandle);
-            commandsHandle.Offset(CbvSrvUavDescriptorCountPerFrame, m_cbvSrvUavDescriptorSize);
-        }
+		CD3DX12_CPU_DESCRIPTOR_HANDLE commandsHandle(m_cbvSrvUavHeap->GetCPUDescriptorHandleForHeapStart(), CommandsOffset, m_cbvSrvUavDescriptorSize);
+		for (UINT frame = 0; frame < FrameCount; frame++)
+		{
+			srvDesc.Buffer.FirstElement = frame * TriangleCount;
+			m_device->CreateShaderResourceView(m_commandBuffer.Get(), &srvDesc, commandsHandle);
+			commandsHandle.Offset(CbvSrvUavDescriptorCountPerFrame, m_cbvSrvUavDescriptorSize);
+		}
 
-        // Create the unordered access views (UAVs) that store the results of the compute work.
-        CD3DX12_CPU_DESCRIPTOR_HANDLE processedCommandsHandle(m_cbvSrvUavHeap->GetCPUDescriptorHandleForHeapStart(), ProcessedCommandsOffset, m_cbvSrvUavDescriptorSize);
-        for (UINT frame = 0; frame < FrameCount; frame++)
-        {
-            // Allocate a buffer large enough to hold all of the indirect commands
-            // for a single frame as well as a UAV counter.
-            commandBufferDesc = CD3DX12_RESOURCE_DESC::Buffer(CommandBufferCounterOffset + sizeof(UINT), D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
-            ThrowIfFailed(m_device->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-                D3D12_HEAP_FLAG_NONE,
-                &commandBufferDesc,
-                D3D12_RESOURCE_STATE_COPY_DEST,
-                nullptr,
-                IID_PPV_ARGS(&m_processedCommandBuffers[frame])));
+		// Create the unordered access views (UAVs) that store the results of the compute work.
+		CD3DX12_CPU_DESCRIPTOR_HANDLE processedCommandsHandle(m_cbvSrvUavHeap->GetCPUDescriptorHandleForHeapStart(), ProcessedCommandsOffset, m_cbvSrvUavDescriptorSize);
+		for (UINT frame = 0; frame < FrameCount; frame++)
+		{
+			// Allocate a buffer large enough to hold all of the indirect commands
+			// for a single frame as well as a UAV counter.
+			commandBufferDesc = CD3DX12_RESOURCE_DESC::Buffer(CommandBufferCounterOffset + sizeof(UINT), D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+			ThrowIfFailed(m_device->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+				D3D12_HEAP_FLAG_NONE,
+				&commandBufferDesc,
+				D3D12_RESOURCE_STATE_COPY_DEST,
+				nullptr,
+				IID_PPV_ARGS(&m_processedCommandBuffers[frame])));
 
-            NAME_D3D12_OBJECT_INDEXED(m_processedCommandBuffers, frame);
+			NAME_D3D12_OBJECT_INDEXED(m_processedCommandBuffers, frame);
 
-            D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
-            uavDesc.Format = DXGI_FORMAT_UNKNOWN;
-            uavDesc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
-            uavDesc.Buffer.FirstElement = 0;
-            uavDesc.Buffer.NumElements = TriangleCount;
-            uavDesc.Buffer.StructureByteStride = sizeof(IndirectCommand);
-            uavDesc.Buffer.CounterOffsetInBytes = CommandBufferCounterOffset;
-            uavDesc.Buffer.Flags = D3D12_BUFFER_UAV_FLAG_NONE;
+			D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
+			uavDesc.Format = DXGI_FORMAT_UNKNOWN;
+			uavDesc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
+			uavDesc.Buffer.FirstElement = 0;
+			uavDesc.Buffer.NumElements = TriangleCount;
+			uavDesc.Buffer.StructureByteStride = sizeof(IndirectCommand);
+			uavDesc.Buffer.CounterOffsetInBytes = CommandBufferCounterOffset;
+			uavDesc.Buffer.Flags = D3D12_BUFFER_UAV_FLAG_NONE;
 
-            m_device->CreateUnorderedAccessView(
-                m_processedCommandBuffers[frame].Get(),
-                m_processedCommandBuffers[frame].Get(),
-                &uavDesc,
-                processedCommandsHandle);
+			m_device->CreateUnorderedAccessView(
+				m_processedCommandBuffers[frame].Get(),
+				m_processedCommandBuffers[frame].Get(),
+				&uavDesc,
+				processedCommandsHandle);
 
-            processedCommandsHandle.Offset(CbvSrvUavDescriptorCountPerFrame, m_cbvSrvUavDescriptorSize);
-        }
+			processedCommandsHandle.Offset(CbvSrvUavDescriptorCountPerFrame, m_cbvSrvUavDescriptorSize);
+		}
 
-        // Allocate a buffer that can be used to reset the UAV counters and initialize
-        // it to 0.
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(sizeof(UINT)),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_processedCommandBufferCounterReset)));
+		// Allocate a buffer that can be used to reset the UAV counters and initialize
+		// it to 0.
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(sizeof(UINT)),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_processedCommandBufferCounterReset)));
 
-        UINT8* pMappedCounterReset = nullptr;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_processedCommandBufferCounterReset->Map(0, &readRange, reinterpret_cast<void**>(&pMappedCounterReset)));
-        ZeroMemory(pMappedCounterReset, sizeof(UINT));
-        m_processedCommandBufferCounterReset->Unmap(0, nullptr);
-    }
+		UINT8* pMappedCounterReset = nullptr;
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_processedCommandBufferCounterReset->Map(0, &readRange, reinterpret_cast<void**>(&pMappedCounterReset)));
+		ZeroMemory(pMappedCounterReset, sizeof(UINT));
+		m_processedCommandBufferCounterReset->Unmap(0, nullptr);
+	}
 
-    // Close the command list and execute it to begin the vertex buffer copy into
-    // the default heap.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the vertex buffer copy into
+	// the default heap.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_computeFence)));
-        m_fenceValues[m_frameIndex]++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_computeFence)));
+		m_fenceValues[m_frameIndex]++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForGpu();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForGpu();
+	}
 }
 
 // Get a random float value between min and max.
 float D3D12ExecuteIndirect::GetRandomFloat(float min, float max)
 {
-    float scale = static_cast<float>(rand()) / RAND_MAX;
-    float range = max - min;
-    return scale * range + min;
+	float scale = static_cast<float>(rand()) / RAND_MAX;
+	float range = max - min;
+	return scale * range + min;
 }
 
 // Update frame-based values.
 void D3D12ExecuteIndirect::OnUpdate()
 {
-    for (UINT n = 0; n < TriangleCount; n++)
-    {
-        const float offsetBounds = 2.5f;
+	for (UINT n = 0; n < TriangleCount; n++)
+	{
+		const float offsetBounds = 2.5f;
 
-        // Animate the triangles.
-        m_constantBufferData[n].offset.x += m_constantBufferData[n].velocity.x;
-        if (m_constantBufferData[n].offset.x > offsetBounds)
-        {
-            m_constantBufferData[n].velocity.x = GetRandomFloat(0.01f, 0.02f);
-            m_constantBufferData[n].offset.x = -offsetBounds;
-        }
-    }
+		// Animate the triangles.
+		m_constantBufferData[n].offset.x += m_constantBufferData[n].velocity.x;
+		if (m_constantBufferData[n].offset.x > offsetBounds)
+		{
+			m_constantBufferData[n].velocity.x = GetRandomFloat(0.01f, 0.02f);
+			m_constantBufferData[n].offset.x = -offsetBounds;
+		}
+	}
 
-    UINT8* destination = m_pCbvDataBegin + (TriangleCount * m_frameIndex * sizeof(SceneConstantBuffer));
-    memcpy(destination, &m_constantBufferData[0], TriangleCount * sizeof(SceneConstantBuffer));
+	UINT8* destination = m_pCbvDataBegin + (TriangleCount * m_frameIndex * sizeof(SceneConstantBuffer));
+	memcpy(destination, &m_constantBufferData[0], TriangleCount * sizeof(SceneConstantBuffer));
 }
 
 // Render the scene.
 void D3D12ExecuteIndirect::OnRender()
 {
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandLists();
-
-    // Execute the compute work.
-    if (m_enableCulling)
+    try
     {
-        PIXBeginEvent(m_commandQueue.Get(), 0, L"Cull invisible triangles");
+        // Record all the commands we need to render the scene into the command list.
+        PopulateCommandLists();
 
-        ID3D12CommandList* ppCommandLists[] = { m_computeCommandList.Get() };
-        m_computeCommandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+        // Execute the compute work.
+        if (m_enableCulling)
+        {
+            PIXBeginEvent(m_commandQueue.Get(), 0, L"Cull invisible triangles");
+
+            ID3D12CommandList* ppCommandLists[] = { m_computeCommandList.Get() };
+            m_computeCommandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+
+            PIXEndEvent(m_commandQueue.Get());
+
+            m_computeCommandQueue->Signal(m_computeFence.Get(), m_fenceValues[m_frameIndex]);
+
+            // Execute the rendering work only when the compute work is complete.
+            m_commandQueue->Wait(m_computeFence.Get(), m_fenceValues[m_frameIndex]);
+        }
+
+        PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+
+        // Execute the rendering work.
+        ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+        m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
         PIXEndEvent(m_commandQueue.Get());
 
-        m_computeCommandQueue->Signal(m_computeFence.Get(), m_fenceValues[m_frameIndex]);
+        // Present the frame.
+        ThrowIfFailed(m_swapChain->Present(1, 0));
 
-        // Execute the rendering work only when the compute work is complete.
-        m_commandQueue->Wait(m_computeFence.Get(), m_fenceValues[m_frameIndex]);
+        MoveToNextFrame();
     }
+    catch (HrException& e)
+    {
+        if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
+        {
+            RestoreD3DResources();
+        }
+        else
+        {
+            throw;
+        }
+    }
+}
 
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+// Release sample's D3D objects.
+void D3D12ExecuteIndirect::ReleaseD3DResources()
+{
+    m_fence.Reset();
+    ResetComPtrArray(&m_renderTargets);
+    m_commandQueue.Reset();
+    m_swapChain.Reset();
+    m_device.Reset();
+}
 
-    // Execute the rendering work.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
-
-    PIXEndEvent(m_commandQueue.Get());
-
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
-
-    MoveToNextFrame();
+// Tears down D3D resources and reinitializes them.
+void D3D12ExecuteIndirect::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
+    {
+        WaitForGpu();
+    }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
 }
 
 void D3D12ExecuteIndirect::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForGpu();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForGpu();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12ExecuteIndirect::OnKeyDown(UINT8 key)
 {
-    if (key == VK_SPACE)
-    {
-        m_enableCulling = !m_enableCulling;
-    }
+	if (key == VK_SPACE)
+	{
+		m_enableCulling = !m_enableCulling;
+	}
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12ExecuteIndirect::PopulateCommandLists()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_computeCommandAllocators[m_frameIndex]->Reset());
-    ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_computeCommandAllocators[m_frameIndex]->Reset());
+	ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_computeCommandList->Reset(m_computeCommandAllocators[m_frameIndex].Get(), m_computeState.Get()));
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_computeCommandList->Reset(m_computeCommandAllocators[m_frameIndex].Get(), m_computeState.Get()));
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
 
-    // Record the compute commands that will cull triangles and prevent them from being processed by the vertex shader.
-    if (m_enableCulling)
-    {
-        UINT frameDescriptorOffset = m_frameIndex * CbvSrvUavDescriptorCountPerFrame;
-        D3D12_GPU_DESCRIPTOR_HANDLE cbvSrvUavHandle = m_cbvSrvUavHeap->GetGPUDescriptorHandleForHeapStart();
+	// Record the compute commands that will cull triangles and prevent them from being processed by the vertex shader.
+	if (m_enableCulling)
+	{
+		UINT frameDescriptorOffset = m_frameIndex * CbvSrvUavDescriptorCountPerFrame;
+		D3D12_GPU_DESCRIPTOR_HANDLE cbvSrvUavHandle = m_cbvSrvUavHeap->GetGPUDescriptorHandleForHeapStart();
 
-        m_computeCommandList->SetComputeRootSignature(m_computeRootSignature.Get());
+		m_computeCommandList->SetComputeRootSignature(m_computeRootSignature.Get());
 
-        ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvUavHeap.Get() };
-        m_computeCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+		ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvUavHeap.Get() };
+		m_computeCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-        m_computeCommandList->SetComputeRootDescriptorTable(
-            SrvUavTable,
-            CD3DX12_GPU_DESCRIPTOR_HANDLE(cbvSrvUavHandle, CbvSrvOffset + frameDescriptorOffset, m_cbvSrvUavDescriptorSize));
+		m_computeCommandList->SetComputeRootDescriptorTable(
+			SrvUavTable,
+			CD3DX12_GPU_DESCRIPTOR_HANDLE(cbvSrvUavHandle, CbvSrvOffset + frameDescriptorOffset, m_cbvSrvUavDescriptorSize));
 
-        m_computeCommandList->SetComputeRoot32BitConstants(RootConstants, 4, reinterpret_cast<void*>(&m_csRootConstants), 0);
+		m_computeCommandList->SetComputeRoot32BitConstants(RootConstants, 4, reinterpret_cast<void*>(&m_csRootConstants), 0);
 
-        // Reset the UAV counter for this frame.
-        m_computeCommandList->CopyBufferRegion(m_processedCommandBuffers[m_frameIndex].Get(), CommandBufferCounterOffset, m_processedCommandBufferCounterReset.Get(), 0, sizeof(UINT));
+		// Reset the UAV counter for this frame.
+		m_computeCommandList->CopyBufferRegion(m_processedCommandBuffers[m_frameIndex].Get(), CommandBufferCounterOffset, m_processedCommandBufferCounterReset.Get(), 0, sizeof(UINT));
 
-        D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(m_processedCommandBuffers[m_frameIndex].Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
-        m_computeCommandList->ResourceBarrier(1, &barrier);
+		D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(m_processedCommandBuffers[m_frameIndex].Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+		m_computeCommandList->ResourceBarrier(1, &barrier);
 
-        m_computeCommandList->Dispatch(static_cast<UINT>(ceil(TriangleCount / float(ComputeThreadBlockSize))), 1, 1);
-    }
+		m_computeCommandList->Dispatch(static_cast<UINT>(ceil(TriangleCount / float(ComputeThreadBlockSize))), 1, 1);
+	}
 
-    ThrowIfFailed(m_computeCommandList->Close());
+	ThrowIfFailed(m_computeCommandList->Close());
 
-    // Record the rendering commands.
-    {
-        // Set necessary state.
-        m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Record the rendering commands.
+	{
+		// Set necessary state.
+		m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-        ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvUavHeap.Get() };
-        m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+		ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvUavHeap.Get() };
+		m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-        m_commandList->RSSetViewports(1, &m_viewport);
-        m_commandList->RSSetScissorRects(1, m_enableCulling ? &m_cullingScissorRect : &m_scissorRect);
+		m_commandList->RSSetViewports(1, &m_viewport);
+		m_commandList->RSSetScissorRects(1, m_enableCulling ? &m_cullingScissorRect : &m_scissorRect);
 
-        // Indicate that the command buffer will be used for indirect drawing
-        // and that the back buffer will be used as a render target.
-        D3D12_RESOURCE_BARRIER barriers[2] = {
-            CD3DX12_RESOURCE_BARRIER::Transition(
-                m_enableCulling ? m_processedCommandBuffers[m_frameIndex].Get() : m_commandBuffer.Get(),
-                m_enableCulling ? D3D12_RESOURCE_STATE_UNORDERED_ACCESS : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT),
-            CD3DX12_RESOURCE_BARRIER::Transition(
-                m_renderTargets[m_frameIndex].Get(),
-                D3D12_RESOURCE_STATE_PRESENT,
-                D3D12_RESOURCE_STATE_RENDER_TARGET)
-        };
+		// Indicate that the command buffer will be used for indirect drawing
+		// and that the back buffer will be used as a render target.
+		D3D12_RESOURCE_BARRIER barriers[2] = {
+			CD3DX12_RESOURCE_BARRIER::Transition(
+				m_enableCulling ? m_processedCommandBuffers[m_frameIndex].Get() : m_commandBuffer.Get(),
+				m_enableCulling ? D3D12_RESOURCE_STATE_UNORDERED_ACCESS : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+				D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT),
+			CD3DX12_RESOURCE_BARRIER::Transition(
+				m_renderTargets[m_frameIndex].Get(),
+				D3D12_RESOURCE_STATE_PRESENT,
+				D3D12_RESOURCE_STATE_RENDER_TARGET)
+		};
 
-        m_commandList->ResourceBarrier(_countof(barriers), barriers);
+		m_commandList->ResourceBarrier(_countof(barriers), barriers);
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-        CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-        m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+		m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
 
-        // Record commands.
-        const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-        m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-        m_commandList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+		// Record commands.
+		const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+		m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+		m_commandList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
 
-        m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-        m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+		m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+		m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
 
-        if (m_enableCulling)
-        {
-            PIXBeginEvent(m_commandList.Get(), 0, L"Draw visible triangles");
+		if (m_enableCulling)
+		{
+			PIXBeginEvent(m_commandList.Get(), 0, L"Draw visible triangles");
 
-            // Draw the triangles that have not been culled.
-            m_commandList->ExecuteIndirect(
-                m_commandSignature.Get(),
-                TriangleCount,
-                m_processedCommandBuffers[m_frameIndex].Get(),
-                0,
-                m_processedCommandBuffers[m_frameIndex].Get(),
-                CommandBufferCounterOffset);
-        }
-        else
-        {
-            PIXBeginEvent(m_commandList.Get(), 0, L"Draw all triangles");
+			// Draw the triangles that have not been culled.
+			m_commandList->ExecuteIndirect(
+				m_commandSignature.Get(),
+				TriangleCount,
+				m_processedCommandBuffers[m_frameIndex].Get(),
+				0,
+				m_processedCommandBuffers[m_frameIndex].Get(),
+				CommandBufferCounterOffset);
+		}
+		else
+		{
+			PIXBeginEvent(m_commandList.Get(), 0, L"Draw all triangles");
 
-            // Draw all of the triangles.
-            m_commandList->ExecuteIndirect(
-                m_commandSignature.Get(),
-                TriangleCount,
-                m_commandBuffer.Get(),
-                CommandSizePerFrame * m_frameIndex,
-                nullptr,
-                0);
-        }
-        PIXEndEvent(m_commandList.Get());
+			// Draw all of the triangles.
+			m_commandList->ExecuteIndirect(
+				m_commandSignature.Get(),
+				TriangleCount,
+				m_commandBuffer.Get(),
+				CommandSizePerFrame * m_frameIndex,
+				nullptr,
+				0);
+		}
+		PIXEndEvent(m_commandList.Get());
 
-        // Indicate that the command buffer may be used by the compute shader
-        // and that the back buffer will now be used to present.
-        barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT;
-        barriers[0].Transition.StateAfter = m_enableCulling ? D3D12_RESOURCE_STATE_COPY_DEST : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
-        barriers[1].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-        barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
+		// Indicate that the command buffer may be used by the compute shader
+		// and that the back buffer will now be used to present.
+		barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT;
+		barriers[0].Transition.StateAfter = m_enableCulling ? D3D12_RESOURCE_STATE_COPY_DEST : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+		barriers[1].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+		barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
 
-        m_commandList->ResourceBarrier(_countof(barriers), barriers);
+		m_commandList->ResourceBarrier(_countof(barriers), barriers);
 
-        ThrowIfFailed(m_commandList->Close());
-    }
+		ThrowIfFailed(m_commandList->Close());
+	}
 }
 
 // Wait for pending GPU work to complete.
 void D3D12ExecuteIndirect::WaitForGpu()
 {
-    // Schedule a Signal command in the queue.
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
+	// Schedule a Signal command in the queue.
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
 
-    // Wait until the fence has been processed.
-    ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-    WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	// Wait until the fence has been processed.
+	ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+	WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
 
-    // Increment the fence value for the current frame.
-    m_fenceValues[m_frameIndex]++;
+	// Increment the fence value for the current frame.
+	m_fenceValues[m_frameIndex]++;
 }
 
 // Prepare to render the next frame.
 void D3D12ExecuteIndirect::MoveToNextFrame()
 {
-    // Schedule a Signal command in the queue.
-    const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
+	// Schedule a Signal command in the queue.
+	const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
 
-    // Update the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Update the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-        WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+		WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	}
 
-    // Set the fence value for the next frame.
-    m_fenceValues[m_frameIndex] = currentFenceValue + 1;
+	// Set the fence value for the next frame.
+	m_fenceValues[m_frameIndex] = currentFenceValue + 1;
 }

--- a/Samples/UWP/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.h
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.h
@@ -25,145 +25,147 @@ using Microsoft::WRL::ComPtr;
 class D3D12ExecuteIndirect : public DXSample
 {
 public:
-    D3D12ExecuteIndirect(UINT width, UINT height, std::wstring name);
+	D3D12ExecuteIndirect(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
-    virtual void OnKeyDown(UINT8 key);
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
+	virtual void OnKeyDown(UINT8 key);
 
 private:
-    static const UINT FrameCount = 3;
-    static const UINT TriangleCount = 1024;
-    static const UINT TriangleResourceCount = TriangleCount * FrameCount;
-    static const UINT CommandSizePerFrame;                // The size of the indirect commands to draw all of the triangles in a single frame.
-    static const UINT CommandBufferCounterOffset;        // The offset of the UAV counter in the processed command buffer.
-    static const UINT ComputeThreadBlockSize = 128;        // Should match the value in compute.hlsl.
-    static const float TriangleHalfWidth;                // The x and y offsets used by the triangle vertices.
-    static const float TriangleDepth;                    // The z offset used by the triangle vertices.
-    static const float CullingCutoff;                    // The +/- x offset of the clipping planes in homogenous space [-1,1].
+	static const UINT FrameCount = 3;
+	static const UINT TriangleCount = 1024;
+	static const UINT TriangleResourceCount = TriangleCount * FrameCount;
+	static const UINT CommandSizePerFrame;				// The size of the indirect commands to draw all of the triangles in a single frame.
+	static const UINT CommandBufferCounterOffset;		// The offset of the UAV counter in the processed command buffer.
+	static const UINT ComputeThreadBlockSize = 128;		// Should match the value in compute.hlsl.
+	static const float TriangleHalfWidth;				// The x and y offsets used by the triangle vertices.
+	static const float TriangleDepth;					// The z offset used by the triangle vertices.
+	static const float CullingCutoff;					// The +/- x offset of the clipping planes in homogenous space [-1,1].
 
-    // Vertex definition.
-    struct Vertex
-    {
-        XMFLOAT3 position;
-    };
+	// Vertex definition.
+	struct Vertex
+	{
+		XMFLOAT3 position;
+	};
 
-    // Constant buffer definition.
-    struct SceneConstantBuffer
-    {
-        XMFLOAT4 velocity;
-        XMFLOAT4 offset;
-        XMFLOAT4 color;
-        XMFLOAT4X4 projection;
+	// Constant buffer definition.
+	struct SceneConstantBuffer
+	{
+		XMFLOAT4 velocity;
+		XMFLOAT4 offset;
+		XMFLOAT4 color;
+		XMFLOAT4X4 projection;
 
-        // Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
-        // to be array-indexed.
-        float padding[36];
-    };
+		// Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
+		// to be array-indexed.
+		float padding[36];
+	};
 
-    // Root constants for the compute shader.
-    struct CSRootConstants
-    {
-        float xOffset;
-        float zOffset;
-        float cullOffset;
-        float commandCount;
-    };
+	// Root constants for the compute shader.
+	struct CSRootConstants
+	{
+		float xOffset;
+		float zOffset;
+		float cullOffset;
+		float commandCount;
+	};
 
-    // Data structure to match the command signature used for ExecuteIndirect.
-    struct IndirectCommand
-    {
-        D3D12_GPU_VIRTUAL_ADDRESS cbv;
-        D3D12_DRAW_ARGUMENTS drawArguments;
-    };
+	// Data structure to match the command signature used for ExecuteIndirect.
+	struct IndirectCommand
+	{
+		D3D12_GPU_VIRTUAL_ADDRESS cbv;
+		D3D12_DRAW_ARGUMENTS drawArguments;
+	};
 
-    // Graphics root signature parameter offsets.
-    enum GraphicsRootParameters
-    {
-        Cbv,
-        GraphicsRootParametersCount
-    };
+	// Graphics root signature parameter offsets.
+	enum GraphicsRootParameters
+	{
+		Cbv,
+		GraphicsRootParametersCount
+	};
 
-    // Compute root signature parameter offsets.
-    enum ComputeRootParameters
-    {
-        SrvUavTable,
-        RootConstants,            // Root constants that give the shader information about the triangle vertices and culling planes.
-        ComputeRootParametersCount
-    };
+	// Compute root signature parameter offsets.
+	enum ComputeRootParameters
+	{
+		SrvUavTable,
+		RootConstants,			// Root constants that give the shader information about the triangle vertices and culling planes.
+		ComputeRootParametersCount
+	};
 
-    // CBV/SRV/UAV desciptor heap offsets.
-    enum HeapOffsets
-    {
-        CbvSrvOffset = 0,                                                    // SRV that points to the constant buffers used by the rendering thread.
-        CommandsOffset = CbvSrvOffset + 1,                                    // SRV that points to all of the indirect commands.
-        ProcessedCommandsOffset = CommandsOffset + 1,                        // UAV that records the commands we actually want to execute.
-        CbvSrvUavDescriptorCountPerFrame = ProcessedCommandsOffset + 1        // 2 SRVs + 1 UAV for the compute shader.
-    };
+	// CBV/SRV/UAV desciptor heap offsets.
+	enum HeapOffsets
+	{
+		CbvSrvOffset = 0,													// SRV that points to the constant buffers used by the rendering thread.
+		CommandsOffset = CbvSrvOffset + 1,									// SRV that points to all of the indirect commands.
+		ProcessedCommandsOffset = CommandsOffset + 1,						// UAV that records the commands we actually want to execute.
+		CbvSrvUavDescriptorCountPerFrame = ProcessedCommandsOffset + 1		// 2 SRVs + 1 UAV for the compute shader.
+	};
 
-    // Each triangle gets its own constant buffer per frame.
-    std::vector<SceneConstantBuffer> m_constantBufferData;
-    UINT8* m_pCbvDataBegin;
+	// Each triangle gets its own constant buffer per frame.
+	std::vector<SceneConstantBuffer> m_constantBufferData;
+	UINT8* m_pCbvDataBegin;
 
-    CSRootConstants m_csRootConstants;    // Constants for the compute shader.
-    bool m_enableCulling;                // Toggle whether the compute shader pre-processes the indirect commands.
+	CSRootConstants m_csRootConstants;	// Constants for the compute shader.
+	bool m_enableCulling;				// Toggle whether the compute shader pre-processes the indirect commands.
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    D3D12_RECT m_cullingScissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_computeCommandAllocators[FrameCount];
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12CommandQueue> m_computeCommandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12RootSignature> m_computeRootSignature;
-    ComPtr<ID3D12CommandSignature> m_commandSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_cbvSrvUavHeap;
-    UINT m_rtvDescriptorSize;
-    UINT m_cbvSrvUavDescriptorSize;
-    UINT m_frameIndex;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	D3D12_RECT m_cullingScissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_computeCommandAllocators[FrameCount];
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12CommandQueue> m_computeCommandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12RootSignature> m_computeRootSignature;
+	ComPtr<ID3D12CommandSignature> m_commandSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_cbvSrvUavHeap;
+	UINT m_rtvDescriptorSize;
+	UINT m_cbvSrvUavDescriptorSize;
+	UINT m_frameIndex;
 
-    // Synchronization objects.
-    ComPtr<ID3D12Fence> m_fence;
-    ComPtr<ID3D12Fence> m_computeFence;
-    UINT64 m_fenceValues[FrameCount];
-    HANDLE m_fenceEvent;
+	// Synchronization objects.
+	ComPtr<ID3D12Fence> m_fence;
+	ComPtr<ID3D12Fence> m_computeFence;
+	UINT64 m_fenceValues[FrameCount];
+	HANDLE m_fenceEvent;
 
-    // Asset objects.
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12PipelineState> m_computeState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    ComPtr<ID3D12GraphicsCommandList> m_computeCommandList;
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    ComPtr<ID3D12Resource> m_constantBuffer;
-    ComPtr<ID3D12Resource> m_depthStencil;
-    ComPtr<ID3D12Resource> m_commandBuffer;
-    ComPtr<ID3D12Resource> m_processedCommandBuffers[FrameCount];
-    ComPtr<ID3D12Resource> m_processedCommandBufferCounterReset;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	// Asset objects.
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12PipelineState> m_computeState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	ComPtr<ID3D12GraphicsCommandList> m_computeCommandList;
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	ComPtr<ID3D12Resource> m_constantBuffer;
+	ComPtr<ID3D12Resource> m_depthStencil;
+	ComPtr<ID3D12Resource> m_commandBuffer;
+	ComPtr<ID3D12Resource> m_processedCommandBuffers[FrameCount];
+	ComPtr<ID3D12Resource> m_processedCommandBufferCounterReset;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
 
-    void LoadPipeline();
-    void LoadAssets();
-    float GetRandomFloat(float min, float max);
-    void PopulateCommandLists();
-    void WaitForGpu();
-    void MoveToNextFrame();
+	void LoadPipeline();
+	void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
+	float GetRandomFloat(float min, float max);
+	void PopulateCommandLists();
+	void WaitForGpu();
+	void MoveToNextFrame();
 
-    // We pack the UAV counter into the same buffer as the commands rather than create
-    // a separate 64K resource/heap for it. The counter must be aligned on 4K boundaries,
-    // so we pad the command buffer (if necessary) such that the counter will be placed
-    // at a valid location in the buffer.
-    static inline UINT AlignForUavCounter(UINT bufferSize)
-    {
-        const UINT alignment = D3D12_UAV_COUNTER_PLACEMENT_ALIGNMENT;
-        return (bufferSize + (alignment - 1)) & ~(alignment - 1);
-    }
+	// We pack the UAV counter into the same buffer as the commands rather than create
+	// a separate 64K resource/heap for it. The counter must be aligned on 4K boundaries,
+	// so we pad the command buffer (if necessary) such that the counter will be placed
+	// at a valid location in the buffer.
+	static inline UINT AlignForUavCounter(UINT bufferSize)
+	{
+		const UINT alignment = D3D12_UAV_COUNTER_PLACEMENT_ALIGNMENT;
+		return (bufferSize + (alignment - 1)) & ~(alignment - 1);
+	}
 };

--- a/Samples/UWP/D3D12ExecuteIndirect/src/DXSample.cpp
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,59 +34,104 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
-    auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(windowText.c_str());
+	std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
+	auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/UWP/D3D12ExecuteIndirect/src/DXSample.h
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/DXSample.h
@@ -16,42 +16,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/UWP/D3D12ExecuteIndirect/src/Main.cpp
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12ExecuteIndirect sample(1200, 900, L"Press the SPACE bar to toggle GPU primitive culling");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12ExecuteIndirect sample(1200, 900, L"Press the SPACE bar to toggle GPU primitive culling");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12ExecuteIndirect/src/View.cpp
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/View.cpp
@@ -15,27 +15,27 @@
 using namespace Windows::Foundation;
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -44,20 +44,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -66,26 +66,26 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnClosed(CoreWindow^ /*sender*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }

--- a/Samples/UWP/D3D12ExecuteIndirect/src/View.h
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/View.h
@@ -23,20 +23,20 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
+	DXSample* m_pSample;
+	bool m_windowClosed;
 };

--- a/Samples/UWP/D3D12ExecuteIndirect/src/ViewProvider.cpp
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12ExecuteIndirect/src/ViewProvider.h
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12ExecuteIndirect/src/compute.hlsl
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/compute.hlsl
@@ -13,54 +13,54 @@
 
 struct SceneConstantBuffer
 {
-    float4 velocity;
-    float4 offset;
-    float4 color;
-    float4x4 projection;
-    float4 padding[9];
+	float4 velocity;
+	float4 offset;
+	float4 color;
+	float4x4 projection;
+	float4 padding[9];
 };
 
 struct IndirectCommand
 {
-    uint2 cbvAddress;
-    uint4 drawArguments;
+	uint2 cbvAddress;
+	uint4 drawArguments;
 };
 
 cbuffer RootConstants : register(b0)
 {
-    float xOffset;        // Half the width of the triangles.
-    float zOffset;        // The z offset for the triangle vertices.
-    float cullOffset;    // The culling plane offset in homogenous space.
-    float commandCount;    // The number of commands to be processed.
+	float xOffset;		// Half the width of the triangles.
+	float zOffset;		// The z offset for the triangle vertices.
+	float cullOffset;	// The culling plane offset in homogenous space.
+	float commandCount;	// The number of commands to be processed.
 };
 
-StructuredBuffer<SceneConstantBuffer> cbv                : register(t0);    // SRV: Wrapped constant buffers
-StructuredBuffer<IndirectCommand> inputCommands            : register(t1);    // SRV: Indirect commands
-AppendStructuredBuffer<IndirectCommand> outputCommands    : register(u0);    // UAV: Processed indirect commands
+StructuredBuffer<SceneConstantBuffer> cbv				: register(t0);	// SRV: Wrapped constant buffers
+StructuredBuffer<IndirectCommand> inputCommands			: register(t1);	// SRV: Indirect commands
+AppendStructuredBuffer<IndirectCommand> outputCommands	: register(u0);	// UAV: Processed indirect commands
 
 [numthreads(threadBlockSize, 1, 1)]
 void CSMain(uint3 groupId : SV_GroupID, uint groupIndex : SV_GroupIndex)
 {
-    // Each thread of the CS operates on one of the indirect commands.
-    uint index = (groupId.x * threadBlockSize) + groupIndex;
+	// Each thread of the CS operates on one of the indirect commands.
+	uint index = (groupId.x * threadBlockSize) + groupIndex;
 
-    // Don't attempt to access commands that don't exist if more threads are allocated
-    // than commands.
-    if (index < commandCount)
-    {
-        // Project the left and right bounds of the triangle into homogenous space.
-        float4 left = float4(-xOffset, 0.0f, zOffset, 1.0f) + cbv[index].offset;
-        left = mul(left, cbv[index].projection);
-        left /= left.w;
+	// Don't attempt to access commands that don't exist if more threads are allocated
+	// than commands.
+	if (index < commandCount)
+	{
+		// Project the left and right bounds of the triangle into homogenous space.
+		float4 left = float4(-xOffset, 0.0f, zOffset, 1.0f) + cbv[index].offset;
+		left = mul(left, cbv[index].projection);
+		left /= left.w;
 
-        float4 right = float4(xOffset, 0.0f, zOffset, 1.0f) + cbv[index].offset;
-        right = mul(right, cbv[index].projection);
-        right /= right.w;
+		float4 right = float4(xOffset, 0.0f, zOffset, 1.0f) + cbv[index].offset;
+		right = mul(right, cbv[index].projection);
+		right /= right.w;
 
-        // Only draw triangles that are within the culling space.
-        if (-cullOffset < right.x && left.x < cullOffset)
-        {
-            outputCommands.Append(inputCommands[index]);
-        }
-    }
+		// Only draw triangles that are within the culling space.
+		if (-cullOffset < right.x && left.x < cullOffset)
+		{
+			outputCommands.Append(inputCommands[index]);
+		}
+	}
 }

--- a/Samples/UWP/D3D12ExecuteIndirect/src/d3dx12.h
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12ExecuteIndirect/src/shaders.hlsl
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/shaders.hlsl
@@ -11,31 +11,31 @@
 
 cbuffer SceneConstantBuffer : register(b0)
 {
-    float4 velocity;
-    float4 offset;
-    float4 color;
-    float4x4 projection;
+	float4 velocity;
+	float4 offset;
+	float4 color;
+	float4x4 projection;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VSMain(float4 position : POSITION)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = mul(position + offset, projection);
+	result.position = mul(position + offset, projection);
 
-    float intensity = saturate((4.0f - result.position.z) / 2.0f);
-    result.color = float4(color.xyz * intensity, 1.0f);
+	float intensity = saturate((4.0f - result.position.z) / 2.0f);
+	result.color = float4(color.xyz * intensity, 1.0f);
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/UWP/D3D12ExecuteIndirect/src/stdafx.h
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include "d3dx12.h"

--- a/Samples/UWP/D3D12Fullscreen/src/D3D12Fullscreen.cpp
+++ b/Samples/UWP/D3D12Fullscreen/src/D3D12Fullscreen.cpp
@@ -19,868 +19,909 @@ const float D3D12Fullscreen::ClearColor[4] = { 0.0f, 0.2f, 0.4f, 1.0f };
 
 const D3D12Fullscreen::Resolution D3D12Fullscreen::m_resolutionOptions[] =
 {
-    { 800u, 600u },
-    { 1200u, 900u },
-    { 1280u, 720u },
-    { 1920u, 1080u },
-    { 1920u, 1200u },
-    { 2560u, 1440u },
-    { 3440u, 1440u },
-    { 3840u, 2160u }
+	{ 800u, 600u },
+	{ 1200u, 900u },
+	{ 1280u, 720u },
+	{ 1920u, 1080u },
+	{ 1920u, 1200u },
+	{ 2560u, 1440u },
+	{ 3440u, 1440u },
+	{ 3840u, 2160u }
 };
 const UINT D3D12Fullscreen::m_resolutionOptionsCount = _countof(m_resolutionOptions);
 UINT D3D12Fullscreen::m_resolutionIndex = 1;
 
 D3D12Fullscreen::D3D12Fullscreen(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_pCbvDataBegin(nullptr),
-    m_sceneViewport(0.0f, 0.0f, 0.0f, 0.0f),
-    m_sceneScissorRect(0, 0, 0, 0),
-    m_postViewport(0.0f, 0.0f, 0.0f, 0.0f),
-    m_postScissorRect(0, 0, 0, 0),
-    m_rtvDescriptorSize(0),
-    m_cbvSrvDescriptorSize(0),
-    m_windowVisible(true),
-    m_windowedMode(true),
-    m_sceneConstantBufferData{},
-    m_fenceValues{}
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_pCbvDataBegin(nullptr),
+	m_sceneViewport(0.0f, 0.0f, 0.0f, 0.0f),
+	m_sceneScissorRect(0, 0, 0, 0),
+	m_postViewport(0.0f, 0.0f, 0.0f, 0.0f),
+	m_postScissorRect(0, 0, 0, 0),
+	m_rtvDescriptorSize(0),
+	m_cbvSrvDescriptorSize(0),
+	m_windowVisible(true),
+	m_windowedMode(true),
+	m_sceneConstantBufferData{},
+	m_fenceValues{}
 {
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
 }
 
 void D3D12Fullscreen::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12Fullscreen::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter, true);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
-    NAME_D3D12_OBJECT(m_commandQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	NAME_D3D12_OBJECT(m_commandQueue);
 
-    // Describe and create the swap chain.
-    // The resolution of the swap chain buffers will match the resolution of the window, enabling the
-    // app to enter iFlip when in fullscreen mode. We will also keep a separate buffer that is not part
-    // of the swap chain as an intermediate render target, whose resolution will control the rendering
-    // resolution of the scene.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	// The resolution of the swap chain buffers will match the resolution of the window, enabling the
+	// app to enter iFlip when in fullscreen mode. We will also keep a separate buffer that is not part
+	// of the swap chain as an intermediate render target, whose resolution will control the rendering
+	// resolution of the scene.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    // It is recommended to always use the tearing flag when it is available.
-    swapChainDesc.Flags = m_tearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
+	// It is recommended to always use the tearing flag when it is available.
+	swapChainDesc.Flags = m_tearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount + 1; // + 1 for the intermediate render target.
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount + 1; // + 1 for the intermediate render target.
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
 
-        // Describe and create a constant buffer view (CBV) and shader resource view (SRV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvSrvHeapDesc = {};
-        cbvSrvHeapDesc.NumDescriptors = FrameCount + 1; // One CBV per frame and one SRV for the intermediate render target.
-        cbvSrvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        cbvSrvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvSrvHeapDesc, IID_PPV_ARGS(&m_cbvSrvHeap)));
+		// Describe and create a constant buffer view (CBV) and shader resource view (SRV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvSrvHeapDesc = {};
+		cbvSrvHeapDesc.NumDescriptors = FrameCount + 1; // One CBV per frame and one SRV for the intermediate render target.
+		cbvSrvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		cbvSrvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvSrvHeapDesc, IID_PPV_ARGS(&m_cbvSrvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-        m_cbvSrvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_cbvSrvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	}
 
-    // Create command allocators for each frame.
-    for (UINT n = 0; n < FrameCount; n++)
-    {
-        ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[n])));
-        ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_postCommandAllocators[n])));
-    }
+	// Create command allocators for each frame.
+	for (UINT n = 0; n < FrameCount; n++)
+	{
+		ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[n])));
+		ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_postCommandAllocators[n])));
+	}
 }
 
 // Load the sample assets.
 void D3D12Fullscreen::LoadAssets()
 {
-    D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-    // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-    featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+	// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+	featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-    if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-    {
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-    }
+	if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+	{
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+	}
 
-    // Create a root signature consisting of a descriptor table with a single CBV.
-    {
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
-        CD3DX12_ROOT_PARAMETER1 rootParameters[1];
+	// Create a root signature consisting of a descriptor table with a single CBV.
+	{
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
+		CD3DX12_ROOT_PARAMETER1 rootParameters[1];
 
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_VERTEX);
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_VERTEX);
 
-        // Allow input layout and deny uneccessary access to certain pipeline stages.
-        D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
-            D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_PIXEL_SHADER_ROOT_ACCESS;
+		// Allow input layout and deny uneccessary access to certain pipeline stages.
+		D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
+			D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_PIXEL_SHADER_ROOT_ACCESS;
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, rootSignatureFlags);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, rootSignatureFlags);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_sceneRootSignature)));
-        NAME_D3D12_OBJECT(m_sceneRootSignature);
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_sceneRootSignature)));
+		NAME_D3D12_OBJECT(m_sceneRootSignature);
+	}
 
-    // Create a root signature consisting of a descriptor table with a SRV and a sampler.
-    {
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
-        CD3DX12_ROOT_PARAMETER1 rootParameters[1];
+	// Create a root signature consisting of a descriptor table with a SRV and a sampler.
+	{
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
+		CD3DX12_ROOT_PARAMETER1 rootParameters[1];
 
-        // We don't modify the SRV in the post-processing command list after
-        // SetGraphicsRootDescriptorTable is executed on the GPU so we can use the default
-        // range behavior: D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
-        rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
+		// We don't modify the SRV in the post-processing command list after
+		// SetGraphicsRootDescriptorTable is executed on the GPU so we can use the default
+		// range behavior: D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
+		rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
 
-        // Allow input layout and pixel shader access and deny uneccessary access to certain pipeline stages.
-        D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
-            D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS;
+		// Allow input layout and pixel shader access and deny uneccessary access to certain pipeline stages.
+		D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
+			D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS;
 
-        // Create a sampler.
-        D3D12_STATIC_SAMPLER_DESC sampler = {};
-        sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-        sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.MipLODBias = 0;
-        sampler.MaxAnisotropy = 0;
-        sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
-        sampler.BorderColor = D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
-        sampler.MinLOD = 0.0f;
-        sampler.MaxLOD = D3D12_FLOAT32_MAX;
-        sampler.ShaderRegister = 0;
-        sampler.RegisterSpace = 0;
-        sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+		// Create a sampler.
+		D3D12_STATIC_SAMPLER_DESC sampler = {};
+		sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.MipLODBias = 0;
+		sampler.MaxAnisotropy = 0;
+		sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
+		sampler.BorderColor = D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
+		sampler.MinLOD = 0.0f;
+		sampler.MaxLOD = D3D12_FLOAT32_MAX;
+		sampler.ShaderRegister = 0;
+		sampler.RegisterSpace = 0;
+		sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &sampler, rootSignatureFlags);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &sampler, rootSignatureFlags);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_postRootSignature)));
-        NAME_D3D12_OBJECT(m_postRootSignature);
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_postRootSignature)));
+		NAME_D3D12_OBJECT(m_postRootSignature);
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> sceneVertexShader;
-        ComPtr<ID3DBlob> scenePixelShader;
-        ComPtr<ID3DBlob> postVertexShader;
-        ComPtr<ID3DBlob> postPixelShader;
-        ComPtr<ID3DBlob> error;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> sceneVertexShader;
+		ComPtr<ID3DBlob> scenePixelShader;
+		ComPtr<ID3DBlob> postVertexShader;
+		ComPtr<ID3DBlob> postPixelShader;
+		ComPtr<ID3DBlob> error;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"sceneShaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &sceneVertexShader, &error));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"sceneShaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &scenePixelShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"sceneShaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &sceneVertexShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"sceneShaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &scenePixelShader, &error));
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"postShaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &postVertexShader, &error));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"postShaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &postPixelShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"postShaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &postVertexShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"postShaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &postPixelShader, &error));
 
-        // Define the vertex input layouts.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
-        D3D12_INPUT_ELEMENT_DESC scaleInputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layouts.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
+		D3D12_INPUT_ELEMENT_DESC scaleInputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Describe and create the graphics pipeline state objects (PSOs).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_sceneRootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(sceneVertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(scenePixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state objects (PSOs).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_sceneRootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(sceneVertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(scenePixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_scenePipelineState)));
-        NAME_D3D12_OBJECT(m_scenePipelineState);
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_scenePipelineState)));
+		NAME_D3D12_OBJECT(m_scenePipelineState);
 
-        psoDesc.InputLayout = { scaleInputElementDescs, _countof(scaleInputElementDescs) };
-        psoDesc.pRootSignature = m_postRootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(postVertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(postPixelShader.Get());
+		psoDesc.InputLayout = { scaleInputElementDescs, _countof(scaleInputElementDescs) };
+		psoDesc.pRootSignature = m_postRootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(postVertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(postPixelShader.Get());
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_postPipelineState)));
-        NAME_D3D12_OBJECT(m_postPipelineState);
-    }
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_postPipelineState)));
+		NAME_D3D12_OBJECT(m_postPipelineState);
+	}
 
-    // Single-use command allocator and command list for creating resources.
-    ComPtr<ID3D12CommandAllocator> commandAllocator;
-    ComPtr<ID3D12GraphicsCommandList> commandList;
+	// Single-use command allocator and command list for creating resources.
+	ComPtr<ID3D12CommandAllocator> commandAllocator;
+	ComPtr<ID3D12GraphicsCommandList> commandList;
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator)));
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
 
-    // Create the command lists.
-    {
-        ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_sceneCommandAllocators[m_frameIndex].Get(), m_scenePipelineState.Get(), IID_PPV_ARGS(&m_sceneCommandList)));
-        NAME_D3D12_OBJECT(m_sceneCommandList);
+	// Create the command lists.
+	{
+		ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_sceneCommandAllocators[m_frameIndex].Get(), m_scenePipelineState.Get(), IID_PPV_ARGS(&m_sceneCommandList)));
+		NAME_D3D12_OBJECT(m_sceneCommandList);
 
-        ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_postCommandAllocators[m_frameIndex].Get(), m_postPipelineState.Get(), IID_PPV_ARGS(&m_postCommandList)));
-        NAME_D3D12_OBJECT(m_postCommandList);
+		ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_postCommandAllocators[m_frameIndex].Get(), m_postPipelineState.Get(), IID_PPV_ARGS(&m_postCommandList)));
+		NAME_D3D12_OBJECT(m_postCommandList);
 
-        // Close the command lists.
-        ThrowIfFailed(m_sceneCommandList->Close());
-        ThrowIfFailed(m_postCommandList->Close());
-    }
+		// Close the command lists.
+		ThrowIfFailed(m_sceneCommandList->Close());
+		ThrowIfFailed(m_postCommandList->Close());
+	}
 
-    LoadSizeDependentResources();
-    LoadSceneResolutionDependentResources();
+	LoadSizeDependentResources();
+	LoadSceneResolutionDependentResources();
 
-    // Create/update the vertex buffer.
-    ComPtr<ID3D12Resource> sceneVertexBufferUpload;
-    {
-        // Define the geometry for a thin quad that will animate across the screen.
-        const float x = QuadWidth / 2.0f;
-        const float y = QuadHeight / 2.0f;
-        SceneVertex quadVertices[] =
-        {
-            { { -x, -y, 1.0f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
-            { { -x, y, 1.0f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
-            { { x, -y, 1.0f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
-            { { x, y, 1.0f }, { 1.0f, 1.0f, 1.0f, 1.0f } }
-        };
+	// Create/update the vertex buffer.
+	ComPtr<ID3D12Resource> sceneVertexBufferUpload;
+	{
+		// Define the geometry for a thin quad that will animate across the screen.
+		const float x = QuadWidth / 2.0f;
+		const float y = QuadHeight / 2.0f;
+		SceneVertex quadVertices[] =
+		{
+			{ { -x, -y, 1.0f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
+			{ { -x, y, 1.0f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
+			{ { x, -y, 1.0f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
+			{ { x, y, 1.0f }, { 1.0f, 1.0f, 1.0f, 1.0f } }
+		};
 
-        const UINT vertexBufferSize = sizeof(quadVertices);
+		const UINT vertexBufferSize = sizeof(quadVertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_sceneVertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_sceneVertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&sceneVertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&sceneVertexBufferUpload)));
 
-        NAME_D3D12_OBJECT(m_sceneVertexBuffer);
+		NAME_D3D12_OBJECT(m_sceneVertexBuffer);
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the vertex buffer.
-        UINT8* pVertexDataBegin;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(sceneVertexBufferUpload->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
-        memcpy(pVertexDataBegin, quadVertices, sizeof(quadVertices));
-        sceneVertexBufferUpload->Unmap(0, nullptr);
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the vertex buffer.
+		UINT8* pVertexDataBegin;
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(sceneVertexBufferUpload->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
+		memcpy(pVertexDataBegin, quadVertices, sizeof(quadVertices));
+		sceneVertexBufferUpload->Unmap(0, nullptr);
 
-        commandList->CopyBufferRegion(m_sceneVertexBuffer.Get(), 0, sceneVertexBufferUpload.Get(), 0, vertexBufferSize);
-        commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_sceneVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		commandList->CopyBufferRegion(m_sceneVertexBuffer.Get(), 0, sceneVertexBufferUpload.Get(), 0, vertexBufferSize);
+		commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_sceneVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer views.
-        m_sceneVertexBufferView.BufferLocation = m_sceneVertexBuffer->GetGPUVirtualAddress();
-        m_sceneVertexBufferView.StrideInBytes = sizeof(SceneVertex);
-        m_sceneVertexBufferView.SizeInBytes = vertexBufferSize;
-    }
+		// Initialize the vertex buffer views.
+		m_sceneVertexBufferView.BufferLocation = m_sceneVertexBuffer->GetGPUVirtualAddress();
+		m_sceneVertexBufferView.StrideInBytes = sizeof(SceneVertex);
+		m_sceneVertexBufferView.SizeInBytes = vertexBufferSize;
+	}
 
-    // Create/update the fullscreen quad vertex buffer.
-    ComPtr<ID3D12Resource> postVertexBufferUpload;
-    {
-        // Define the geometry for a fullscreen quad.
-        PostVertex quadVertices[] =
-        {
-            { { -1.0f, -1.0f, 0.0f, 1.0f }, { 0.0f, 0.0f } },    // Bottom left.
-            { { -1.0f, 1.0f, 0.0f, 1.0f }, { 0.0f, 1.0f } },    // Top left.
-            { { 1.0f, -1.0f, 0.0f, 1.0f }, { 1.0f, 0.0f } },    // Bottom right.
-            { { 1.0f, 1.0f, 0.0f, 1.0f }, { 1.0f, 1.0f } }        // Top right.
-        };
+	// Create/update the fullscreen quad vertex buffer.
+	ComPtr<ID3D12Resource> postVertexBufferUpload;
+	{
+		// Define the geometry for a fullscreen quad.
+		PostVertex quadVertices[] =
+		{
+			{ { -1.0f, -1.0f, 0.0f, 1.0f }, { 0.0f, 0.0f } },	// Bottom left.
+			{ { -1.0f, 1.0f, 0.0f, 1.0f }, { 0.0f, 1.0f } },	// Top left.
+			{ { 1.0f, -1.0f, 0.0f, 1.0f }, { 1.0f, 0.0f } },	// Bottom right.
+			{ { 1.0f, 1.0f, 0.0f, 1.0f }, { 1.0f, 1.0f } }		// Top right.
+		};
 
-        const UINT vertexBufferSize = sizeof(quadVertices);
+		const UINT vertexBufferSize = sizeof(quadVertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_postVertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_postVertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&postVertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&postVertexBufferUpload)));
 
-        NAME_D3D12_OBJECT(m_postVertexBuffer);
+		NAME_D3D12_OBJECT(m_postVertexBuffer);
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the vertex buffer.
-        UINT8* pVertexDataBegin;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(postVertexBufferUpload->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
-        memcpy(pVertexDataBegin, quadVertices, sizeof(quadVertices));
-        postVertexBufferUpload->Unmap(0, nullptr);
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the vertex buffer.
+		UINT8* pVertexDataBegin;
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(postVertexBufferUpload->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
+		memcpy(pVertexDataBegin, quadVertices, sizeof(quadVertices));
+		postVertexBufferUpload->Unmap(0, nullptr);
 
-        commandList->CopyBufferRegion(m_postVertexBuffer.Get(), 0, postVertexBufferUpload.Get(), 0, vertexBufferSize);
-        commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_postVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		commandList->CopyBufferRegion(m_postVertexBuffer.Get(), 0, postVertexBufferUpload.Get(), 0, vertexBufferSize);
+		commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_postVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer views.
-        m_postVertexBufferView.BufferLocation = m_postVertexBuffer->GetGPUVirtualAddress();
-        m_postVertexBufferView.StrideInBytes = sizeof(PostVertex);
-        m_postVertexBufferView.SizeInBytes = vertexBufferSize;
-    }
+		// Initialize the vertex buffer views.
+		m_postVertexBufferView.BufferLocation = m_postVertexBuffer->GetGPUVirtualAddress();
+		m_postVertexBufferView.StrideInBytes = sizeof(PostVertex);
+		m_postVertexBufferView.SizeInBytes = vertexBufferSize;
+	}
 
-    // Create the constant buffer.
-    {
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(sizeof(SceneConstantBuffer) * FrameCount),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_sceneConstantBuffer)));
+	// Create the constant buffer.
+	{
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(sizeof(SceneConstantBuffer) * FrameCount),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_sceneConstantBuffer)));
 
-        NAME_D3D12_OBJECT(m_sceneConstantBuffer);
+		NAME_D3D12_OBJECT(m_sceneConstantBuffer);
 
-        // Describe and create constant buffer views.
-        D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
-        cbvDesc.BufferLocation = m_sceneConstantBuffer->GetGPUVirtualAddress();
-        cbvDesc.SizeInBytes = sizeof(SceneConstantBuffer);
+		// Describe and create constant buffer views.
+		D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
+		cbvDesc.BufferLocation = m_sceneConstantBuffer->GetGPUVirtualAddress();
+		cbvDesc.SizeInBytes = sizeof(SceneConstantBuffer);
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart(), 1, m_cbvSrvDescriptorSize);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart(), 1, m_cbvSrvDescriptorSize);
 
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            m_device->CreateConstantBufferView(&cbvDesc, cpuHandle);
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			m_device->CreateConstantBufferView(&cbvDesc, cpuHandle);
 
-            cbvDesc.BufferLocation += sizeof(SceneConstantBuffer);
-            cpuHandle.Offset(m_cbvSrvDescriptorSize);
-        }
+			cbvDesc.BufferLocation += sizeof(SceneConstantBuffer);
+			cpuHandle.Offset(m_cbvSrvDescriptorSize);
+		}
 
-        // Map and initialize the constant buffer. We don't unmap this until the
-        // app closes. Keeping things mapped for the lifetime of the resource is okay.
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_sceneConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbvDataBegin)));
-        memcpy(m_pCbvDataBegin, &m_sceneConstantBufferData, sizeof(m_sceneConstantBufferData));
-    }
+		// Map and initialize the constant buffer. We don't unmap this until the
+		// app closes. Keeping things mapped for the lifetime of the resource is okay.
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_sceneConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbvDataBegin)));
+		memcpy(m_pCbvDataBegin, &m_sceneConstantBufferData, sizeof(m_sceneConstantBufferData));
+	}
 
-    // Close the resource creation command list and execute it to begin the vertex buffer copy into
-    // the default heap.
-    ThrowIfFailed(commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the resource creation command list and execute it to begin the vertex buffer copy into
+	// the default heap.
+	ThrowIfFailed(commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValues[m_frameIndex]++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValues[m_frameIndex]++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute before continuing.
-        WaitForGpu();
-    }
+		// Wait for the command list to execute before continuing.
+		WaitForGpu();
+	}
 }
 
 void D3D12Fullscreen::LoadSizeDependentResources()
 {
-    UpdatePostViewAndScissor();
+	UpdatePostViewAndScissor();
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
+		// Create a RTV for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-            NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
-        }
-    }
+			NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
+		}
+	}
 
-    // Update resolutions shown in app title.
-    UpdateTitle();
+	// Update resolutions shown in app title.
+	UpdateTitle();
 
-    // This is where you would create/resize intermediate render targets, depth stencils, or other resources
-    // dependent on the window size.
+	// This is where you would create/resize intermediate render targets, depth stencils, or other resources
+	// dependent on the window size.
 }
 
 // Update frame-based values.
 void D3D12Fullscreen::OnUpdate()
 {
-    const float translationSpeed = 0.0001f;
-    const float offsetBounds = 1.0f;
+	const float translationSpeed = 0.0001f;
+	const float offsetBounds = 1.0f;
 
-    m_sceneConstantBufferData.offset.x += translationSpeed;
-    if (m_sceneConstantBufferData.offset.x > offsetBounds)
-    {
-        m_sceneConstantBufferData.offset.x = -offsetBounds;
-    }
+	m_sceneConstantBufferData.offset.x += translationSpeed;
+	if (m_sceneConstantBufferData.offset.x > offsetBounds)
+	{
+		m_sceneConstantBufferData.offset.x = -offsetBounds;
+	}
 
-    XMMATRIX transform = XMMatrixMultiply(
-        XMMatrixOrthographicLH(static_cast<float>(m_resolutionOptions[m_resolutionIndex].Width), static_cast<float>(m_resolutionOptions[m_resolutionIndex].Height), 0.0f, 100.0f),
-        XMMatrixTranslation(m_sceneConstantBufferData.offset.x, 0.0f, 0.0f));
+	XMMATRIX transform = XMMatrixMultiply(
+		XMMatrixOrthographicLH(static_cast<float>(m_resolutionOptions[m_resolutionIndex].Width), static_cast<float>(m_resolutionOptions[m_resolutionIndex].Height), 0.0f, 100.0f),
+		XMMatrixTranslation(m_sceneConstantBufferData.offset.x, 0.0f, 0.0f));
 
-    XMStoreFloat4x4(&m_sceneConstantBufferData.transform, XMMatrixTranspose(transform));
+	XMStoreFloat4x4(&m_sceneConstantBufferData.transform, XMMatrixTranspose(transform));
 
-    UINT offset = m_frameIndex * sizeof(SceneConstantBuffer);
-    memcpy(m_pCbvDataBegin + offset, &m_sceneConstantBufferData, sizeof(m_sceneConstantBufferData));
+	UINT offset = m_frameIndex * sizeof(SceneConstantBuffer);
+	memcpy(m_pCbvDataBegin + offset, &m_sceneConstantBufferData, sizeof(m_sceneConstantBufferData));
 }
 
 // Render the scene.
 void D3D12Fullscreen::OnRender()
 {
-    if (m_windowVisible)
+	if (m_windowVisible)
+	{
+        try
+        {
+            PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+
+            // Record all the commands we need to render the scene into the command lists.
+            PopulateCommandLists();
+
+            // Execute the command lists.
+            ID3D12CommandList* ppCommandLists[] = { m_sceneCommandList.Get(), m_postCommandList.Get() };
+            m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+
+            PIXEndEvent(m_commandQueue.Get());
+
+            // When using sync interval 0, it is recommended to always pass the tearing
+            // flag when it is supported, even when presenting in windowed mode.
+            // However, this flag cannot be used if the app is in fullscreen mode as a
+            // result of calling SetFullscreenState.
+            UINT presentFlags = (m_tearingSupport && m_windowedMode) ? DXGI_PRESENT_ALLOW_TEARING : 0;
+
+            // Present the frame.
+            ThrowIfFailed(m_swapChain->Present(0, presentFlags));
+
+            MoveToNextFrame();
+        }
+        catch (HrException& e)
+        {
+            if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
+            {
+                RestoreD3DResources();
+            }
+            else
+            {
+                throw;
+            }
+        }
+	}
+}
+
+// Release sample's D3D objects.
+void D3D12Fullscreen::ReleaseD3DResources()
+{
+    m_fence.Reset();
+    ResetComPtrArray(&m_renderTargets);
+    m_commandQueue.Reset();
+    m_swapChain.Reset();
+    m_device.Reset();
+}
+
+// Tears down D3D resources and reinitializes them.
+void D3D12Fullscreen::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
     {
-        PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
-
-        // Record all the commands we need to render the scene into the command lists.
-        PopulateCommandLists();
-
-        // Execute the command lists.
-        ID3D12CommandList* ppCommandLists[] = { m_sceneCommandList.Get(), m_postCommandList.Get() };
-        m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
-
-        PIXEndEvent(m_commandQueue.Get());
-
-        // When using sync interval 0, it is recommended to always pass the tearing
-        // flag when it is supported, even when presenting in windowed mode.
-        // However, this flag cannot be used if the app is in fullscreen mode as a
-        // result of calling SetFullscreenState.
-        UINT presentFlags = (m_tearingSupport && m_windowedMode) ? DXGI_PRESENT_ALLOW_TEARING : 0;
-
-        // Present the frame.
-        ThrowIfFailed(m_swapChain->Present(0, presentFlags));
-
-        MoveToNextFrame();
+        WaitForGpu();
     }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
 }
 
 void D3D12Fullscreen::OnSizeChanged(UINT width, UINT height, bool minimized)
 {
-    // Determine if the swap buffers and other resources need to be resized or not.
-    if ((width != m_width || height != m_height) && !minimized)
-    {
-        // Flush all current GPU commands.
-        WaitForGpu();
+	// Determine if the swap buffers and other resources need to be resized or not.
+	if ((width != m_width || height != m_height) && !minimized)
+	{
+		// Flush all current GPU commands.
+		WaitForGpu();
 
-        // Release the resources holding references to the swap chain (requirement of
-        // IDXGISwapChain::ResizeBuffers) and reset the frame fence values to the
-        // current fence value.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            m_renderTargets[n].Reset();
-            m_fenceValues[n] = m_fenceValues[m_frameIndex];
-        }
+		// Release the resources holding references to the swap chain (requirement of
+		// IDXGISwapChain::ResizeBuffers) and reset the frame fence values to the
+		// current fence value.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			m_renderTargets[n].Reset();
+			m_fenceValues[n] = m_fenceValues[m_frameIndex];
+		}
 
-        // Resize the swap chain to the desired dimensions.
-        DXGI_SWAP_CHAIN_DESC desc = {};
-        m_swapChain->GetDesc(&desc);
-        ThrowIfFailed(m_swapChain->ResizeBuffers(FrameCount, width, height, desc.BufferDesc.Format, desc.Flags));
+		// Resize the swap chain to the desired dimensions.
+		DXGI_SWAP_CHAIN_DESC desc = {};
+		m_swapChain->GetDesc(&desc);
+		ThrowIfFailed(m_swapChain->ResizeBuffers(FrameCount, width, height, desc.BufferDesc.Format, desc.Flags));
 
-        // Reset the frame index to the current back buffer index.
-        m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+		// Reset the frame index to the current back buffer index.
+		m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-        // Update the width, height, and aspect ratio member variables.
-        UpdateForSizeChange(width, height);
+		// Update the width, height, and aspect ratio member variables.
+		UpdateForSizeChange(width, height);
 
-        LoadSizeDependentResources();
-    }
+		LoadSizeDependentResources();
+	}
 
-    m_windowVisible = !minimized;
+	m_windowVisible = !minimized;
 }
 
 void D3D12Fullscreen::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForGpu();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForGpu();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12Fullscreen::OnKeyDown(UINT8 key)
 {
-    switch (key)
-    {
-    // Instrument the Space Bar to toggle between fullscreen states.
-    // The CoreWindow will fire a SizeChanged event once the window is in the
-    // fullscreen state. At that point, the IDXGISwapChain should be resized
-    // to match the new window size.
-    case VK_SPACE:
-    {
-        auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-        if (applicationView->IsFullScreenMode)
-        {
-            applicationView->ExitFullScreenMode();
-        }
-        else
-        {
-            applicationView->TryEnterFullScreenMode();
-        }
-        break;
-    }
+	switch (key)
+	{
+	// Instrument the Space Bar to toggle between fullscreen states.
+	// The CoreWindow will fire a SizeChanged event once the window is in the
+	// fullscreen state. At that point, the IDXGISwapChain should be resized
+	// to match the new window size.
+	case VK_SPACE:
+	{
+		auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+		if (applicationView->IsFullScreenMode)
+		{
+			applicationView->ExitFullScreenMode();
+		}
+		else
+		{
+			applicationView->TryEnterFullScreenMode();
+		}
+		break;
+	}
 
-    // Instrument the Right Arrow key to change the scene rendering resolution 
-    // to the next resolution option. 
-    case VK_RIGHT:
-    {
-        m_resolutionIndex = (m_resolutionIndex + 1) % m_resolutionOptionsCount;
+	// Instrument the Right Arrow key to change the scene rendering resolution 
+	// to the next resolution option. 
+	case VK_RIGHT:
+	{
+		m_resolutionIndex = (m_resolutionIndex + 1) % m_resolutionOptionsCount;
 
-        // Wait for the GPU to finish with the resources we're about to free.
-        WaitForGpu();
+		// Wait for the GPU to finish with the resources we're about to free.
+		WaitForGpu();
 
-        // Update resources dependent on the scene rendering resolution.
-        LoadSceneResolutionDependentResources();
-    }
-    break;
+		// Update resources dependent on the scene rendering resolution.
+		LoadSceneResolutionDependentResources();
+	}
+	break;
 
-    // Instrument the Left Arrow key to change the scene rendering resolution 
-    // to the previous resolution option.
-    case VK_LEFT:
-    {
-        if (m_resolutionIndex == 0)
-        {
-            m_resolutionIndex = m_resolutionOptionsCount - 1;
-        }
-        else
-        {
-            m_resolutionIndex--;
-        }
+	// Instrument the Left Arrow key to change the scene rendering resolution 
+	// to the previous resolution option.
+	case VK_LEFT:
+	{
+		if (m_resolutionIndex == 0)
+		{
+			m_resolutionIndex = m_resolutionOptionsCount - 1;
+		}
+		else
+		{
+			m_resolutionIndex--;
+		}
 
-        // Wait for the GPU to finish with the resources we're about to free.
-        WaitForGpu();
+		// Wait for the GPU to finish with the resources we're about to free.
+		WaitForGpu();
 
-        // Update resources dependent on the scene rendering resolution.
-        LoadSceneResolutionDependentResources();
-    }
-    break;
-    }
+		// Update resources dependent on the scene rendering resolution.
+		LoadSceneResolutionDependentResources();
+	}
+	break;
+	}
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12Fullscreen::PopulateCommandLists()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_sceneCommandAllocators[m_frameIndex]->Reset());
-    ThrowIfFailed(m_postCommandAllocators[m_frameIndex]->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_sceneCommandAllocators[m_frameIndex]->Reset());
+	ThrowIfFailed(m_postCommandAllocators[m_frameIndex]->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_sceneCommandList->Reset(m_sceneCommandAllocators[m_frameIndex].Get(), m_scenePipelineState.Get()));
-    ThrowIfFailed(m_postCommandList->Reset(m_postCommandAllocators[m_frameIndex].Get(), m_postPipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_sceneCommandList->Reset(m_sceneCommandAllocators[m_frameIndex].Get(), m_scenePipelineState.Get()));
+	ThrowIfFailed(m_postCommandList->Reset(m_postCommandAllocators[m_frameIndex].Get(), m_postPipelineState.Get()));
 
-    // Populate m_sceneCommandList to render scene to intermediate render target.
-    {
-        // Set necessary state.
-        m_sceneCommandList->SetGraphicsRootSignature(m_sceneRootSignature.Get());
+	// Populate m_sceneCommandList to render scene to intermediate render target.
+	{
+		// Set necessary state.
+		m_sceneCommandList->SetGraphicsRootSignature(m_sceneRootSignature.Get());
 
-        ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvHeap.Get() };
-        m_sceneCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+		ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvHeap.Get() };
+		m_sceneCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-        CD3DX12_GPU_DESCRIPTOR_HANDLE cbvHandle(m_cbvSrvHeap->GetGPUDescriptorHandleForHeapStart(), m_frameIndex + 1, m_cbvSrvDescriptorSize);
-        m_sceneCommandList->SetGraphicsRootDescriptorTable(0, cbvHandle);
-        m_sceneCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-        m_sceneCommandList->RSSetViewports(1, &m_sceneViewport);
-        m_sceneCommandList->RSSetScissorRects(1, &m_sceneScissorRect);
+		CD3DX12_GPU_DESCRIPTOR_HANDLE cbvHandle(m_cbvSrvHeap->GetGPUDescriptorHandleForHeapStart(), m_frameIndex + 1, m_cbvSrvDescriptorSize);
+		m_sceneCommandList->SetGraphicsRootDescriptorTable(0, cbvHandle);
+		m_sceneCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+		m_sceneCommandList->RSSetViewports(1, &m_sceneViewport);
+		m_sceneCommandList->RSSetScissorRects(1, &m_sceneScissorRect);
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSize);
-        m_sceneCommandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSize);
+		m_sceneCommandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-        // Record commands.
-        m_sceneCommandList->ClearRenderTargetView(rtvHandle, ClearColor, 0, nullptr);
-        m_sceneCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-        m_sceneCommandList->IASetVertexBuffers(0, 1, &m_sceneVertexBufferView);
+		// Record commands.
+		m_sceneCommandList->ClearRenderTargetView(rtvHandle, ClearColor, 0, nullptr);
+		m_sceneCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+		m_sceneCommandList->IASetVertexBuffers(0, 1, &m_sceneVertexBufferView);
 
-        PIXBeginEvent(m_sceneCommandList.Get(), 0, L"Draw a thin rectangle");
-        m_sceneCommandList->DrawInstanced(4, 1, 0, 0);
-        PIXEndEvent(m_sceneCommandList.Get());
-    }
+		PIXBeginEvent(m_sceneCommandList.Get(), 0, L"Draw a thin rectangle");
+		m_sceneCommandList->DrawInstanced(4, 1, 0, 0);
+		PIXEndEvent(m_sceneCommandList.Get());
+	}
 
-    ThrowIfFailed(m_sceneCommandList->Close());
+	ThrowIfFailed(m_sceneCommandList->Close());
 
-    // Populate m_postCommandList to scale intermediate render target to screen.
-    {
-        // Set necessary state.
-        m_postCommandList->SetGraphicsRootSignature(m_postRootSignature.Get());
+	// Populate m_postCommandList to scale intermediate render target to screen.
+	{
+		// Set necessary state.
+		m_postCommandList->SetGraphicsRootSignature(m_postRootSignature.Get());
 
-        ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvHeap.Get() };
-        m_postCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+		ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvHeap.Get() };
+		m_postCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-        // Indicate that the back buffer will be used as a render target and the
-        // intermediate render target will be used as a SRV.
-        D3D12_RESOURCE_BARRIER barriers[] = {
-            CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET),
-            CD3DX12_RESOURCE_BARRIER::Transition(m_intermediateRenderTarget.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE)
-        };
+		// Indicate that the back buffer will be used as a render target and the
+		// intermediate render target will be used as a SRV.
+		D3D12_RESOURCE_BARRIER barriers[] = {
+			CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET),
+			CD3DX12_RESOURCE_BARRIER::Transition(m_intermediateRenderTarget.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE)
+		};
 
-        m_postCommandList->ResourceBarrier(_countof(barriers), barriers);
+		m_postCommandList->ResourceBarrier(_countof(barriers), barriers);
 
-        m_postCommandList->SetGraphicsRootDescriptorTable(0, m_cbvSrvHeap->GetGPUDescriptorHandleForHeapStart());
-        m_postCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-        m_postCommandList->RSSetViewports(1, &m_postViewport);
-        m_postCommandList->RSSetScissorRects(1, &m_postScissorRect);
+		m_postCommandList->SetGraphicsRootDescriptorTable(0, m_cbvSrvHeap->GetGPUDescriptorHandleForHeapStart());
+		m_postCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+		m_postCommandList->RSSetViewports(1, &m_postViewport);
+		m_postCommandList->RSSetScissorRects(1, &m_postScissorRect);
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-        m_postCommandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+		m_postCommandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-        // Record commands.
-        m_postCommandList->ClearRenderTargetView(rtvHandle, LetterboxColor, 0, nullptr);
-        m_postCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-        m_postCommandList->IASetVertexBuffers(0, 1, &m_postVertexBufferView);
+		// Record commands.
+		m_postCommandList->ClearRenderTargetView(rtvHandle, LetterboxColor, 0, nullptr);
+		m_postCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+		m_postCommandList->IASetVertexBuffers(0, 1, &m_postVertexBufferView);
 
-        PIXBeginEvent(m_postCommandList.Get(), 0, L"Draw texture to screen.");
-        m_postCommandList->DrawInstanced(4, 1, 0, 0);
-        PIXEndEvent(m_postCommandList.Get());
+		PIXBeginEvent(m_postCommandList.Get(), 0, L"Draw texture to screen.");
+		m_postCommandList->DrawInstanced(4, 1, 0, 0);
+		PIXEndEvent(m_postCommandList.Get());
 
-        // Revert resource states back to original values.
-        barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-        barriers[0].Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
-        barriers[1].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-        barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+		// Revert resource states back to original values.
+		barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+		barriers[0].Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
+		barriers[1].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+		barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
 
-        m_postCommandList->ResourceBarrier(_countof(barriers), barriers);
-    }
+		m_postCommandList->ResourceBarrier(_countof(barriers), barriers);
+	}
 
-    ThrowIfFailed(m_postCommandList->Close());
+	ThrowIfFailed(m_postCommandList->Close());
 }
 
 // Wait for pending GPU work to complete.
 void D3D12Fullscreen::WaitForGpu()
 {
-    // Schedule a Signal command in the queue.
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
+	// Schedule a Signal command in the queue.
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
 
-    // Wait until the fence has been processed.
-    ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-    WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	// Wait until the fence has been processed.
+	ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+	WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
 
-    // Increment the fence value for the current frame.
-    m_fenceValues[m_frameIndex]++;
+	// Increment the fence value for the current frame.
+	m_fenceValues[m_frameIndex]++;
 }
 
 // Prepare to render the next frame.
 void D3D12Fullscreen::MoveToNextFrame()
 {
-    // Schedule a Signal command in the queue.
-    const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
+	// Schedule a Signal command in the queue.
+	const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
 
-    // Update the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Update the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-        WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+		WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	}
 
-    // Set the fence value for the next frame.
-    m_fenceValues[m_frameIndex] = currentFenceValue + 1;
+	// Set the fence value for the next frame.
+	m_fenceValues[m_frameIndex] = currentFenceValue + 1;
 }
 
 // Set up the screen viewport and scissor rect to match the current window size and scene rendering resolution.
 void D3D12Fullscreen::UpdatePostViewAndScissor()
 {
-    float viewWidthRatio = static_cast<float>(m_resolutionOptions[m_resolutionIndex].Width) / m_width;
-    float viewHeightRatio = static_cast<float>(m_resolutionOptions[m_resolutionIndex].Height) / m_height;
+	float viewWidthRatio = static_cast<float>(m_resolutionOptions[m_resolutionIndex].Width) / m_width;
+	float viewHeightRatio = static_cast<float>(m_resolutionOptions[m_resolutionIndex].Height) / m_height;
 
-    float x = 1.0f;
-    float y = 1.0f;
+	float x = 1.0f;
+	float y = 1.0f;
 
-    if (viewWidthRatio < viewHeightRatio)
-    {
-        // The scaled image's height will fit to the viewport's height and 
-        // its width will be smaller than the viewport's width.
-        x = viewWidthRatio / viewHeightRatio;
-    }
-    else
-    {
-        // The scaled image's width will fit to the viewport's width and 
-        // its height may be smaller than the viewport's height.
-        y = viewHeightRatio / viewWidthRatio;
-    }
+	if (viewWidthRatio < viewHeightRatio)
+	{
+		// The scaled image's height will fit to the viewport's height and 
+		// its width will be smaller than the viewport's width.
+		x = viewWidthRatio / viewHeightRatio;
+	}
+	else
+	{
+		// The scaled image's width will fit to the viewport's width and 
+		// its height may be smaller than the viewport's height.
+		y = viewHeightRatio / viewWidthRatio;
+	}
 
-    m_postViewport.TopLeftX = m_width * (1.0f - x) / 2.0f;
-    m_postViewport.TopLeftY = m_height * (1.0f - y) / 2.0f;
-    m_postViewport.Width = x * m_width;
-    m_postViewport.Height = y * m_height;
+	m_postViewport.TopLeftX = m_width * (1.0f - x) / 2.0f;
+	m_postViewport.TopLeftY = m_height * (1.0f - y) / 2.0f;
+	m_postViewport.Width = x * m_width;
+	m_postViewport.Height = y * m_height;
 
-    m_postScissorRect.left = static_cast<LONG>(m_postViewport.TopLeftX);
-    m_postScissorRect.right = static_cast<LONG>(m_postViewport.TopLeftX + m_postViewport.Width);
-    m_postScissorRect.top = static_cast<LONG>(m_postViewport.TopLeftY);
-    m_postScissorRect.bottom = static_cast<LONG>(m_postViewport.TopLeftY + m_postViewport.Height);
+	m_postScissorRect.left = static_cast<LONG>(m_postViewport.TopLeftX);
+	m_postScissorRect.right = static_cast<LONG>(m_postViewport.TopLeftX + m_postViewport.Width);
+	m_postScissorRect.top = static_cast<LONG>(m_postViewport.TopLeftY);
+	m_postScissorRect.bottom = static_cast<LONG>(m_postViewport.TopLeftY + m_postViewport.Height);
 }
 
 // Set up appropriate views for the intermediate render target.
 void D3D12Fullscreen::LoadSceneResolutionDependentResources()
 {
-    // Update resolutions shown in app title.
-    UpdateTitle();
+	// Update resolutions shown in app title.
+	UpdateTitle();
 
-    // Set up the scene viewport and scissor rect to match the current scene rendering resolution.
-    {
-        m_sceneViewport.Width = static_cast<float>(m_resolutionOptions[m_resolutionIndex].Width);
-        m_sceneViewport.Height = static_cast<float>(m_resolutionOptions[m_resolutionIndex].Height);
+	// Set up the scene viewport and scissor rect to match the current scene rendering resolution.
+	{
+		m_sceneViewport.Width = static_cast<float>(m_resolutionOptions[m_resolutionIndex].Width);
+		m_sceneViewport.Height = static_cast<float>(m_resolutionOptions[m_resolutionIndex].Height);
 
-        m_sceneScissorRect.right = static_cast<LONG>(m_resolutionOptions[m_resolutionIndex].Width);
-        m_sceneScissorRect.bottom = static_cast<LONG>(m_resolutionOptions[m_resolutionIndex].Height);
-    }
+		m_sceneScissorRect.right = static_cast<LONG>(m_resolutionOptions[m_resolutionIndex].Width);
+		m_sceneScissorRect.bottom = static_cast<LONG>(m_resolutionOptions[m_resolutionIndex].Height);
+	}
 
-    // Update post-process viewport and scissor rectangle.
-    UpdatePostViewAndScissor();
+	// Update post-process viewport and scissor rectangle.
+	UpdatePostViewAndScissor();
 
-    // Create RTV for the intermediate render target.
-    {
-        D3D12_RESOURCE_DESC swapChainDesc = m_renderTargets[m_frameIndex]->GetDesc();
-        const CD3DX12_CLEAR_VALUE clearValue(swapChainDesc.Format, ClearColor);
-        const CD3DX12_RESOURCE_DESC renderTargetDesc = CD3DX12_RESOURCE_DESC::Tex2D(
-            swapChainDesc.Format,
-            m_resolutionOptions[m_resolutionIndex].Width,
-            m_resolutionOptions[m_resolutionIndex].Height,
-            1u, 1u,
-            swapChainDesc.SampleDesc.Count,
-            swapChainDesc.SampleDesc.Quality,
-            D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET,
-            D3D12_TEXTURE_LAYOUT_UNKNOWN, 0u);
+	// Create RTV for the intermediate render target.
+	{
+		D3D12_RESOURCE_DESC swapChainDesc = m_renderTargets[m_frameIndex]->GetDesc();
+		const CD3DX12_CLEAR_VALUE clearValue(swapChainDesc.Format, ClearColor);
+		const CD3DX12_RESOURCE_DESC renderTargetDesc = CD3DX12_RESOURCE_DESC::Tex2D(
+			swapChainDesc.Format,
+			m_resolutionOptions[m_resolutionIndex].Width,
+			m_resolutionOptions[m_resolutionIndex].Height,
+			1u, 1u,
+			swapChainDesc.SampleDesc.Count,
+			swapChainDesc.SampleDesc.Quality,
+			D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET,
+			D3D12_TEXTURE_LAYOUT_UNKNOWN, 0u);
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSize);
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &renderTargetDesc,
-            D3D12_RESOURCE_STATE_RENDER_TARGET,
-            &clearValue,
-            IID_PPV_ARGS(&m_intermediateRenderTarget)));
-        m_device->CreateRenderTargetView(m_intermediateRenderTarget.Get(), nullptr, rtvHandle);
-        NAME_D3D12_OBJECT(m_intermediateRenderTarget);
-    }
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSize);
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&renderTargetDesc,
+			D3D12_RESOURCE_STATE_RENDER_TARGET,
+			&clearValue,
+			IID_PPV_ARGS(&m_intermediateRenderTarget)));
+		m_device->CreateRenderTargetView(m_intermediateRenderTarget.Get(), nullptr, rtvHandle);
+		NAME_D3D12_OBJECT(m_intermediateRenderTarget);
+	}
 
-    // Create SRV for the intermediate render target.
-    m_device->CreateShaderResourceView(m_intermediateRenderTarget.Get(), nullptr, m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create SRV for the intermediate render target.
+	m_device->CreateShaderResourceView(m_intermediateRenderTarget.Get(), nullptr, m_cbvSrvHeap->GetCPUDescriptorHandleForHeapStart());
 }
 
 void D3D12Fullscreen::UpdateTitle() 
 {
-    // Update resolutions shown in app title.
-    wchar_t updatedTitle[256];
-    swprintf_s(updatedTitle, L"( %u x %u ) scaled to ( %u x %u )", m_resolutionOptions[m_resolutionIndex].Width, m_resolutionOptions[m_resolutionIndex].Height, m_width, m_height);
-    SetCustomWindowText(updatedTitle);
+	// Update resolutions shown in app title.
+	wchar_t updatedTitle[256];
+	swprintf_s(updatedTitle, L"( %u x %u ) scaled to ( %u x %u )", m_resolutionOptions[m_resolutionIndex].Width, m_resolutionOptions[m_resolutionIndex].Height, m_width, m_height);
+	SetCustomWindowText(updatedTitle);
 }
 
 void D3D12Fullscreen::OnWindowMoved(int, int)

--- a/Samples/UWP/D3D12Fullscreen/src/D3D12Fullscreen.h
+++ b/Samples/UWP/D3D12Fullscreen/src/D3D12Fullscreen.h
@@ -26,104 +26,106 @@ using Microsoft::WRL::ComPtr;
 class D3D12Fullscreen : public DXSample
 {
 public:
-    D3D12Fullscreen(UINT width, UINT height, std::wstring name);
+	D3D12Fullscreen(UINT width, UINT height, std::wstring name);
 
 protected:
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
     virtual void OnWindowMoved(int, int);
-    virtual void OnDestroy();
-    virtual void OnKeyDown(UINT8 key);
+	virtual void OnDestroy();
+	virtual void OnKeyDown(UINT8 key);
     virtual IDXGISwapChain* GetSwapchain() { return m_swapChain.Get(); }
 
 private:
-    static const UINT FrameCount = 2;
-    static const float QuadWidth;
-    static const float QuadHeight;
-    static const float LetterboxColor[4];
-    static const float ClearColor[4];
+	static const UINT FrameCount = 2;
+	static const float QuadWidth;
+	static const float QuadHeight;
+	static const float LetterboxColor[4];
+	static const float ClearColor[4];
 
-    struct SceneVertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT4 color;
-    };
+	struct SceneVertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT4 color;
+	};
 
-    struct PostVertex
-    {
-        XMFLOAT4 position;
-        XMFLOAT2 uv;
-    };
+	struct PostVertex
+	{
+		XMFLOAT4 position;
+		XMFLOAT2 uv;
+	};
 
-    struct SceneConstantBuffer
-    {
-        XMFLOAT4X4 transform;
-        XMFLOAT4 offset;
-        UINT padding[44];
-    }; 
-    
-    struct Resolution
-    {
-        UINT Width;
-        UINT Height;
-    };
+	struct SceneConstantBuffer
+	{
+		XMFLOAT4X4 transform;
+		XMFLOAT4 offset;
+		UINT padding[44];
+	}; 
+	
+	struct Resolution
+	{
+		UINT Width;
+		UINT Height;
+	};
 
-    static const Resolution m_resolutionOptions[];
-    static const UINT m_resolutionOptionsCount;
-    static UINT m_resolutionIndex; // Index of the current scene rendering resolution from m_resolutionOptions.
+	static const Resolution m_resolutionOptions[];
+	static const UINT m_resolutionOptionsCount;
+	static UINT m_resolutionIndex; // Index of the current scene rendering resolution from m_resolutionOptions.
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_sceneViewport;
-    CD3DX12_VIEWPORT m_postViewport;
-    CD3DX12_RECT m_sceneScissorRect;
-    CD3DX12_RECT m_postScissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12Resource> m_intermediateRenderTarget;
-    ComPtr<ID3D12CommandAllocator> m_sceneCommandAllocators[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_postCommandAllocators[FrameCount];
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_sceneRootSignature;
-    ComPtr<ID3D12RootSignature> m_postRootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_cbvSrvHeap;
-    ComPtr<ID3D12PipelineState> m_scenePipelineState;
-    ComPtr<ID3D12PipelineState> m_postPipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_sceneCommandList;
-    ComPtr<ID3D12GraphicsCommandList> m_postCommandList;
-    UINT m_rtvDescriptorSize;
-    UINT m_cbvSrvDescriptorSize;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_sceneViewport;
+	CD3DX12_VIEWPORT m_postViewport;
+	CD3DX12_RECT m_sceneScissorRect;
+	CD3DX12_RECT m_postScissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12Resource> m_intermediateRenderTarget;
+	ComPtr<ID3D12CommandAllocator> m_sceneCommandAllocators[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_postCommandAllocators[FrameCount];
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_sceneRootSignature;
+	ComPtr<ID3D12RootSignature> m_postRootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_cbvSrvHeap;
+	ComPtr<ID3D12PipelineState> m_scenePipelineState;
+	ComPtr<ID3D12PipelineState> m_postPipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_sceneCommandList;
+	ComPtr<ID3D12GraphicsCommandList> m_postCommandList;
+	UINT m_rtvDescriptorSize;
+	UINT m_cbvSrvDescriptorSize;
 
-    // App resources.
-    ComPtr<ID3D12Resource> m_sceneVertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_sceneVertexBufferView;
-    ComPtr<ID3D12Resource> m_postVertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_postVertexBufferView;
-    ComPtr<ID3D12Resource> m_sceneConstantBuffer;
-    SceneConstantBuffer m_sceneConstantBufferData;
-    UINT8* m_pCbvDataBegin;
+	// App resources.
+	ComPtr<ID3D12Resource> m_sceneVertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_sceneVertexBufferView;
+	ComPtr<ID3D12Resource> m_postVertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_postVertexBufferView;
+	ComPtr<ID3D12Resource> m_sceneConstantBuffer;
+	SceneConstantBuffer m_sceneConstantBufferData;
+	UINT8* m_pCbvDataBegin;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValues[FrameCount];
+	// Synchronization objects.
+	UINT m_frameIndex;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValues[FrameCount];
 
-    // Track the state of the window.
-    // If it's minimized the app may decide not to render frames.
-    bool m_windowVisible;
-    bool m_windowedMode;
+	// Track the state of the window.
+	// If it's minimized the app may decide not to render frames.
+	bool m_windowVisible;
+	bool m_windowedMode;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void LoadSizeDependentResources();
-    void LoadSceneResolutionDependentResources();
-    void PopulateCommandLists();
-    void WaitForGpu();
-    void MoveToNextFrame();
-    void UpdatePostViewAndScissor();
-    void UpdateTitle();
+	void LoadPipeline();
+	void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
+	void LoadSizeDependentResources();
+	void LoadSceneResolutionDependentResources();
+	void PopulateCommandLists();
+	void WaitForGpu();
+	void MoveToNextFrame();
+	void UpdatePostViewAndScissor();
+	void UpdateTitle();
 };

--- a/Samples/UWP/D3D12Fullscreen/src/DXSample.cpp
+++ b/Samples/UWP/D3D12Fullscreen/src/DXSample.cpp
@@ -52,33 +52,78 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
+
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+            }
+#if !defined(_XBOX_ONE)
+        }
+#endif
 
     *ppAdapter = adapter.Detach();
-}
+    }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)

--- a/Samples/UWP/D3D12Fullscreen/src/DXSample.h
+++ b/Samples/UWP/D3D12Fullscreen/src/DXSample.h
@@ -48,7 +48,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/UWP/D3D12Fullscreen/src/Main.cpp
+++ b/Samples/UWP/D3D12Fullscreen/src/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12Fullscreen sample(1200, 900, L"Press the SPACE bar to toggle fullscreen mode and use the left and right arrow keys to change the rendering resolution");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12Fullscreen sample(1200, 900, L"Press the SPACE bar to toggle fullscreen mode and use the left and right arrow keys to change the rendering resolution");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12Fullscreen/src/View.cpp
+++ b/Samples/UWP/D3D12Fullscreen/src/View.cpp
@@ -17,61 +17,61 @@ using namespace Windows::System;
 
 inline int ConvertToPixels(float dimension, float dpi)
 {
-    return static_cast<int>(dimension * dpi / 96.0f + 0.5f);
+	return static_cast<int>(dimension * dpi / 96.0f + 0.5f);
 }
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false),
-    m_windowResizing(false),
-    m_windowVisible(true),
-    m_logicalWidth(0),
-    m_logicalHeight(0)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false),
+	m_windowResizing(false),
+	m_windowVisible(true),
+	m_logicalWidth(0),
+	m_logicalHeight(0)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    m_logicalWidth = window->Bounds.Width;
-    m_logicalHeight = window->Bounds.Height;
+	m_logicalWidth = window->Bounds.Width;
+	m_logicalHeight = window->Bounds.Height;
 
     auto dispatcher = CoreWindow::GetForCurrentThread()->Dispatcher;
     dispatcher->AcceleratorKeyActivated +=
         ref new TypedEventHandler<CoreDispatcher^, AcceleratorKeyEventArgs^>(this, &View::OnAcceleratorKeyActivated);
 
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->SizeChanged += ref new TypedEventHandler<CoreWindow^, WindowSizeChangedEventArgs^>(this, &View::OnSizeChanged);
-    window->VisibilityChanged += ref new TypedEventHandler<CoreWindow^, VisibilityChangedEventArgs^>(this, &View::OnVisibilityChanged);
-    window->Closed += ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &View::OnClosed);
-    window->PointerMoved += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerMoved);
-    window->PointerPressed += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerPressed);
-    window->PointerReleased += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerReleased);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->SizeChanged += ref new TypedEventHandler<CoreWindow^, WindowSizeChangedEventArgs^>(this, &View::OnSizeChanged);
+	window->VisibilityChanged += ref new TypedEventHandler<CoreWindow^, VisibilityChangedEventArgs^>(this, &View::OnVisibilityChanged);
+	window->Closed += ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &View::OnClosed);
+	window->PointerMoved += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerMoved);
+	window->PointerPressed += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerPressed);
+	window->PointerReleased += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerReleased);
 
-    try
-    {
-        window->ResizeStarted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeStarted);
-        window->ResizeCompleted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeCompleted);
-    }
-    catch (Exception^ e)
-    {
-        // Requires Windows 10 Creators Update (10.0.15063) or later.
-    }
+	try
+	{
+		window->ResizeStarted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeStarted);
+		window->ResizeCompleted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeCompleted);
+	}
+	catch (Exception^ e)
+	{
+		// Requires Windows 10 Creators Update (10.0.15063) or later.
+	}
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 
-    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-    displayInformation->DpiChanged += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDpiChanged);
-    displayInformation->DisplayContentsInvalidated += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDisplayContentsInvalidated);
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	displayInformation->DpiChanged += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDpiChanged);
+	displayInformation->DisplayContentsInvalidated += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDisplayContentsInvalidated);
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -80,20 +80,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -102,15 +102,15 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
     if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnAcceleratorKeyActivated(CoreDispatcher^, AcceleratorKeyEventArgs^ args)
@@ -138,97 +138,97 @@ void View::OnAcceleratorKeyActivated(CoreDispatcher^, AcceleratorKeyEventArgs^ a
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnSizeChanged(CoreWindow^ /*window*/, WindowSizeChangedEventArgs^ args)
 {
-    m_logicalWidth = args->Size.Width;
-    m_logicalHeight = args->Size.Height;
+	m_logicalWidth = args->Size.Width;
+	m_logicalHeight = args->Size.Height;
 
-    if (!m_windowResizing)
-    {
-        UpdateWindowSize();
-    }
+	if (!m_windowResizing)
+	{
+		UpdateWindowSize();
+	}
 }
 
 void View::OnResizeStarted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
 {
-    m_windowResizing = true;
+	m_windowResizing = true;
 }
 
 void View::OnResizeCompleted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
 {
-    m_windowResizing = false;
-    UpdateWindowSize();
+	m_windowResizing = false;
+	UpdateWindowSize();
 }
 
 void View::OnDpiChanged(DisplayInformation^ /*sender*/, Object^ /*args*/)
 {
-    UpdateWindowSize();
+	UpdateWindowSize();
 }
 
 void View::OnVisibilityChanged(CoreWindow^ /*window*/, VisibilityChangedEventArgs^ args)
 {
-    m_windowVisible = args->Visible;
-    UpdateWindowSize();
+	m_windowVisible = args->Visible;
+	UpdateWindowSize();
 }
 
 void View::OnClosed(CoreWindow^ /*window*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }
 
 void View::OnPointerMoved(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
-    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-    float dpi = displayInformation->LogicalDpi;
-    m_pSample->OnMouseMove(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	float dpi = displayInformation->LogicalDpi;
+	m_pSample->OnMouseMove(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
 }
 
 void View::OnPointerPressed(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
-    // For simplicity, we only consider left button press here.
-    if(args->CurrentPoint->Properties->IsLeftButtonPressed)
-    {
-        DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-        float dpi = displayInformation->LogicalDpi;
-        m_pSample->OnLeftButtonDown(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
-    }
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonDown(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
 }
 
 void View::OnPointerReleased(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
-    // For simplicity, we only consider left button press here.
-    if(args->CurrentPoint->Properties->IsLeftButtonPressed)
-    {
-        DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-        float dpi = displayInformation->LogicalDpi;
-        m_pSample->OnLeftButtonUp(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
-    }
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonUp(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
 }
 
 void View::UpdateWindowSize()
 {
-    CoreWindow^ window = CoreWindow::GetForCurrentThread();
-    Windows::Foundation::Rect windowBounds = window->Bounds;
+	CoreWindow^ window = CoreWindow::GetForCurrentThread();
+	Windows::Foundation::Rect windowBounds = window->Bounds;
 
-    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-    float dpi = displayInformation->LogicalDpi;
-    
-    m_pSample->SetWindowBounds(
-        ConvertToPixels(windowBounds.Left, dpi),
-        ConvertToPixels(windowBounds.Top, dpi),
-        ConvertToPixels(windowBounds.Right, dpi),
-        ConvertToPixels(windowBounds.Bottom, dpi));
-        
-    m_pSample->OnSizeChanged(ConvertToPixels(m_logicalWidth, dpi), ConvertToPixels(m_logicalHeight, dpi), !m_windowVisible);
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	float dpi = displayInformation->LogicalDpi;
+	
+	m_pSample->SetWindowBounds(
+		ConvertToPixels(windowBounds.Left, dpi),
+		ConvertToPixels(windowBounds.Top, dpi),
+		ConvertToPixels(windowBounds.Right, dpi),
+		ConvertToPixels(windowBounds.Bottom, dpi));
+		
+	m_pSample->OnSizeChanged(ConvertToPixels(m_logicalWidth, dpi), ConvertToPixels(m_logicalHeight, dpi), !m_windowVisible);
 }
 
 void View::OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args)
 {
-    m_pSample->OnDisplayChanged();
+	m_pSample->OnDisplayChanged();
 }

--- a/Samples/UWP/D3D12Fullscreen/src/View.h
+++ b/Samples/UWP/D3D12Fullscreen/src/View.h
@@ -24,36 +24,36 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
     void OnAcceleratorKeyActivated(CoreDispatcher^, AcceleratorKeyEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ args);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ args);
-    void OnSizeChanged(CoreWindow^ window, WindowSizeChangedEventArgs^ args);
-    void OnResizeStarted(CoreWindow^ window, Object^ args);
-    void OnResizeCompleted(CoreWindow^ window, Object^ args);
-    void OnDpiChanged(DisplayInformation^ sender, Object^ args);
-    void OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args);
-    void OnClosed(CoreWindow^ window, CoreWindowEventArgs^ args);
-    void OnPointerMoved(CoreWindow^ window, PointerEventArgs^ args);
-    void OnPointerPressed(CoreWindow^ window, PointerEventArgs^ args);
-    void OnPointerReleased(CoreWindow^ window, PointerEventArgs^ args);
-    void OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args);
-    
-    void UpdateWindowSize();
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ args);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ args);
+	void OnSizeChanged(CoreWindow^ window, WindowSizeChangedEventArgs^ args);
+	void OnResizeStarted(CoreWindow^ window, Object^ args);
+	void OnResizeCompleted(CoreWindow^ window, Object^ args);
+	void OnDpiChanged(DisplayInformation^ sender, Object^ args);
+	void OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args);
+	void OnClosed(CoreWindow^ window, CoreWindowEventArgs^ args);
+	void OnPointerMoved(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerPressed(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerReleased(CoreWindow^ window, PointerEventArgs^ args);
+	void OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args);
+	
+	void UpdateWindowSize();
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
-    bool m_windowResizing;
-    bool m_windowVisible;
-    float m_logicalWidth;
-    float m_logicalHeight;
+	DXSample* m_pSample;
+	bool m_windowClosed;
+	bool m_windowResizing;
+	bool m_windowVisible;
+	float m_logicalWidth;
+	float m_logicalHeight;
 };

--- a/Samples/UWP/D3D12Fullscreen/src/ViewProvider.cpp
+++ b/Samples/UWP/D3D12Fullscreen/src/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12Fullscreen/src/ViewProvider.h
+++ b/Samples/UWP/D3D12Fullscreen/src/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12Fullscreen/src/d3dx12.h
+++ b/Samples/UWP/D3D12Fullscreen/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12Fullscreen/src/postShaders.hlsl
+++ b/Samples/UWP/D3D12Fullscreen/src/postShaders.hlsl
@@ -14,22 +14,22 @@ SamplerState g_sampler : register(s0);
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 // A pass-through function for the texture coordinate data.
 PSInput VSMain(float4 position : POSITION, float2 uv : TEXCOORD)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.uv = uv;
+	result.position = position;
+	result.uv = uv;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return g_texture.Sample(g_sampler, input.uv);
+	return g_texture.Sample(g_sampler, input.uv);
 }

--- a/Samples/UWP/D3D12Fullscreen/src/sceneShaders.hlsl
+++ b/Samples/UWP/D3D12Fullscreen/src/sceneShaders.hlsl
@@ -11,27 +11,27 @@
 
 cbuffer SceneConstantBuffer : register(b0)
 {
-    float4x4 transform;
-    float4 offset;
+	float4x4 transform;
+	float4 offset;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VSMain(float4 position : POSITION, float4 color : COLOR)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = mul(position, transform);
-    result.color = color;
+	result.position = mul(position, transform);
+	result.color = color;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/UWP/D3D12HDR/src/D3D12HDR.cpp
+++ b/Samples/UWP/D3D12HDR/src/D3D12HDR.cpp
@@ -52,90 +52,90 @@ D3D12HDR::D3D12HDR(UINT width, UINT height, std::wstring name) :
     m_windowVisible(true),
     m_windowedMode(true)
 {
-    // Alias the root constants so that we can easily set them as either floats or UINTs.
-    m_rootConstantsF = reinterpret_cast<float*>(m_rootConstants);
+	// Alias the root constants so that we can easily set them as either floats or UINTs.
+	m_rootConstantsF = reinterpret_cast<float*>(m_rootConstants);
 }
 
 void D3D12HDR::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12HDR::LoadPipeline()
 {
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            m_dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			m_dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ThrowIfFailed(CreateDXGIFactory2(m_dxgiFactoryFlags, IID_PPV_ARGS(&m_dxgiFactory)));
+	ThrowIfFailed(CreateDXGIFactory2(m_dxgiFactoryFlags, IID_PPV_ARGS(&m_dxgiFactory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(m_dxgiFactory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(m_dxgiFactory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(m_dxgiFactory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(m_dxgiFactory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
-    NAME_D3D12_OBJECT(m_commandQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	NAME_D3D12_OBJECT(m_commandQueue);
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = m_swapChainFormats[m_currentSwapChainBitDepth];
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = m_swapChainFormats[m_currentSwapChainBitDepth];
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    // It is recommended to always use the tearing flag when it is available.
-    swapChainDesc.Flags = m_tearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
+	// It is recommended to always use the tearing flag when it is available.
+	swapChainDesc.Flags = m_tearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(m_dxgiFactory->CreateSwapChainForCoreWindow(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(m_dxgiFactory->CreateSwapChainForCoreWindow(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
+	ThrowIfFailed(swapChain.As(&m_swapChain));
     
     // Check display HDR support and initialize ST.2084 support to match the display's support.
     CheckDisplayHDRSupport();
@@ -143,425 +143,425 @@ void D3D12HDR::LoadPipeline()
     EnsureSwapChainColorSpace(m_currentSwapChainBitDepth, m_enableST2084);
     SetHDRMetaData(HDRMetaDataPool[m_hdrMetaDataPoolIdx][0], HDRMetaDataPool[m_hdrMetaDataPoolIdx][1], HDRMetaDataPool[m_hdrMetaDataPoolIdx][2], HDRMetaDataPool[m_hdrMetaDataPoolIdx][3]);
 
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount + 2;    // A descriptor for each frame + 2 intermediate render targets.
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount + 2;	// A descriptor for each frame + 2 intermediate render targets.
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a shader resource view (SRV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
-        srvHeapDesc.NumDescriptors = 2;                    // A descriptor for each of the 2 intermediate render targets.
-        srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
+		// Describe and create a shader resource view (SRV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
+		srvHeapDesc.NumDescriptors = 2;					// A descriptor for each of the 2 intermediate render targets.
+		srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-        m_srvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_srvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	}
 
-    // Create a command allocator for each frame.
-    for (UINT n = 0; n < FrameCount; n++)
-    {
-        ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
-    }
+	// Create a command allocator for each frame.
+	for (UINT n = 0; n < FrameCount; n++)
+	{
+		ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
+	}
 }
 
 // Load the sample assets.
 void D3D12HDR::LoadAssets()
 {
-    // Create a root signature containing root constants for brightness information
-    // and the desired output curve as well as a SRV descriptor table pointing to the
-    // intermediate render targets.
-    {
-        CD3DX12_DESCRIPTOR_RANGE ranges[1];
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 0);
+	// Create a root signature containing root constants for brightness information
+	// and the desired output curve as well as a SRV descriptor table pointing to the
+	// intermediate render targets.
+	{
+		CD3DX12_DESCRIPTOR_RANGE ranges[1];
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 0);
 
-        CD3DX12_ROOT_PARAMETER rootParameters[2];
-        rootParameters[0].InitAsConstants(4, 0);
-        rootParameters[1].InitAsDescriptorTable(1, &ranges[0]);
+		CD3DX12_ROOT_PARAMETER rootParameters[2];
+		rootParameters[0].InitAsConstants(4, 0);
+		rootParameters[1].InitAsDescriptorTable(1, &ranges[0]);
 
-        D3D12_STATIC_SAMPLER_DESC sampler = {};
-        sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
-        sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
-        sampler.MaxLOD = D3D12_FLOAT32_MAX;
-        sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+		D3D12_STATIC_SAMPLER_DESC sampler = {};
+		sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
+		sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
+		sampler.MaxLOD = D3D12_FLOAT32_MAX;
+		sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
 
-        // Allow input layout and deny uneccessary access to certain pipeline stages.
-        D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
-            D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS;
+		// Allow input layout and deny uneccessary access to certain pipeline stages.
+		D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
+			D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS;
 
-        CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init(_countof(rootParameters), rootParameters, 1, &sampler, rootSignatureFlags);
+		CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init(_countof(rootParameters), rootParameters, 1, &sampler, rootSignatureFlags);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+	}
 
-    // Create the pipeline state objects for the different views and render target formats
-    // as well as the intermediate blend step.
-    {
-        // Create the pipeline state for the scene geometry.
+	// Create the pipeline state objects for the different views and render target formats
+	// as well as the intermediate blend step.
+	{
+		// Create the pipeline state for the scene geometry.
 
-        D3D12_INPUT_ELEMENT_DESC gradientElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "COLOR", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+		D3D12_INPUT_ELEMENT_DESC gradientElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "COLOR", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        // Describe and create the graphics pipeline state objects (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { gradientElementDescs, _countof(gradientElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_gradientVS, sizeof(g_gradientVS));
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_gradientPS, sizeof(g_gradientPS));
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = m_intermediateRenderTargetFormat;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state objects (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { gradientElementDescs, _countof(gradientElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_gradientVS, sizeof(g_gradientVS));
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_gradientPS, sizeof(g_gradientPS));
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = m_intermediateRenderTargetFormat;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStates[GradientPSO])));
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStates[GradientPSO])));
 
-        // Create pipeline state for the color space triangles.
+		// Create pipeline state for the color space triangles.
 
-        D3D12_INPUT_ELEMENT_DESC colorElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+		D3D12_INPUT_ELEMENT_DESC colorElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        psoDesc.InputLayout = { colorElementDescs, _countof(colorElementDescs) };
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_paletteVS, sizeof(g_paletteVS));
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_palettePS, sizeof(g_palettePS));
-        psoDesc.RTVFormats[0] = m_intermediateRenderTargetFormat;
+		psoDesc.InputLayout = { colorElementDescs, _countof(colorElementDescs) };
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_paletteVS, sizeof(g_paletteVS));
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_palettePS, sizeof(g_palettePS));
+		psoDesc.RTVFormats[0] = m_intermediateRenderTargetFormat;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStates[PalettePSO])));
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStates[PalettePSO])));
 
-        // Create pipeline states for the final blend step.
-        // There will be one for each swap chain format the sample supports.
+		// Create pipeline states for the final blend step.
+		// There will be one for each swap chain format the sample supports.
 
-        D3D12_INPUT_ELEMENT_DESC quadElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+		D3D12_INPUT_ELEMENT_DESC quadElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        psoDesc.InputLayout = { quadElementDescs, _countof(quadElementDescs) };
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_presentVS, sizeof(g_presentVS));
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_presentPS, sizeof(g_presentPS));
-        psoDesc.RTVFormats[0] = m_swapChainFormats[_8];
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStates[Present8bitPSO])));
+		psoDesc.InputLayout = { quadElementDescs, _countof(quadElementDescs) };
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_presentVS, sizeof(g_presentVS));
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_presentPS, sizeof(g_presentPS));
+		psoDesc.RTVFormats[0] = m_swapChainFormats[_8];
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStates[Present8bitPSO])));
 
-        psoDesc.RTVFormats[0] = m_swapChainFormats[_10];
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStates[Present10bitPSO])));
+		psoDesc.RTVFormats[0] = m_swapChainFormats[_10];
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStates[Present10bitPSO])));
 
-        psoDesc.RTVFormats[0] = m_swapChainFormats[_16];
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStates[Present16bitPSO])));
-    }
+		psoDesc.RTVFormats[0] = m_swapChainFormats[_16];
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStates[Present16bitPSO])));
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), nullptr, IID_PPV_ARGS(&m_commandList)));
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), nullptr, IID_PPV_ARGS(&m_commandList)));
 
-    // Create the vertex buffer.
-    {
-        // Create geometry for the different sections of the render target.
-        GradientVertex gradientVertices[] =
-        {
-            // Upper strip. SDR Gradient from [0,1].
+	// Create the vertex buffer.
+	{
+		// Create geometry for the different sections of the render target.
+		GradientVertex gradientVertices[] =
+		{
+			// Upper strip. SDR Gradient from [0,1].
 
-            { { -1.0f, 0.45f, 0.0f }, { 0.0f, 0.0f, 0.0f } },
-            { { -1.0f, 0.55f, 0.0f }, { 0.0f, 0.0f, 0.0f } },
-            { { 0.0f, 0.45f, 0.0f }, { 1.0f, 1.0f, 1.0f } },
-            { { 0.0f, 0.55f, 0.0f }, { 1.0f, 1.0f, 1.0f } },
+			{ { -1.0f, 0.45f, 0.0f }, { 0.0f, 0.0f, 0.0f } },
+			{ { -1.0f, 0.55f, 0.0f }, { 0.0f, 0.0f, 0.0f } },
+			{ { 0.0f, 0.45f, 0.0f }, { 1.0f, 1.0f, 1.0f } },
+			{ { 0.0f, 0.55f, 0.0f }, { 1.0f, 1.0f, 1.0f } },
 
-            // Lower strip. HDR Gradient from [0,9]. Perceptually, 9.0 is about 3 times as bright as 1.0. (See gradientPS.hlsl.)
+			// Lower strip. HDR Gradient from [0,9]. Perceptually, 9.0 is about 3 times as bright as 1.0. (See gradientPS.hlsl.)
 
-            { { -1.0f, -0.55f, 0.0f }, { 0.0f, 0.0f, 0.0f } },
-            { { -1.0f, -0.45f, 0.0f }, { 0.0f, 0.0f, 0.0f } },
-            { { 0.0f, -0.55f, 0.0f }, { 3.0f, 3.0f, 3.0f } },
-            { { 0.0f, -0.45f, 0.0f }, { 3.0f, 3.0f, 3.0f } },
-        };
+			{ { -1.0f, -0.55f, 0.0f }, { 0.0f, 0.0f, 0.0f } },
+			{ { -1.0f, -0.45f, 0.0f }, { 0.0f, 0.0f, 0.0f } },
+			{ { 0.0f, -0.55f, 0.0f }, { 3.0f, 3.0f, 3.0f } },
+			{ { 0.0f, -0.45f, 0.0f }, { 3.0f, 3.0f, 3.0f } },
+		};
 
-        // The vertices for the color space triangles are dependent on the size of the
-        // render target and will not be loaded at this time. We'll leave a gap in the
-        // buffer that will be filled in later.
-        const UINT triangleVerticesSize = sizeof(TrianglesVertex) * TrianglesVertexCount;
-        m_updateVertexBuffer = true;
+		// The vertices for the color space triangles are dependent on the size of the
+		// render target and will not be loaded at this time. We'll leave a gap in the
+		// buffer that will be filled in later.
+		const UINT triangleVerticesSize = sizeof(TrianglesVertex) * TrianglesVertexCount;
+		m_updateVertexBuffer = true;
 
-        PresentVertex presentVertices[] =
-        {
-            // 1 triangle that fills the entire render target.
+		PresentVertex presentVertices[] =
+		{
+			// 1 triangle that fills the entire render target.
 
-            { { -1.0f, -3.0f, 0.0f }, { 0.0f, 2.0f } },    // Bottom left
-            { { -1.0f, 1.0f, 0.0f }, { 0.0f, 0.0f } },    // Top left
-            { { 3.0f, 1.0f, 0.0f }, { 2.0f, 0.0f } },    // Top right
-        };
+			{ { -1.0f, -3.0f, 0.0f }, { 0.0f, 2.0f } },	// Bottom left
+			{ { -1.0f, 1.0f, 0.0f }, { 0.0f, 0.0f } },	// Top left
+			{ { 3.0f, 1.0f, 0.0f }, { 2.0f, 0.0f } },	// Top right
+		};
 
-        const UINT vertexBufferSize = sizeof(gradientVertices) + triangleVerticesSize + sizeof(presentVertices);
+		const UINT vertexBufferSize = sizeof(gradientVertices) + triangleVerticesSize + sizeof(presentVertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap. It will be uploaded to the
-        // DEFAULT buffer when the color space triangle vertices are updated.
-        UINT8* mappedUploadHeap = nullptr;
-        ThrowIfFailed(m_vertexBufferUpload->Map(0, &CD3DX12_RANGE(0, 0), reinterpret_cast<void**>(&mappedUploadHeap)));
+		// Copy data to the intermediate upload heap. It will be uploaded to the
+		// DEFAULT buffer when the color space triangle vertices are updated.
+		UINT8* mappedUploadHeap = nullptr;
+		ThrowIfFailed(m_vertexBufferUpload->Map(0, &CD3DX12_RANGE(0, 0), reinterpret_cast<void**>(&mappedUploadHeap)));
 
-        memcpy(mappedUploadHeap, gradientVertices, sizeof(gradientVertices));
-        mappedUploadHeap += sizeof(gradientVertices) + triangleVerticesSize;
-        memcpy(mappedUploadHeap, presentVertices, sizeof(presentVertices));
+		memcpy(mappedUploadHeap, gradientVertices, sizeof(gradientVertices));
+		mappedUploadHeap += sizeof(gradientVertices) + triangleVerticesSize;
+		memcpy(mappedUploadHeap, presentVertices, sizeof(presentVertices));
 
-        m_vertexBufferUpload->Unmap(0, &CD3DX12_RANGE(0, 0));
+		m_vertexBufferUpload->Unmap(0, &CD3DX12_RANGE(0, 0));
 
-        // Initialize the vertex buffer views.
-        m_gradientVertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_gradientVertexBufferView.StrideInBytes = sizeof(GradientVertex);
-        m_gradientVertexBufferView.SizeInBytes = sizeof(gradientVertices);
+		// Initialize the vertex buffer views.
+		m_gradientVertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_gradientVertexBufferView.StrideInBytes = sizeof(GradientVertex);
+		m_gradientVertexBufferView.SizeInBytes = sizeof(gradientVertices);
 
-        m_trianglesVertexBufferView.BufferLocation = m_gradientVertexBufferView.BufferLocation + m_gradientVertexBufferView.SizeInBytes;
-        m_trianglesVertexBufferView.StrideInBytes = sizeof(TrianglesVertex);
-        m_trianglesVertexBufferView.SizeInBytes = triangleVerticesSize;
+		m_trianglesVertexBufferView.BufferLocation = m_gradientVertexBufferView.BufferLocation + m_gradientVertexBufferView.SizeInBytes;
+		m_trianglesVertexBufferView.StrideInBytes = sizeof(TrianglesVertex);
+		m_trianglesVertexBufferView.SizeInBytes = triangleVerticesSize;
 
-        m_presentVertexBufferView.BufferLocation = m_trianglesVertexBufferView.BufferLocation + m_trianglesVertexBufferView.SizeInBytes;
-        m_presentVertexBufferView.StrideInBytes = sizeof(PresentVertex);
-        m_presentVertexBufferView.SizeInBytes = sizeof(presentVertices);
-    }
+		m_presentVertexBufferView.BufferLocation = m_trianglesVertexBufferView.BufferLocation + m_trianglesVertexBufferView.SizeInBytes;
+		m_presentVertexBufferView.StrideInBytes = sizeof(PresentVertex);
+		m_presentVertexBufferView.SizeInBytes = sizeof(presentVertices);
+	}
 
-    LoadSizeDependentResources();
+	LoadSizeDependentResources();
 
-    // Close the command list and execute it to begin the vertex buffer copy into
-    // the default heap.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the vertex buffer copy into
+	// the default heap.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValues[m_frameIndex]++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValues[m_frameIndex]++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForGpu();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForGpu();
+	}
 }
 
 // Load resources that are dependent on the size of the main window.
 void D3D12HDR::LoadSizeDependentResources()
 {
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
+		// Create a RTV for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-            NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
-        }
+			NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
+		}
 
-        // Create the intermediate render target and an RTV for it.
-        D3D12_RESOURCE_DESC renderTargetDesc = m_renderTargets[0]->GetDesc();
-        renderTargetDesc.Format = m_intermediateRenderTargetFormat;
+		// Create the intermediate render target and an RTV for it.
+		D3D12_RESOURCE_DESC renderTargetDesc = m_renderTargets[0]->GetDesc();
+		renderTargetDesc.Format = m_intermediateRenderTargetFormat;
 
-        D3D12_CLEAR_VALUE clearValue = {};
-        clearValue.Format = m_intermediateRenderTargetFormat;
+		D3D12_CLEAR_VALUE clearValue = {};
+		clearValue.Format = m_intermediateRenderTargetFormat;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &renderTargetDesc,
-            D3D12_RESOURCE_STATE_RENDER_TARGET,
-            &clearValue,
-            IID_PPV_ARGS(&m_intermediateRenderTarget)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&renderTargetDesc,
+			D3D12_RESOURCE_STATE_RENDER_TARGET,
+			&clearValue,
+			IID_PPV_ARGS(&m_intermediateRenderTarget)));
 
-        NAME_D3D12_OBJECT(m_intermediateRenderTarget);
+		NAME_D3D12_OBJECT(m_intermediateRenderTarget);
 
-        m_device->CreateRenderTargetView(m_intermediateRenderTarget.Get(), nullptr, rtvHandle);
-        rtvHandle.Offset(1, m_rtvDescriptorSize);
+		m_device->CreateRenderTargetView(m_intermediateRenderTarget.Get(), nullptr, rtvHandle);
+		rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_srvHeap->GetCPUDescriptorHandleForHeapStart());
-        m_device->CreateShaderResourceView(m_intermediateRenderTarget.Get(), nullptr, srvHandle);
-        srvHandle.Offset(1, m_srvDescriptorSize);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_srvHeap->GetCPUDescriptorHandleForHeapStart());
+		m_device->CreateShaderResourceView(m_intermediateRenderTarget.Get(), nullptr, srvHandle);
+		srvHandle.Offset(1, m_srvDescriptorSize);
 
-        // Create the UI render target and an RTV for it.
-        renderTargetDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        clearValue.Format = renderTargetDesc.Format;
+		// Create the UI render target and an RTV for it.
+		renderTargetDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+		clearValue.Format = renderTargetDesc.Format;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &renderTargetDesc,
-            D3D12_RESOURCE_STATE_RENDER_TARGET,
-            &clearValue,
-            IID_PPV_ARGS(&m_UIRenderTarget)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&renderTargetDesc,
+			D3D12_RESOURCE_STATE_RENDER_TARGET,
+			&clearValue,
+			IID_PPV_ARGS(&m_UIRenderTarget)));
 
-        NAME_D3D12_OBJECT(m_UIRenderTarget);
+		NAME_D3D12_OBJECT(m_UIRenderTarget);
 
-        m_device->CreateRenderTargetView(m_UIRenderTarget.Get(), nullptr, rtvHandle);
-        m_device->CreateShaderResourceView(m_UIRenderTarget.Get(), nullptr, srvHandle);
-    }
+		m_device->CreateRenderTargetView(m_UIRenderTarget.Get(), nullptr, rtvHandle);
+		m_device->CreateShaderResourceView(m_UIRenderTarget.Get(), nullptr, srvHandle);
+	}
 
-    m_viewport.Width = static_cast<float>(m_width);
-    m_viewport.Height = static_cast<float>(m_height);
+	m_viewport.Width = static_cast<float>(m_width);
+	m_viewport.Height = static_cast<float>(m_height);
 
     m_scissorRect.left = 0;
     m_scissorRect.top = 0;
-    m_scissorRect.right = static_cast<LONG>(m_width);
-    m_scissorRect.bottom = static_cast<LONG>(m_height);
+	m_scissorRect.right = static_cast<LONG>(m_width);
+	m_scissorRect.bottom = static_cast<LONG>(m_height);
 
-    // Update the color space triangle vertices when the command list is back in
-    // the recording state.
-    m_updateVertexBuffer = true;
+	// Update the color space triangle vertices when the command list is back in
+	// the recording state.
+	m_updateVertexBuffer = true;
 
-    if (m_enableUI)
-    {
-        if (!m_uiLayer)
-        {
-            m_uiLayer = std::make_shared<UILayer>(this);
-        }
-        else
-        {
-            m_uiLayer->Resize();
-        }
-    }
+	if (m_enableUI)
+	{
+		if (!m_uiLayer)
+		{
+			m_uiLayer = std::make_shared<UILayer>(this);
+		}
+		else
+		{
+			m_uiLayer->Resize();
+		}
+	}
 }
 
 // Transform the triangle coordinates so that they remain centered and at the right scale.
 // (mapping a [0,0,1,1] square into a [0,0,1,1] rectangle)
 inline XMFLOAT3 D3D12HDR::TransformVertex(XMFLOAT2 point, XMFLOAT2 offset)
 {
-    auto scale = XMFLOAT2(min(1.0f, 1.0f / m_aspectRatio), min(1.0f, m_aspectRatio));
-    auto margin = XMFLOAT2(0.5f * (1.0f - scale.x), 0.5f * (1.0f - scale.y));
-    auto v = XMVectorMultiplyAdd(
-        XMLoadFloat2(&point),
-        XMLoadFloat2(&scale),
-        XMVectorAdd(XMLoadFloat2(&margin), XMLoadFloat2(&offset)));
+	auto scale = XMFLOAT2(min(1.0f, 1.0f / m_aspectRatio), min(1.0f, m_aspectRatio));
+	auto margin = XMFLOAT2(0.5f * (1.0f - scale.x), 0.5f * (1.0f - scale.y));
+	auto v = XMVectorMultiplyAdd(
+		XMLoadFloat2(&point),
+		XMLoadFloat2(&scale),
+		XMVectorAdd(XMLoadFloat2(&margin), XMLoadFloat2(&offset)));
 
-    XMFLOAT3 result;
-    XMStoreFloat3(&result, v);
-    return result;
+	XMFLOAT3 result;
+	XMStoreFloat3(&result, v);
+	return result;
 }
 
 // Recalculate vertex positions for the color space triangles and then update the vertex buffer.
 // The scene's command list must be in the recording state when this method is called.
 void D3D12HDR::UpdateVertexBuffer()
 {
-    const XMFLOAT2 primaries709[] =
-    {
-        { 0.64f, 0.33f },
-        { 0.30f, 0.60f },
-        { 0.15f, 0.06f },
-        { 0.3127f, 0.3290f }
-    };
-    const XMFLOAT2 primaries2020[] =
-    {
-        { 0.708f, 0.292f },
-        { 0.170f, 0.797f },
-        { 0.131f, 0.046f },
-        { 0.3127f, 0.3290f }
-    };
-    const XMFLOAT2 offset1 = { 0.2f, 0.0f };
-    const XMFLOAT2 offset2 = { 0.2f, -1.0f };
-    const XMFLOAT3 triangle709[] =
-    {
-        TransformVertex(primaries709[0], offset1),    // R
-        TransformVertex(primaries709[1], offset1),    // G
-        TransformVertex(primaries709[2], offset1),    // B
-        TransformVertex(primaries709[3], offset1)    // White
-    };
-    const XMFLOAT3 triangle2020[] =
-    {
-        TransformVertex(primaries2020[0], offset2),    // R
-        TransformVertex(primaries2020[1], offset2),    // G
-        TransformVertex(primaries2020[2], offset2),    // B
-        TransformVertex(primaries2020[3], offset2)    // White
-    };
+	const XMFLOAT2 primaries709[] =
+	{
+		{ 0.64f, 0.33f },
+		{ 0.30f, 0.60f },
+		{ 0.15f, 0.06f },
+		{ 0.3127f, 0.3290f }
+	};
+	const XMFLOAT2 primaries2020[] =
+	{
+		{ 0.708f, 0.292f },
+		{ 0.170f, 0.797f },
+		{ 0.131f, 0.046f },
+		{ 0.3127f, 0.3290f }
+	};
+	const XMFLOAT2 offset1 = { 0.2f, 0.0f };
+	const XMFLOAT2 offset2 = { 0.2f, -1.0f };
+	const XMFLOAT3 triangle709[] =
+	{
+		TransformVertex(primaries709[0], offset1),	// R
+		TransformVertex(primaries709[1], offset1),	// G
+		TransformVertex(primaries709[2], offset1),	// B
+		TransformVertex(primaries709[3], offset1)	// White
+	};
+	const XMFLOAT3 triangle2020[] =
+	{
+		TransformVertex(primaries2020[0], offset2),	// R
+		TransformVertex(primaries2020[1], offset2),	// G
+		TransformVertex(primaries2020[2], offset2),	// B
+		TransformVertex(primaries2020[3], offset2)	// White
+	};
 
-    TrianglesVertex triangleVertices[] =
-    {
-        // Upper triangles.  Rec 709 primaries.
+	TrianglesVertex triangleVertices[] =
+	{
+		// Upper triangles.  Rec 709 primaries.
 
-        { triangle709[2], primaries709[2] },
-        { triangle709[1], primaries709[1] },
-        { triangle709[3], primaries709[3] },
+		{ triangle709[2], primaries709[2] },
+		{ triangle709[1], primaries709[1] },
+		{ triangle709[3], primaries709[3] },
 
-        { triangle709[1], primaries709[1] },
-        { triangle709[0], primaries709[0] },
-        { triangle709[3], primaries709[3] },
+		{ triangle709[1], primaries709[1] },
+		{ triangle709[0], primaries709[0] },
+		{ triangle709[3], primaries709[3] },
 
-        { triangle709[0], primaries709[0] },
-        { triangle709[2], primaries709[2] },
-        { triangle709[3], primaries709[3] },
+		{ triangle709[0], primaries709[0] },
+		{ triangle709[2], primaries709[2] },
+		{ triangle709[3], primaries709[3] },
 
-        // Lower triangles. Rec 2020 primaries.
+		// Lower triangles. Rec 2020 primaries.
 
-        { triangle2020[2], primaries2020[2] },
-        { triangle2020[1], primaries2020[1] },
-        { triangle2020[3], primaries2020[3] },
+		{ triangle2020[2], primaries2020[2] },
+		{ triangle2020[1], primaries2020[1] },
+		{ triangle2020[3], primaries2020[3] },
 
-        { triangle2020[1], primaries2020[1] },
-        { triangle2020[0], primaries2020[0] },
-        { triangle2020[3], primaries2020[3] },
+		{ triangle2020[1], primaries2020[1] },
+		{ triangle2020[0], primaries2020[0] },
+		{ triangle2020[3], primaries2020[3] },
 
-        { triangle2020[0], primaries2020[0] },
-        { triangle2020[2], primaries2020[2] },
-        { triangle2020[3], primaries2020[3] },
-    };
+		{ triangle2020[0], primaries2020[0] },
+		{ triangle2020[2], primaries2020[2] },
+		{ triangle2020[3], primaries2020[3] },
+	};
 
-    // Copy data to the intermediate upload heap and then schedule a copy
-    // from the upload heap to the vertex buffer.
-    UINT8* mappedUploadHeap = nullptr;
-    ThrowIfFailed(m_vertexBufferUpload->Map(0, &CD3DX12_RANGE(0, 0), reinterpret_cast<void**>(&mappedUploadHeap)));
+	// Copy data to the intermediate upload heap and then schedule a copy
+	// from the upload heap to the vertex buffer.
+	UINT8* mappedUploadHeap = nullptr;
+	ThrowIfFailed(m_vertexBufferUpload->Map(0, &CD3DX12_RANGE(0, 0), reinterpret_cast<void**>(&mappedUploadHeap)));
 
-    mappedUploadHeap += m_gradientVertexBufferView.SizeInBytes;
-    memcpy(mappedUploadHeap, triangleVertices, sizeof(triangleVertices));
+	mappedUploadHeap += m_gradientVertexBufferView.SizeInBytes;
+	memcpy(mappedUploadHeap, triangleVertices, sizeof(triangleVertices));
 
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER, D3D12_RESOURCE_STATE_COPY_DEST));
-    m_commandList->CopyBufferRegion(m_vertexBuffer.Get(), 0, m_vertexBufferUpload.Get(), 0, m_vertexBuffer->GetDesc().Width);
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER, D3D12_RESOURCE_STATE_COPY_DEST));
+	m_commandList->CopyBufferRegion(m_vertexBuffer.Get(), 0, m_vertexBufferUpload.Get(), 0, m_vertexBuffer->GetDesc().Width);
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 }
 
 // Update frame-based values.
@@ -576,152 +576,152 @@ void D3D12HDR::OnUpdate()
 // Render the scene.
 void D3D12HDR::OnRender()
 {
-    if (m_windowVisible)
-    {
-        if (m_enableUI)
-        {
-            PIXBeginEvent(m_commandQueue.Get(), 0, L"Render UI");
-            m_uiLayer->Render();
-            PIXEndEvent(m_commandQueue.Get());
-        }
+	if (m_windowVisible)
+	{
+		if (m_enableUI)
+		{
+			PIXBeginEvent(m_commandQueue.Get(), 0, L"Render UI");
+			m_uiLayer->Render();
+			PIXEndEvent(m_commandQueue.Get());
+		}
 
-        PIXBeginEvent(m_commandQueue.Get(), 0, L"Render Scene");
-        RenderScene();
-        PIXEndEvent(m_commandQueue.Get());
+		PIXBeginEvent(m_commandQueue.Get(), 0, L"Render Scene");
+		RenderScene();
+		PIXEndEvent(m_commandQueue.Get());
 
-        // Present the frame.
-        ThrowIfFailed(m_swapChain->Present(1, 0));
+		// Present the frame.
+		ThrowIfFailed(m_swapChain->Present(1, 0));
 
-        MoveToNextFrame();
-    }
+		MoveToNextFrame();
+	}
 }
 
 // Fill the command list with all the render commands and dependent state and
 // submit it to the command queue.
 void D3D12HDR::RenderScene()
 {
-    // Command list allocators can only be reset when the associated
-    // command lists have finished execution on the GPU; apps should use
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
+	// Command list allocators can only be reset when the associated
+	// command lists have finished execution on the GPU; apps should use
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command
-    // list, that command list can then be reset at any time and must be before
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineStates[GradientPSO].Get()));
+	// However, when ExecuteCommandList() is called on a particular command
+	// list, that command list can then be reset at any time and must be before
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineStates[GradientPSO].Get()));
 
-    if (m_updateVertexBuffer)
-    {
-        UpdateVertexBuffer();
-        m_updateVertexBuffer = false;
-    }
+	if (m_updateVertexBuffer)
+	{
+		UpdateVertexBuffer();
+		m_updateVertexBuffer = false;
+	}
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
-    m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
+	m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Bind the root constants and the SRV table to the pipeline.
-    m_rootConstantsF[ReferenceWhiteNits] = m_referenceWhiteNits;
+	// Bind the root constants and the SRV table to the pipeline.
+	m_rootConstantsF[ReferenceWhiteNits] = m_referenceWhiteNits;
 
-    m_commandList->SetGraphicsRoot32BitConstants(0, RootConstantsCount, m_rootConstants, 0);
-    m_commandList->SetGraphicsRootDescriptorTable(1, m_srvHeap->GetGPUDescriptorHandleForHeapStart());
+	m_commandList->SetGraphicsRoot32BitConstants(0, RootConstantsCount, m_rootConstants, 0);
+	m_commandList->SetGraphicsRootDescriptorTable(1, m_srvHeap->GetGPUDescriptorHandleForHeapStart());
 
-    // Draw the scene into the intermediate render target.
-    {
-        PIXBeginEvent(m_commandList.Get(), 0, L"Draw scene content");
+	// Draw the scene into the intermediate render target.
+	{
+		PIXBeginEvent(m_commandList.Get(), 0, L"Draw scene content");
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE intermediateRtv(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSize);
-        m_commandList->OMSetRenderTargets(1, &intermediateRtv, FALSE, nullptr);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE intermediateRtv(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSize);
+		m_commandList->OMSetRenderTargets(1, &intermediateRtv, FALSE, nullptr);
 
-        const float clearColor[] = { 0.0f, 0.0f, 0.0f, 0.0f };
-        m_commandList->ClearRenderTargetView(intermediateRtv, clearColor, 0, nullptr);
+		const float clearColor[] = { 0.0f, 0.0f, 0.0f, 0.0f };
+		m_commandList->ClearRenderTargetView(intermediateRtv, clearColor, 0, nullptr);
 
-        m_commandList->IASetVertexBuffers(0, 1, &m_gradientVertexBufferView);
-        PIXBeginEvent(m_commandList.Get(), 0, L"Standard Gradient");
-        m_commandList->DrawInstanced(4, 1, 0, 0);
-        PIXEndEvent(m_commandList.Get());
+		m_commandList->IASetVertexBuffers(0, 1, &m_gradientVertexBufferView);
+		PIXBeginEvent(m_commandList.Get(), 0, L"Standard Gradient");
+		m_commandList->DrawInstanced(4, 1, 0, 0);
+		PIXEndEvent(m_commandList.Get());
 
-        PIXBeginEvent(m_commandList.Get(), 0, L"Bright Gradient");
-        m_commandList->DrawInstanced(4, 1, 4, 0);
-        PIXEndEvent(m_commandList.Get());
+		PIXBeginEvent(m_commandList.Get(), 0, L"Bright Gradient");
+		m_commandList->DrawInstanced(4, 1, 4, 0);
+		PIXEndEvent(m_commandList.Get());
 
-        m_commandList->SetPipelineState(m_pipelineStates[PalettePSO].Get());
-        m_commandList->IASetVertexBuffers(0, 1, &m_trianglesVertexBufferView);
-        m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+		m_commandList->SetPipelineState(m_pipelineStates[PalettePSO].Get());
+		m_commandList->IASetVertexBuffers(0, 1, &m_trianglesVertexBufferView);
+		m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 
-        PIXBeginEvent(m_commandList.Get(), 0, L"Rec709 Triangles");
-        m_commandList->DrawInstanced(3, 1, 0, 0);
-        m_commandList->DrawInstanced(3, 1, 3, 0);
-        m_commandList->DrawInstanced(3, 1, 6, 0);
-        PIXEndEvent(m_commandList.Get());
+		PIXBeginEvent(m_commandList.Get(), 0, L"Rec709 Triangles");
+		m_commandList->DrawInstanced(3, 1, 0, 0);
+		m_commandList->DrawInstanced(3, 1, 3, 0);
+		m_commandList->DrawInstanced(3, 1, 6, 0);
+		PIXEndEvent(m_commandList.Get());
 
-        m_commandList->SetPipelineState(m_pipelineStates[PalettePSO].Get());
-        PIXBeginEvent(m_commandList.Get(), 0, L"Rec2020 Triangles");
-        m_commandList->DrawInstanced(3, 1, 9, 0);
-        m_commandList->DrawInstanced(3, 1, 12, 0);
-        m_commandList->DrawInstanced(3, 1, 15, 0);
-        PIXEndEvent(m_commandList.Get());
+		m_commandList->SetPipelineState(m_pipelineStates[PalettePSO].Get());
+		PIXBeginEvent(m_commandList.Get(), 0, L"Rec2020 Triangles");
+		m_commandList->DrawInstanced(3, 1, 9, 0);
+		m_commandList->DrawInstanced(3, 1, 12, 0);
+		m_commandList->DrawInstanced(3, 1, 15, 0);
+		PIXEndEvent(m_commandList.Get());
 
-        PIXEndEvent(m_commandList.Get());
+		PIXEndEvent(m_commandList.Get());
 
-        if (!m_enableUI)
-        {
-            intermediateRtv.Offset(1, m_rtvDescriptorSize);
-            m_commandList->OMSetRenderTargets(1, &intermediateRtv, FALSE, nullptr);
-            m_commandList->ClearRenderTargetView(intermediateRtv, clearColor, 0, nullptr);
-        }
-    }
+		if (!m_enableUI)
+		{
+			intermediateRtv.Offset(1, m_rtvDescriptorSize);
+			m_commandList->OMSetRenderTargets(1, &intermediateRtv, FALSE, nullptr);
+			m_commandList->ClearRenderTargetView(intermediateRtv, clearColor, 0, nullptr);
+		}
+	}
 
-    // Indicate that the intermediates will be used as SRVs in the pixel shader
-    // and the back buffer will be used as a render target.
-    D3D12_RESOURCE_BARRIER barriers[] = {
-        CD3DX12_RESOURCE_BARRIER::Transition(m_intermediateRenderTarget.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE),
-        CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET),
-        CD3DX12_RESOURCE_BARRIER::Transition(m_UIRenderTarget.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE),
-    };
+	// Indicate that the intermediates will be used as SRVs in the pixel shader
+	// and the back buffer will be used as a render target.
+	D3D12_RESOURCE_BARRIER barriers[] = {
+		CD3DX12_RESOURCE_BARRIER::Transition(m_intermediateRenderTarget.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE),
+		CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET),
+		CD3DX12_RESOURCE_BARRIER::Transition(m_UIRenderTarget.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE),
+	};
 
-    // Process the intermediate and draw into the swap chain render target.
-    {
-        PIXBeginEvent(m_commandList.Get(), 0, L"Apply HDR");
+	// Process the intermediate and draw into the swap chain render target.
+	{
+		PIXBeginEvent(m_commandList.Get(), 0, L"Apply HDR");
 
-        // If the UI is enabled, the 11on12 layer will do the state transition for us.
-        UINT barrierCount = m_enableUI ? 2 : _countof(barriers);
-        m_commandList->ResourceBarrier(barrierCount, barriers);
-        m_commandList->SetPipelineState(m_pipelineStates[Present8bitPSO + m_currentSwapChainBitDepth].Get());
+		// If the UI is enabled, the 11on12 layer will do the state transition for us.
+		UINT barrierCount = m_enableUI ? 2 : _countof(barriers);
+		m_commandList->ResourceBarrier(barrierCount, barriers);
+		m_commandList->SetPipelineState(m_pipelineStates[Present8bitPSO + m_currentSwapChainBitDepth].Get());
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-        m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+		m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-        m_commandList->ClearRenderTargetView(rtvHandle, ClearColor, 0, nullptr);
+		m_commandList->ClearRenderTargetView(rtvHandle, ClearColor, 0, nullptr);
 
-        m_commandList->IASetVertexBuffers(0, 1, &m_presentVertexBufferView);
-        m_commandList->DrawInstanced(3, 1, 0, 0);
+		m_commandList->IASetVertexBuffers(0, 1, &m_presentVertexBufferView);
+		m_commandList->DrawInstanced(3, 1, 0, 0);
 
-        PIXEndEvent(m_commandList.Get());
-    }
+		PIXEndEvent(m_commandList.Get());
+	}
 
-    // Indicate that the intermediates will be used as render targets and the swap chain
-    // back buffer will be used for presentation.
-    barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-    barriers[0].Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barriers[1].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
-    barriers[2].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-    barriers[2].Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	// Indicate that the intermediates will be used as render targets and the swap chain
+	// back buffer will be used for presentation.
+	barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	barriers[0].Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barriers[1].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
+	barriers[2].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	barriers[2].Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
 
-    m_commandList->ResourceBarrier(_countof(barriers), barriers);
+	m_commandList->ResourceBarrier(_countof(barriers), barriers);
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 }
 
 
@@ -749,36 +749,36 @@ void D3D12HDR::OnSizeChanged(UINT width, UINT height, bool minimized)
 
 void D3D12HDR::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForGpu();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForGpu();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12HDR::OnKeyDown(UINT8 key)
 {
-    switch (key)
-    {
-        // Instrument the Space Bar to toggle between fullscreen states.
-        // The CoreWindow will fire a SizeChanged event once the window is in the
-        // fullscreen state. At that point, the IDXGISwapChain should be resized
-        // to match the new window size.
-        case VK_SPACE:
-        {
-            auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-            if (applicationView->IsFullScreenMode)
-            {
-                applicationView->ExitFullScreenMode();
-            }
-            else
-            {
-                applicationView->TryEnterFullScreenMode();
-            }
-            break;
-        }
+	switch (key)
+	{
+	    // Instrument the Space Bar to toggle between fullscreen states.
+	    // The CoreWindow will fire a SizeChanged event once the window is in the
+	    // fullscreen state. At that point, the IDXGISwapChain should be resized
+	    // to match the new window size.
+	    case VK_SPACE:
+	    {
+		    auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+		    if (applicationView->IsFullScreenMode)
+		    {
+			    applicationView->ExitFullScreenMode();
+		    }
+		    else
+		    {
+			    applicationView->TryEnterFullScreenMode();
+		    }
+		    break;
+	    }
 
-        case VK_PRIOR:    // Page Up
+	    case VK_PRIOR:	// Page Up
         {
             m_currentSwapChainBitDepth = static_cast<SwapChainBitDepth>((m_currentSwapChainBitDepth - 1 + SwapChainBitDepthCount) % SwapChainBitDepthCount);
             DXGI_FORMAT newFormat = m_swapChainFormats[m_currentSwapChainBitDepth];
@@ -787,7 +787,7 @@ void D3D12HDR::OnKeyDown(UINT8 key)
             break;
         }
 
-        case VK_NEXT:    // Page Down
+	    case VK_NEXT:	// Page Down
         {
             m_currentSwapChainBitDepth = static_cast<SwapChainBitDepth>((m_currentSwapChainBitDepth + 1) % SwapChainBitDepthCount);
             DXGI_FORMAT newFormat = m_swapChainFormats[m_currentSwapChainBitDepth];
@@ -796,7 +796,7 @@ void D3D12HDR::OnKeyDown(UINT8 key)
             break;
         }
 
-        case 'H':
+	    case 'H':
         {
             m_enableST2084 = !m_enableST2084;
             if (m_currentSwapChainBitDepth == _10)
@@ -808,7 +808,7 @@ void D3D12HDR::OnKeyDown(UINT8 key)
             break;
         }
 
-        case 'U':
+	    case 'U':
         {
             m_enableUI = !m_enableUI;
             if (m_enableUI)
@@ -830,42 +830,42 @@ void D3D12HDR::OnKeyDown(UINT8 key)
             SetHDRMetaData(HDRMetaDataPool[m_hdrMetaDataPoolIdx][0], HDRMetaDataPool[m_hdrMetaDataPoolIdx][1], HDRMetaDataPool[m_hdrMetaDataPoolIdx][2], HDRMetaDataPool[m_hdrMetaDataPoolIdx][3]);
             break;
         }
-    }
+	}
 }
 
 // Wait for pending GPU work to complete.
 void D3D12HDR::WaitForGpu()
 {
-    // Schedule a Signal command in the queue.
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
+	// Schedule a Signal command in the queue.
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
 
-    // Wait until the fence has been processed.
-    ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-    WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	// Wait until the fence has been processed.
+	ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+	WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
 
-    // Increment the fence value for the current frame.
-    m_fenceValues[m_frameIndex]++;
+	// Increment the fence value for the current frame.
+	m_fenceValues[m_frameIndex]++;
 }
 
 // Prepare to render the next frame.
 void D3D12HDR::MoveToNextFrame()
 {
-    // Schedule a Signal command in the queue.
-    const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
+	// Schedule a Signal command in the queue.
+	const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
 
-    // Update the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Update the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-        WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+		WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	}
 
-    // Set the fence value for the next frame.
-    m_fenceValues[m_frameIndex] = currentFenceValue + 1;
+	// Set the fence value for the next frame.
+	m_fenceValues[m_frameIndex] = currentFenceValue + 1;
 }
 
 
@@ -920,7 +920,7 @@ void D3D12HDR::SetHDRMetaData(float MaxOutputNits /*=1000.0f*/, float MinOutputN
     if (!m_hdrSupport)
     {
         ThrowIfFailed(m_swapChain->SetHDRMetaData(DXGI_HDR_METADATA_TYPE_NONE, 0, nullptr));
-        return;
+		return;
     }
 
     static const DisplayChromacities DisplayChromacityList[] =

--- a/Samples/UWP/D3D12HDR/src/D3D12HDR.h
+++ b/Samples/UWP/D3D12HDR/src/D3D12HDR.h
@@ -28,56 +28,56 @@ class UILayer;
 class D3D12HDR : public DXSample
 {
 public:
-    D3D12HDR(UINT width, UINT height, std::wstring name);
+	D3D12HDR(UINT width, UINT height, std::wstring name);
 
-    inline ID3D12Device* GetDevice() { return m_device.Get(); }
+	inline ID3D12Device* GetDevice() { return m_device.Get(); }
     inline ID3D12CommandQueue* GetCommandQueue() { return m_commandQueue.Get(); }
-    inline ID3D12Resource* GetUIRenderTarget() { return m_UIRenderTarget.Get(); }
-    inline DXGI_FORMAT GetBackBufferFormat() { return m_swapChainFormats[m_currentSwapChainBitDepth]; }
-    inline std::wstring GetDisplayCurve()
-    {
-        return m_rootConstants[DisplayCurve] == sRGB ? L"sRGB" : m_rootConstants[DisplayCurve] == ST2084 ? L"ST.2084" : L"Linear";
-    }
-    inline bool GetHDRSupport() { return m_hdrSupport; }
-    inline float GetReferenceWhiteNits() { return m_referenceWhiteNits; }
+	inline ID3D12Resource* GetUIRenderTarget() { return m_UIRenderTarget.Get(); }
+	inline DXGI_FORMAT GetBackBufferFormat() { return m_swapChainFormats[m_currentSwapChainBitDepth]; }
+	inline std::wstring GetDisplayCurve()
+	{
+		return m_rootConstants[DisplayCurve] == sRGB ? L"sRGB" : m_rootConstants[DisplayCurve] == ST2084 ? L"ST.2084" : L"Linear";
+	}
+	inline bool GetHDRSupport() { return m_hdrSupport; }
+	inline float GetReferenceWhiteNits() { return m_referenceWhiteNits; }
     inline UINT GetHDRMetaDataPoolIndex() { return m_hdrMetaDataPoolIdx; }
 
     static const float HDRMetaDataPool[4][4];
-    static const UINT FrameCount = 2;
+	static const UINT FrameCount = 2;
 
 protected:
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
     virtual void OnWindowMoved(int xPos, int yPos);
-    virtual void OnDestroy();
-    virtual void OnKeyDown(UINT8 key);
+	virtual void OnDestroy();
+	virtual void OnKeyDown(UINT8 key);
     virtual void OnDisplayChanged();
     virtual IDXGISwapChain* GetSwapchain() { return m_swapChain.Get(); }
 
 private:
-    static const float ClearColor[4];
-    static const UINT TrianglesVertexCount = 18;
+	static const float ClearColor[4];
+	static const UINT TrianglesVertexCount = 18;
 
-    // Vertex definitions.
-    struct GradientVertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT3 color;
-    };
+	// Vertex definitions.
+	struct GradientVertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT3 color;
+	};
 
-    struct TrianglesVertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT2 uv;
-    };
+	struct TrianglesVertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT2 uv;
+	};
 
-    struct PresentVertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT2 uv;
-    };
+	struct PresentVertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT2 uv;
+	};
 
     struct DisplayChromacities
     {
@@ -91,101 +91,101 @@ private:
         float WhiteY;
     };
 
-    enum PipelineStates
-    {
-        GradientPSO = 0,
-        PalettePSO,
-        Present8bitPSO,
-        Present10bitPSO,
-        Present16bitPSO,
-        PipelineStateCount
-    };
+	enum PipelineStates
+	{
+		GradientPSO = 0,
+		PalettePSO,
+		Present8bitPSO,
+		Present10bitPSO,
+		Present16bitPSO,
+		PipelineStateCount
+	};
 
-    enum SwapChainBitDepth
-    {
-        _8 = 0,
-        _10,
-        _16,
-        SwapChainBitDepthCount
-    };
+	enum SwapChainBitDepth
+	{
+		_8 = 0,
+		_10,
+		_16,
+		SwapChainBitDepthCount
+	};
 
-    enum RootConstants
-    {
-        ReferenceWhiteNits = 0,
-        DisplayCurve,
-        RootConstantsCount
-    };
+	enum RootConstants
+	{
+		ReferenceWhiteNits = 0,
+		DisplayCurve,
+		RootConstantsCount
+	};
 
-    enum DisplayCurve
-    {
-        sRGB = 0,    // The display expects an sRGB signal.
-        ST2084,        // The display expects an HDR10 signal.
-        None        // The display expects a linear signal.
-    };
+	enum DisplayCurve
+	{
+		sRGB = 0,	// The display expects an sRGB signal.
+		ST2084,		// The display expects an HDR10 signal.
+		None		// The display expects a linear signal.
+	};
 
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGIFactory4> m_dxgiFactory;
-    ComPtr<IDXGISwapChain4> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12Resource> m_intermediateRenderTarget;
-    ComPtr<ID3D12Resource> m_UIRenderTarget;
-    ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_srvHeap;
-    UINT m_rtvDescriptorSize;
-    UINT m_srvDescriptorSize;
-    DXGI_FORMAT m_swapChainFormats[SwapChainBitDepthCount];
-    DXGI_COLOR_SPACE_TYPE m_currentSwapChainColorSpace;
-    SwapChainBitDepth m_currentSwapChainBitDepth;
-    bool m_swapChainFormatChanged;
-    DXGI_FORMAT m_intermediateRenderTargetFormat;
-    UINT m_dxgiFactoryFlags;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGIFactory4> m_dxgiFactory;
+	ComPtr<IDXGISwapChain4> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12Resource> m_intermediateRenderTarget;
+	ComPtr<ID3D12Resource> m_UIRenderTarget;
+	ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_srvHeap;
+	UINT m_rtvDescriptorSize;
+	UINT m_srvDescriptorSize;
+	DXGI_FORMAT m_swapChainFormats[SwapChainBitDepthCount];
+	DXGI_COLOR_SPACE_TYPE m_currentSwapChainColorSpace;
+	SwapChainBitDepth m_currentSwapChainBitDepth;
+	bool m_swapChainFormatChanged;
+	DXGI_FORMAT m_intermediateRenderTargetFormat;
+	UINT m_dxgiFactoryFlags;
 
-    // App resources.
-    ComPtr<ID3D12PipelineState> m_pipelineStates[PipelineStateCount];
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    ComPtr<ID3D12Resource> m_vertexBufferUpload;
-    D3D12_VERTEX_BUFFER_VIEW m_gradientVertexBufferView;
-    D3D12_VERTEX_BUFFER_VIEW m_trianglesVertexBufferView;
-    D3D12_VERTEX_BUFFER_VIEW m_presentVertexBufferView;
-    UINT m_rootConstants[RootConstantsCount];
-    float* m_rootConstantsF;
-    bool m_updateVertexBuffer;
-    std::shared_ptr<UILayer> m_uiLayer;
-    bool m_enableUI = true;
+	// App resources.
+	ComPtr<ID3D12PipelineState> m_pipelineStates[PipelineStateCount];
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	ComPtr<ID3D12Resource> m_vertexBufferUpload;
+	D3D12_VERTEX_BUFFER_VIEW m_gradientVertexBufferView;
+	D3D12_VERTEX_BUFFER_VIEW m_trianglesVertexBufferView;
+	D3D12_VERTEX_BUFFER_VIEW m_presentVertexBufferView;
+	UINT m_rootConstants[RootConstantsCount];
+	float* m_rootConstantsF;
+	bool m_updateVertexBuffer;
+	std::shared_ptr<UILayer> m_uiLayer;
+	bool m_enableUI = true;
     UINT m_hdrMetaDataPoolIdx = 0;
 
-    // Color.
-    bool m_hdrSupport = false;
-    bool m_enableST2084 = false;
-    float m_referenceWhiteNits = 80.0f;    // The reference brightness level of the display.
+	// Color.
+	bool m_hdrSupport = false;
+	bool m_enableST2084 = false;
+	float m_referenceWhiteNits = 80.0f;	// The reference brightness level of the display.
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValues[FrameCount];
+	// Synchronization objects.
+	UINT m_frameIndex;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValues[FrameCount];
 
-    // Track the state of the window.
-    // If it's minimized the app may decide not to render frames.
-    bool m_windowVisible;
-    bool m_windowedMode;
+	// Track the state of the window.
+	// If it's minimized the app may decide not to render frames.
+	bool m_windowVisible;
+	bool m_windowedMode;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void LoadSizeDependentResources();
-    XMFLOAT3 TransformVertex(XMFLOAT2 point, XMFLOAT2 offset);
-    void UpdateVertexBuffer();
-    void RenderScene();
-    void WaitForGpu();
-    void MoveToNextFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	void LoadSizeDependentResources();
+	XMFLOAT3 TransformVertex(XMFLOAT2 point, XMFLOAT2 offset);
+	void UpdateVertexBuffer();
+	void RenderScene();
+	void WaitForGpu();
+	void MoveToNextFrame();
     void EnsureSwapChainColorSpace(SwapChainBitDepth d, bool enableST2084);
     void CheckDisplayHDRSupport();
     void SetHDRMetaData(float MaxOutputNits = 1000.0f, float MinOutputNits = 0.001f, float MaxCLL = 2000.0f, float MaxFALL = 500.0f);

--- a/Samples/UWP/D3D12HDR/src/DXSample.cpp
+++ b/Samples/UWP/D3D12HDR/src/DXSample.cpp
@@ -52,33 +52,78 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
+
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+            }
+#if !defined(_XBOX_ONE)
+        }
+#endif
 
     *ppAdapter = adapter.Detach();
-}
+    }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)

--- a/Samples/UWP/D3D12HDR/src/DXSample.h
+++ b/Samples/UWP/D3D12HDR/src/DXSample.h
@@ -48,7 +48,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/UWP/D3D12HDR/src/Main.cpp
+++ b/Samples/UWP/D3D12HDR/src/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12HDR sample(1200, 900, L"");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12HDR sample(1200, 900, L"");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12HDR/src/UILayer.cpp
+++ b/Samples/UWP/D3D12HDR/src/UILayer.cpp
@@ -13,135 +13,135 @@
 #include "UILayer.h"
 
 UILayer::UILayer(D3D12HDR* pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
-    m_ui.resize(StringsCount);
-    m_labels.resize(StringsCount);
+	m_ui.resize(StringsCount);
+	m_labels.resize(StringsCount);
 
-    m_labels[Format] = L"Back Buffer Format";
-    m_labels[Signal] = L"Output Signal";
-    m_labels[HDRSupport] = L"Current Output HDR Support";
-    m_labels[StandardGradient] = L"SDR Gradient [0,1]";
-    m_labels[BrightGradient] = L"HDR Gradient [0,9]";
-    m_labels[Rec709] = L"Rec 709";
-    m_labels[Rec2020] = L"Rec 2020";
-    m_labels[ChangeFormat] = L"PgUp/PgDn\tChange back buffer format";
-    m_labels[ChangeCurve] = L"H\tToggle between sRGB and ST.2084 (10-bit swap chain only)";
-    m_labels[HideUI] = L"U\tToggle UI Visibility";
+	m_labels[Format] = L"Back Buffer Format";
+	m_labels[Signal] = L"Output Signal";
+	m_labels[HDRSupport] = L"Current Output HDR Support";
+	m_labels[StandardGradient] = L"SDR Gradient [0,1]";
+	m_labels[BrightGradient] = L"HDR Gradient [0,9]";
+	m_labels[Rec709] = L"Rec 709";
+	m_labels[Rec2020] = L"Rec 2020";
+	m_labels[ChangeFormat] = L"PgUp/PgDn\tChange back buffer format";
+	m_labels[ChangeCurve] = L"H\tToggle between sRGB and ST.2084 (10-bit swap chain only)";
+	m_labels[HideUI] = L"U\tToggle UI Visibility";
     m_labels[MetaData] = L"M\tToggle HDR Meta Data";
 
-    Initialize();
+	Initialize();
 }
 
 void UILayer::Initialize()
 {
-    UINT d3d11DeviceFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
-    D2D1_FACTORY_OPTIONS d2dFactoryOptions = {};
+	UINT d3d11DeviceFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
+	D2D1_FACTORY_OPTIONS d2dFactoryOptions = {};
 
 #if defined(_DEBUG)
-    // Enable the D2D debug layer.
-    d2dFactoryOptions.debugLevel = D2D1_DEBUG_LEVEL_INFORMATION;
+	// Enable the D2D debug layer.
+	d2dFactoryOptions.debugLevel = D2D1_DEBUG_LEVEL_INFORMATION;
 
-    // Enable the D3D11 debug layer.
-    d3d11DeviceFlags |= D3D11_CREATE_DEVICE_DEBUG;
+	// Enable the D3D11 debug layer.
+	d3d11DeviceFlags |= D3D11_CREATE_DEVICE_DEBUG;
 #endif
 
-    // Create an 11 device wrapped around the 12 device and share
-    // 12's command queue.
-    ComPtr<ID3D11Device> d3d11Device;
-    ID3D12CommandQueue* ppCommandQueues[] = { m_pSample->GetCommandQueue() };
-    ThrowIfFailed(D3D11On12CreateDevice(
-        m_pSample->GetDevice(),
-        d3d11DeviceFlags,
-        nullptr,
-        0,
-        reinterpret_cast<IUnknown**>(ppCommandQueues),
-        _countof(ppCommandQueues),
-        0,
-        &d3d11Device,
-        &m_d3d11DeviceContext,
-        nullptr
-        ));
+	// Create an 11 device wrapped around the 12 device and share
+	// 12's command queue.
+	ComPtr<ID3D11Device> d3d11Device;
+	ID3D12CommandQueue* ppCommandQueues[] = { m_pSample->GetCommandQueue() };
+	ThrowIfFailed(D3D11On12CreateDevice(
+		m_pSample->GetDevice(),
+		d3d11DeviceFlags,
+		nullptr,
+		0,
+		reinterpret_cast<IUnknown**>(ppCommandQueues),
+		_countof(ppCommandQueues),
+		0,
+		&d3d11Device,
+		&m_d3d11DeviceContext,
+		nullptr
+		));
 
-    // Query the 11On12 device from the 11 device.
-    ThrowIfFailed(d3d11Device.As(&m_d3d11On12Device));
+	// Query the 11On12 device from the 11 device.
+	ThrowIfFailed(d3d11Device.As(&m_d3d11On12Device));
 
 #if defined(_DEBUG)
-    // Filter a debug error coming from the 11on12 layer.
-    ComPtr<ID3D12InfoQueue> infoQueue;
-    if (SUCCEEDED(m_pSample->GetDevice()->QueryInterface(IID_PPV_ARGS(&infoQueue))))
-    {
-        // Suppress messages based on their severity level.
-        D3D12_MESSAGE_SEVERITY severities[] =
-        {
-            D3D12_MESSAGE_SEVERITY_INFO,
-        };
+	// Filter a debug error coming from the 11on12 layer.
+	ComPtr<ID3D12InfoQueue> infoQueue;
+	if (SUCCEEDED(m_pSample->GetDevice()->QueryInterface(IID_PPV_ARGS(&infoQueue))))
+	{
+		// Suppress messages based on their severity level.
+		D3D12_MESSAGE_SEVERITY severities[] =
+		{
+			D3D12_MESSAGE_SEVERITY_INFO,
+		};
 
-        // Suppress individual messages by their ID.
-        D3D12_MESSAGE_ID denyIds[] =
-        {
-            // This occurs when there are uninitialized descriptors in a descriptor table, even when a
-            // shader does not access the missing descriptors.
-            D3D12_MESSAGE_ID_INVALID_DESCRIPTOR_HANDLE,
-        };
+		// Suppress individual messages by their ID.
+		D3D12_MESSAGE_ID denyIds[] =
+		{
+			// This occurs when there are uninitialized descriptors in a descriptor table, even when a
+			// shader does not access the missing descriptors.
+			D3D12_MESSAGE_ID_INVALID_DESCRIPTOR_HANDLE,
+		};
 
-        D3D12_INFO_QUEUE_FILTER filter = {};
-        filter.DenyList.NumSeverities = _countof(severities);
-        filter.DenyList.pSeverityList = severities;
-        filter.DenyList.NumIDs = _countof(denyIds);
-        filter.DenyList.pIDList = denyIds;
+		D3D12_INFO_QUEUE_FILTER filter = {};
+		filter.DenyList.NumSeverities = _countof(severities);
+		filter.DenyList.pSeverityList = severities;
+		filter.DenyList.NumIDs = _countof(denyIds);
+		filter.DenyList.pIDList = denyIds;
 
-        ThrowIfFailed(infoQueue->PushStorageFilter(&filter));
-    }
+		ThrowIfFailed(infoQueue->PushStorageFilter(&filter));
+	}
 #endif
 
-    // Create D2D/DWrite components.
-    {
-        ComPtr<IDXGIDevice> dxgiDevice;
-        ThrowIfFailed(m_d3d11On12Device.As(&dxgiDevice));
+	// Create D2D/DWrite components.
+	{
+		ComPtr<IDXGIDevice> dxgiDevice;
+		ThrowIfFailed(m_d3d11On12Device.As(&dxgiDevice));
 
-        ThrowIfFailed(D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, __uuidof(ID2D1Factory3), &d2dFactoryOptions, &m_d2dFactory));
-        ThrowIfFailed(m_d2dFactory->CreateDevice(dxgiDevice.Get(), &m_d2dDevice));
-        ThrowIfFailed(m_d2dDevice->CreateDeviceContext(D2D1_DEVICE_CONTEXT_OPTIONS_NONE, &m_d2dDeviceContext));
+		ThrowIfFailed(D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, __uuidof(ID2D1Factory3), &d2dFactoryOptions, &m_d2dFactory));
+		ThrowIfFailed(m_d2dFactory->CreateDevice(dxgiDevice.Get(), &m_d2dDevice));
+		ThrowIfFailed(m_d2dDevice->CreateDeviceContext(D2D1_DEVICE_CONTEXT_OPTIONS_NONE, &m_d2dDeviceContext));
 
-        m_d2dDeviceContext->SetTextAntialiasMode(D2D1_TEXT_ANTIALIAS_MODE_GRAYSCALE);
-        ThrowIfFailed(m_d2dDeviceContext->CreateSolidColorBrush(D2D1::ColorF(D2D1::ColorF::White), &m_textBrush));
+		m_d2dDeviceContext->SetTextAntialiasMode(D2D1_TEXT_ANTIALIAS_MODE_GRAYSCALE);
+		ThrowIfFailed(m_d2dDeviceContext->CreateSolidColorBrush(D2D1::ColorF(D2D1::ColorF::White), &m_textBrush));
 
-        ThrowIfFailed(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &m_dwriteFactory));
-    }
+		ThrowIfFailed(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &m_dwriteFactory));
+	}
 
-    UpdateLabels();
-    Resize();
+	UpdateLabels();
+	Resize();
 }
 
 void UILayer::UpdateLabels()
 {
-    switch (m_pSample->GetBackBufferFormat())
-    {
-    case DXGI_FORMAT_R8G8B8A8_UNORM:
-        m_labels[Format] = L"Back Buffer Format = R8G8B8A8_UNORM";
-        break;
+	switch (m_pSample->GetBackBufferFormat())
+	{
+	case DXGI_FORMAT_R8G8B8A8_UNORM:
+		m_labels[Format] = L"Back Buffer Format = R8G8B8A8_UNORM";
+		break;
 
-    case DXGI_FORMAT_R10G10B10A2_UNORM:
-        m_labels[Format] = L"Back Buffer Format = R10G10B10A2_UNORM";
-        break;
+	case DXGI_FORMAT_R10G10B10A2_UNORM:
+		m_labels[Format] = L"Back Buffer Format = R10G10B10A2_UNORM";
+		break;
 
-    case DXGI_FORMAT_R16G16B16A16_FLOAT:
-        m_labels[Format] = L"Back Buffer Format = R16G16B16A16_FLOAT";
-        break;
+	case DXGI_FORMAT_R16G16B16A16_FLOAT:
+		m_labels[Format] = L"Back Buffer Format = R16G16B16A16_FLOAT";
+		break;
 
-    default:
-        m_labels[Format] = L"Back Buffer Format = Unknown";
-        break;
-    }
+	default:
+		m_labels[Format] = L"Back Buffer Format = Unknown";
+		break;
+	}
 
-    m_labels[Signal] = L"Output Signal = " + m_pSample->GetDisplayCurve();
-    m_labels[HDRSupport] = L"Current Output HDR Support = ";
-    m_labels[HDRSupport] += m_pSample->GetHDRSupport() ? L"true" : L"false";
+	m_labels[Signal] = L"Output Signal = " + m_pSample->GetDisplayCurve();
+	m_labels[HDRSupport] = L"Current Output HDR Support = ";
+	m_labels[HDRSupport] += m_pSample->GetHDRSupport() ? L"true" : L"false";
 
-    m_ui[Format].text = m_labels[Format];
-    m_ui[Signal].text = m_labels[Signal];
-    m_ui[HDRSupport].text = m_labels[HDRSupport];
+	m_ui[Format].text = m_labels[Format];
+	m_ui[Signal].text = m_labels[Signal];
+	m_ui[HDRSupport].text = m_labels[HDRSupport];
 
     float MaxOutputNits = D3D12HDR::HDRMetaDataPool[m_pSample->GetHDRMetaDataPoolIndex()][0];
     float MinOutputNits = D3D12HDR::HDRMetaDataPool[m_pSample->GetHDRMetaDataPoolIndex()][1];
@@ -157,111 +157,111 @@ void UILayer::UpdateLabels()
 // Render the UI.
 void UILayer::Render()
 {
-    ID3D11Resource* ppResources[] = { m_wrappedRenderTarget.Get() };
+	ID3D11Resource* ppResources[] = { m_wrappedRenderTarget.Get() };
 
-    // Acquire our wrapped render target resource for the current back buffer.
-    m_d3d11On12Device->AcquireWrappedResources(ppResources, _countof(ppResources));
+	// Acquire our wrapped render target resource for the current back buffer.
+	m_d3d11On12Device->AcquireWrappedResources(ppResources, _countof(ppResources));
 
-    m_d2dDeviceContext->BeginDraw();
-    m_d2dDeviceContext->Clear();
-    for (auto textBlock : m_ui)
-    {
-        m_d2dDeviceContext->DrawText(
-            textBlock.text.c_str(),
-            static_cast<UINT>(textBlock.text.length()),
-            textBlock.pFormat,
-            textBlock.layout,
-            m_textBrush.Get());
-    }
-    m_d2dDeviceContext->EndDraw();
+	m_d2dDeviceContext->BeginDraw();
+	m_d2dDeviceContext->Clear();
+	for (auto textBlock : m_ui)
+	{
+		m_d2dDeviceContext->DrawText(
+			textBlock.text.c_str(),
+			static_cast<UINT>(textBlock.text.length()),
+			textBlock.pFormat,
+			textBlock.layout,
+			m_textBrush.Get());
+	}
+	m_d2dDeviceContext->EndDraw();
 
-    // Release our wrapped render target resource. Releasing
-    // transitions the back buffer resource to the state specified
-    // as the OutState when the wrapped resource was created.
-    m_d3d11On12Device->ReleaseWrappedResources(ppResources, _countof(ppResources));
+	// Release our wrapped render target resource. Releasing
+	// transitions the back buffer resource to the state specified
+	// as the OutState when the wrapped resource was created.
+	m_d3d11On12Device->ReleaseWrappedResources(ppResources, _countof(ppResources));
 
-    // Flush to submit the 11 command list to the shared command queue.
-    m_d3d11DeviceContext->Flush();
+	// Flush to submit the 11 command list to the shared command queue.
+	m_d3d11DeviceContext->Flush();
 }
 
 // Releases resources that reference the DXGI swap chain so that it can be resized.
 void UILayer::ReleaseResources()
 {
-    m_wrappedRenderTarget.Reset();
-    m_d2dRenderTarget.Reset();
-    m_d2dDeviceContext->SetTarget(nullptr);
+	m_wrappedRenderTarget.Reset();
+	m_d2dRenderTarget.Reset();
+	m_d2dDeviceContext->SetTarget(nullptr);
 }
 
 void UILayer::Resize()
 {
-    // Query the desktop's dpi settings, which will be used to create
-    // D2D's render targets.
-    D2D1_BITMAP_PROPERTIES1 bitmapProperties = D2D1::BitmapProperties1(
-        D2D1_BITMAP_OPTIONS_TARGET | D2D1_BITMAP_OPTIONS_CANNOT_DRAW,
-        D2D1::PixelFormat(DXGI_FORMAT_UNKNOWN, D2D1_ALPHA_MODE_PREMULTIPLIED));
+	// Query the desktop's dpi settings, which will be used to create
+	// D2D's render targets.
+	D2D1_BITMAP_PROPERTIES1 bitmapProperties = D2D1::BitmapProperties1(
+		D2D1_BITMAP_OPTIONS_TARGET | D2D1_BITMAP_OPTIONS_CANNOT_DRAW,
+		D2D1::PixelFormat(DXGI_FORMAT_UNKNOWN, D2D1_ALPHA_MODE_PREMULTIPLIED));
 
-    // Create a wrapped 11On12 resource of this back buffer.
-    // When ReleaseWrappedResources() is called on the 11On12 device, the resource
-    // will be transitioned to the PIXEL_SHADER_RESOURCE state.
-    D3D11_RESOURCE_FLAGS d3d11Flags = { D3D11_BIND_RENDER_TARGET };
-    ThrowIfFailed(m_d3d11On12Device->CreateWrappedResource(
-        m_pSample->GetUIRenderTarget(),
-        &d3d11Flags,
-        D3D12_RESOURCE_STATE_RENDER_TARGET,
-        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-        IID_PPV_ARGS(&m_wrappedRenderTarget)));
+	// Create a wrapped 11On12 resource of this back buffer.
+	// When ReleaseWrappedResources() is called on the 11On12 device, the resource
+	// will be transitioned to the PIXEL_SHADER_RESOURCE state.
+	D3D11_RESOURCE_FLAGS d3d11Flags = { D3D11_BIND_RENDER_TARGET };
+	ThrowIfFailed(m_d3d11On12Device->CreateWrappedResource(
+		m_pSample->GetUIRenderTarget(),
+		&d3d11Flags,
+		D3D12_RESOURCE_STATE_RENDER_TARGET,
+		D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+		IID_PPV_ARGS(&m_wrappedRenderTarget)));
 
-    // Create a render target for D2D to draw directly to this back buffer.
-    ComPtr<IDXGISurface> surface;
-    ThrowIfFailed(m_wrappedRenderTarget.As(&surface));
-    ThrowIfFailed(m_d2dDeviceContext->CreateBitmapFromDxgiSurface(
-        surface.Get(),
-        &bitmapProperties,
-        &m_d2dRenderTarget));
+	// Create a render target for D2D to draw directly to this back buffer.
+	ComPtr<IDXGISurface> surface;
+	ThrowIfFailed(m_wrappedRenderTarget.As(&surface));
+	ThrowIfFailed(m_d2dDeviceContext->CreateBitmapFromDxgiSurface(
+		surface.Get(),
+		&bitmapProperties,
+		&m_d2dRenderTarget));
 
-    // Set the render target on the D2D context.
-    m_d2dDeviceContext->SetTarget(m_d2dRenderTarget.Get());
+	// Set the render target on the D2D context.
+	m_d2dDeviceContext->SetTarget(m_d2dRenderTarget.Get());
 
-    // Create DWrite text format objects.
-    float width = static_cast<float>(m_pSample->GetWidth());
-    float height = static_cast<float>(m_pSample->GetHeight());
-    const float fontSize = height / 30.0f;
-    const float smallFontSize = height / 40.0f;
+	// Create DWrite text format objects.
+	float width = static_cast<float>(m_pSample->GetWidth());
+	float height = static_cast<float>(m_pSample->GetHeight());
+	const float fontSize = height / 30.0f;
+	const float smallFontSize = height / 40.0f;
 
-    ThrowIfFailed(m_dwriteFactory->CreateTextFormat(
-        L"Arial",
-        nullptr,
-        DWRITE_FONT_WEIGHT_NORMAL,
-        DWRITE_FONT_STYLE_NORMAL,
-        DWRITE_FONT_STRETCH_NORMAL,
-        fontSize,
-        L"en-us",
-        &m_textFormat));
+	ThrowIfFailed(m_dwriteFactory->CreateTextFormat(
+		L"Arial",
+		nullptr,
+		DWRITE_FONT_WEIGHT_NORMAL,
+		DWRITE_FONT_STYLE_NORMAL,
+		DWRITE_FONT_STRETCH_NORMAL,
+		fontSize,
+		L"en-us",
+		&m_textFormat));
 
-    ThrowIfFailed(m_textFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER));
-    ThrowIfFailed(m_textFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_NEAR));
+	ThrowIfFailed(m_textFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER));
+	ThrowIfFailed(m_textFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_NEAR));
 
-    ThrowIfFailed(m_dwriteFactory->CreateTextFormat(
-        L"Arial",
-        nullptr,
-        DWRITE_FONT_WEIGHT_NORMAL,
-        DWRITE_FONT_STYLE_NORMAL,
-        DWRITE_FONT_STRETCH_NORMAL,
-        smallFontSize,
-        L"en-us",
-        &m_smallTextFormat));
+	ThrowIfFailed(m_dwriteFactory->CreateTextFormat(
+		L"Arial",
+		nullptr,
+		DWRITE_FONT_WEIGHT_NORMAL,
+		DWRITE_FONT_STYLE_NORMAL,
+		DWRITE_FONT_STRETCH_NORMAL,
+		smallFontSize,
+		L"en-us",
+		&m_smallTextFormat));
 
-    // Update the UI elements.
-    m_ui[Format] = { m_labels[Format], D2D1::RectF(0.0f, 0.0f, width, height), m_textFormat.Get() };
-    m_ui[Signal] = { m_labels[Signal], D2D1::RectF(0.0f, fontSize, width, height), m_textFormat.Get() };
-    m_ui[HDRSupport] = { m_labels[HDRSupport], D2D1::RectF(0.0f, fontSize * 2.0f, width, height), m_textFormat.Get() };
-    m_ui[StandardGradient] = { m_labels[StandardGradient], D2D1::RectF(0.0f, height * 0.25f + fontSize, width * 0.5f, height), m_textFormat.Get() };
-    m_ui[BrightGradient] = { m_labels[BrightGradient], D2D1::RectF(0.0f, height * 0.75f + fontSize, width * 0.5f, height), m_textFormat.Get() };
-    m_ui[Rec709] = { m_labels[Rec709], D2D1::RectF(width * 0.5f, height * 0.25f + fontSize, width * 0.8f, height), m_textFormat.Get() };
-    m_ui[Rec2020] = { m_labels[Rec2020], D2D1::RectF(width * 0.5f, height * 0.75f + fontSize, width * 0.8f, height), m_textFormat.Get() };
+	// Update the UI elements.
+	m_ui[Format] = { m_labels[Format], D2D1::RectF(0.0f, 0.0f, width, height), m_textFormat.Get() };
+	m_ui[Signal] = { m_labels[Signal], D2D1::RectF(0.0f, fontSize, width, height), m_textFormat.Get() };
+	m_ui[HDRSupport] = { m_labels[HDRSupport], D2D1::RectF(0.0f, fontSize * 2.0f, width, height), m_textFormat.Get() };
+	m_ui[StandardGradient] = { m_labels[StandardGradient], D2D1::RectF(0.0f, height * 0.25f + fontSize, width * 0.5f, height), m_textFormat.Get() };
+	m_ui[BrightGradient] = { m_labels[BrightGradient], D2D1::RectF(0.0f, height * 0.75f + fontSize, width * 0.5f, height), m_textFormat.Get() };
+	m_ui[Rec709] = { m_labels[Rec709], D2D1::RectF(width * 0.5f, height * 0.25f + fontSize, width * 0.8f, height), m_textFormat.Get() };
+	m_ui[Rec2020] = { m_labels[Rec2020], D2D1::RectF(width * 0.5f, height * 0.75f + fontSize, width * 0.8f, height), m_textFormat.Get() };
 
-    m_ui[ChangeFormat] = { m_labels[ChangeFormat], D2D1::RectF(smallFontSize, height - fontSize * 5.0f, width, height), m_smallTextFormat.Get() };
-    m_ui[ChangeCurve] = { m_labels[ChangeCurve], D2D1::RectF(smallFontSize, height - fontSize * 3.0f, width, height), m_smallTextFormat.Get() };
-    m_ui[HideUI] = { m_labels[HideUI], D2D1::RectF(smallFontSize, height - fontSize * 2.0f, width, height), m_smallTextFormat.Get() };
+	m_ui[ChangeFormat] = { m_labels[ChangeFormat], D2D1::RectF(smallFontSize, height - fontSize * 5.0f, width, height), m_smallTextFormat.Get() };
+	m_ui[ChangeCurve] = { m_labels[ChangeCurve], D2D1::RectF(smallFontSize, height - fontSize * 3.0f, width, height), m_smallTextFormat.Get() };
+	m_ui[HideUI] = { m_labels[HideUI], D2D1::RectF(smallFontSize, height - fontSize * 2.0f, width, height), m_smallTextFormat.Get() };
     m_ui[MetaData] = { m_labels[MetaData], D2D1::RectF(smallFontSize, height - fontSize * 1.0f, width, height), m_smallTextFormat.Get() };
 }

--- a/Samples/UWP/D3D12HDR/src/UILayer.h
+++ b/Samples/UWP/D3D12HDR/src/UILayer.h
@@ -16,53 +16,53 @@
 class UILayer
 {
 public:
-    UILayer(D3D12HDR* pSample);
+	UILayer(D3D12HDR* pSample);
 
-    void UpdateLabels();
-    void Render();
-    void ReleaseResources();
-    void Resize();
+	void UpdateLabels();
+	void Render();
+	void ReleaseResources();
+	void Resize();
 
 private:
-    struct TextBlock
-    {
-        std::wstring text;
-        D2D1_RECT_F layout;
-        IDWriteTextFormat* pFormat;
-    };
+	struct TextBlock
+	{
+		std::wstring text;
+		D2D1_RECT_F layout;
+		IDWriteTextFormat* pFormat;
+	};
 
-    enum Strings
-    {
-        Format = 0,
-        Signal,
-        HDRSupport,
-        StandardGradient,
-        BrightGradient,
-        Rec709,
-        Rec2020,
-        ChangeFormat,
-        ChangeCurve,
-        HideUI,
+	enum Strings
+	{
+		Format = 0,
+		Signal,
+		HDRSupport,
+		StandardGradient,
+		BrightGradient,
+		Rec709,
+		Rec2020,
+		ChangeFormat,
+		ChangeCurve,
+		HideUI,
         MetaData,
-        StringsCount
-    };
+		StringsCount
+	};
 
-    D3D12HDR* m_pSample;
-    ComPtr<ID3D11DeviceContext> m_d3d11DeviceContext;
-    ComPtr<ID3D11On12Device> m_d3d11On12Device;
-    ComPtr<IDWriteFactory> m_dwriteFactory;
-    ComPtr<ID2D1Factory3> m_d2dFactory;
-    ComPtr<ID2D1Device2> m_d2dDevice;
-    ComPtr<ID2D1DeviceContext2> m_d2dDeviceContext;
-    ComPtr<ID3D11Resource> m_wrappedRenderTarget;
-    ComPtr<ID2D1Bitmap1> m_d2dRenderTarget;
-    ComPtr<ID2D1SolidColorBrush> m_textBrush;
-    ComPtr<IDWriteTextFormat> m_textFormat;
-    ComPtr<IDWriteTextFormat> m_smallTextFormat;
+	D3D12HDR* m_pSample;
+	ComPtr<ID3D11DeviceContext> m_d3d11DeviceContext;
+	ComPtr<ID3D11On12Device> m_d3d11On12Device;
+	ComPtr<IDWriteFactory> m_dwriteFactory;
+	ComPtr<ID2D1Factory3> m_d2dFactory;
+	ComPtr<ID2D1Device2> m_d2dDevice;
+	ComPtr<ID2D1DeviceContext2> m_d2dDeviceContext;
+	ComPtr<ID3D11Resource> m_wrappedRenderTarget;
+	ComPtr<ID2D1Bitmap1> m_d2dRenderTarget;
+	ComPtr<ID2D1SolidColorBrush> m_textBrush;
+	ComPtr<IDWriteTextFormat> m_textFormat;
+	ComPtr<IDWriteTextFormat> m_smallTextFormat;
 
-    std::vector<std::wstring> m_labels;
-    std::vector<TextBlock> m_ui;
+	std::vector<std::wstring> m_labels;
+	std::vector<TextBlock> m_ui;
 
-    void Initialize();
+	void Initialize();
 };
 

--- a/Samples/UWP/D3D12HDR/src/View.cpp
+++ b/Samples/UWP/D3D12HDR/src/View.cpp
@@ -17,61 +17,61 @@ using namespace Windows::System;
 
 inline int ConvertToPixels(float dimension, float dpi)
 {
-    return static_cast<int>(dimension * dpi / 96.0f + 0.5f);
+	return static_cast<int>(dimension * dpi / 96.0f + 0.5f);
 }
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false),
-    m_windowResizing(false),
-    m_windowVisible(true),
-    m_logicalWidth(0),
-    m_logicalHeight(0)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false),
+	m_windowResizing(false),
+	m_windowVisible(true),
+	m_logicalWidth(0),
+	m_logicalHeight(0)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    m_logicalWidth = window->Bounds.Width;
-    m_logicalHeight = window->Bounds.Height;
+	m_logicalWidth = window->Bounds.Width;
+	m_logicalHeight = window->Bounds.Height;
 
     auto dispatcher = CoreWindow::GetForCurrentThread()->Dispatcher;
     dispatcher->AcceleratorKeyActivated +=
         ref new TypedEventHandler<CoreDispatcher^, AcceleratorKeyEventArgs^>(this, &View::OnAcceleratorKeyActivated);
 
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->SizeChanged += ref new TypedEventHandler<CoreWindow^, WindowSizeChangedEventArgs^>(this, &View::OnSizeChanged);
-    window->VisibilityChanged += ref new TypedEventHandler<CoreWindow^, VisibilityChangedEventArgs^>(this, &View::OnVisibilityChanged);
-    window->Closed += ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &View::OnClosed);
-    window->PointerMoved += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerMoved);
-    window->PointerPressed += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerPressed);
-    window->PointerReleased += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerReleased);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->SizeChanged += ref new TypedEventHandler<CoreWindow^, WindowSizeChangedEventArgs^>(this, &View::OnSizeChanged);
+	window->VisibilityChanged += ref new TypedEventHandler<CoreWindow^, VisibilityChangedEventArgs^>(this, &View::OnVisibilityChanged);
+	window->Closed += ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &View::OnClosed);
+	window->PointerMoved += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerMoved);
+	window->PointerPressed += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerPressed);
+	window->PointerReleased += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerReleased);
 
-    try
-    {
-        window->ResizeStarted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeStarted);
-        window->ResizeCompleted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeCompleted);
-    }
-    catch (Exception^ e)
-    {
-        // Requires Windows 10 Creators Update (10.0.15063) or later.
-    }
+	try
+	{
+		window->ResizeStarted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeStarted);
+		window->ResizeCompleted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeCompleted);
+	}
+	catch (Exception^ e)
+	{
+		// Requires Windows 10 Creators Update (10.0.15063) or later.
+	}
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 
-    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-    displayInformation->DpiChanged += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDpiChanged);
-    displayInformation->DisplayContentsInvalidated += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDisplayContentsInvalidated);
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	displayInformation->DpiChanged += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDpiChanged);
+	displayInformation->DisplayContentsInvalidated += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDisplayContentsInvalidated);
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -80,20 +80,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -102,15 +102,15 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
     if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnAcceleratorKeyActivated(CoreDispatcher^, AcceleratorKeyEventArgs^ args)
@@ -138,97 +138,97 @@ void View::OnAcceleratorKeyActivated(CoreDispatcher^, AcceleratorKeyEventArgs^ a
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnSizeChanged(CoreWindow^ /*window*/, WindowSizeChangedEventArgs^ args)
 {
-    m_logicalWidth = args->Size.Width;
-    m_logicalHeight = args->Size.Height;
+	m_logicalWidth = args->Size.Width;
+	m_logicalHeight = args->Size.Height;
 
-    if (!m_windowResizing)
-    {
-        UpdateWindowSize();
-    }
+	if (!m_windowResizing)
+	{
+		UpdateWindowSize();
+	}
 }
 
 void View::OnResizeStarted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
 {
-    m_windowResizing = true;
+	m_windowResizing = true;
 }
 
 void View::OnResizeCompleted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
 {
-    m_windowResizing = false;
-    UpdateWindowSize();
+	m_windowResizing = false;
+	UpdateWindowSize();
 }
 
 void View::OnDpiChanged(DisplayInformation^ /*sender*/, Object^ /*args*/)
 {
-    UpdateWindowSize();
+	UpdateWindowSize();
 }
 
 void View::OnVisibilityChanged(CoreWindow^ /*window*/, VisibilityChangedEventArgs^ args)
 {
-    m_windowVisible = args->Visible;
-    UpdateWindowSize();
+	m_windowVisible = args->Visible;
+	UpdateWindowSize();
 }
 
 void View::OnClosed(CoreWindow^ /*window*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }
 
 void View::OnPointerMoved(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
-    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-    float dpi = displayInformation->LogicalDpi;
-    m_pSample->OnMouseMove(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	float dpi = displayInformation->LogicalDpi;
+	m_pSample->OnMouseMove(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
 }
 
 void View::OnPointerPressed(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
-    // For simplicity, we only consider left button press here.
-    if(args->CurrentPoint->Properties->IsLeftButtonPressed)
-    {
-        DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-        float dpi = displayInformation->LogicalDpi;
-        m_pSample->OnLeftButtonDown(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
-    }
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonDown(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
 }
 
 void View::OnPointerReleased(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
-    // For simplicity, we only consider left button press here.
-    if(args->CurrentPoint->Properties->IsLeftButtonPressed)
-    {
-        DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-        float dpi = displayInformation->LogicalDpi;
-        m_pSample->OnLeftButtonUp(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
-    }
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonUp(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
 }
 
 void View::UpdateWindowSize()
 {
-    CoreWindow^ window = CoreWindow::GetForCurrentThread();
-    Windows::Foundation::Rect windowBounds = window->Bounds;
+	CoreWindow^ window = CoreWindow::GetForCurrentThread();
+	Windows::Foundation::Rect windowBounds = window->Bounds;
 
-    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-    float dpi = displayInformation->LogicalDpi;
-    
-    m_pSample->SetWindowBounds(
-        ConvertToPixels(windowBounds.Left, dpi),
-        ConvertToPixels(windowBounds.Top, dpi),
-        ConvertToPixels(windowBounds.Right, dpi),
-        ConvertToPixels(windowBounds.Bottom, dpi));
-        
-    m_pSample->OnSizeChanged(ConvertToPixels(m_logicalWidth, dpi), ConvertToPixels(m_logicalHeight, dpi), !m_windowVisible);
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	float dpi = displayInformation->LogicalDpi;
+	
+	m_pSample->SetWindowBounds(
+		ConvertToPixels(windowBounds.Left, dpi),
+		ConvertToPixels(windowBounds.Top, dpi),
+		ConvertToPixels(windowBounds.Right, dpi),
+		ConvertToPixels(windowBounds.Bottom, dpi));
+		
+	m_pSample->OnSizeChanged(ConvertToPixels(m_logicalWidth, dpi), ConvertToPixels(m_logicalHeight, dpi), !m_windowVisible);
 }
 
 void View::OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args)
 {
-    m_pSample->OnDisplayChanged();
+	m_pSample->OnDisplayChanged();
 }

--- a/Samples/UWP/D3D12HDR/src/View.h
+++ b/Samples/UWP/D3D12HDR/src/View.h
@@ -24,36 +24,36 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
     void OnAcceleratorKeyActivated(CoreDispatcher^, AcceleratorKeyEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ args);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ args);
-    void OnSizeChanged(CoreWindow^ window, WindowSizeChangedEventArgs^ args);
-    void OnResizeStarted(CoreWindow^ window, Object^ args);
-    void OnResizeCompleted(CoreWindow^ window, Object^ args);
-    void OnDpiChanged(DisplayInformation^ sender, Object^ args);
-    void OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args);
-    void OnClosed(CoreWindow^ window, CoreWindowEventArgs^ args);
-    void OnPointerMoved(CoreWindow^ window, PointerEventArgs^ args);
-    void OnPointerPressed(CoreWindow^ window, PointerEventArgs^ args);
-    void OnPointerReleased(CoreWindow^ window, PointerEventArgs^ args);
-    void OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args);
-    
-    void UpdateWindowSize();
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ args);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ args);
+	void OnSizeChanged(CoreWindow^ window, WindowSizeChangedEventArgs^ args);
+	void OnResizeStarted(CoreWindow^ window, Object^ args);
+	void OnResizeCompleted(CoreWindow^ window, Object^ args);
+	void OnDpiChanged(DisplayInformation^ sender, Object^ args);
+	void OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args);
+	void OnClosed(CoreWindow^ window, CoreWindowEventArgs^ args);
+	void OnPointerMoved(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerPressed(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerReleased(CoreWindow^ window, PointerEventArgs^ args);
+	void OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args);
+	
+	void UpdateWindowSize();
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
-    bool m_windowResizing;
-    bool m_windowVisible;
-    float m_logicalWidth;
-    float m_logicalHeight;
+	DXSample* m_pSample;
+	bool m_windowClosed;
+	bool m_windowResizing;
+	bool m_windowVisible;
+	float m_logicalWidth;
+	float m_logicalHeight;
 };

--- a/Samples/UWP/D3D12HDR/src/ViewProvider.cpp
+++ b/Samples/UWP/D3D12HDR/src/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12HDR/src/ViewProvider.h
+++ b/Samples/UWP/D3D12HDR/src/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12HDR/src/color.hlsli
+++ b/Samples/UWP/D3D12HDR/src/color.hlsli
@@ -16,75 +16,75 @@
 
 float3 xyYToRec709(float2 xy, float Y = 1.0)
 {
-    // https://github.com/ampas/aces-dev/blob/v1.0.3/transforms/ctl/README-MATRIX.md
-    static const float3x3 XYZtoRGB =
-    {
-        3.2409699419, -1.5373831776, -0.4986107603,
-        -0.9692436363, 1.8759675015, 0.0415550574,
-        0.0556300797, -0.2039769589, 1.0569715142
-    };
-    float3 XYZ = Y * float3(xy.x / xy.y, 1.0, (1.0 - xy.x - xy.y) / xy.y);
-    float3 RGB = mul(XYZtoRGB, XYZ);
-    float maxChannel = max(RGB.r, max(RGB.g, RGB.b));
-    return RGB / max(maxChannel, 1.0);
+	// https://github.com/ampas/aces-dev/blob/v1.0.3/transforms/ctl/README-MATRIX.md
+	static const float3x3 XYZtoRGB =
+	{
+		3.2409699419, -1.5373831776, -0.4986107603,
+		-0.9692436363, 1.8759675015, 0.0415550574,
+		0.0556300797, -0.2039769589, 1.0569715142
+	};
+	float3 XYZ = Y * float3(xy.x / xy.y, 1.0, (1.0 - xy.x - xy.y) / xy.y);
+	float3 RGB = mul(XYZtoRGB, XYZ);
+	float maxChannel = max(RGB.r, max(RGB.g, RGB.b));
+	return RGB / max(maxChannel, 1.0);
 }
 
 float3 xyYToRec2020(float2 xy, float Y = 1.0)
 {
-    // https://github.com/ampas/aces-dev/blob/v1.0.3/transforms/ctl/README-MATRIX.md
-    static const float3x3 XYZtoRGB =
-    {
-        1.7166511880, -0.3556707838, -0.2533662814,
-        -0.6666843518, 1.6164812366, 0.0157685458,
-        0.0176398574, -0.0427706133, 0.9421031212
-    };
-    float3 XYZ = Y * float3(xy.x / xy.y, 1.0, (1.0 - xy.x - xy.y) / xy.y);
-    float3 RGB = mul(XYZtoRGB, XYZ);
-    float maxChannel = max(RGB.r, max(RGB.g, RGB.b));
-    return RGB / max(maxChannel, 1.0);
+	// https://github.com/ampas/aces-dev/blob/v1.0.3/transforms/ctl/README-MATRIX.md
+	static const float3x3 XYZtoRGB =
+	{
+		1.7166511880, -0.3556707838, -0.2533662814,
+		-0.6666843518, 1.6164812366, 0.0157685458,
+		0.0176398574, -0.0427706133, 0.9421031212
+	};
+	float3 XYZ = Y * float3(xy.x / xy.y, 1.0, (1.0 - xy.x - xy.y) / xy.y);
+	float3 RGB = mul(XYZtoRGB, XYZ);
+	float maxChannel = max(RGB.r, max(RGB.g, RGB.b));
+	return RGB / max(maxChannel, 1.0);
 }
 
 float3 LinearToSRGB(float3 color)
 {
-    // Approximately pow(color, 1.0 / 2.2)
-    return color < 0.0031308 ? 12.92 * color : 1.055 * pow(abs(color), 1.0 / 2.4) - 0.055;
+	// Approximately pow(color, 1.0 / 2.2)
+	return color < 0.0031308 ? 12.92 * color : 1.055 * pow(abs(color), 1.0 / 2.4) - 0.055;
 }
 
 float3 SRGBToLinear(float3 color)
 {
-    // Approximately pow(color, 2.2)
-    return color < 0.04045 ? color / 12.92 : pow(abs(color + 0.055) / 1.055, 2.4);
+	// Approximately pow(color, 2.2)
+	return color < 0.04045 ? color / 12.92 : pow(abs(color + 0.055) / 1.055, 2.4);
 }
 
 float3 Rec709ToRec2020(float3 color)
 {
-    static const float3x3 conversion =
-    {
-        0.627402, 0.329292, 0.043306,
-        0.069095, 0.919544, 0.011360,
-        0.016394, 0.088028, 0.895578
-    };
-    return mul(conversion, color);
+	static const float3x3 conversion =
+	{
+		0.627402, 0.329292, 0.043306,
+		0.069095, 0.919544, 0.011360,
+		0.016394, 0.088028, 0.895578
+	};
+	return mul(conversion, color);
 }
 
 float3 Rec2020ToRec709(float3 color)
 {
-    static const float3x3 conversion =
-    {
-        1.660496, -0.587656, -0.072840,
-        -0.124547, 1.132895, -0.008348,
-        -0.018154, -0.100597, 1.118751
-    };
-    return mul(conversion, color);
+	static const float3x3 conversion =
+	{
+		1.660496, -0.587656, -0.072840,
+		-0.124547, 1.132895, -0.008348,
+		-0.018154, -0.100597, 1.118751
+	};
+	return mul(conversion, color);
 }
 
 float3 LinearToST2084(float3 color)
 {
-    float m1 = 2610.0 / 4096.0 / 4;
-    float m2 = 2523.0 / 4096.0 * 128;
-    float c1 = 3424.0 / 4096.0;
-    float c2 = 2413.0 / 4096.0 * 32;
-    float c3 = 2392.0 / 4096.0 * 32;
-    float3 cp = pow(abs(color), m1);
-    return pow((c1 + c2 * cp) / (1 + c3 * cp), m2);
+	float m1 = 2610.0 / 4096.0 / 4;
+	float m2 = 2523.0 / 4096.0 * 128;
+	float c1 = 3424.0 / 4096.0;
+	float c2 = 2413.0 / 4096.0 * 32;
+	float c3 = 2392.0 / 4096.0 * 32;
+	float3 cp = pow(abs(color), m1);
+	return pow((c1 + c2 * cp) / (1 + c3 * cp), m2);
 }

--- a/Samples/UWP/D3D12HDR/src/d3dx12.h
+++ b/Samples/UWP/D3D12HDR/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12HDR/src/gradient.hlsli
+++ b/Samples/UWP/D3D12HDR/src/gradient.hlsli
@@ -11,12 +11,12 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 cbuffer RootConstants : register(b0)
 {
-    float standardNits;        // The reference brightness level of the display.
-    uint displayCurve;        // The expected format of the output signal.
+	float standardNits;		// The reference brightness level of the display.
+	uint displayCurve;		// The expected format of the output signal.
 };

--- a/Samples/UWP/D3D12HDR/src/gradientPS.hlsl
+++ b/Samples/UWP/D3D12HDR/src/gradientPS.hlsl
@@ -14,6 +14,6 @@
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    // This draws a perceptual gradient rather than a linear gradient.
-    return float4(pow(abs(input.color.rgb), 2.2), input.color.a);
+	// This draws a perceptual gradient rather than a linear gradient.
+	return float4(pow(abs(input.color.rgb), 2.2), input.color.a);
 }

--- a/Samples/UWP/D3D12HDR/src/gradientVS.hlsl
+++ b/Samples/UWP/D3D12HDR/src/gradientVS.hlsl
@@ -13,10 +13,10 @@
 
 PSInput VSMain(float4 position : POSITION, float4 color : COLOR)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.color = color;
+	result.position = position;
+	result.color = color;
 
-    return result;
+	return result;
 }

--- a/Samples/UWP/D3D12HDR/src/palette.hlsli
+++ b/Samples/UWP/D3D12HDR/src/palette.hlsli
@@ -11,12 +11,12 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 cbuffer RootConstants : register(b0)
 {
-    float standardNits;        // The reference brightness level of the display.
-    uint displayCurve;        // The expected format of the output signal.
+	float standardNits;		// The reference brightness level of the display.
+	uint displayCurve;		// The expected format of the output signal.
 };

--- a/Samples/UWP/D3D12HDR/src/palettePS.hlsl
+++ b/Samples/UWP/D3D12HDR/src/palettePS.hlsl
@@ -14,6 +14,6 @@
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    // The triangle stores the data in CIE xyY color space. We convert the data to RGB format in Rec709 RGB color space.
-    return float4(xyYToRec709(input.uv), 1.0);
+	// The triangle stores the data in CIE xyY color space. We convert the data to RGB format in Rec709 RGB color space.
+	return float4(xyYToRec709(input.uv), 1.0);
 }

--- a/Samples/UWP/D3D12HDR/src/paletteVS.hlsl
+++ b/Samples/UWP/D3D12HDR/src/paletteVS.hlsl
@@ -13,10 +13,10 @@
 
 PSInput VSMain(float4 position : POSITION, float2 uv : TEXCOORD)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.uv = uv;
+	result.position = position;
+	result.uv = uv;
 
-    return result;
+	return result;
 }

--- a/Samples/UWP/D3D12HDR/src/present.hlsli
+++ b/Samples/UWP/D3D12HDR/src/present.hlsli
@@ -11,14 +11,14 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 cbuffer RootConstants : register(b0)
 {
-    float standardNits;        // The reference brightness level of the display.
-    uint displayCurve;        // The expected format of the output signal.
+	float standardNits;		// The reference brightness level of the display.
+	uint displayCurve;		// The expected format of the output signal.
 };
 
 Texture2D g_scene : register(t0);

--- a/Samples/UWP/D3D12HDR/src/presentPS.hlsl
+++ b/Samples/UWP/D3D12HDR/src/presentPS.hlsl
@@ -14,34 +14,34 @@
 
 float3 PSMain(PSInput input) : SV_TARGET
 {
-    // The scene, including brightness bars and color palettes, is rendered with linear gamma and Rec.709 primaries. (DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709) 
-    float3 scene = g_scene.Sample(g_sampler, input.uv).rgb;
+	// The scene, including brightness bars and color palettes, is rendered with linear gamma and Rec.709 primaries. (DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709) 
+	float3 scene = g_scene.Sample(g_sampler, input.uv).rgb;
 
-    // Direct2D renders the UI layer with gamma 2.2 in Rec.709 primaries. (DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709, known as sRGB)
-    float4 uiLayer = g_ui.Sample(g_sampler, input.uv);
+	// Direct2D renders the UI layer with gamma 2.2 in Rec.709 primaries. (DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709, known as sRGB)
+	float4 uiLayer = g_ui.Sample(g_sampler, input.uv);
 
-    // Compose the scene and UI layers. Note that we convert UI layer from gamma 2.2 to to linear gamma before composing so both UI layers and the scene are with linear gamma and Rec.709 primaries. 
-    float3 result = lerp(scene, SRGBToLinear(uiLayer.rgb), uiLayer.a);
+	// Compose the scene and UI layers. Note that we convert UI layer from gamma 2.2 to to linear gamma before composing so both UI layers and the scene are with linear gamma and Rec.709 primaries. 
+	float3 result = lerp(scene, SRGBToLinear(uiLayer.rgb), uiLayer.a);
 
-    if (displayCurve == DISPLAY_CURVE_SRGB)
-    {
-        result = LinearToSRGB(result);
-    }
-    else if (displayCurve == DISPLAY_CURVE_ST2084)
-    {
-        const float st2084max = 10000.0;
+	if (displayCurve == DISPLAY_CURVE_SRGB)
+	{
+		result = LinearToSRGB(result);
+	}
+	else if (displayCurve == DISPLAY_CURVE_ST2084)
+	{
+		const float st2084max = 10000.0;
         const float hdrScalar = standardNits / st2084max;
 
-        // The HDR scene is in Rec.709, but the display is Rec.2020
-        result = Rec709ToRec2020(result);
+		// The HDR scene is in Rec.709, but the display is Rec.2020
+		result = Rec709ToRec2020(result);
 
-        // Apply the ST.2084 curve to the scene.
-        result = LinearToST2084(result * hdrScalar);
-    }
-    else // displayCurve == DISPLAY_CURVE_LINEAR
-    {
-        // Just pass through
-    }
+		// Apply the ST.2084 curve to the scene.
+		result = LinearToST2084(result * hdrScalar);
+	}
+	else // displayCurve == DISPLAY_CURVE_LINEAR
+	{
+		// Just pass through
+	}
 
-    return result;
+	return result;
 }

--- a/Samples/UWP/D3D12HDR/src/presentVS.hlsl
+++ b/Samples/UWP/D3D12HDR/src/presentVS.hlsl
@@ -13,10 +13,10 @@
 
 PSInput VSMain(float4 position : POSITION, float2 uv : TEXCOORD)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.uv = uv;
+	result.position = position;
+	result.uv = uv;
 
-    return result;
+	return result;
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.cpp
@@ -13,249 +13,249 @@
 #include "D3D12HelloBundles.h"
 
 D3D12HelloBundles::D3D12HelloBundles(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0)
 {
 }
 
 void D3D12HelloBundles::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12HelloBundles::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
-        }
-    }
+		// Create a RTV for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
+		}
+	}
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_BUNDLE, IID_PPV_ARGS(&m_bundleAllocator)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_BUNDLE, IID_PPV_ARGS(&m_bundleAllocator)));
 }
 
 // Load the sample assets.
 void D3D12HelloBundles::LoadAssets()
 {
-    // Create an empty root signature.
-    {
-        CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+	// Create an empty root signature.
+	{
+		CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Describe and create the graphics pipeline state object (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.SampleDesc.Count = 1;
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-    }
+		// Describe and create the graphics pipeline state object (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.SampleDesc.Count = 1;
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
 
-    // Command lists are created in the recording state, but there is nothing
-    // to record yet. The main loop expects it to be closed, so close it now.
-    ThrowIfFailed(m_commandList->Close());
+	// Command lists are created in the recording state, but there is nothing
+	// to record yet. The main loop expects it to be closed, so close it now.
+	ThrowIfFailed(m_commandList->Close());
 
-    // Create the vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        Vertex triangleVertices[] =
-        {
-            { { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
-            { { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
-            { { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
-        };
+	// Create the vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		Vertex triangleVertices[] =
+		{
+			{ { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
+			{ { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
+			{ { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
+		};
 
-        const UINT vertexBufferSize = sizeof(triangleVertices);
+		const UINT vertexBufferSize = sizeof(triangleVertices);
 
-        // Note: using upload heaps to transfer static data like vert buffers is not 
-        // recommended. Every time the GPU needs it, the upload heap will be marshalled 
-        // over. Please read up on Default Heap usage. An upload heap is used here for 
-        // code simplicity and because there are very few verts to actually transfer.
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		// Note: using upload heaps to transfer static data like vert buffers is not 
+		// recommended. Every time the GPU needs it, the upload heap will be marshalled 
+		// over. Please read up on Default Heap usage. An upload heap is used here for 
+		// code simplicity and because there are very few verts to actually transfer.
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        // Copy the triangle data to the vertex buffer.
-        UINT8* pVertexDataBegin;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
-        memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
-        m_vertexBuffer->Unmap(0, nullptr);
+		// Copy the triangle data to the vertex buffer.
+		UINT8* pVertexDataBegin;
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
+		memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
+		m_vertexBuffer->Unmap(0, nullptr);
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = vertexBufferSize;
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = vertexBufferSize;
+	}
 
-    // Create and record the bundle.
-    {
-        ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_BUNDLE, m_bundleAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_bundle)));
-        m_bundle->SetGraphicsRootSignature(m_rootSignature.Get());
-        m_bundle->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-        m_bundle->IASetVertexBuffers(0, 1, &m_vertexBufferView);
-        m_bundle->DrawInstanced(3, 1, 0, 0);
-        ThrowIfFailed(m_bundle->Close());
-    }
+	// Create and record the bundle.
+	{
+		ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_BUNDLE, m_bundleAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_bundle)));
+		m_bundle->SetGraphicsRootSignature(m_rootSignature.Get());
+		m_bundle->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+		m_bundle->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+		m_bundle->DrawInstanced(3, 1, 0, 0);
+		ThrowIfFailed(m_bundle->Close());
+	}
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValue = 1;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValue = 1;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForPreviousFrame();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForPreviousFrame();
+	}
 }
 
 // Update frame-based values.
@@ -266,82 +266,82 @@ void D3D12HelloBundles::OnUpdate()
 // Render the scene.
 void D3D12HelloBundles::OnRender()
 {
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+	// Present the frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    WaitForPreviousFrame();
+	WaitForPreviousFrame();
 }
 
 void D3D12HelloBundles::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForPreviousFrame();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForPreviousFrame();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12HelloBundles::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocator->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocator->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
 
-    // Execute the commands stored in the bundle.
-    m_commandList->ExecuteBundle(m_bundle.Get());
+	// Execute the commands stored in the bundle.
+	m_commandList->ExecuteBundle(m_bundle.Get());
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 void D3D12HelloBundles::WaitForPreviousFrame()
 {
-    // WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
-    // This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
-    // sample illustrates how to use fences for efficient resource usage and to
-    // maximize GPU utilization.
+	// WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
+	// This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
+	// sample illustrates how to use fences for efficient resource usage and to
+	// maximize GPU utilization.
 
-    // Signal and increment the fence value.
-    const UINT64 fence = m_fenceValue;
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
-    m_fenceValue++;
+	// Signal and increment the fence value.
+	const UINT64 fence = m_fenceValue;
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
+	m_fenceValue++;
 
-    // Wait until the previous frame is finished.
-    if (m_fence->GetCompletedValue() < fence)
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+	// Wait until the previous frame is finished.
+	if (m_fence->GetCompletedValue() < fence)
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.h
@@ -25,50 +25,50 @@ using Microsoft::WRL::ComPtr;
 class D3D12HelloBundles : public DXSample
 {
 public:
-    D3D12HelloBundles(UINT width, UINT height, std::wstring name);
+	D3D12HelloBundles(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    static const UINT FrameCount = 2;
+	static const UINT FrameCount = 2;
 
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT4 color;
-    };
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT4 color;
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandAllocator> m_bundleAllocator;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    ComPtr<ID3D12GraphicsCommandList> m_bundle;
-    UINT m_rtvDescriptorSize;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandAllocator> m_bundleAllocator;
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	ComPtr<ID3D12GraphicsCommandList> m_bundle;
+	UINT m_rtvDescriptorSize;
 
-    // App resources.
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	// App resources.
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValue;
+	// Synchronization objects.
+	UINT m_frameIndex;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValue;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void PopulateCommandList();
-    void WaitForPreviousFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	void PopulateCommandList();
+	void WaitForPreviousFrame();
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloBundles/DXSample.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloBundles/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,59 +34,104 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
-    auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(windowText.c_str());
+	std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
+	auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloBundles/DXSample.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloBundles/DXSample.h
@@ -16,42 +16,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloBundles/Main.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloBundles/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12HelloBundles sample(1200, 900, L"");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12HelloBundles sample(1200, 900, L"");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloBundles/View.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloBundles/View.cpp
@@ -15,27 +15,27 @@
 using namespace Windows::Foundation;
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -44,20 +44,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -66,26 +66,26 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnClosed(CoreWindow^ /*sender*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloBundles/View.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloBundles/View.h
@@ -23,20 +23,20 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
+	DXSample* m_pSample;
+	bool m_windowClosed;
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloBundles/ViewProvider.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloBundles/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloBundles/ViewProvider.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloBundles/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloBundles/d3dx12.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloBundles/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12HelloWorld/src/HelloBundles/shaders.hlsl
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloBundles/shaders.hlsl
@@ -11,21 +11,21 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VSMain(float4 position : POSITION, float4 color : COLOR)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.color = color;
+	result.position = position;
+	result.color = color;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.cpp
@@ -13,398 +13,398 @@
 #include "D3D12HelloConstBuffers.h"
 
 D3D12HelloConstBuffers::D3D12HelloConstBuffers(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_pCbvDataBegin(nullptr),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0),
-    m_constantBufferData{}
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_pCbvDataBegin(nullptr),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0),
+	m_constantBufferData{}
 {
 }
 
 void D3D12HelloConstBuffers::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12HelloConstBuffers::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
 
-        // Describe and create a constant buffer view (CBV) descriptor heap.
-        // Flags indicate that this descriptor heap can be bound to the pipeline 
-        // and that descriptors contained in it can be referenced by a root table.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
-        cbvHeapDesc.NumDescriptors = 1;
-        cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_cbvHeap)));
-    }
+		// Describe and create a constant buffer view (CBV) descriptor heap.
+		// Flags indicate that this descriptor heap can be bound to the pipeline 
+		// and that descriptors contained in it can be referenced by a root table.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
+		cbvHeapDesc.NumDescriptors = 1;
+		cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_cbvHeap)));
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
-        }
-    }
+		// Create a RTV for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
+		}
+	}
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
 }
 
 // Load the sample assets.
 void D3D12HelloConstBuffers::LoadAssets()
 {
-    // Create a root signature consisting of a descriptor table with a single CBV.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create a root signature consisting of a descriptor table with a single CBV.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
-        CD3DX12_ROOT_PARAMETER1 rootParameters[1];
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
+		CD3DX12_ROOT_PARAMETER1 rootParameters[1];
 
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_VERTEX);
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_VERTEX);
 
-        // Allow input layout and deny uneccessary access to certain pipeline stages.
-        D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
-            D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_PIXEL_SHADER_ROOT_ACCESS;
+		// Allow input layout and deny uneccessary access to certain pipeline stages.
+		D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
+			D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_PIXEL_SHADER_ROOT_ACCESS;
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, rootSignatureFlags);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, rootSignatureFlags);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Describe and create the graphics pipeline state object (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state object (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-    }
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
 
-    // Command lists are created in the recording state, but there is nothing
-    // to record yet. The main loop expects it to be closed, so close it now.
-    ThrowIfFailed(m_commandList->Close());
+	// Command lists are created in the recording state, but there is nothing
+	// to record yet. The main loop expects it to be closed, so close it now.
+	ThrowIfFailed(m_commandList->Close());
 
-    // Create the vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        Vertex triangleVertices[] =
-        {
-            { { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
-            { { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
-            { { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
-        };
+	// Create the vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		Vertex triangleVertices[] =
+		{
+			{ { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
+			{ { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
+			{ { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
+		};
 
-        const UINT vertexBufferSize = sizeof(triangleVertices);
+		const UINT vertexBufferSize = sizeof(triangleVertices);
 
-        // Note: using upload heaps to transfer static data like vert buffers is not 
-        // recommended. Every time the GPU needs it, the upload heap will be marshalled 
-        // over. Please read up on Default Heap usage. An upload heap is used here for 
-        // code simplicity and because there are very few verts to actually transfer.
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		// Note: using upload heaps to transfer static data like vert buffers is not 
+		// recommended. Every time the GPU needs it, the upload heap will be marshalled 
+		// over. Please read up on Default Heap usage. An upload heap is used here for 
+		// code simplicity and because there are very few verts to actually transfer.
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        // Copy the triangle data to the vertex buffer.
-        UINT8* pVertexDataBegin;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
-        memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
-        m_vertexBuffer->Unmap(0, nullptr);
+		// Copy the triangle data to the vertex buffer.
+		UINT8* pVertexDataBegin;
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
+		memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
+		m_vertexBuffer->Unmap(0, nullptr);
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = vertexBufferSize;
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = vertexBufferSize;
+	}
 
-    // Create the constant buffer.
-    {
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(1024 * 64),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_constantBuffer)));
+	// Create the constant buffer.
+	{
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(1024 * 64),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_constantBuffer)));
 
-        // Describe and create a constant buffer view.
-        D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
-        cbvDesc.BufferLocation = m_constantBuffer->GetGPUVirtualAddress();
-        cbvDesc.SizeInBytes = (sizeof(SceneConstantBuffer) + 255) & ~255;    // CB size is required to be 256-byte aligned.
-        m_device->CreateConstantBufferView(&cbvDesc, m_cbvHeap->GetCPUDescriptorHandleForHeapStart());
+		// Describe and create a constant buffer view.
+		D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
+		cbvDesc.BufferLocation = m_constantBuffer->GetGPUVirtualAddress();
+		cbvDesc.SizeInBytes = (sizeof(SceneConstantBuffer) + 255) & ~255;	// CB size is required to be 256-byte aligned.
+		m_device->CreateConstantBufferView(&cbvDesc, m_cbvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Map and initialize the constant buffer. We don't unmap this until the
-        // app closes. Keeping things mapped for the lifetime of the resource is okay.
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbvDataBegin)));
-        memcpy(m_pCbvDataBegin, &m_constantBufferData, sizeof(m_constantBufferData));
-    }
+		// Map and initialize the constant buffer. We don't unmap this until the
+		// app closes. Keeping things mapped for the lifetime of the resource is okay.
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbvDataBegin)));
+		memcpy(m_pCbvDataBegin, &m_constantBufferData, sizeof(m_constantBufferData));
+	}
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValue = 1;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValue = 1;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForPreviousFrame();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForPreviousFrame();
+	}
 }
 
 // Update frame-based values.
 void D3D12HelloConstBuffers::OnUpdate()
 {
-    const float translationSpeed = 0.005f;
-    const float offsetBounds = 1.25f;
+	const float translationSpeed = 0.005f;
+	const float offsetBounds = 1.25f;
 
-    m_constantBufferData.offset.x += translationSpeed;
-    if (m_constantBufferData.offset.x > offsetBounds)
-    {
-        m_constantBufferData.offset.x = -offsetBounds;
-    }
-    memcpy(m_pCbvDataBegin, &m_constantBufferData, sizeof(m_constantBufferData));
+	m_constantBufferData.offset.x += translationSpeed;
+	if (m_constantBufferData.offset.x > offsetBounds)
+	{
+		m_constantBufferData.offset.x = -offsetBounds;
+	}
+	memcpy(m_pCbvDataBegin, &m_constantBufferData, sizeof(m_constantBufferData));
 }
 
 // Render the scene.
 void D3D12HelloConstBuffers::OnRender()
 {
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+	// Present the frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    WaitForPreviousFrame();
+	WaitForPreviousFrame();
 }
 
 void D3D12HelloConstBuffers::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForPreviousFrame();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForPreviousFrame();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12HelloConstBuffers::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocator->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocator->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_cbvHeap.Get() };
-    m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_cbvHeap.Get() };
+	m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_commandList->SetGraphicsRootDescriptorTable(0, m_cbvHeap->GetGPUDescriptorHandleForHeapStart());
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	m_commandList->SetGraphicsRootDescriptorTable(0, m_cbvHeap->GetGPUDescriptorHandleForHeapStart());
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
-    m_commandList->DrawInstanced(3, 1, 0, 0);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+	m_commandList->DrawInstanced(3, 1, 0, 0);
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 void D3D12HelloConstBuffers::WaitForPreviousFrame()
 {
-    // WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
-    // This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
-    // sample illustrates how to use fences for efficient resource usage and to
-    // maximize GPU utilization.
+	// WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
+	// This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
+	// sample illustrates how to use fences for efficient resource usage and to
+	// maximize GPU utilization.
 
-    // Signal and increment the fence value.
-    const UINT64 fence = m_fenceValue;
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
-    m_fenceValue++;
+	// Signal and increment the fence value.
+	const UINT64 fence = m_fenceValue;
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
+	m_fenceValue++;
 
-    // Wait until the previous frame is finished.
-    if (m_fence->GetCompletedValue() < fence)
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+	// Wait until the previous frame is finished.
+	if (m_fence->GetCompletedValue() < fence)
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.h
@@ -25,57 +25,57 @@ using Microsoft::WRL::ComPtr;
 class D3D12HelloConstBuffers : public DXSample
 {
 public:
-    D3D12HelloConstBuffers(UINT width, UINT height, std::wstring name);
+	D3D12HelloConstBuffers(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    static const UINT FrameCount = 2;
+	static const UINT FrameCount = 2;
 
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT4 color;
-    };
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT4 color;
+	};
 
-    struct SceneConstantBuffer
-    {
-        XMFLOAT4 offset;
-    };
+	struct SceneConstantBuffer
+	{
+		XMFLOAT4 offset;
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_cbvHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    UINT m_rtvDescriptorSize;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_cbvHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	UINT m_rtvDescriptorSize;
 
-    // App resources.
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
-    ComPtr<ID3D12Resource> m_constantBuffer;
-    SceneConstantBuffer m_constantBufferData;
-    UINT8* m_pCbvDataBegin;
+	// App resources.
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	ComPtr<ID3D12Resource> m_constantBuffer;
+	SceneConstantBuffer m_constantBufferData;
+	UINT8* m_pCbvDataBegin;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValue;
+	// Synchronization objects.
+	UINT m_frameIndex;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValue;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void PopulateCommandList();
-    void WaitForPreviousFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	void PopulateCommandList();
+	void WaitForPreviousFrame();
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/DXSample.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,59 +34,104 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
-    auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(windowText.c_str());
+	std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
+	auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/DXSample.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/DXSample.h
@@ -16,42 +16,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/Main.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12HelloConstBuffers sample(1200, 900, L"");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12HelloConstBuffers sample(1200, 900, L"");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/View.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/View.cpp
@@ -15,27 +15,27 @@
 using namespace Windows::Foundation;
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -44,20 +44,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -66,26 +66,26 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnClosed(CoreWindow^ /*sender*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/View.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/View.h
@@ -23,20 +23,20 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
+	DXSample* m_pSample;
+	bool m_windowClosed;
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/ViewProvider.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/ViewProvider.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/d3dx12.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/shaders.hlsl
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/shaders.hlsl
@@ -11,26 +11,26 @@
 
 cbuffer SceneConstantBuffer : register(b0)
 {
-    float4 offset;
+	float4 offset;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VSMain(float4 position : POSITION, float4 color : COLOR)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position + offset;
-    result.color = color;
+	result.position = position + offset;
+	result.color = color;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/D3D12HelloFrameBuffering.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/D3D12HelloFrameBuffering.cpp
@@ -13,239 +13,239 @@
 #include "D3D12HelloFrameBuffering.h"
 
 D3D12HelloFrameBuffering::D3D12HelloFrameBuffering(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_fenceValues{},
-    m_rtvDescriptorSize(0)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_fenceValues{},
+	m_rtvDescriptorSize(0)
 {
 }
 
 void D3D12HelloFrameBuffering::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12HelloFrameBuffering::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV and a command allocator for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
+		// Create a RTV and a command allocator for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-            ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
-        }
-    }
+			ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
+		}
+	}
 }
 
 // Load the sample assets.
 void D3D12HelloFrameBuffering::LoadAssets()
 {
-    // Create an empty root signature.
-    {
-        CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+	// Create an empty root signature.
+	{
+		CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Describe and create the graphics pipeline state object (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.SampleDesc.Count = 1;
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-    }
+		// Describe and create the graphics pipeline state object (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.SampleDesc.Count = 1;
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
 
-    // Command lists are created in the recording state, but there is nothing
-    // to record yet. The main loop expects it to be closed, so close it now.
-    ThrowIfFailed(m_commandList->Close());
+	// Command lists are created in the recording state, but there is nothing
+	// to record yet. The main loop expects it to be closed, so close it now.
+	ThrowIfFailed(m_commandList->Close());
 
-    // Create the vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        Vertex triangleVertices[] =
-        {
-            { { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
-            { { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
-            { { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
-        };
+	// Create the vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		Vertex triangleVertices[] =
+		{
+			{ { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
+			{ { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
+			{ { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
+		};
 
-        const UINT vertexBufferSize = sizeof(triangleVertices);
+		const UINT vertexBufferSize = sizeof(triangleVertices);
 
-        // Note: using upload heaps to transfer static data like vert buffers is not 
-        // recommended. Every time the GPU needs it, the upload heap will be marshalled 
-        // over. Please read up on Default Heap usage. An upload heap is used here for 
-        // code simplicity and because there are very few verts to actually transfer.
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		// Note: using upload heaps to transfer static data like vert buffers is not 
+		// recommended. Every time the GPU needs it, the upload heap will be marshalled 
+		// over. Please read up on Default Heap usage. An upload heap is used here for 
+		// code simplicity and because there are very few verts to actually transfer.
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        // Copy the triangle data to the vertex buffer.
-        UINT8* pVertexDataBegin;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
-        memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
-        m_vertexBuffer->Unmap(0, nullptr);
+		// Copy the triangle data to the vertex buffer.
+		UINT8* pVertexDataBegin;
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
+		memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
+		m_vertexBuffer->Unmap(0, nullptr);
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = vertexBufferSize;
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = vertexBufferSize;
+	}
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValues[m_frameIndex]++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValues[m_frameIndex]++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForGpu();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForGpu();
+	}
 }
 
 // Update frame-based values.
@@ -256,95 +256,95 @@ void D3D12HelloFrameBuffering::OnUpdate()
 // Render the scene.
 void D3D12HelloFrameBuffering::OnRender()
 {
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+	// Present the frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    MoveToNextFrame();
+	MoveToNextFrame();
 }
 
 void D3D12HelloFrameBuffering::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForGpu();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForGpu();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12HelloFrameBuffering::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
-    m_commandList->DrawInstanced(3, 1, 0, 0);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+	m_commandList->DrawInstanced(3, 1, 0, 0);
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 // Wait for pending GPU work to complete.
 void D3D12HelloFrameBuffering::WaitForGpu()
 {
-    // Schedule a Signal command in the queue.
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
+	// Schedule a Signal command in the queue.
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
 
-    // Wait until the fence has been processed.
-    ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-    WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	// Wait until the fence has been processed.
+	ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+	WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
 
-    // Increment the fence value for the current frame.
-    m_fenceValues[m_frameIndex]++;
+	// Increment the fence value for the current frame.
+	m_fenceValues[m_frameIndex]++;
 }
 
 // Prepare to render the next frame.
 void D3D12HelloFrameBuffering::MoveToNextFrame()
 {
-    // Schedule a Signal command in the queue.
-    const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
+	// Schedule a Signal command in the queue.
+	const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
 
-    // Update the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Update the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-        WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+		WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	}
 
-    // Set the fence value for the next frame.
-    m_fenceValues[m_frameIndex] = currentFenceValue + 1;
+	// Set the fence value for the next frame.
+	m_fenceValues[m_frameIndex] = currentFenceValue + 1;
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/D3D12HelloFrameBuffering.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/D3D12HelloFrameBuffering.h
@@ -25,57 +25,57 @@ using Microsoft::WRL::ComPtr;
 class D3D12HelloFrameBuffering : public DXSample
 {
 public:
-    D3D12HelloFrameBuffering(UINT width, UINT height, std::wstring name);
+	D3D12HelloFrameBuffering(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    // In this sample we overload the meaning of FrameCount to mean both the maximum
-    // number of frames that will be queued to the GPU at a time, as well as the number
-    // of back buffers in the DXGI swap chain. For the majority of applications, this
-    // is convenient and works well. However, there will be certain cases where an
-    // application may want to queue up more frames than there are back buffers
-    // available.
-    // It should be noted that excessive buffering of frames dependent on user input
-    // may result in noticeable latency in your app.
-    static const UINT FrameCount = 2;
+	// In this sample we overload the meaning of FrameCount to mean both the maximum
+	// number of frames that will be queued to the GPU at a time, as well as the number
+	// of back buffers in the DXGI swap chain. For the majority of applications, this
+	// is convenient and works well. However, there will be certain cases where an
+	// application may want to queue up more frames than there are back buffers
+	// available.
+	// It should be noted that excessive buffering of frames dependent on user input
+	// may result in noticeable latency in your app.
+	static const UINT FrameCount = 2;
 
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT4 color;
-    };
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT4 color;
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    UINT m_rtvDescriptorSize;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	UINT m_rtvDescriptorSize;
 
-    // App resources.
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	// App resources.
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValues[FrameCount];
+	// Synchronization objects.
+	UINT m_frameIndex;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValues[FrameCount];
 
-    void LoadPipeline();
-    void LoadAssets();
-    void PopulateCommandList();
-    void MoveToNextFrame();
-    void WaitForGpu();
+	void LoadPipeline();
+	void LoadAssets();
+	void PopulateCommandList();
+	void MoveToNextFrame();
+	void WaitForGpu();
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/DXSample.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,59 +34,104 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
-    auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(windowText.c_str());
+	std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
+	auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/DXSample.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/DXSample.h
@@ -16,42 +16,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/Main.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12HelloFrameBuffering sample(1200, 900, L"");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12HelloFrameBuffering sample(1200, 900, L"");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/View.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/View.cpp
@@ -15,27 +15,27 @@
 using namespace Windows::Foundation;
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -44,20 +44,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -66,26 +66,26 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnClosed(CoreWindow^ /*sender*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/View.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/View.h
@@ -23,20 +23,20 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
+	DXSample* m_pSample;
+	bool m_windowClosed;
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/ViewProvider.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/ViewProvider.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/d3dx12.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/shaders.hlsl
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/shaders.hlsl
@@ -11,21 +11,21 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VSMain(float4 position : POSITION, float4 color : COLOR)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.color = color;
+	result.position = position;
+	result.color = color;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.cpp
@@ -13,374 +13,374 @@
 #include "D3D12HelloTexture.h"
 
 D3D12HelloTexture::D3D12HelloTexture(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0)
 {
 }
 
 void D3D12HelloTexture::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12HelloTexture::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a shader resource view (SRV) heap for the texture.
-        D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
-        srvHeapDesc.NumDescriptors = 1;
-        srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
+		// Describe and create a shader resource view (SRV) heap for the texture.
+		D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
+		srvHeapDesc.NumDescriptors = 1;
+		srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
-        }
-    }
+		// Create a RTV for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
+		}
+	}
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
 }
 
 // Load the sample assets.
 void D3D12HelloTexture::LoadAssets()
 {
-    // Create the root signature.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signature.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
 
-        CD3DX12_ROOT_PARAMETER1 rootParameters[1];
-        rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
+		CD3DX12_ROOT_PARAMETER1 rootParameters[1];
+		rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
 
-        D3D12_STATIC_SAMPLER_DESC sampler = {};
-        sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
-        sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.MipLODBias = 0;
-        sampler.MaxAnisotropy = 0;
-        sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
-        sampler.BorderColor = D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
-        sampler.MinLOD = 0.0f;
-        sampler.MaxLOD = D3D12_FLOAT32_MAX;
-        sampler.ShaderRegister = 0;
-        sampler.RegisterSpace = 0;
-        sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+		D3D12_STATIC_SAMPLER_DESC sampler = {};
+		sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
+		sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.MipLODBias = 0;
+		sampler.MaxAnisotropy = 0;
+		sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
+		sampler.BorderColor = D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
+		sampler.MinLOD = 0.0f;
+		sampler.MaxLOD = D3D12_FLOAT32_MAX;
+		sampler.ShaderRegister = 0;
+		sampler.RegisterSpace = 0;
+		sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &sampler, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &sampler, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Describe and create the graphics pipeline state object (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.SampleDesc.Count = 1;
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-    }
+		// Describe and create the graphics pipeline state object (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.SampleDesc.Count = 1;
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
 
-    // Create the vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        Vertex triangleVertices[] =
-        {
-            { { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 0.5f, 0.0f } },
-            { { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 1.0f, 1.0f } },
-            { { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f } }
-        };
+	// Create the vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		Vertex triangleVertices[] =
+		{
+			{ { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 0.5f, 0.0f } },
+			{ { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 1.0f, 1.0f } },
+			{ { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f } }
+		};
 
-        const UINT vertexBufferSize = sizeof(triangleVertices);
+		const UINT vertexBufferSize = sizeof(triangleVertices);
 
-        // Note: using upload heaps to transfer static data like vert buffers is not 
-        // recommended. Every time the GPU needs it, the upload heap will be marshalled 
-        // over. Please read up on Default Heap usage. An upload heap is used here for 
-        // code simplicity and because there are very few verts to actually transfer.
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		// Note: using upload heaps to transfer static data like vert buffers is not 
+		// recommended. Every time the GPU needs it, the upload heap will be marshalled 
+		// over. Please read up on Default Heap usage. An upload heap is used here for 
+		// code simplicity and because there are very few verts to actually transfer.
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        // Copy the triangle data to the vertex buffer.
-        UINT8* pVertexDataBegin;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
-        memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
-        m_vertexBuffer->Unmap(0, nullptr);
+		// Copy the triangle data to the vertex buffer.
+		UINT8* pVertexDataBegin;
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
+		memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
+		m_vertexBuffer->Unmap(0, nullptr);
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = vertexBufferSize;
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = vertexBufferSize;
+	}
 
-    // Note: ComPtr's are CPU objects but this resource needs to stay in scope until
-    // the command list that references it has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resource is not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> textureUploadHeap;
+	// Note: ComPtr's are CPU objects but this resource needs to stay in scope until
+	// the command list that references it has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resource is not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> textureUploadHeap;
 
-    // Create the texture.
-    {
-        // Describe and create a Texture2D.
-        D3D12_RESOURCE_DESC textureDesc = {};
-        textureDesc.MipLevels = 1;
-        textureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        textureDesc.Width = TextureWidth;
-        textureDesc.Height = TextureHeight;
-        textureDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
-        textureDesc.DepthOrArraySize = 1;
-        textureDesc.SampleDesc.Count = 1;
-        textureDesc.SampleDesc.Quality = 0;
-        textureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+	// Create the texture.
+	{
+		// Describe and create a Texture2D.
+		D3D12_RESOURCE_DESC textureDesc = {};
+		textureDesc.MipLevels = 1;
+		textureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+		textureDesc.Width = TextureWidth;
+		textureDesc.Height = TextureHeight;
+		textureDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
+		textureDesc.DepthOrArraySize = 1;
+		textureDesc.SampleDesc.Count = 1;
+		textureDesc.SampleDesc.Quality = 0;
+		textureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &textureDesc,
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_texture)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&textureDesc,
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_texture)));
 
-        const UINT64 uploadBufferSize = GetRequiredIntermediateSize(m_texture.Get(), 0, 1);
+		const UINT64 uploadBufferSize = GetRequiredIntermediateSize(m_texture.Get(), 0, 1);
 
-        // Create the GPU upload buffer.
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&textureUploadHeap)));
+		// Create the GPU upload buffer.
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&textureUploadHeap)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the Texture2D.
-        std::vector<UINT8> texture = GenerateTextureData();
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the Texture2D.
+		std::vector<UINT8> texture = GenerateTextureData();
 
-        D3D12_SUBRESOURCE_DATA textureData = {};
-        textureData.pData = &texture[0];
-        textureData.RowPitch = TextureWidth * TexturePixelSize;
-        textureData.SlicePitch = textureData.RowPitch * TextureHeight;
+		D3D12_SUBRESOURCE_DATA textureData = {};
+		textureData.pData = &texture[0];
+		textureData.RowPitch = TextureWidth * TexturePixelSize;
+		textureData.SlicePitch = textureData.RowPitch * TextureHeight;
 
-        UpdateSubresources(m_commandList.Get(), m_texture.Get(), textureUploadHeap.Get(), 0, 0, 1, &textureData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_texture.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
+		UpdateSubresources(m_commandList.Get(), m_texture.Get(), textureUploadHeap.Get(), 0, 0, 1, &textureData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_texture.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
 
-        // Describe and create a SRV for the texture.
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Format = textureDesc.Format;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = 1;
-        m_device->CreateShaderResourceView(m_texture.Get(), &srvDesc, m_srvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
-    
-    // Close the command list and execute it to begin the initial GPU setup.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+		// Describe and create a SRV for the texture.
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Format = textureDesc.Format;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = 1;
+		m_device->CreateShaderResourceView(m_texture.Get(), &srvDesc, m_srvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
+	
+	// Close the command list and execute it to begin the initial GPU setup.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValue = 1;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValue = 1;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForPreviousFrame();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForPreviousFrame();
+	}
 }
 
 // Generate a simple black and white checkerboard texture.
 std::vector<UINT8> D3D12HelloTexture::GenerateTextureData()
 {
-    const UINT rowPitch = TextureWidth * TexturePixelSize;
-    const UINT cellPitch = rowPitch >> 3;        // The width of a cell in the checkboard texture.
-    const UINT cellHeight = TextureWidth >> 3;    // The height of a cell in the checkerboard texture.
-    const UINT textureSize = rowPitch * TextureHeight;
+	const UINT rowPitch = TextureWidth * TexturePixelSize;
+	const UINT cellPitch = rowPitch >> 3;		// The width of a cell in the checkboard texture.
+	const UINT cellHeight = TextureWidth >> 3;	// The height of a cell in the checkerboard texture.
+	const UINT textureSize = rowPitch * TextureHeight;
 
-    std::vector<UINT8> data(textureSize);
-    UINT8* pData = &data[0];
+	std::vector<UINT8> data(textureSize);
+	UINT8* pData = &data[0];
 
-    for (UINT n = 0; n < textureSize; n += TexturePixelSize)
-    {
-        UINT x = n % rowPitch;
-        UINT y = n / rowPitch;
-        UINT i = x / cellPitch;
-        UINT j = y / cellHeight;
+	for (UINT n = 0; n < textureSize; n += TexturePixelSize)
+	{
+		UINT x = n % rowPitch;
+		UINT y = n / rowPitch;
+		UINT i = x / cellPitch;
+		UINT j = y / cellHeight;
 
-        if (i % 2 == j % 2)
-        {
-            pData[n] = 0x00;        // R
-            pData[n + 1] = 0x00;    // G
-            pData[n + 2] = 0x00;    // B
-            pData[n + 3] = 0xff;    // A
-        }
-        else
-        {
-            pData[n] = 0xff;        // R
-            pData[n + 1] = 0xff;    // G
-            pData[n + 2] = 0xff;    // B
-            pData[n + 3] = 0xff;    // A
-        }
-    }
+		if (i % 2 == j % 2)
+		{
+			pData[n] = 0x00;		// R
+			pData[n + 1] = 0x00;	// G
+			pData[n + 2] = 0x00;	// B
+			pData[n + 3] = 0xff;	// A
+		}
+		else
+		{
+			pData[n] = 0xff;		// R
+			pData[n + 1] = 0xff;	// G
+			pData[n + 2] = 0xff;	// B
+			pData[n + 3] = 0xff;	// A
+		}
+	}
 
-    return data;
+	return data;
 }
 
 // Update frame-based values.
@@ -391,87 +391,87 @@ void D3D12HelloTexture::OnUpdate()
 // Render the scene.
 void D3D12HelloTexture::OnRender()
 {
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+	// Present the frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    WaitForPreviousFrame();
+	WaitForPreviousFrame();
 }
 
 void D3D12HelloTexture::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForPreviousFrame();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForPreviousFrame();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12HelloTexture::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocator->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocator->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
-    m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
+	m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_commandList->SetGraphicsRootDescriptorTable(0, m_srvHeap->GetGPUDescriptorHandleForHeapStart());
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	m_commandList->SetGraphicsRootDescriptorTable(0, m_srvHeap->GetGPUDescriptorHandleForHeapStart());
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
-    m_commandList->DrawInstanced(3, 1, 0, 0);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+	m_commandList->DrawInstanced(3, 1, 0, 0);
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 void D3D12HelloTexture::WaitForPreviousFrame()
 {
-    // WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
-    // This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
-    // sample illustrates how to use fences for efficient resource usage and to
-    // maximize GPU utilization.
+	// WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
+	// This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
+	// sample illustrates how to use fences for efficient resource usage and to
+	// maximize GPU utilization.
 
-    // Signal and increment the fence value.
-    const UINT64 fence = m_fenceValue;
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
-    m_fenceValue++;
+	// Signal and increment the fence value.
+	const UINT64 fence = m_fenceValue;
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
+	m_fenceValue++;
 
-    // Wait until the previous frame is finished.
-    if (m_fence->GetCompletedValue() < fence)
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+	// Wait until the previous frame is finished.
+	if (m_fence->GetCompletedValue() < fence)
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.h
@@ -25,54 +25,54 @@ using Microsoft::WRL::ComPtr;
 class D3D12HelloTexture : public DXSample
 {
 public:
-    D3D12HelloTexture(UINT width, UINT height, std::wstring name);
+	D3D12HelloTexture(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    static const UINT FrameCount = 2;
-    static const UINT TextureWidth = 256;
-    static const UINT TextureHeight = 256;
-    static const UINT TexturePixelSize = 4;    // The number of bytes used to represent a pixel in the texture.
+	static const UINT FrameCount = 2;
+	static const UINT TextureWidth = 256;
+	static const UINT TextureHeight = 256;
+	static const UINT TexturePixelSize = 4;	// The number of bytes used to represent a pixel in the texture.
 
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT2 uv;
-    };
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT2 uv;
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_srvHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    UINT m_rtvDescriptorSize;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_srvHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	UINT m_rtvDescriptorSize;
 
-    // App resources.
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
-    ComPtr<ID3D12Resource> m_texture;
+	// App resources.
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	ComPtr<ID3D12Resource> m_texture;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValue;
+	// Synchronization objects.
+	UINT m_frameIndex;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValue;
 
-    void LoadPipeline();
-    void LoadAssets();
-    std::vector<UINT8> GenerateTextureData();
-    void PopulateCommandList();
-    void WaitForPreviousFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	std::vector<UINT8> GenerateTextureData();
+	void PopulateCommandList();
+	void WaitForPreviousFrame();
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTexture/DXSample.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTexture/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,59 +34,104 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
-    auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(windowText.c_str());
+	std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
+	auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTexture/DXSample.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTexture/DXSample.h
@@ -16,42 +16,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTexture/Main.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTexture/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12HelloTexture sample(1200, 900, L"");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12HelloTexture sample(1200, 900, L"");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTexture/View.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTexture/View.cpp
@@ -15,27 +15,27 @@
 using namespace Windows::Foundation;
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -44,20 +44,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -66,26 +66,26 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnClosed(CoreWindow^ /*sender*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTexture/View.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTexture/View.h
@@ -23,20 +23,20 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
+	DXSample* m_pSample;
+	bool m_windowClosed;
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTexture/ViewProvider.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTexture/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTexture/ViewProvider.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTexture/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTexture/d3dx12.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTexture/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTexture/shaders.hlsl
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTexture/shaders.hlsl
@@ -11,8 +11,8 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 Texture2D g_texture : register(t0);
@@ -20,15 +20,15 @@ SamplerState g_sampler : register(s0);
 
 PSInput VSMain(float4 position : POSITION, float4 uv : TEXCOORD)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.uv = uv;
+	result.position = position;
+	result.uv = uv;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return g_texture.Sample(g_sampler, input.uv);
+	return g_texture.Sample(g_sampler, input.uv);
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.cpp
@@ -13,238 +13,238 @@
 #include "D3D12HelloTriangle.h"
 
 D3D12HelloTriangle::D3D12HelloTriangle(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0)
 {
 }
 
 void D3D12HelloTriangle::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12HelloTriangle::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
-        }
-    }
+		// Create a RTV for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
+		}
+	}
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
 }
 
 // Load the sample assets.
 void D3D12HelloTriangle::LoadAssets()
 {
-    // Create an empty root signature.
-    {
-        CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+	// Create an empty root signature.
+	{
+		CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Describe and create the graphics pipeline state object (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.SampleDesc.Count = 1;
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-    }
+		// Describe and create the graphics pipeline state object (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.SampleDesc.Count = 1;
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
 
-    // Command lists are created in the recording state, but there is nothing
-    // to record yet. The main loop expects it to be closed, so close it now.
-    ThrowIfFailed(m_commandList->Close());
+	// Command lists are created in the recording state, but there is nothing
+	// to record yet. The main loop expects it to be closed, so close it now.
+	ThrowIfFailed(m_commandList->Close());
 
-    // Create the vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        Vertex triangleVertices[] =
-        {
-            { { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
-            { { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
-            { { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
-        };
+	// Create the vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		Vertex triangleVertices[] =
+		{
+			{ { 0.0f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
+			{ { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
+			{ { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
+		};
 
-        const UINT vertexBufferSize = sizeof(triangleVertices);
+		const UINT vertexBufferSize = sizeof(triangleVertices);
 
-        // Note: using upload heaps to transfer static data like vert buffers is not 
-        // recommended. Every time the GPU needs it, the upload heap will be marshalled 
-        // over. Please read up on Default Heap usage. An upload heap is used here for 
-        // code simplicity and because there are very few verts to actually transfer.
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		// Note: using upload heaps to transfer static data like vert buffers is not 
+		// recommended. Every time the GPU needs it, the upload heap will be marshalled 
+		// over. Please read up on Default Heap usage. An upload heap is used here for 
+		// code simplicity and because there are very few verts to actually transfer.
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        // Copy the triangle data to the vertex buffer.
-        UINT8* pVertexDataBegin;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
-        memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
-        m_vertexBuffer->Unmap(0, nullptr);
+		// Copy the triangle data to the vertex buffer.
+		UINT8* pVertexDataBegin;
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
+		memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
+		m_vertexBuffer->Unmap(0, nullptr);
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = vertexBufferSize;
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = vertexBufferSize;
+	}
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValue = 1;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValue = 1;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForPreviousFrame();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForPreviousFrame();
+	}
 }
 
 // Update frame-based values.
@@ -255,82 +255,82 @@ void D3D12HelloTriangle::OnUpdate()
 // Render the scene.
 void D3D12HelloTriangle::OnRender()
 {
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+	// Present the frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    WaitForPreviousFrame();
+	WaitForPreviousFrame();
 }
 
 void D3D12HelloTriangle::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForPreviousFrame();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForPreviousFrame();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12HelloTriangle::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocator->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocator->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
-    m_commandList->DrawInstanced(3, 1, 0, 0);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+	m_commandList->DrawInstanced(3, 1, 0, 0);
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 void D3D12HelloTriangle::WaitForPreviousFrame()
 {
-    // WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
-    // This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
-    // sample illustrates how to use fences for efficient resource usage and to
-    // maximize GPU utilization.
+	// WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
+	// This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
+	// sample illustrates how to use fences for efficient resource usage and to
+	// maximize GPU utilization.
 
-    // Signal and increment the fence value.
-    const UINT64 fence = m_fenceValue;
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
-    m_fenceValue++;
+	// Signal and increment the fence value.
+	const UINT64 fence = m_fenceValue;
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
+	m_fenceValue++;
 
-    // Wait until the previous frame is finished.
-    if (m_fence->GetCompletedValue() < fence)
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+	// Wait until the previous frame is finished.
+	if (m_fence->GetCompletedValue() < fence)
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.h
@@ -25,48 +25,48 @@ using Microsoft::WRL::ComPtr;
 class D3D12HelloTriangle : public DXSample
 {
 public:
-    D3D12HelloTriangle(UINT width, UINT height, std::wstring name);
+	D3D12HelloTriangle(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    static const UINT FrameCount = 2;
+	static const UINT FrameCount = 2;
 
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT4 color;
-    };
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT4 color;
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    UINT m_rtvDescriptorSize;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	UINT m_rtvDescriptorSize;
 
-    // App resources.
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	// App resources.
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValue;
+	// Synchronization objects.
+	UINT m_frameIndex;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValue;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void PopulateCommandList();
-    void WaitForPreviousFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	void PopulateCommandList();
+	void WaitForPreviousFrame();
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/DXSample.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,59 +34,104 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
-    auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(windowText.c_str());
+	std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
+	auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/DXSample.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/DXSample.h
@@ -16,42 +16,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/Main.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12HelloTriangle sample(1200, 900, L"");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12HelloTriangle sample(1200, 900, L"");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/View.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/View.cpp
@@ -15,27 +15,27 @@
 using namespace Windows::Foundation;
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -44,20 +44,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -66,26 +66,26 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnClosed(CoreWindow^ /*sender*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/View.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/View.h
@@ -23,20 +23,20 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
+	DXSample* m_pSample;
+	bool m_windowClosed;
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/ViewProvider.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/ViewProvider.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/d3dx12.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/shaders.hlsl
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/shaders.hlsl
@@ -11,21 +11,21 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VSMain(float4 position : POSITION, float4 color : COLOR)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.color = color;
+	result.position = position;
+	result.color = color;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.cpp
@@ -13,143 +13,143 @@
 #include "D3D12HelloWindow.h"
 
 D3D12HelloWindow::D3D12HelloWindow(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_rtvDescriptorSize(0)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_rtvDescriptorSize(0)
 {
 }
 
 void D3D12HelloWindow::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12HelloWindow::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
-        }
-    }
+		// Create a RTV for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
+		}
+	}
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
 }
 
 // Load the sample assets.
 void D3D12HelloWindow::LoadAssets()
 {
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), nullptr, IID_PPV_ARGS(&m_commandList)));
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), nullptr, IID_PPV_ARGS(&m_commandList)));
 
-    // Command lists are created in the recording state, but there is nothing
-    // to record yet. The main loop expects it to be closed, so close it now.
-    ThrowIfFailed(m_commandList->Close());
+	// Command lists are created in the recording state, but there is nothing
+	// to record yet. The main loop expects it to be closed, so close it now.
+	ThrowIfFailed(m_commandList->Close());
 
-    // Create synchronization objects.
-    {
-        ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValue = 1;
+	// Create synchronization objects.
+	{
+		ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValue = 1;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
-    }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
+	}
 }
 
 // Update frame-based values.
@@ -160,73 +160,73 @@ void D3D12HelloWindow::OnUpdate()
 // Render the scene.
 void D3D12HelloWindow::OnRender()
 {
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+	// Present the frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    WaitForPreviousFrame();
+	WaitForPreviousFrame();
 }
 
 void D3D12HelloWindow::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForPreviousFrame();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForPreviousFrame();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12HelloWindow::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocator->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocator->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()));
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 void D3D12HelloWindow::WaitForPreviousFrame()
 {
-    // WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
-    // This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
-    // sample illustrates how to use fences for efficient resource usage and to
-    // maximize GPU utilization.
+	// WAITING FOR THE FRAME TO COMPLETE BEFORE CONTINUING IS NOT BEST PRACTICE.
+	// This is code implemented as such for simplicity. The D3D12HelloFrameBuffering
+	// sample illustrates how to use fences for efficient resource usage and to
+	// maximize GPU utilization.
 
-    // Signal and increment the fence value.
-    const UINT64 fence = m_fenceValue;
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
-    m_fenceValue++;
+	// Signal and increment the fence value.
+	const UINT64 fence = m_fenceValue;
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
+	m_fenceValue++;
 
-    // Wait until the previous frame is finished.
-    if (m_fence->GetCompletedValue() < fence)
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+	// Wait until the previous frame is finished.
+	if (m_fence->GetCompletedValue() < fence)
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.h
@@ -23,35 +23,35 @@ using Microsoft::WRL::ComPtr;
 class D3D12HelloWindow : public DXSample
 {
 public:
-    D3D12HelloWindow(UINT width, UINT height, std::wstring name);
+	D3D12HelloWindow(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    static const UINT FrameCount = 2;
+	static const UINT FrameCount = 2;
 
-    // Pipeline objects.
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    UINT m_rtvDescriptorSize;
+	// Pipeline objects.
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	UINT m_rtvDescriptorSize;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValue;
+	// Synchronization objects.
+	UINT m_frameIndex;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValue;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void PopulateCommandList();
-    void WaitForPreviousFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	void PopulateCommandList();
+	void WaitForPreviousFrame();
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloWindow/DXSample.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloWindow/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,59 +34,104 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
-    auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(windowText.c_str());
+	std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
+	auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloWindow/DXSample.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloWindow/DXSample.h
@@ -16,42 +16,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloWindow/Main.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloWindow/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12HelloWindow sample(1200, 900, L"");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12HelloWindow sample(1200, 900, L"");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloWindow/View.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloWindow/View.cpp
@@ -15,27 +15,27 @@
 using namespace Windows::Foundation;
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -44,20 +44,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -66,26 +66,26 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnClosed(CoreWindow^ /*sender*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloWindow/View.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloWindow/View.h
@@ -23,20 +23,20 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
+	DXSample* m_pSample;
+	bool m_windowClosed;
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloWindow/ViewProvider.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloWindow/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12HelloWorld/src/HelloWindow/ViewProvider.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloWindow/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12HelloWorld/src/HelloWindow/d3dx12.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloWindow/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/D3D12HeterogeneousMultiadapter.cpp
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/D3D12HeterogeneousMultiadapter.cpp
@@ -17,1237 +17,1306 @@ const float D3D12HeterogeneousMultiadapter::TriangleDepth = 1.0f;
 const float D3D12HeterogeneousMultiadapter::ClearColor[4] = { 0.0f, 0.2f, 0.3f, 1.0f };
 
 D3D12HeterogeneousMultiadapter::D3D12HeterogeneousMultiadapter(int width, int height, LPCWSTR name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_triangleCount(MaxTriangleCount / 2),
-    m_psLoopCount(0),
-    m_blurPSLoopCount(0),
-    m_currentTimesIndex(0),
-    m_drawTimeMovingAverage(0),
-    m_blurTimeMovingAverage(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_currentPresentFenceValue(1),
-    m_currentRenderFenceValue(1),
-    m_currentCrossAdapterFenceValue(1),
-    m_workloadConstantBufferData(),
-    m_blurWorkloadConstantBufferData(),
-    m_crossAdapterTextureSupport(false),
-    m_rtvDescriptorSizes{},
-    m_srvDescriptorSizes{},
-    m_drawTimes{},
-    m_blurTimes{},
-    m_frameFenceValues{}
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_triangleCount(MaxTriangleCount / 2),
+	m_psLoopCount(0),
+	m_blurPSLoopCount(0),
+	m_currentTimesIndex(0),
+	m_drawTimeMovingAverage(0),
+	m_blurTimeMovingAverage(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_currentPresentFenceValue(1),
+	m_currentRenderFenceValue(1),
+	m_currentCrossAdapterFenceValue(1),
+	m_workloadConstantBufferData(),
+	m_blurWorkloadConstantBufferData(),
+	m_crossAdapterTextureSupport(false),
+	m_rtvDescriptorSizes{},
+	m_srvDescriptorSizes{},
+	m_drawTimes{},
+	m_blurTimes{},
+	m_frameFenceValues{}
 {
-    m_constantBufferData.resize(MaxTriangleCount);
+	m_constantBufferData.resize(MaxTriangleCount);
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
 }
 
 void D3D12HeterogeneousMultiadapter::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
-    UpdateWindowTitle();
+	LoadPipeline();
+	LoadAssets();
+	UpdateWindowTitle();
 }
 
 // Enumerate adapters to use for heterogeneous multiadaper.
 _Use_decl_annotations_
 HRESULT D3D12HeterogeneousMultiadapter::GetHardwareAdapters(IDXGIFactory2* pFactory, IDXGIAdapter1** ppPrimaryAdapter, IDXGIAdapter1** ppSecondaryAdapter)
 {
-    if (pFactory == nullptr)
-    {
-        return E_POINTER;
-    }
+	if (pFactory == nullptr)
+	{
+		return E_POINTER;
+	}
 
-    // Adapter 0 is the adapter that Presents frames to the display. It is assigned as
-    // the "secondary" adapter because it is the adapter that performs the second set
-    // of operations (the blur effect) in this sample.
-    // Adapter 1 is an additional GPU that the app can take advantage of, but it does
-    // not own the presentation step. It is assigned as the "primary" adapter because
-    // it is the adapter that performs the first set of operations (rendering triangles)
-    // in this sample.
+	// Adapter 0 is the adapter that Presents frames to the display. It is assigned as
+	// the "secondary" adapter because it is the adapter that performs the second set
+	// of operations (the blur effect) in this sample.
+	// Adapter 1 is an additional GPU that the app can take advantage of, but it does
+	// not own the presentation step. It is assigned as the "primary" adapter because
+	// it is the adapter that performs the first set of operations (rendering triangles)
+	// in this sample.
 
     ThrowIfFailed(pFactory->EnumAdapters1(0, ppSecondaryAdapter));
-    ThrowIfFailed(pFactory->EnumAdapters1(1, ppPrimaryAdapter));
+    DXGI_ADAPTER_DESC1 descSecondary;
+    ThrowIfFailed((*ppSecondaryAdapter)->GetDesc1(&descSecondary));
 
-    return S_OK;
+    *ppPrimaryAdapter = nullptr;
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(adapterIndex, DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE, IID_PPV_ARGS(&adapter)); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 descPrimary;
+            ThrowIfFailed(adapter->GetDesc1(&descPrimary));
+            if (descPrimary.AdapterLuid.HighPart != descSecondary.AdapterLuid.HighPart || descPrimary.AdapterLuid.LowPart != descSecondary.AdapterLuid.LowPart)
+            {
+                break;
+            }
+        }
+        *ppPrimaryAdapter = adapter.Detach();
+    }
+    else
+    {
+        ThrowIfFailed(pFactory->EnumAdapters1(1, ppPrimaryAdapter));
+    }
+	return S_OK;
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12HeterogeneousMultiadapter::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    ComPtr<IDXGIAdapter1> primaryAdapter;
-    ComPtr<IDXGIAdapter1> secondaryAdapter;
-    if (m_useWarpDevice)
-    {
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&primaryAdapter)));
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&secondaryAdapter)));
-    }
-    else
-    {
-        ThrowIfFailed(GetHardwareAdapters(factory.Get(), &primaryAdapter, &secondaryAdapter));
-    }
+	ComPtr<IDXGIAdapter1> primaryAdapter;
+	ComPtr<IDXGIAdapter1> secondaryAdapter;
+	if (m_useWarpDevice)
+	{
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&primaryAdapter)));
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&secondaryAdapter)));
+	}
+	else
+	{
+		ThrowIfFailed(GetHardwareAdapters(factory.Get(), &primaryAdapter, &secondaryAdapter));
+	}
 
-    DXGI_ADAPTER_DESC1 desc;
-    primaryAdapter->GetDesc1(&desc);
-    if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
-    {
-        // There is actually only one physical GPU on the system.
-        // Reduce the starting triangle count to make the sample run better.
-        m_triangleCount = MaxTriangleCount / 50;
-    }
+	DXGI_ADAPTER_DESC1 desc;
+	primaryAdapter->GetDesc1(&desc);
+	if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+	{
+		// There is actually only one physical GPU on the system.
+		// Reduce the starting triangle count to make the sample run better.
+		m_triangleCount = MaxTriangleCount / 50;
+	}
 
-    IDXGIAdapter1* ppAdapters[] = { primaryAdapter.Get(), secondaryAdapter.Get() };
-    for (UINT i = 0; i < GraphicsAdaptersCount; i++)
-    {
-        ThrowIfFailed(D3D12CreateDevice(ppAdapters[i], D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&m_devices[i])));
-        ThrowIfFailed(ppAdapters[i]->GetDesc1(&m_adapterDescs[i]));
-    }
+	IDXGIAdapter1* ppAdapters[] = { primaryAdapter.Get(), secondaryAdapter.Get() };
+	for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+	{
+		ThrowIfFailed(D3D12CreateDevice(ppAdapters[i], D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&m_devices[i])));
+		ThrowIfFailed(ppAdapters[i]->GetDesc1(&m_adapterDescs[i]));
+	}
 
-    // Describe and create the command queues and get their timestamp frequency.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queues and get their timestamp frequency.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    for (UINT i = 0; i < GraphicsAdaptersCount; i++)
-    {
-        ThrowIfFailed(m_devices[i]->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_directCommandQueues[i])));
-        ThrowIfFailed(m_directCommandQueues[i]->GetTimestampFrequency(&m_directCommandQueueTimestampFrequencies[i]));
-    }
+	for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+	{
+		ThrowIfFailed(m_devices[i]->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_directCommandQueues[i])));
+		ThrowIfFailed(m_directCommandQueues[i]->GetTimestampFrequency(&m_directCommandQueueTimestampFrequencies[i]));
+	}
 
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_COPY;
-    ThrowIfFailed(m_devices[Primary]->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_copyCommandQueue)));
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_COPY;
+	ThrowIfFailed(m_devices[Primary]->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_copyCommandQueue)));
 
-    // Describe and create the swap chain on the secondary device because that's where we present from.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain on the secondary device because that's where we present from.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_directCommandQueues[Secondary].Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
+		m_directCommandQueues[Secondary].Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heaps.
-        for (UINT i = 0; i < GraphicsAdaptersCount; i++)
-        {
-            D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-            rtvHeapDesc.NumDescriptors = FrameCount;
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heaps.
+		for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+		{
+			D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+			rtvHeapDesc.NumDescriptors = FrameCount;
 
-            if (i == Secondary)
-            {
-                // Add space for the intermediate render target.
-                rtvHeapDesc.NumDescriptors++;
-            }
+			if (i == Secondary)
+			{
+				// Add space for the intermediate render target.
+				rtvHeapDesc.NumDescriptors++;
+			}
 
-            rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-            rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-            ThrowIfFailed(m_devices[i]->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeaps[i])));
-        }
+			rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+			rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+			ThrowIfFailed(m_devices[i]->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeaps[i])));
+		}
 
-        // Describe and create a depth stencil view (DSV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
-        dsvHeapDesc.NumDescriptors = 1;
-        dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-        dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_devices[Primary]->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
+		// Describe and create a depth stencil view (DSV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
+		dsvHeapDesc.NumDescriptors = 1;
+		dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+		dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_devices[Primary]->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
 
-        // Describe and create a shader resource view (SRV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvSrvUavHeapDesc = {};
-        cbvSrvUavHeapDesc.NumDescriptors = FrameCount + 1;    // +1 for the intermediate blur render target.
-        cbvSrvUavHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        cbvSrvUavHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_devices[Secondary]->CreateDescriptorHeap(&cbvSrvUavHeapDesc, IID_PPV_ARGS(&m_cbvSrvUavHeap)));
+		// Describe and create a shader resource view (SRV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvSrvUavHeapDesc = {};
+		cbvSrvUavHeapDesc.NumDescriptors = FrameCount + 1;	// +1 for the intermediate blur render target.
+		cbvSrvUavHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		cbvSrvUavHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_devices[Secondary]->CreateDescriptorHeap(&cbvSrvUavHeapDesc, IID_PPV_ARGS(&m_cbvSrvUavHeap)));
 
-        for (UINT i = 0; i < GraphicsAdaptersCount; i++)
-        {
-            m_rtvDescriptorSizes[i] = m_devices[i]->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-            m_srvDescriptorSizes[i] = m_devices[i]->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-        }
-    }
+		for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+		{
+			m_rtvDescriptorSizes[i] = m_devices[i]->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+			m_srvDescriptorSizes[i] = m_devices[i]->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+		}
+	}
 
-    // Create query heaps and result buffers.
-    {
-        // Two timestamps for each frame.
-        const UINT resultCount = 2 * FrameCount;
-        const UINT resultBufferSize = resultCount * sizeof(UINT64);
+	// Create query heaps and result buffers.
+	{
+		// Two timestamps for each frame.
+		const UINT resultCount = 2 * FrameCount;
+		const UINT resultBufferSize = resultCount * sizeof(UINT64);
 
-        D3D12_QUERY_HEAP_DESC timestampHeapDesc = {};
-        timestampHeapDesc.Type = D3D12_QUERY_HEAP_TYPE_TIMESTAMP;
-        timestampHeapDesc.Count = resultCount;
+		D3D12_QUERY_HEAP_DESC timestampHeapDesc = {};
+		timestampHeapDesc.Type = D3D12_QUERY_HEAP_TYPE_TIMESTAMP;
+		timestampHeapDesc.Count = resultCount;
 
-        for (UINT i = 0; i < GraphicsAdaptersCount; i++)
-        {
-            ThrowIfFailed(m_devices[i]->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK),
-                D3D12_HEAP_FLAG_NONE,
-                &CD3DX12_RESOURCE_DESC::Buffer(resultBufferSize),
-                D3D12_RESOURCE_STATE_COPY_DEST,
-                nullptr,
-                IID_PPV_ARGS(&m_timestampResultBuffers[i])));
+		for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+		{
+			ThrowIfFailed(m_devices[i]->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK),
+				D3D12_HEAP_FLAG_NONE,
+				&CD3DX12_RESOURCE_DESC::Buffer(resultBufferSize),
+				D3D12_RESOURCE_STATE_COPY_DEST,
+				nullptr,
+				IID_PPV_ARGS(&m_timestampResultBuffers[i])));
 
-            ThrowIfFailed(m_devices[i]->CreateQueryHeap(&timestampHeapDesc, IID_PPV_ARGS(&m_timestampQueryHeaps[i])));
-        }
-    }
+			ThrowIfFailed(m_devices[i]->CreateQueryHeap(&timestampHeapDesc, IID_PPV_ARGS(&m_timestampQueryHeaps[i])));
+		}
+	}
 
-    // Create frame resources.
-    {
-        const CD3DX12_CLEAR_VALUE clearValue(swapChainDesc.Format, ClearColor);
-        const CD3DX12_RESOURCE_DESC renderTargetDesc = CD3DX12_RESOURCE_DESC::Tex2D(
-            swapChainDesc.Format,
-            swapChainDesc.Width,
-            swapChainDesc.Height,
-            1u, 1u,
-            swapChainDesc.SampleDesc.Count,
-            swapChainDesc.SampleDesc.Quality,
-            D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET,
-            D3D12_TEXTURE_LAYOUT_UNKNOWN, 0u);
+	// Create frame resources.
+	{
+		const CD3DX12_CLEAR_VALUE clearValue(swapChainDesc.Format, ClearColor);
+		const CD3DX12_RESOURCE_DESC renderTargetDesc = CD3DX12_RESOURCE_DESC::Tex2D(
+			swapChainDesc.Format,
+			swapChainDesc.Width,
+			swapChainDesc.Height,
+			1u, 1u,
+			swapChainDesc.SampleDesc.Count,
+			swapChainDesc.SampleDesc.Quality,
+			D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET,
+			D3D12_TEXTURE_LAYOUT_UNKNOWN, 0u);
 
-        for (UINT i = 0; i < GraphicsAdaptersCount; i++)
-        {
-            CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeaps[i]->GetCPUDescriptorHandleForHeapStart());
+		for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+		{
+			CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeaps[i]->GetCPUDescriptorHandleForHeapStart());
 
-            // Create a RTV and a command allocator for each frame.
-            for (UINT n = 0; n < FrameCount; n++)
-            {
-                if (i == Secondary)
-                {
-                    ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[i][n])));
-                }
-                else
-                {
-                    ThrowIfFailed(m_devices[i]->CreateCommittedResource(
-                        &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-                        D3D12_HEAP_FLAG_NONE,
-                        &renderTargetDesc,
-                        D3D12_RESOURCE_STATE_COMMON,
-                        &clearValue,
-                        IID_PPV_ARGS(&m_renderTargets[i][n])));
-                }
-                
-                m_devices[i]->CreateRenderTargetView(m_renderTargets[i][n].Get(), nullptr, rtvHandle);
-                rtvHandle.Offset(1, m_rtvDescriptorSizes[i]);
+			// Create a RTV and a command allocator for each frame.
+			for (UINT n = 0; n < FrameCount; n++)
+			{
+				if (i == Secondary)
+				{
+					ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[i][n])));
+				}
+				else
+				{
+					ThrowIfFailed(m_devices[i]->CreateCommittedResource(
+						&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+						D3D12_HEAP_FLAG_NONE,
+						&renderTargetDesc,
+						D3D12_RESOURCE_STATE_COMMON,
+						&clearValue,
+						IID_PPV_ARGS(&m_renderTargets[i][n])));
+				}
+				
+				m_devices[i]->CreateRenderTargetView(m_renderTargets[i][n].Get(), nullptr, rtvHandle);
+				rtvHandle.Offset(1, m_rtvDescriptorSizes[i]);
 
-                ThrowIfFailed(m_devices[i]->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_directCommandAllocators[i][n])));
+				ThrowIfFailed(m_devices[i]->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_directCommandAllocators[i][n])));
 
-                if (i == Primary)
-                {
-                    ThrowIfFailed(m_devices[i]->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_COPY, IID_PPV_ARGS(&m_copyCommandAllocators[n])));
-                }
-            }
-        }
+				if (i == Primary)
+				{
+					ThrowIfFailed(m_devices[i]->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_COPY, IID_PPV_ARGS(&m_copyCommandAllocators[n])));
+				}
+			}
+		}
 
-        // Create cross-adapter shared resources on the primary adapter, and open the shared handles on the secondary adapter.
-        {
-            // Check whether shared row-major textures can be directly sampled by the
-            // secondary adapter. Support of this feature (or the lack thereof) will
-            // determine our sharing strategy for the resource in question.
-            D3D12_FEATURE_DATA_D3D12_OPTIONS options = {};
-            ThrowIfFailed(m_devices[Secondary]->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, reinterpret_cast<void*>(&options), sizeof(options)));
-            m_crossAdapterTextureSupport = options.CrossAdapterRowMajorTextureSupported;
+		// Create cross-adapter shared resources on the primary adapter, and open the shared handles on the secondary adapter.
+		{
+			// Check whether shared row-major textures can be directly sampled by the
+			// secondary adapter. Support of this feature (or the lack thereof) will
+			// determine our sharing strategy for the resource in question.
+			D3D12_FEATURE_DATA_D3D12_OPTIONS options = {};
+			ThrowIfFailed(m_devices[Secondary]->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, reinterpret_cast<void*>(&options), sizeof(options)));
+			m_crossAdapterTextureSupport = options.CrossAdapterRowMajorTextureSupported;
 
-            UINT64 textureSize = 0;
-            D3D12_RESOURCE_DESC crossAdapterDesc;
+			UINT64 textureSize = 0;
+			D3D12_RESOURCE_DESC crossAdapterDesc;
 
-            if (m_crossAdapterTextureSupport)
-            {
-                // If cross-adapter row-major textures are supported by the adapter,
-                // then they can be sampled directly.
-                crossAdapterDesc = renderTargetDesc;
-                crossAdapterDesc.Flags = D3D12_RESOURCE_FLAG_ALLOW_CROSS_ADAPTER;
-                crossAdapterDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+			if (m_crossAdapterTextureSupport)
+			{
+				// If cross-adapter row-major textures are supported by the adapter,
+				// then they can be sampled directly.
+				crossAdapterDesc = renderTargetDesc;
+				crossAdapterDesc.Flags = D3D12_RESOURCE_FLAG_ALLOW_CROSS_ADAPTER;
+				crossAdapterDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
 
-                D3D12_RESOURCE_ALLOCATION_INFO textureInfo = m_devices[Primary]->GetResourceAllocationInfo(0, 1, &crossAdapterDesc);
-                textureSize = textureInfo.SizeInBytes;
-            }
-            else
-            {
-                // If cross-adapter row-major textures are not supported by the adapter,
-                // then they will be shared as buffers and then copied to a destination
-                // texture on the secondary adapter.
+				D3D12_RESOURCE_ALLOCATION_INFO textureInfo = m_devices[Primary]->GetResourceAllocationInfo(0, 1, &crossAdapterDesc);
+				textureSize = textureInfo.SizeInBytes;
+			}
+			else
+			{
+				// If cross-adapter row-major textures are not supported by the adapter,
+				// then they will be shared as buffers and then copied to a destination
+				// texture on the secondary adapter.
 
-                D3D12_PLACED_SUBRESOURCE_FOOTPRINT layout;
-                m_devices[Primary]->GetCopyableFootprints(&renderTargetDesc, 0, 1, 0, &layout, nullptr, nullptr, nullptr);
-                textureSize = Align(layout.Footprint.RowPitch * layout.Footprint.Height);
+				D3D12_PLACED_SUBRESOURCE_FOOTPRINT layout;
+				m_devices[Primary]->GetCopyableFootprints(&renderTargetDesc, 0, 1, 0, &layout, nullptr, nullptr, nullptr);
+				textureSize = Align(layout.Footprint.RowPitch * layout.Footprint.Height);
 
-                // Create a buffer with the same layout as the render target texture.
-                crossAdapterDesc = CD3DX12_RESOURCE_DESC::Buffer(textureSize, D3D12_RESOURCE_FLAG_ALLOW_CROSS_ADAPTER);
-            }
+				// Create a buffer with the same layout as the render target texture.
+				crossAdapterDesc = CD3DX12_RESOURCE_DESC::Buffer(textureSize, D3D12_RESOURCE_FLAG_ALLOW_CROSS_ADAPTER);
+			}
 
-            // Create a heap that will be shared by both adapters.
-            CD3DX12_HEAP_DESC heapDesc(
-                textureSize * FrameCount,
-                D3D12_HEAP_TYPE_DEFAULT,
-                0,
-                D3D12_HEAP_FLAG_SHARED | D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER);
+			// Create a heap that will be shared by both adapters.
+			CD3DX12_HEAP_DESC heapDesc(
+				textureSize * FrameCount,
+				D3D12_HEAP_TYPE_DEFAULT,
+				0,
+				D3D12_HEAP_FLAG_SHARED | D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER);
 
-            ThrowIfFailed(m_devices[Primary]->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_crossAdapterResourceHeaps[Primary])));
+			ThrowIfFailed(m_devices[Primary]->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_crossAdapterResourceHeaps[Primary])));
 
-            HANDLE heapHandle = nullptr;
-            ThrowIfFailed(m_devices[Primary]->CreateSharedHandle(
-                m_crossAdapterResourceHeaps[Primary].Get(),
-                nullptr,
-                GENERIC_ALL,
-                nullptr,
-                &heapHandle));
+			HANDLE heapHandle = nullptr;
+			ThrowIfFailed(m_devices[Primary]->CreateSharedHandle(
+				m_crossAdapterResourceHeaps[Primary].Get(),
+				nullptr,
+				GENERIC_ALL,
+				nullptr,
+				&heapHandle));
 
-            HRESULT openSharedHandleResult = m_devices[Secondary]->OpenSharedHandle(heapHandle, IID_PPV_ARGS(&m_crossAdapterResourceHeaps[Secondary]));
+			HRESULT openSharedHandleResult = m_devices[Secondary]->OpenSharedHandle(heapHandle, IID_PPV_ARGS(&m_crossAdapterResourceHeaps[Secondary]));
 
-            // We can close the handle after opening the cross-adapter shared resource.
-            CloseHandle(heapHandle);
+			// We can close the handle after opening the cross-adapter shared resource.
+			CloseHandle(heapHandle);
 
-            ThrowIfFailed(openSharedHandleResult);
+			ThrowIfFailed(openSharedHandleResult);
 
-            // Create placed resources for each frame per adapter in the shared heap.
-            for (UINT n = 0; n < FrameCount; n++)
-            {
-                ThrowIfFailed(m_devices[Primary]->CreatePlacedResource(
-                    m_crossAdapterResourceHeaps[Primary].Get(),
-                    textureSize * n,
-                    &crossAdapterDesc,
-                    D3D12_RESOURCE_STATE_COPY_DEST,
-                    nullptr,
-                    IID_PPV_ARGS(&m_crossAdapterResources[Primary][n])));
+			// Create placed resources for each frame per adapter in the shared heap.
+			for (UINT n = 0; n < FrameCount; n++)
+			{
+				ThrowIfFailed(m_devices[Primary]->CreatePlacedResource(
+					m_crossAdapterResourceHeaps[Primary].Get(),
+					textureSize * n,
+					&crossAdapterDesc,
+					D3D12_RESOURCE_STATE_COPY_DEST,
+					nullptr,
+					IID_PPV_ARGS(&m_crossAdapterResources[Primary][n])));
 
-                ThrowIfFailed(m_devices[Secondary]->CreatePlacedResource(
-                    m_crossAdapterResourceHeaps[Secondary].Get(),
-                    textureSize * n,
-                    &crossAdapterDesc,
-                    m_crossAdapterTextureSupport ? D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_COPY_SOURCE,
-                    nullptr,
-                    IID_PPV_ARGS(&m_crossAdapterResources[Secondary][n])));
+				ThrowIfFailed(m_devices[Secondary]->CreatePlacedResource(
+					m_crossAdapterResourceHeaps[Secondary].Get(),
+					textureSize * n,
+					&crossAdapterDesc,
+					m_crossAdapterTextureSupport ? D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_COPY_SOURCE,
+					nullptr,
+					IID_PPV_ARGS(&m_crossAdapterResources[Secondary][n])));
 
-                if (!m_crossAdapterTextureSupport)
-                {
-                    // If the primary adapter's render target must be shared as a buffer,
-                    // create a texture resource to copy it into on the secondary adapter.
-                    ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
-                        &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-                        D3D12_HEAP_FLAG_NONE,
-                        &renderTargetDesc,
-                        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                        nullptr,
-                        IID_PPV_ARGS(&m_secondaryAdapterTextures[n])));
-                }
-            }
-        }
+				if (!m_crossAdapterTextureSupport)
+				{
+					// If the primary adapter's render target must be shared as a buffer,
+					// create a texture resource to copy it into on the secondary adapter.
+					ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
+						&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+						D3D12_HEAP_FLAG_NONE,
+						&renderTargetDesc,
+						D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+						nullptr,
+						IID_PPV_ARGS(&m_secondaryAdapterTextures[n])));
+				}
+			}
+		}
 
-        // Create an intermediate render target and view on the secondary adapter.
-        {
-            const D3D12_RESOURCE_DESC intermediateRenderTargetDesc = m_renderTargets[Primary][0]->GetDesc();
+		// Create an intermediate render target and view on the secondary adapter.
+		{
+			const D3D12_RESOURCE_DESC intermediateRenderTargetDesc = m_renderTargets[Primary][0]->GetDesc();
 
-            ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-                D3D12_HEAP_FLAG_NONE,
-                &intermediateRenderTargetDesc,
-                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                nullptr,
-                IID_PPV_ARGS(&m_intermediateBlurRenderTarget)));
+			ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+				D3D12_HEAP_FLAG_NONE,
+				&intermediateRenderTargetDesc,
+				D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+				nullptr,
+				IID_PPV_ARGS(&m_intermediateBlurRenderTarget)));
 
-            CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeaps[Secondary]->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSizes[Secondary]);
-            m_devices[Secondary]->CreateRenderTargetView(m_intermediateBlurRenderTarget.Get(), nullptr, rtvHandle);
-        }
-        
-        // Create SRVs for the shared resources and intermediate render target on the secondary adapter.
-        {
-            CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_cbvSrvUavHeap->GetCPUDescriptorHandleForHeapStart());
-            for (UINT n = 0; n < FrameCount; n++)
-            {
-                ID3D12Resource* pSrvResource = m_crossAdapterTextureSupport ? m_crossAdapterResources[Secondary][n].Get() : m_secondaryAdapterTextures[n].Get();
-                m_devices[Secondary]->CreateShaderResourceView(pSrvResource, nullptr, srvHandle);
-                srvHandle.Offset(m_srvDescriptorSizes[Secondary]);
-            }
+			CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeaps[Secondary]->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSizes[Secondary]);
+			m_devices[Secondary]->CreateRenderTargetView(m_intermediateBlurRenderTarget.Get(), nullptr, rtvHandle);
+		}
+		
+		// Create SRVs for the shared resources and intermediate render target on the secondary adapter.
+		{
+			CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_cbvSrvUavHeap->GetCPUDescriptorHandleForHeapStart());
+			for (UINT n = 0; n < FrameCount; n++)
+			{
+				ID3D12Resource* pSrvResource = m_crossAdapterTextureSupport ? m_crossAdapterResources[Secondary][n].Get() : m_secondaryAdapterTextures[n].Get();
+				m_devices[Secondary]->CreateShaderResourceView(pSrvResource, nullptr, srvHandle);
+				srvHandle.Offset(m_srvDescriptorSizes[Secondary]);
+			}
 
-            m_devices[Secondary]->CreateShaderResourceView(m_intermediateBlurRenderTarget.Get(), nullptr, srvHandle);
-        }
-    }
+			m_devices[Secondary]->CreateShaderResourceView(m_intermediateBlurRenderTarget.Get(), nullptr, srvHandle);
+		}
+	}
 }
 
 // Load the sample assets.
 void D3D12HeterogeneousMultiadapter::LoadAssets()
 {
-    // Create the root signatures.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signatures.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_devices[Primary]->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_devices[Primary]->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        CD3DX12_ROOT_PARAMETER1 rootParameters[2];
-        rootParameters[0].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_VERTEX);
-        rootParameters[1].InitAsConstantBufferView(1, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_PIXEL);
+		CD3DX12_ROOT_PARAMETER1 rootParameters[2];
+		rootParameters[0].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_VERTEX);
+		rootParameters[1].InitAsConstantBufferView(1, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_PIXEL);
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_devices[Primary]->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_devices[Primary]->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
 
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_devices[Secondary]->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_devices[Secondary]->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        // We don't modify the SRV in the command list after SetGraphicsRootDescriptorTable
-        // is executed on the GPU so we can use the default range behavior:
-        // D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0);
+		// We don't modify the SRV in the command list after SetGraphicsRootDescriptorTable
+		// is executed on the GPU so we can use the default range behavior:
+		// D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0);
 
-        CD3DX12_ROOT_PARAMETER1 blurRootParameters[3];
-        blurRootParameters[0].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_PIXEL);
-        blurRootParameters[1].InitAsDescriptorTable(_countof(ranges), ranges, D3D12_SHADER_VISIBILITY_PIXEL);
-        blurRootParameters[2].InitAsConstantBufferView(1, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_PIXEL);
+		CD3DX12_ROOT_PARAMETER1 blurRootParameters[3];
+		blurRootParameters[0].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_PIXEL);
+		blurRootParameters[1].InitAsDescriptorTable(_countof(ranges), ranges, D3D12_SHADER_VISIBILITY_PIXEL);
+		blurRootParameters[2].InitAsConstantBufferView(1, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_PIXEL);
 
-        CD3DX12_STATIC_SAMPLER_DESC staticPointSampler(0);
-        staticPointSampler.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
-        staticPointSampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+		CD3DX12_STATIC_SAMPLER_DESC staticPointSampler(0);
+		staticPointSampler.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
+		staticPointSampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
 
-        CD3DX12_STATIC_SAMPLER_DESC staticLinearSampler(1);
-        staticLinearSampler.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-        staticLinearSampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+		CD3DX12_STATIC_SAMPLER_DESC staticLinearSampler(1);
+		staticLinearSampler.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		staticLinearSampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
 
-        D3D12_STATIC_SAMPLER_DESC staticSamplers[] = { staticPointSampler, staticLinearSampler };
-        rootSignatureDesc.Init_1_1(_countof(blurRootParameters), blurRootParameters, _countof(staticSamplers), staticSamplers, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+		D3D12_STATIC_SAMPLER_DESC staticSamplers[] = { staticPointSampler, staticLinearSampler };
+		rootSignatureDesc.Init_1_1(_countof(blurRootParameters), blurRootParameters, _countof(staticSamplers), staticSamplers, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_devices[Secondary]->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_blurRootSignature)));
-    }
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_devices[Secondary]->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_blurRootSignature)));
+	}
 
-    // Create the pipeline states, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
-        ComPtr<ID3DBlob> vertexShaderBlur;
-        ComPtr<ID3DBlob> pixelShaderBlurU;
-        ComPtr<ID3DBlob> pixelShaderBlurV;
-        ComPtr<ID3DBlob> error;
+	// Create the pipeline states, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
+		ComPtr<ID3DBlob> vertexShaderBlur;
+		ComPtr<ID3DBlob> pixelShaderBlurU;
+		ComPtr<ID3DBlob> pixelShaderBlurV;
+		ComPtr<ID3DBlob> error;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VShader", "vs_5_0", compileFlags, 0, &vertexShader, &error));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PShader", "ps_5_0", compileFlags, 0, &pixelShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VShader", "vs_5_0", compileFlags, 0, &vertexShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PShader", "ps_5_0", compileFlags, 0, &pixelShader, &error));
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"blurShaders.hlsl").c_str(), nullptr, nullptr, "VSSimpleBlur", "vs_5_0", compileFlags, 0, &vertexShaderBlur, &error));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"blurShaders.hlsl").c_str(), nullptr, nullptr, "PSSimpleBlurU", "ps_5_0", compileFlags, 0, &pixelShaderBlurU, &error));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"blurShaders.hlsl").c_str(), nullptr, nullptr, "PSSimpleBlurV", "ps_5_0", compileFlags, 0, &pixelShaderBlurV, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"blurShaders.hlsl").c_str(), nullptr, nullptr, "VSSimpleBlur", "vs_5_0", compileFlags, 0, &vertexShaderBlur, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"blurShaders.hlsl").c_str(), nullptr, nullptr, "PSSimpleBlurU", "ps_5_0", compileFlags, 0, &pixelShaderBlurU, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"blurShaders.hlsl").c_str(), nullptr, nullptr, "PSSimpleBlurV", "ps_5_0", compileFlags, 0, &pixelShaderBlurV, &error));
 
-        // Define the vertex input layouts.
-        const D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+		// Define the vertex input layouts.
+		const D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        const D3D12_INPUT_ELEMENT_DESC blurInputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+		const D3D12_INPUT_ELEMENT_DESC blurInputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        // Describe and create the graphics pipeline state objects (PSOs).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
-        psoDesc.SampleDesc.Count = 1;
-        ThrowIfFailed(m_devices[Primary]->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+		// Describe and create the graphics pipeline state objects (PSOs).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+		psoDesc.SampleDesc.Count = 1;
+		ThrowIfFailed(m_devices[Primary]->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
 
-        psoDesc.InputLayout = { blurInputElementDescs, _countof(blurInputElementDescs) };
-        psoDesc.pRootSignature = m_blurRootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShaderBlur.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShaderBlurU.Get());
-        psoDesc.DepthStencilState.DepthEnable = false;
-        psoDesc.DSVFormat = DXGI_FORMAT_UNKNOWN;
-        ThrowIfFailed(m_devices[Secondary]->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_blurPipelineStates[0])));
+		psoDesc.InputLayout = { blurInputElementDescs, _countof(blurInputElementDescs) };
+		psoDesc.pRootSignature = m_blurRootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShaderBlur.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShaderBlurU.Get());
+		psoDesc.DepthStencilState.DepthEnable = false;
+		psoDesc.DSVFormat = DXGI_FORMAT_UNKNOWN;
+		ThrowIfFailed(m_devices[Secondary]->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_blurPipelineStates[0])));
 
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShaderBlurV.Get());
-        ThrowIfFailed(m_devices[Secondary]->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_blurPipelineStates[1])));
-    }
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShaderBlurV.Get());
+		ThrowIfFailed(m_devices[Secondary]->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_blurPipelineStates[1])));
+	}
 
-    // Create the command lists.
-    ThrowIfFailed(m_devices[Primary]->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_directCommandAllocators[Primary][m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_directCommandLists[Primary])));
-    ThrowIfFailed(m_devices[Primary]->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_COPY, m_copyCommandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_copyCommandList)));
-    ThrowIfFailed(m_copyCommandList->Close());
+	// Create the command lists.
+	ThrowIfFailed(m_devices[Primary]->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_directCommandAllocators[Primary][m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_directCommandLists[Primary])));
+	ThrowIfFailed(m_devices[Primary]->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_COPY, m_copyCommandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_copyCommandList)));
+	ThrowIfFailed(m_copyCommandList->Close());
 
-    ThrowIfFailed(m_devices[Secondary]->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_directCommandAllocators[Secondary][m_frameIndex].Get(), m_blurPipelineStates[0].Get(), IID_PPV_ARGS(&m_directCommandLists[Secondary])));
+	ThrowIfFailed(m_devices[Secondary]->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_directCommandAllocators[Secondary][m_frameIndex].Get(), m_blurPipelineStates[0].Get(), IID_PPV_ARGS(&m_directCommandLists[Secondary])));
 
-    // Note: ComPtr's are CPU objects but these resources need to stay in scope until
-    // the command list that references them has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resources are not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> vertexBufferUpload;
-    ComPtr<ID3D12Resource> fullscreenQuadVertexBufferUpload;
+	// Note: ComPtr's are CPU objects but these resources need to stay in scope until
+	// the command list that references them has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resources are not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> vertexBufferUpload;
+	ComPtr<ID3D12Resource> fullscreenQuadVertexBufferUpload;
 
-    // Create the vertex buffer for the primary adapter.
-    {
-        // Define the geometry for a triangle.
-        Vertex triangleVertices[] =
-        {
-            { { 0.0f, TriangleHalfWidth, TriangleDepth } },
-            { { TriangleHalfWidth, -TriangleHalfWidth, TriangleDepth } },
-            { { -TriangleHalfWidth, -TriangleHalfWidth, TriangleDepth } }
-        };
+	// Create the vertex buffer for the primary adapter.
+	{
+		// Define the geometry for a triangle.
+		Vertex triangleVertices[] =
+		{
+			{ { 0.0f, TriangleHalfWidth, TriangleDepth } },
+			{ { TriangleHalfWidth, -TriangleHalfWidth, TriangleDepth } },
+			{ { -TriangleHalfWidth, -TriangleHalfWidth, TriangleDepth } }
+		};
 
-        const UINT vertexBufferSize = sizeof(triangleVertices);
+		const UINT vertexBufferSize = sizeof(triangleVertices);
 
-        ThrowIfFailed(m_devices[Primary]->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		ThrowIfFailed(m_devices[Primary]->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        ThrowIfFailed(m_devices[Primary]->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&vertexBufferUpload)));
+		ThrowIfFailed(m_devices[Primary]->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&vertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(triangleVertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(triangleVertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(m_directCommandLists[Primary].Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        m_directCommandLists[Primary]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(m_directCommandLists[Primary].Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		m_directCommandLists[Primary]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = sizeof(triangleVertices);
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = sizeof(triangleVertices);
+	}
 
-    // Create the vertex buffer for the secondary adapter.
-    {
-        // Define the geometry for a fullscreen triangle.
-        VertexPositionUV quadVertices[] =
-        {
-            { { -1.0f, -1.0f, 0.0f, 1.0f }, { 0.0f, 0.0f } },    // Bottom left.
-            { { -1.0f, 1.0f, 0.0f, 1.0f }, { 0.0f, 1.0f } },    // Top left.
-            { { 1.0f, -1.0f, 0.0f, 1.0f }, { 1.0f, 0.0f } },    // Bottom right.
-            { { 1.0f, 1.0f, 0.0f, 1.0f }, { 1.0f, 1.0f } },        // Top right.
-        };
+	// Create the vertex buffer for the secondary adapter.
+	{
+		// Define the geometry for a fullscreen triangle.
+		VertexPositionUV quadVertices[] =
+		{
+			{ { -1.0f, -1.0f, 0.0f, 1.0f }, { 0.0f, 0.0f } },	// Bottom left.
+			{ { -1.0f, 1.0f, 0.0f, 1.0f }, { 0.0f, 1.0f } },	// Top left.
+			{ { 1.0f, -1.0f, 0.0f, 1.0f }, { 1.0f, 0.0f } },	// Bottom right.
+			{ { 1.0f, 1.0f, 0.0f, 1.0f }, { 1.0f, 1.0f } },		// Top right.
+		};
 
-        const UINT vertexBufferSize = sizeof(quadVertices);
+		const UINT vertexBufferSize = sizeof(quadVertices);
 
-        ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_fullscreenQuadVertexBuffer)));
+		ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_fullscreenQuadVertexBuffer)));
 
-        ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&fullscreenQuadVertexBufferUpload)));
+		ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&fullscreenQuadVertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(quadVertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(quadVertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(m_directCommandLists[Secondary].Get(), m_fullscreenQuadVertexBuffer.Get(), fullscreenQuadVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        m_directCommandLists[Secondary]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_fullscreenQuadVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(m_directCommandLists[Secondary].Get(), m_fullscreenQuadVertexBuffer.Get(), fullscreenQuadVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		m_directCommandLists[Secondary]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_fullscreenQuadVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_fullscreenQuadVertexBufferView.BufferLocation = m_fullscreenQuadVertexBuffer->GetGPUVirtualAddress();
-        m_fullscreenQuadVertexBufferView.StrideInBytes = sizeof(VertexPositionUV);
-        m_fullscreenQuadVertexBufferView.SizeInBytes = sizeof(quadVertices);
-    }
+		// Initialize the vertex buffer view.
+		m_fullscreenQuadVertexBufferView.BufferLocation = m_fullscreenQuadVertexBuffer->GetGPUVirtualAddress();
+		m_fullscreenQuadVertexBufferView.StrideInBytes = sizeof(VertexPositionUV);
+		m_fullscreenQuadVertexBufferView.SizeInBytes = sizeof(quadVertices);
+	}
 
-    // Create the depth stencil view.
-    {
-        D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
-        depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
-        depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
-        depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
+	// Create the depth stencil view.
+	{
+		D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
+		depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
+		depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+		depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
 
-        const CD3DX12_CLEAR_VALUE clearValue(DXGI_FORMAT_D32_FLOAT, 1.0f, 0);
+		const CD3DX12_CLEAR_VALUE clearValue(DXGI_FORMAT_D32_FLOAT, 1.0f, 0);
 
-        ThrowIfFailed(m_devices[Primary]->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
-            D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            &clearValue,
-            IID_PPV_ARGS(&m_depthStencil)
-            ));
+		ThrowIfFailed(m_devices[Primary]->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
+			D3D12_RESOURCE_STATE_DEPTH_WRITE,
+			&clearValue,
+			IID_PPV_ARGS(&m_depthStencil)
+			));
 
-        m_devices[Primary]->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		m_devices[Primary]->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    // Create the constant buffers.
-    {
-        {
-            const UINT64 constantBufferSize = sizeof(SceneConstantBuffer) * MaxTriangleCount * FrameCount;
+	// Create the constant buffers.
+	{
+		{
+			const UINT64 constantBufferSize = sizeof(SceneConstantBuffer) * MaxTriangleCount * FrameCount;
 
-            ThrowIfFailed(m_devices[Primary]->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-                D3D12_HEAP_FLAG_NONE,
-                &CD3DX12_RESOURCE_DESC::Buffer(constantBufferSize),
-                D3D12_RESOURCE_STATE_GENERIC_READ,
-                nullptr,
-                IID_PPV_ARGS(&m_constantBuffer)));
+			ThrowIfFailed(m_devices[Primary]->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+				D3D12_HEAP_FLAG_NONE,
+				&CD3DX12_RESOURCE_DESC::Buffer(constantBufferSize),
+				D3D12_RESOURCE_STATE_GENERIC_READ,
+				nullptr,
+				IID_PPV_ARGS(&m_constantBuffer)));
 
-            // Setup constant buffer data.
-            for (UINT n = 0; n < MaxTriangleCount; n++)
-            {
-                m_constantBufferData[n].velocity = XMFLOAT4(GetRandomFloat(0.01f, 0.02f), 0.0f, 0.0f, 0.0f);
-                m_constantBufferData[n].offset = XMFLOAT4(GetRandomFloat(-5.0f, -1.5f), GetRandomFloat(-1.0f, 1.0f), GetRandomFloat(0.0f, 2.0f), 0.0f);
-                m_constantBufferData[n].color = XMFLOAT4(GetRandomFloat(0.5f, 1.0f), GetRandomFloat(0.5f, 1.0f), GetRandomFloat(0.5f, 1.0f), 1.0f);
-                XMStoreFloat4x4(&m_constantBufferData[n].projection, XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f)));
-            }
+			// Setup constant buffer data.
+			for (UINT n = 0; n < MaxTriangleCount; n++)
+			{
+				m_constantBufferData[n].velocity = XMFLOAT4(GetRandomFloat(0.01f, 0.02f), 0.0f, 0.0f, 0.0f);
+				m_constantBufferData[n].offset = XMFLOAT4(GetRandomFloat(-5.0f, -1.5f), GetRandomFloat(-1.0f, 1.0f), GetRandomFloat(0.0f, 2.0f), 0.0f);
+				m_constantBufferData[n].color = XMFLOAT4(GetRandomFloat(0.5f, 1.0f), GetRandomFloat(0.5f, 1.0f), GetRandomFloat(0.5f, 1.0f), 1.0f);
+				XMStoreFloat4x4(&m_constantBufferData[n].projection, XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f)));
+			}
 
-            // Map and initialize the constant buffer. We don't unmap this until the
-            // app closes. Keeping things mapped for the lifetime of the resource is okay.
-            CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-            ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbvDataBegin)));
-            memcpy(m_pCbvDataBegin, &m_constantBufferData[0], constantBufferSize / FrameCount);
-        }
+			// Map and initialize the constant buffer. We don't unmap this until the
+			// app closes. Keeping things mapped for the lifetime of the resource is okay.
+			CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+			ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbvDataBegin)));
+			memcpy(m_pCbvDataBegin, &m_constantBufferData[0], constantBufferSize / FrameCount);
+		}
 
-        {
-            const UINT64 workloadConstantBufferSize = sizeof(WorkloadConstantBufferData) * FrameCount;
+		{
+			const UINT64 workloadConstantBufferSize = sizeof(WorkloadConstantBufferData) * FrameCount;
 
-            ThrowIfFailed(m_devices[Primary]->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-                D3D12_HEAP_FLAG_NONE,
-                &CD3DX12_RESOURCE_DESC::Buffer(workloadConstantBufferSize),
-                D3D12_RESOURCE_STATE_GENERIC_READ,
-                nullptr,
-                IID_PPV_ARGS(&m_workloadConstantBuffer)));
+			ThrowIfFailed(m_devices[Primary]->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+				D3D12_HEAP_FLAG_NONE,
+				&CD3DX12_RESOURCE_DESC::Buffer(workloadConstantBufferSize),
+				D3D12_RESOURCE_STATE_GENERIC_READ,
+				nullptr,
+				IID_PPV_ARGS(&m_workloadConstantBuffer)));
 
-            // Setup constant buffer data.
-            m_workloadConstantBufferData.loopCount = m_psLoopCount;
+			// Setup constant buffer data.
+			m_workloadConstantBufferData.loopCount = m_psLoopCount;
 
-            // Map and initialize the constant buffer. We don't unmap this until the
-            // app closes. Keeping things mapped for the lifetime of the resource is okay.
-            CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-            ThrowIfFailed(m_workloadConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pWorkloadCbvDataBegin)));
-            memcpy(m_pWorkloadCbvDataBegin, &m_workloadConstantBufferData, workloadConstantBufferSize / FrameCount);
-        }
+			// Map and initialize the constant buffer. We don't unmap this until the
+			// app closes. Keeping things mapped for the lifetime of the resource is okay.
+			CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+			ThrowIfFailed(m_workloadConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pWorkloadCbvDataBegin)));
+			memcpy(m_pWorkloadCbvDataBegin, &m_workloadConstantBufferData, workloadConstantBufferSize / FrameCount);
+		}
 
-        {
-            const UINT64 blurWorkloadConstantBufferSize = sizeof(WorkloadConstantBufferData) * FrameCount;
+		{
+			const UINT64 blurWorkloadConstantBufferSize = sizeof(WorkloadConstantBufferData) * FrameCount;
 
-            ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-                D3D12_HEAP_FLAG_NONE,
-                &CD3DX12_RESOURCE_DESC::Buffer(blurWorkloadConstantBufferSize),
-                D3D12_RESOURCE_STATE_GENERIC_READ,
-                nullptr,
-                IID_PPV_ARGS(&m_blurWorkloadConstantBuffer)));
+			ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+				D3D12_HEAP_FLAG_NONE,
+				&CD3DX12_RESOURCE_DESC::Buffer(blurWorkloadConstantBufferSize),
+				D3D12_RESOURCE_STATE_GENERIC_READ,
+				nullptr,
+				IID_PPV_ARGS(&m_blurWorkloadConstantBuffer)));
 
-            // Setup constant buffer data.
-            m_blurWorkloadConstantBufferData.loopCount = m_blurPSLoopCount;
+			// Setup constant buffer data.
+			m_blurWorkloadConstantBufferData.loopCount = m_blurPSLoopCount;
 
-            // Map and initialize the constant buffer. We don't unmap this until the
-            // app closes. Keeping things mapped for the lifetime of the resource is okay.
-            CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-            ThrowIfFailed(m_blurWorkloadConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pBlurWorkloadCbvDataBegin)));
-            memcpy(m_pBlurWorkloadCbvDataBegin, &m_blurWorkloadConstantBufferData, blurWorkloadConstantBufferSize / FrameCount);
-        }
+			// Map and initialize the constant buffer. We don't unmap this until the
+			// app closes. Keeping things mapped for the lifetime of the resource is okay.
+			CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+			ThrowIfFailed(m_blurWorkloadConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pBlurWorkloadCbvDataBegin)));
+			memcpy(m_pBlurWorkloadCbvDataBegin, &m_blurWorkloadConstantBufferData, blurWorkloadConstantBufferSize / FrameCount);
+		}
 
-        {
-            ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-                D3D12_HEAP_FLAG_NONE,
-                &CD3DX12_RESOURCE_DESC::Buffer(sizeof(BlurConstantBufferData)),
-                D3D12_RESOURCE_STATE_GENERIC_READ,
-                nullptr,
-                IID_PPV_ARGS(&m_blurConstantBuffer)));
+		{
+			ThrowIfFailed(m_devices[Secondary]->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+				D3D12_HEAP_FLAG_NONE,
+				&CD3DX12_RESOURCE_DESC::Buffer(sizeof(BlurConstantBufferData)),
+				D3D12_RESOURCE_STATE_GENERIC_READ,
+				nullptr,
+				IID_PPV_ARGS(&m_blurConstantBuffer)));
 
-            // Map the constant buffer.
-            CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-            ThrowIfFailed(m_blurConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pBlurCbvDataBegin)));
+			// Map the constant buffer.
+			CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+			ThrowIfFailed(m_blurConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pBlurCbvDataBegin)));
 
-            // Setup constant buffer data.
-            m_pBlurCbvDataBegin[0].offset = 0.5f;
-            m_pBlurCbvDataBegin[0].textureDimensions.x = static_cast<float>(m_width);
-            m_pBlurCbvDataBegin[0].textureDimensions.y = static_cast<float>(m_height);
+			// Setup constant buffer data.
+			m_pBlurCbvDataBegin[0].offset = 0.5f;
+			m_pBlurCbvDataBegin[0].textureDimensions.x = static_cast<float>(m_width);
+			m_pBlurCbvDataBegin[0].textureDimensions.y = static_cast<float>(m_height);
 
-            // Unmap the constant buffer because we don't update this again.
-            // If we ever do, it should be buffered by the number of frames like other constant buffers.
-            const CD3DX12_RANGE emptyRange(0, 0);
-            m_blurConstantBuffer->Unmap(0, &emptyRange);
-            m_pBlurCbvDataBegin = nullptr;
-        }
-    }
+			// Unmap the constant buffer because we don't update this again.
+			// If we ever do, it should be buffered by the number of frames like other constant buffers.
+			const CD3DX12_RANGE emptyRange(0, 0);
+			m_blurConstantBuffer->Unmap(0, &emptyRange);
+			m_pBlurCbvDataBegin = nullptr;
+		}
+	}
 
-    // Close the command lists and execute them to begin the vertex buffer copies into the default heaps.
-    for (UINT i = 0; i < GraphicsAdaptersCount; i++)
-    {
-        ThrowIfFailed(m_directCommandLists[i]->Close());
-        ID3D12CommandList* ppCommandLists[] = { m_directCommandLists[i].Get() };
-        m_directCommandQueues[i]->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
-    }
+	// Close the command lists and execute them to begin the vertex buffer copies into the default heaps.
+	for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+	{
+		ThrowIfFailed(m_directCommandLists[i]->Close());
+		ID3D12CommandList* ppCommandLists[] = { m_directCommandLists[i].Get() };
+		m_directCommandQueues[i]->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	}
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    // We use a cross-adapter fence for handling Signals and Waits between adapters.
-    // We use regular fences for things that don't need to be cross adapter because they don't need the additional overhead associated with being cross-adapter.
-    {
-        // Fence used to control CPU pacing.
-        ThrowIfFailed(m_devices[Secondary]->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_frameFence)));
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	// We use a cross-adapter fence for handling Signals and Waits between adapters.
+	// We use regular fences for things that don't need to be cross adapter because they don't need the additional overhead associated with being cross-adapter.
+	{
+		// Fence used to control CPU pacing.
+		ThrowIfFailed(m_devices[Secondary]->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_frameFence)));
 
-        // Fence used by the primary adapter to signal its copy queue that it has completed rendering.
-        // When this is signaled, the primary adapter's copy queue can begin copying to the cross-adapter shared resource.
-        ThrowIfFailed(m_devices[Primary]->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_renderFence)));
+		// Fence used by the primary adapter to signal its copy queue that it has completed rendering.
+		// When this is signaled, the primary adapter's copy queue can begin copying to the cross-adapter shared resource.
+		ThrowIfFailed(m_devices[Primary]->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_renderFence)));
 
-        // Cross-adapter shared fence used by both adapters.
-        // Used by the primary adapter to signal the secondary adapter that it has completed copying to the cross-adapter shared resource.
-        // When this is signaled, the secondary adapter can begin its work.
-        ThrowIfFailed(m_devices[Primary]->CreateFence(0, D3D12_FENCE_FLAG_SHARED | D3D12_FENCE_FLAG_SHARED_CROSS_ADAPTER, IID_PPV_ARGS(&m_crossAdapterFences[Primary]))); 
+		// Cross-adapter shared fence used by both adapters.
+		// Used by the primary adapter to signal the secondary adapter that it has completed copying to the cross-adapter shared resource.
+		// When this is signaled, the secondary adapter can begin its work.
+		ThrowIfFailed(m_devices[Primary]->CreateFence(0, D3D12_FENCE_FLAG_SHARED | D3D12_FENCE_FLAG_SHARED_CROSS_ADAPTER, IID_PPV_ARGS(&m_crossAdapterFences[Primary]))); 
 
-        // For now, require GENERIC_ALL access.
-        HANDLE fenceHandle = nullptr;
-        ThrowIfFailed(m_devices[Primary]->CreateSharedHandle(
-            m_crossAdapterFences[Primary].Get(),
-            nullptr,
-            GENERIC_ALL,
-            nullptr,
-            &fenceHandle));
+		// For now, require GENERIC_ALL access.
+		HANDLE fenceHandle = nullptr;
+		ThrowIfFailed(m_devices[Primary]->CreateSharedHandle(
+			m_crossAdapterFences[Primary].Get(),
+			nullptr,
+			GENERIC_ALL,
+			nullptr,
+			&fenceHandle));
 
-        HRESULT openSharedHandleResult = m_devices[Secondary]->OpenSharedHandle(fenceHandle, IID_PPV_ARGS(&m_crossAdapterFences[Secondary]));
+		HRESULT openSharedHandleResult = m_devices[Secondary]->OpenSharedHandle(fenceHandle, IID_PPV_ARGS(&m_crossAdapterFences[Secondary]));
 
-        // We can close the handle after opening the cross-adapter shared fence.
-        CloseHandle(fenceHandle);
+		// We can close the handle after opening the cross-adapter shared fence.
+		CloseHandle(fenceHandle);
 
-        ThrowIfFailed(openSharedHandleResult);
+		ThrowIfFailed(openSharedHandleResult);
 
-        for (UINT i = 0; i < GraphicsAdaptersCount; i++)
-        {
-            // Create an event handle to use for frame synchronization.
-            m_fenceEvents[i] = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-            if (m_fenceEvents == nullptr)
-            {
-                ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-            }
+		for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+		{
+			// Create an event handle to use for frame synchronization.
+			m_fenceEvents[i] = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+			if (m_fenceEvents == nullptr)
+			{
+				ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+			}
 
-            // Wait for the command list to execute; we are reusing the same command 
-            // list in our main loop but for now, we just want to wait for setup to 
-            // complete before continuing.
-            WaitForGpu(static_cast<GraphicsAdapter>(i));
-        }
-    }
+			// Wait for the command list to execute; we are reusing the same command 
+			// list in our main loop but for now, we just want to wait for setup to 
+			// complete before continuing.
+			WaitForGpu(static_cast<GraphicsAdapter>(i));
+		}
+	}
 }
 
 // Get a random float value between min and max.
 float D3D12HeterogeneousMultiadapter::GetRandomFloat(float min, float max)
 {
-    float scale = static_cast<float>(rand()) / RAND_MAX;
-    float range = max - min;
-    return scale * range + min;
+	float scale = static_cast<float>(rand()) / RAND_MAX;
+	float range = max - min;
+	return scale * range + min;
 }
 
 // Update frame-based values.
 void D3D12HeterogeneousMultiadapter::OnUpdate()
 {
-    // Add the oldest timestamp data to our moving average counters.
-    // Use the oldest timestamp index to limit CPU waits.
-    {
-        // The oldest frame is the current frame index and it will always be complete due to the wait in MoveToNextFrame().
-        const UINT oldestFrameIndex = m_frameIndex;
-        assert(m_frameFenceValues[oldestFrameIndex] <= m_frameFence->GetCompletedValue());
+	// Add the oldest timestamp data to our moving average counters.
+	// Use the oldest timestamp index to limit CPU waits.
+	{
+		// The oldest frame is the current frame index and it will always be complete due to the wait in MoveToNextFrame().
+		const UINT oldestFrameIndex = m_frameIndex;
+		assert(m_frameFenceValues[oldestFrameIndex] <= m_frameFence->GetCompletedValue());
 
-        // Get the timestamp values from the result buffers.
-        D3D12_RANGE readRange = {};
-        const D3D12_RANGE emptyRange = {};
+		// Get the timestamp values from the result buffers.
+		D3D12_RANGE readRange = {};
+		const D3D12_RANGE emptyRange = {};
 
-        UINT64* ppMovingAverage[] = { m_drawTimes, m_blurTimes };
-        for (UINT i = 0; i < GraphicsAdaptersCount; i++)
-        {
-            readRange.Begin = 2 * oldestFrameIndex * sizeof(UINT64);
-            readRange.End = readRange.Begin + 2 * sizeof(UINT64);
+		UINT64* ppMovingAverage[] = { m_drawTimes, m_blurTimes };
+		for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+		{
+			readRange.Begin = 2 * oldestFrameIndex * sizeof(UINT64);
+			readRange.End = readRange.Begin + 2 * sizeof(UINT64);
 
-            void* pData = nullptr;
-            ThrowIfFailed(m_timestampResultBuffers[i]->Map(0, &readRange, &pData));
+			void* pData = nullptr;
+			ThrowIfFailed(m_timestampResultBuffers[i]->Map(0, &readRange, &pData));
 
-            const UINT64* pTimestamps = reinterpret_cast<UINT64*>(static_cast<UINT8*>(pData) + readRange.Begin);
-            const UINT64 timeStampDelta = pTimestamps[1] - pTimestamps[0];
+			const UINT64* pTimestamps = reinterpret_cast<UINT64*>(static_cast<UINT8*>(pData) + readRange.Begin);
+			const UINT64 timeStampDelta = pTimestamps[1] - pTimestamps[0];
 
-            // Unmap with an empty range (written range).
-            m_timestampResultBuffers[i]->Unmap(0, &emptyRange);
+			// Unmap with an empty range (written range).
+			m_timestampResultBuffers[i]->Unmap(0, &emptyRange);
 
-            // Calculate the GPU execution time in microseconds.
-            const UINT64 gpuTimeUS =  (timeStampDelta * 1000000) / m_directCommandQueueTimestampFrequencies[i];
-            ppMovingAverage[i][m_currentTimesIndex] = gpuTimeUS;
-        }
+			// Calculate the GPU execution time in microseconds.
+			const UINT64 gpuTimeUS =  (timeStampDelta * 1000000) / m_directCommandQueueTimestampFrequencies[i];
+			ppMovingAverage[i][m_currentTimesIndex] = gpuTimeUS;
+		}
 
-        // Move to the next index.
-        m_currentTimesIndex = (m_currentTimesIndex + 1) % MovingAverageFrameCount;
-    }
+		// Move to the next index.
+		m_currentTimesIndex = (m_currentTimesIndex + 1) % MovingAverageFrameCount;
+	}
 
-    // Dynamically change the workload on the primary adapter. This is a VERY naive implementation.
-    // The point here is to show that applications have a choice with how to spend their extra cycles.
-    // Note: If copies take longer then you should take that into account as well.
-    {
-        static UINT64 framesSinceLastUpdate = 0;
-        framesSinceLastUpdate++;
-        if (framesSinceLastUpdate > MovingAverageFrameCount)
-        {
-            // Calculate the average draw and blur times for last few frames.
-            m_drawTimeMovingAverage = 0;
-            m_blurTimeMovingAverage = 0;
-            for (UINT i = 0; i < MovingAverageFrameCount; i++)
-            {
-                m_drawTimeMovingAverage += m_drawTimes[i];
-                m_blurTimeMovingAverage += m_blurTimes[i];
-            }
+	// Dynamically change the workload on the primary adapter. This is a VERY naive implementation.
+	// The point here is to show that applications have a choice with how to spend their extra cycles.
+	// Note: If copies take longer then you should take that into account as well.
+	{
+		static UINT64 framesSinceLastUpdate = 0;
+		framesSinceLastUpdate++;
+		if (framesSinceLastUpdate > MovingAverageFrameCount)
+		{
+			// Calculate the average draw and blur times for last few frames.
+			m_drawTimeMovingAverage = 0;
+			m_blurTimeMovingAverage = 0;
+			for (UINT i = 0; i < MovingAverageFrameCount; i++)
+			{
+				m_drawTimeMovingAverage += m_drawTimes[i];
+				m_blurTimeMovingAverage += m_blurTimes[i];
+			}
 
-            m_drawTimeMovingAverage /= MovingAverageFrameCount;
-            m_blurTimeMovingAverage /= MovingAverageFrameCount;
-            framesSinceLastUpdate = 0;
+			m_drawTimeMovingAverage /= MovingAverageFrameCount;
+			m_blurTimeMovingAverage /= MovingAverageFrameCount;
+			framesSinceLastUpdate = 0;
 
-            // Adjust the shader blur time to be at least 20ms/frame.
-            // Note: This is just done to show that we can reach ~100% utilization of both adapters.
-            if (AllowShaderDynamicWorkload)
-            {
-                const UINT64 desiredBlurPSTimeUS = 20000;    // 20 ms
-                if (m_blurTimeMovingAverage < desiredBlurPSTimeUS || m_blurPSLoopCount != 0)
-                {
-                    // Adjust the PS blur time based on the moving average.
-                    const float timeDelta = (static_cast<float>(desiredBlurPSTimeUS) - static_cast<float>(m_blurTimeMovingAverage)) / static_cast<float>(m_blurTimeMovingAverage);
-                    if (timeDelta < -.05f || timeDelta > .01f)
-                    {
-                        const float stepSize = max(1.0f, m_blurPSLoopCount);
-                        m_blurPSLoopCount += static_cast<INT>(stepSize * timeDelta);
-                    }
-                }
-            }
+			// Adjust the shader blur time to be at least 20ms/frame.
+			// Note: This is just done to show that we can reach ~100% utilization of both adapters.
+			if (AllowShaderDynamicWorkload)
+			{
+				const UINT64 desiredBlurPSTimeUS = 20000;	// 20 ms
+				if (m_blurTimeMovingAverage < desiredBlurPSTimeUS || m_blurPSLoopCount != 0)
+				{
+					// Adjust the PS blur time based on the moving average.
+					const float timeDelta = (static_cast<float>(desiredBlurPSTimeUS) - static_cast<float>(m_blurTimeMovingAverage)) / static_cast<float>(m_blurTimeMovingAverage);
+					if (timeDelta < -.05f || timeDelta > .01f)
+					{
+						const float stepSize = max(1.0f, m_blurPSLoopCount);
+						m_blurPSLoopCount += static_cast<INT>(stepSize * timeDelta);
+					}
+				}
+			}
 
-            // Adjust the render time to be greater than the blur time.
-            {
-                const UINT64 desiredDrawPSTimeUS = m_blurTimeMovingAverage + static_cast<UINT64>(m_blurTimeMovingAverage * .10f);
-                const float timeDelta = (static_cast<float>(desiredDrawPSTimeUS) - static_cast<float>(m_drawTimeMovingAverage)) / static_cast<float>(m_drawTimeMovingAverage);
-                if (timeDelta < -.10f || timeDelta > .01f)
-                {
-                    if (AllowDrawDynamicWorkload)
-                    {
-                        // Adjust the number of triangles drawn.
-                        const float stepSize = max(1.0f, m_triangleCount);
-                        m_triangleCount = min(m_triangleCount + static_cast<INT>(stepSize * timeDelta), MaxTriangleCount);
-                    }
-                    else if (AllowShaderDynamicWorkload)
-                    {
-                        // Adjust the number of the PS loop count based on the moving average.
-                        const float stepSize = max(1.0f, m_psLoopCount);
-                        m_psLoopCount += static_cast<INT>(stepSize * timeDelta);
-                    }
-                }
-            }
-        }
+			// Adjust the render time to be greater than the blur time.
+			{
+				const UINT64 desiredDrawPSTimeUS = m_blurTimeMovingAverage + static_cast<UINT64>(m_blurTimeMovingAverage * .10f);
+				const float timeDelta = (static_cast<float>(desiredDrawPSTimeUS) - static_cast<float>(m_drawTimeMovingAverage)) / static_cast<float>(m_drawTimeMovingAverage);
+				if (timeDelta < -.10f || timeDelta > .01f)
+				{
+					if (AllowDrawDynamicWorkload)
+					{
+						// Adjust the number of triangles drawn.
+						const float stepSize = max(1.0f, m_triangleCount);
+						m_triangleCount = min(m_triangleCount + static_cast<INT>(stepSize * timeDelta), MaxTriangleCount);
+					}
+					else if (AllowShaderDynamicWorkload)
+					{
+						// Adjust the number of the PS loop count based on the moving average.
+						const float stepSize = max(1.0f, m_psLoopCount);
+						m_psLoopCount += static_cast<INT>(stepSize * timeDelta);
+					}
+				}
+			}
+		}
 
-        // Conditionally update the window's title.
-        if (framesSinceLastUpdate % WindowTextUpdateFrequency == 0)
-        {
-            UpdateWindowTitle();
-        }
-    }
+		// Conditionally update the window's title.
+		if (framesSinceLastUpdate % WindowTextUpdateFrequency == 0)
+		{
+			UpdateWindowTitle();
+		}
+	}
 
-    // Update the workloads.
-    {
-        WorkloadConstantBufferData* pWorkloadDst = m_pWorkloadCbvDataBegin + m_frameIndex;
-        WorkloadConstantBufferData* pWorkloadSrc = &m_workloadConstantBufferData;
-        pWorkloadSrc->loopCount = m_psLoopCount;
-        memcpy(pWorkloadDst, pWorkloadSrc, sizeof(WorkloadConstantBufferData));
+	// Update the workloads.
+	{
+		WorkloadConstantBufferData* pWorkloadDst = m_pWorkloadCbvDataBegin + m_frameIndex;
+		WorkloadConstantBufferData* pWorkloadSrc = &m_workloadConstantBufferData;
+		pWorkloadSrc->loopCount = m_psLoopCount;
+		memcpy(pWorkloadDst, pWorkloadSrc, sizeof(WorkloadConstantBufferData));
 
-        WorkloadConstantBufferData* pBlurWorkloadDst = m_pBlurWorkloadCbvDataBegin + m_frameIndex;
-        WorkloadConstantBufferData* pBlurWorkloadSrc = &m_blurWorkloadConstantBufferData;
-        pBlurWorkloadSrc->loopCount = m_blurPSLoopCount;
-        memcpy(pBlurWorkloadDst, pBlurWorkloadSrc, sizeof(WorkloadConstantBufferData));
-    }
+		WorkloadConstantBufferData* pBlurWorkloadDst = m_pBlurWorkloadCbvDataBegin + m_frameIndex;
+		WorkloadConstantBufferData* pBlurWorkloadSrc = &m_blurWorkloadConstantBufferData;
+		pBlurWorkloadSrc->loopCount = m_blurPSLoopCount;
+		memcpy(pBlurWorkloadDst, pBlurWorkloadSrc, sizeof(WorkloadConstantBufferData));
+	}
 
-    // Update the triangles.
-    {
-        const float offsetBounds = 2.5f;
+	// Update the triangles.
+	{
+		const float offsetBounds = 2.5f;
 
-        for (UINT n = 0; n < m_triangleCount; n++)
-        {
-            // Animate the triangles.
-            m_constantBufferData[n].offset.x += m_constantBufferData[n].velocity.x;
-            if (m_constantBufferData[n].offset.x > offsetBounds)
-            {
-                m_constantBufferData[n].velocity.x = GetRandomFloat(0.01f, 0.02f);
-                m_constantBufferData[n].offset.x = -offsetBounds;
-            }
-        }
+		for (UINT n = 0; n < m_triangleCount; n++)
+		{
+			// Animate the triangles.
+			m_constantBufferData[n].offset.x += m_constantBufferData[n].velocity.x;
+			if (m_constantBufferData[n].offset.x > offsetBounds)
+			{
+				m_constantBufferData[n].velocity.x = GetRandomFloat(0.01f, 0.02f);
+				m_constantBufferData[n].offset.x = -offsetBounds;
+			}
+		}
 
-        SceneConstantBuffer* dst = m_pCbvDataBegin + (m_frameIndex * MaxTriangleCount);
-        memcpy(dst, &m_constantBufferData[0], m_triangleCount * sizeof(SceneConstantBuffer));
-    }
+		SceneConstantBuffer* dst = m_pCbvDataBegin + (m_frameIndex * MaxTriangleCount);
+		memcpy(dst, &m_constantBufferData[0], m_triangleCount * sizeof(SceneConstantBuffer));
+	}
 }
 
 // Render the scene.
 void D3D12HeterogeneousMultiadapter::OnRender()
 {
-    // Record all the commands we need to render the scene into the command lists.
-    PopulateCommandLists();
-
-    // Execute the command lists.
+    try
     {
-        {
-            ID3D12CommandList* ppRenderCommandLists[] = { m_directCommandLists[Primary].Get() };
-            m_directCommandQueues[Primary]->ExecuteCommandLists(_countof(ppRenderCommandLists), ppRenderCommandLists);
+        // Record all the commands we need to render the scene into the command lists.
+        PopulateCommandLists();
 
-            // Signal the copy queue to indicate render is complete.
-            ThrowIfFailed(m_directCommandQueues[Primary]->Signal(m_renderFence.Get(), m_currentRenderFenceValue));
+        // Execute the command lists.
+        {
+            {
+                ID3D12CommandList* ppRenderCommandLists[] = { m_directCommandLists[Primary].Get() };
+                m_directCommandQueues[Primary]->ExecuteCommandLists(_countof(ppRenderCommandLists), ppRenderCommandLists);
+
+                // Signal the copy queue to indicate render is complete.
+                ThrowIfFailed(m_directCommandQueues[Primary]->Signal(m_renderFence.Get(), m_currentRenderFenceValue));
+            }
+
+            {
+                // GPU Wait for the primary adapter to finish rendering.
+                ThrowIfFailed(m_copyCommandQueue->Wait(m_renderFence.Get(), m_currentRenderFenceValue));
+                m_currentRenderFenceValue++;
+
+                ID3D12CommandList* ppCopyCommandLists[] = { m_copyCommandList.Get() };
+                m_copyCommandQueue->ExecuteCommandLists(_countof(ppCopyCommandLists), ppCopyCommandLists);
+
+                // Signal the secondary adapter to indicate the copy is complete.
+                ThrowIfFailed(m_copyCommandQueue->Signal(m_crossAdapterFences[Primary].Get(), m_currentCrossAdapterFenceValue));
+            }
+
+            {
+                // GPU Wait for the primary adapter to finish copying.
+                ThrowIfFailed(m_directCommandQueues[Secondary]->Wait(m_crossAdapterFences[Secondary].Get(), m_currentCrossAdapterFenceValue));
+                m_currentCrossAdapterFenceValue++;
+
+                ID3D12CommandList* ppBlurCommandLists[] = { m_directCommandLists[Secondary].Get() };
+                m_directCommandQueues[Secondary]->ExecuteCommandLists(_countof(ppBlurCommandLists), ppBlurCommandLists);
+            }
         }
 
+        // Present the frame.
+        ThrowIfFailed(m_swapChain->Present(1, 0));
+
+        // Signal the frame is complete.
+        ThrowIfFailed(m_directCommandQueues[Secondary]->Signal(m_frameFence.Get(), m_currentPresentFenceValue));
+        m_frameFenceValues[m_frameIndex] = m_currentPresentFenceValue;
+        m_currentPresentFenceValue++;
+
+        MoveToNextFrame();
+    }
+    catch (HrException& e)
+    {
+        if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
         {
-            // GPU Wait for the primary adapter to finish rendering.
-            ThrowIfFailed(m_copyCommandQueue->Wait(m_renderFence.Get(), m_currentRenderFenceValue));
-            m_currentRenderFenceValue++;
-
-            ID3D12CommandList* ppCopyCommandLists[] = { m_copyCommandList.Get() };
-            m_copyCommandQueue->ExecuteCommandLists(_countof(ppCopyCommandLists), ppCopyCommandLists);
-
-            // Signal the secondary adapter to indicate the copy is complete.
-            ThrowIfFailed(m_copyCommandQueue->Signal(m_crossAdapterFences[Primary].Get(), m_currentCrossAdapterFenceValue));
+            RestoreD3DResources();
         }
-
+        else
         {
-            // GPU Wait for the primary adapter to finish copying.
-            ThrowIfFailed(m_directCommandQueues[Secondary]->Wait(m_crossAdapterFences[Secondary].Get(), m_currentCrossAdapterFenceValue));
-            m_currentCrossAdapterFenceValue++;
-
-            ID3D12CommandList* ppBlurCommandLists[] = { m_directCommandLists[Secondary].Get() };
-            m_directCommandQueues[Secondary]->ExecuteCommandLists(_countof(ppBlurCommandLists), ppBlurCommandLists);
+            throw;
         }
     }
+}
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+// Release sample's D3D objects.
+void D3D12HeterogeneousMultiadapter::ReleaseD3DResources()
+{
+    m_frameFence.Reset();
+    m_swapChain.Reset();
+    ResetComPtrArray(&m_devices);
+    ResetComPtrArray(&m_directCommandQueues);
+    for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+    {
+        ResetComPtrArray(&m_renderTargets[i]);
+    }
+}
 
-    // Signal the frame is complete.
-    ThrowIfFailed(m_directCommandQueues[Secondary]->Signal(m_frameFence.Get(), m_currentPresentFenceValue));
-    m_frameFenceValues[m_frameIndex] = m_currentPresentFenceValue;
-    m_currentPresentFenceValue++;
-
-    MoveToNextFrame();
+// Tears down D3D resources and reinitializes them.
+void D3D12HeterogeneousMultiadapter::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
+    {
+        for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+        {
+            WaitForGpu(static_cast<GraphicsAdapter>(i));
+        }
+    }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
 }
 
 void D3D12HeterogeneousMultiadapter::OnDestroy()
 {
-    // Ensure that the GPUs are no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    for (UINT i = 0; i < GraphicsAdaptersCount; i++)
-    {
-        WaitForGpu(static_cast<GraphicsAdapter>(i));
-        CloseHandle(m_fenceEvents[i]);
-    }
+	// Ensure that the GPUs are no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+	{
+		WaitForGpu(static_cast<GraphicsAdapter>(i));
+		CloseHandle(m_fenceEvents[i]);
+	}
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12HeterogeneousMultiadapter::PopulateCommandLists()
 {
-    // Command list to render target the triangles on the primary adapter.
-    {
-        const GraphicsAdapter adapter = Primary;
+	// Command list to render target the triangles on the primary adapter.
+	{
+		const GraphicsAdapter adapter = Primary;
 
-        // Command list allocators can only be reset when the associated 
-        // command lists have finished execution on the GPU; apps should use 
-        // fences to determine GPU execution progress.
-        ThrowIfFailed(m_directCommandAllocators[adapter][m_frameIndex]->Reset());
+		// Command list allocators can only be reset when the associated 
+		// command lists have finished execution on the GPU; apps should use 
+		// fences to determine GPU execution progress.
+		ThrowIfFailed(m_directCommandAllocators[adapter][m_frameIndex]->Reset());
 
-        // However, when ExecuteCommandList() is called on a particular command 
-        // list, that command list can then be reset at any time and must be before 
-        // re-recording.
-        ThrowIfFailed(m_directCommandLists[adapter]->Reset(m_directCommandAllocators[adapter][m_frameIndex].Get(), m_pipelineState.Get()));
+		// However, when ExecuteCommandList() is called on a particular command 
+		// list, that command list can then be reset at any time and must be before 
+		// re-recording.
+		ThrowIfFailed(m_directCommandLists[adapter]->Reset(m_directCommandAllocators[adapter][m_frameIndex].Get(), m_pipelineState.Get()));
 
-        // Get a timestamp at the start of the command list.
-        const UINT timestampHeapIndex = 2 * m_frameIndex;
-        m_directCommandLists[adapter]->EndQuery(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex);
+		// Get a timestamp at the start of the command list.
+		const UINT timestampHeapIndex = 2 * m_frameIndex;
+		m_directCommandLists[adapter]->EndQuery(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex);
 
-        // Set necessary state.
-        m_directCommandLists[adapter]->SetGraphicsRootSignature(m_rootSignature.Get());
+		// Set necessary state.
+		m_directCommandLists[adapter]->SetGraphicsRootSignature(m_rootSignature.Get());
 
-        m_directCommandLists[adapter]->RSSetViewports(1, &m_viewport);
-        m_directCommandLists[adapter]->RSSetScissorRects(1, &m_scissorRect);
+		m_directCommandLists[adapter]->RSSetViewports(1, &m_viewport);
+		m_directCommandLists[adapter]->RSSetScissorRects(1, &m_scissorRect);
 
-        // Indicate that the render target will be used as a render target.
-        m_directCommandLists[adapter]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[adapter][m_frameIndex].Get(), D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_RENDER_TARGET));
+		// Indicate that the render target will be used as a render target.
+		m_directCommandLists[adapter]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[adapter][m_frameIndex].Get(), D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeaps[adapter]->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSizes[adapter]);
-        CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-        m_directCommandLists[adapter]->OMSetRenderTargets(1, &rtvHandle, false, &dsvHandle);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeaps[adapter]->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSizes[adapter]);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+		m_directCommandLists[adapter]->OMSetRenderTargets(1, &rtvHandle, false, &dsvHandle);
 
-        // Record commands.
-        m_directCommandLists[adapter]->ClearRenderTargetView(rtvHandle, ClearColor, 0, nullptr);
-        m_directCommandLists[adapter]->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+		// Record commands.
+		m_directCommandLists[adapter]->ClearRenderTargetView(rtvHandle, ClearColor, 0, nullptr);
+		m_directCommandLists[adapter]->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
 
-        // Draw the triangles.
-        m_directCommandLists[adapter]->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-        m_directCommandLists[adapter]->IASetVertexBuffers(0, 1, &m_vertexBufferView);
-        m_directCommandLists[adapter]->SetGraphicsRootConstantBufferView(1, m_workloadConstantBuffer->GetGPUVirtualAddress() + (m_frameIndex * sizeof(WorkloadConstantBufferData)));
+		// Draw the triangles.
+		m_directCommandLists[adapter]->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+		m_directCommandLists[adapter]->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+		m_directCommandLists[adapter]->SetGraphicsRootConstantBufferView(1, m_workloadConstantBuffer->GetGPUVirtualAddress() + (m_frameIndex * sizeof(WorkloadConstantBufferData)));
 
-        const D3D12_GPU_VIRTUAL_ADDRESS cbVirtualAddress = m_constantBuffer->GetGPUVirtualAddress();
-        for (UINT n = 0; n < m_triangleCount; n++)
-        {
-            const D3D12_GPU_VIRTUAL_ADDRESS cbLocation = cbVirtualAddress + (m_frameIndex * MaxTriangleCount * sizeof(SceneConstantBuffer)) + (n * sizeof(SceneConstantBuffer));
-            m_directCommandLists[adapter]->SetGraphicsRootConstantBufferView(0, cbLocation);
-            m_directCommandLists[adapter]->DrawInstanced(3, 1, 0, 0);
-        }
+		const D3D12_GPU_VIRTUAL_ADDRESS cbVirtualAddress = m_constantBuffer->GetGPUVirtualAddress();
+		for (UINT n = 0; n < m_triangleCount; n++)
+		{
+			const D3D12_GPU_VIRTUAL_ADDRESS cbLocation = cbVirtualAddress + (m_frameIndex * MaxTriangleCount * sizeof(SceneConstantBuffer)) + (n * sizeof(SceneConstantBuffer));
+			m_directCommandLists[adapter]->SetGraphicsRootConstantBufferView(0, cbLocation);
+			m_directCommandLists[adapter]->DrawInstanced(3, 1, 0, 0);
+		}
 
-        // Indicate that the render target will now be used to copy.
-        m_directCommandLists[adapter]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[adapter][m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COMMON));
+		// Indicate that the render target will now be used to copy.
+		m_directCommandLists[adapter]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[adapter][m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COMMON));
 
-        // Get a timestamp at the end of the command list and resolve the query data.
-        m_directCommandLists[adapter]->EndQuery(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex + 1);
-        m_directCommandLists[adapter]->ResolveQueryData(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex, 2, m_timestampResultBuffers[adapter].Get(), timestampHeapIndex * sizeof(UINT64));
+		// Get a timestamp at the end of the command list and resolve the query data.
+		m_directCommandLists[adapter]->EndQuery(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex + 1);
+		m_directCommandLists[adapter]->ResolveQueryData(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex, 2, m_timestampResultBuffers[adapter].Get(), timestampHeapIndex * sizeof(UINT64));
 
-        ThrowIfFailed(m_directCommandLists[adapter]->Close());
-    }
+		ThrowIfFailed(m_directCommandLists[adapter]->Close());
+	}
 
-    // Command list to copy the render target to the shared heap on the primary adapter.
-    {
-        const GraphicsAdapter adapter = Primary;
+	// Command list to copy the render target to the shared heap on the primary adapter.
+	{
+		const GraphicsAdapter adapter = Primary;
 
-        // Reset the copy command allocator and command list.
-        ThrowIfFailed(m_copyCommandAllocators[m_frameIndex]->Reset());
-        ThrowIfFailed(m_copyCommandList->Reset(m_copyCommandAllocators[m_frameIndex].Get(), nullptr));
+		// Reset the copy command allocator and command list.
+		ThrowIfFailed(m_copyCommandAllocators[m_frameIndex]->Reset());
+		ThrowIfFailed(m_copyCommandList->Reset(m_copyCommandAllocators[m_frameIndex].Get(), nullptr));
 
-        // Copy the intermediate render target to the cross-adapter shared resource.
-        // Transition barriers are not required since there are fences guarding against
-        // concurrent read/write access to the shared heap.
-        if (m_crossAdapterTextureSupport)
-        {
-            // If cross-adapter row-major textures are supported by the adapter,
-            // simply copy the texture into the cross-adapter texture.
-            m_copyCommandList->CopyResource(m_crossAdapterResources[adapter][m_frameIndex].Get(), m_renderTargets[adapter][m_frameIndex].Get());
-        }
-        else
-        {
-            // If cross-adapter row-major textures are not supported by the adapter,
-            // the texture will be copied over as a buffer so that the texture row
-            // pitch can be explicitly managed.
+		// Copy the intermediate render target to the cross-adapter shared resource.
+		// Transition barriers are not required since there are fences guarding against
+		// concurrent read/write access to the shared heap.
+		if (m_crossAdapterTextureSupport)
+		{
+			// If cross-adapter row-major textures are supported by the adapter,
+			// simply copy the texture into the cross-adapter texture.
+			m_copyCommandList->CopyResource(m_crossAdapterResources[adapter][m_frameIndex].Get(), m_renderTargets[adapter][m_frameIndex].Get());
+		}
+		else
+		{
+			// If cross-adapter row-major textures are not supported by the adapter,
+			// the texture will be copied over as a buffer so that the texture row
+			// pitch can be explicitly managed.
 
-            // Copy the intermediate render target into the shared buffer using the
-            // memory layout prescribed by the render target.
-            D3D12_RESOURCE_DESC renderTargetDesc = m_renderTargets[adapter][m_frameIndex]->GetDesc();
-            D3D12_PLACED_SUBRESOURCE_FOOTPRINT renderTargetLayout;
+			// Copy the intermediate render target into the shared buffer using the
+			// memory layout prescribed by the render target.
+			D3D12_RESOURCE_DESC renderTargetDesc = m_renderTargets[adapter][m_frameIndex]->GetDesc();
+			D3D12_PLACED_SUBRESOURCE_FOOTPRINT renderTargetLayout;
 
-            m_devices[adapter]->GetCopyableFootprints(&renderTargetDesc, 0, 1, 0, &renderTargetLayout, nullptr, nullptr, nullptr);
+			m_devices[adapter]->GetCopyableFootprints(&renderTargetDesc, 0, 1, 0, &renderTargetLayout, nullptr, nullptr, nullptr);
 
-            CD3DX12_TEXTURE_COPY_LOCATION dest(m_crossAdapterResources[adapter][m_frameIndex].Get(), renderTargetLayout);
-            CD3DX12_TEXTURE_COPY_LOCATION src(m_renderTargets[adapter][m_frameIndex].Get(), 0);
-            CD3DX12_BOX box(0, 0, m_width, m_height);
+			CD3DX12_TEXTURE_COPY_LOCATION dest(m_crossAdapterResources[adapter][m_frameIndex].Get(), renderTargetLayout);
+			CD3DX12_TEXTURE_COPY_LOCATION src(m_renderTargets[adapter][m_frameIndex].Get(), 0);
+			CD3DX12_BOX box(0, 0, m_width, m_height);
 
-            m_copyCommandList->CopyTextureRegion(&dest, 0, 0, 0, &src, &box);
-        }
+			m_copyCommandList->CopyTextureRegion(&dest, 0, 0, 0, &src, &box);
+		}
 
-        ThrowIfFailed(m_copyCommandList->Close());
-    }
+		ThrowIfFailed(m_copyCommandList->Close());
+	}
 
-    // Command list to blur the render target and present.
-    {
-        const GraphicsAdapter adapter = Secondary;
+	// Command list to blur the render target and present.
+	{
+		const GraphicsAdapter adapter = Secondary;
 
-        // Command list allocators can only be reset when the associated 
-        // command lists have finished execution on the GPU; apps should use 
-        // fences to determine GPU execution progress.
-        ThrowIfFailed(m_directCommandAllocators[adapter][m_frameIndex]->Reset());
+		// Command list allocators can only be reset when the associated 
+		// command lists have finished execution on the GPU; apps should use 
+		// fences to determine GPU execution progress.
+		ThrowIfFailed(m_directCommandAllocators[adapter][m_frameIndex]->Reset());
 
-        // However, when ExecuteCommandList() is called on a particular command 
-        // list, that command list can then be reset at any time and must be before 
-        // re-recording.
-        ThrowIfFailed(m_directCommandLists[adapter]->Reset(m_directCommandAllocators[adapter][m_frameIndex].Get(), m_blurPipelineStates[0].Get()));
+		// However, when ExecuteCommandList() is called on a particular command 
+		// list, that command list can then be reset at any time and must be before 
+		// re-recording.
+		ThrowIfFailed(m_directCommandLists[adapter]->Reset(m_directCommandAllocators[adapter][m_frameIndex].Get(), m_blurPipelineStates[0].Get()));
 
-        if (!m_crossAdapterTextureSupport)
-        {
-            // Copy the buffer in the shared heap into a texture that the secondary
-            // adapter can sample from.
-            D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(
-                m_secondaryAdapterTextures[m_frameIndex].Get(),
-                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_COPY_DEST);
-            m_directCommandLists[adapter]->ResourceBarrier(1, &barrier);
+		if (!m_crossAdapterTextureSupport)
+		{
+			// Copy the buffer in the shared heap into a texture that the secondary
+			// adapter can sample from.
+			D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(
+				m_secondaryAdapterTextures[m_frameIndex].Get(),
+				D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+				D3D12_RESOURCE_STATE_COPY_DEST);
+			m_directCommandLists[adapter]->ResourceBarrier(1, &barrier);
 
-            // Copy the shared buffer contents into the texture using the memory
-            // layout prescribed by the texture.
-            D3D12_RESOURCE_DESC secondaryAdapterTexture = m_secondaryAdapterTextures[m_frameIndex]->GetDesc();
-            D3D12_PLACED_SUBRESOURCE_FOOTPRINT textureLayout;
+			// Copy the shared buffer contents into the texture using the memory
+			// layout prescribed by the texture.
+			D3D12_RESOURCE_DESC secondaryAdapterTexture = m_secondaryAdapterTextures[m_frameIndex]->GetDesc();
+			D3D12_PLACED_SUBRESOURCE_FOOTPRINT textureLayout;
 
-            m_devices[adapter]->GetCopyableFootprints(&secondaryAdapterTexture, 0, 1, 0, &textureLayout, nullptr, nullptr, nullptr);
+			m_devices[adapter]->GetCopyableFootprints(&secondaryAdapterTexture, 0, 1, 0, &textureLayout, nullptr, nullptr, nullptr);
 
-            CD3DX12_TEXTURE_COPY_LOCATION dest(m_secondaryAdapterTextures[m_frameIndex].Get(), 0);
-            CD3DX12_TEXTURE_COPY_LOCATION src(m_crossAdapterResources[adapter][m_frameIndex].Get(), textureLayout);
-            CD3DX12_BOX box(0, 0, m_width, m_height);
+			CD3DX12_TEXTURE_COPY_LOCATION dest(m_secondaryAdapterTextures[m_frameIndex].Get(), 0);
+			CD3DX12_TEXTURE_COPY_LOCATION src(m_crossAdapterResources[adapter][m_frameIndex].Get(), textureLayout);
+			CD3DX12_BOX box(0, 0, m_width, m_height);
 
-            m_directCommandLists[adapter]->CopyTextureRegion(&dest, 0, 0, 0, &src, &box);
+			m_directCommandLists[adapter]->CopyTextureRegion(&dest, 0, 0, 0, &src, &box);
 
-            barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
-            barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-            m_directCommandLists[adapter]->ResourceBarrier(1, &barrier);
-        }
+			barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
+			barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+			m_directCommandLists[adapter]->ResourceBarrier(1, &barrier);
+		}
 
-        // Get a timestamp at the start of the command list.
-        const UINT timestampHeapIndex = 2 * m_frameIndex;
-        m_directCommandLists[adapter]->EndQuery(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex);
+		// Get a timestamp at the start of the command list.
+		const UINT timestampHeapIndex = 2 * m_frameIndex;
+		m_directCommandLists[adapter]->EndQuery(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex);
 
-        // Set necessary state.
-        m_directCommandLists[adapter]->SetGraphicsRootSignature(m_blurRootSignature.Get());
+		// Set necessary state.
+		m_directCommandLists[adapter]->SetGraphicsRootSignature(m_blurRootSignature.Get());
 
-        ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvUavHeap.Get() };
-        m_directCommandLists[adapter]->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+		ID3D12DescriptorHeap* ppHeaps[] = { m_cbvSrvUavHeap.Get() };
+		m_directCommandLists[adapter]->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-        m_directCommandLists[adapter]->RSSetViewports(1, &m_viewport);
-        m_directCommandLists[adapter]->RSSetScissorRects(1, &m_scissorRect);
+		m_directCommandLists[adapter]->RSSetViewports(1, &m_viewport);
+		m_directCommandLists[adapter]->RSSetScissorRects(1, &m_scissorRect);
 
-        // Indicate that the intermediate render target will be used as a render target.
-        m_directCommandLists[adapter]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_intermediateBlurRenderTarget.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET));
+		// Indicate that the intermediate render target will be used as a render target.
+		m_directCommandLists[adapter]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_intermediateBlurRenderTarget.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-        // Record commands.
-        m_directCommandLists[adapter]->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-        m_directCommandLists[adapter]->IASetVertexBuffers(0, 1, &m_fullscreenQuadVertexBufferView);
-        m_directCommandLists[adapter]->SetGraphicsRootConstantBufferView(0, m_blurConstantBuffer->GetGPUVirtualAddress());
-        m_directCommandLists[adapter]->SetGraphicsRootConstantBufferView(2, m_blurWorkloadConstantBuffer->GetGPUVirtualAddress() + (m_frameIndex * sizeof(WorkloadConstantBufferData)));
+		// Record commands.
+		m_directCommandLists[adapter]->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+		m_directCommandLists[adapter]->IASetVertexBuffers(0, 1, &m_fullscreenQuadVertexBufferView);
+		m_directCommandLists[adapter]->SetGraphicsRootConstantBufferView(0, m_blurConstantBuffer->GetGPUVirtualAddress());
+		m_directCommandLists[adapter]->SetGraphicsRootConstantBufferView(2, m_blurWorkloadConstantBuffer->GetGPUVirtualAddress() + (m_frameIndex * sizeof(WorkloadConstantBufferData)));
 
-        // Draw the fullscreen quad - Blur pass #1.
-        {
-            CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_cbvSrvUavHeap->GetGPUDescriptorHandleForHeapStart(), m_frameIndex, m_srvDescriptorSizes[adapter]);
-            m_directCommandLists[adapter]->SetGraphicsRootDescriptorTable(1, srvHandle);
+		// Draw the fullscreen quad - Blur pass #1.
+		{
+			CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_cbvSrvUavHeap->GetGPUDescriptorHandleForHeapStart(), m_frameIndex, m_srvDescriptorSizes[adapter]);
+			m_directCommandLists[adapter]->SetGraphicsRootDescriptorTable(1, srvHandle);
 
-            CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeaps[adapter]->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSizes[adapter]);
-            m_directCommandLists[adapter]->OMSetRenderTargets(1, &rtvHandle, false, nullptr);
+			CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeaps[adapter]->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSizes[adapter]);
+			m_directCommandLists[adapter]->OMSetRenderTargets(1, &rtvHandle, false, nullptr);
 
-            m_directCommandLists[adapter]->DrawInstanced(4, 1, 0, 0);
-        }
+			m_directCommandLists[adapter]->DrawInstanced(4, 1, 0, 0);
+		}
 
-        // Draw the fullscreen quad - Blur pass #2.
-        {
-            m_directCommandLists[adapter]->SetPipelineState(m_blurPipelineStates[1].Get());
+		// Draw the fullscreen quad - Blur pass #2.
+		{
+			m_directCommandLists[adapter]->SetPipelineState(m_blurPipelineStates[1].Get());
 
-            // Indicate that the back buffer will be used as a render target and the
-            // intermediate render target will be used as a SRV.
-            D3D12_RESOURCE_BARRIER barriers[] = {
-                CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[adapter][m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET),
-                CD3DX12_RESOURCE_BARRIER::Transition(m_intermediateBlurRenderTarget.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE)
-            };
+			// Indicate that the back buffer will be used as a render target and the
+			// intermediate render target will be used as a SRV.
+			D3D12_RESOURCE_BARRIER barriers[] = {
+				CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[adapter][m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET),
+				CD3DX12_RESOURCE_BARRIER::Transition(m_intermediateBlurRenderTarget.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE)
+			};
 
-            m_directCommandLists[adapter]->ResourceBarrier(_countof(barriers), barriers);
+			m_directCommandLists[adapter]->ResourceBarrier(_countof(barriers), barriers);
 
-            CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_cbvSrvUavHeap->GetGPUDescriptorHandleForHeapStart(), FrameCount, m_srvDescriptorSizes[adapter]);
-            m_directCommandLists[adapter]->SetGraphicsRootDescriptorTable(1, srvHandle);
+			CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_cbvSrvUavHeap->GetGPUDescriptorHandleForHeapStart(), FrameCount, m_srvDescriptorSizes[adapter]);
+			m_directCommandLists[adapter]->SetGraphicsRootDescriptorTable(1, srvHandle);
 
-            CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeaps[adapter]->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSizes[adapter]);
-            m_directCommandLists[adapter]->OMSetRenderTargets(1, &rtvHandle, false, nullptr);
+			CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeaps[adapter]->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSizes[adapter]);
+			m_directCommandLists[adapter]->OMSetRenderTargets(1, &rtvHandle, false, nullptr);
 
-            m_directCommandLists[adapter]->DrawInstanced(4, 1, 0, 0);
-        }
+			m_directCommandLists[adapter]->DrawInstanced(4, 1, 0, 0);
+		}
 
-        // Indicate that the back buffer will now be used to present.
-        m_directCommandLists[adapter]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[adapter][m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+		// Indicate that the back buffer will now be used to present.
+		m_directCommandLists[adapter]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[adapter][m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-        // Get a timestamp at the end of the command list and resolve the query data.
-        m_directCommandLists[adapter]->EndQuery(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex + 1);
-        m_directCommandLists[adapter]->ResolveQueryData(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex, 2, m_timestampResultBuffers[adapter].Get(), timestampHeapIndex * sizeof(UINT64));
+		// Get a timestamp at the end of the command list and resolve the query data.
+		m_directCommandLists[adapter]->EndQuery(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex + 1);
+		m_directCommandLists[adapter]->ResolveQueryData(m_timestampQueryHeaps[adapter].Get(), D3D12_QUERY_TYPE_TIMESTAMP, timestampHeapIndex, 2, m_timestampResultBuffers[adapter].Get(), timestampHeapIndex * sizeof(UINT64));
 
-        ThrowIfFailed(m_directCommandLists[adapter]->Close());
-    }
+		ThrowIfFailed(m_directCommandLists[adapter]->Close());
+	}
 }
 
 void D3D12HeterogeneousMultiadapter::UpdateWindowTitle()
 {
-    std::wstringstream stringStream;
+	std::wstringstream stringStream;
 
-    stringStream << L"[" << m_triangleCount << L" triangles]";
-    stringStream << L" [Render, " << m_adapterDescs[Primary].Description << ": " << m_drawTimeMovingAverage << L"us" << L" (PS loop count : " << m_psLoopCount<< ")]";
-    stringStream << L" [Blur, " << m_adapterDescs[Secondary].Description << ": " << m_blurTimeMovingAverage << L"us" << L" (PS loop count : " << m_blurPSLoopCount << ")]";
+	stringStream << L"[" << m_triangleCount << L" triangles]";
+	stringStream << L" [Render, " << m_adapterDescs[Primary].Description << ": " << m_drawTimeMovingAverage << L"us" << L" (PS loop count : " << m_psLoopCount<< ")]";
+	stringStream << L" [Blur, " << m_adapterDescs[Secondary].Description << ": " << m_blurTimeMovingAverage << L"us" << L" (PS loop count : " << m_blurPSLoopCount << ")]";
 
-    SetCustomWindowText(stringStream.str().c_str());
+	SetCustomWindowText(stringStream.str().c_str());
 }
 
 // Wait for pending GPU work to complete.
 void D3D12HeterogeneousMultiadapter::WaitForGpu(GraphicsAdapter adapter)
 {
-    // Schedule a Signal command in the queue.
-    // Note we just re-use the cross adapter fence for convenience.
-    ThrowIfFailed(m_directCommandQueues[adapter]->Signal(m_crossAdapterFences[adapter].Get(), m_currentCrossAdapterFenceValue));
+	// Schedule a Signal command in the queue.
+	// Note we just re-use the cross adapter fence for convenience.
+	ThrowIfFailed(m_directCommandQueues[adapter]->Signal(m_crossAdapterFences[adapter].Get(), m_currentCrossAdapterFenceValue));
 
-    // Wait until the fence has been processed.
-    ThrowIfFailed(m_crossAdapterFences[adapter]->SetEventOnCompletion(m_currentCrossAdapterFenceValue, m_fenceEvents[adapter]));
-    WaitForSingleObject(m_fenceEvents[adapter], INFINITE);
-    m_currentCrossAdapterFenceValue++;
+	// Wait until the fence has been processed.
+	ThrowIfFailed(m_crossAdapterFences[adapter]->SetEventOnCompletion(m_currentCrossAdapterFenceValue, m_fenceEvents[adapter]));
+	WaitForSingleObject(m_fenceEvents[adapter], INFINITE);
+	m_currentCrossAdapterFenceValue++;
 }
 
 // Prepare to render the next frame.
 void D3D12HeterogeneousMultiadapter::MoveToNextFrame()
 {
-    // Get the current the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Get the current the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    const UINT64 completedFenceValue = m_frameFence->GetCompletedValue();
-    if (completedFenceValue < m_frameFenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_frameFence->SetEventOnCompletion(m_frameFenceValues[m_frameIndex], m_fenceEvents[Secondary]));
-        WaitForSingleObject(m_fenceEvents[Secondary], INFINITE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	const UINT64 completedFenceValue = m_frameFence->GetCompletedValue();
+	if (completedFenceValue < m_frameFenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_frameFence->SetEventOnCompletion(m_frameFenceValues[m_frameIndex], m_fenceEvents[Secondary]));
+		WaitForSingleObject(m_fenceEvents[Secondary], INFINITE);
+	}
 }

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/D3D12HeterogeneousMultiadapter.h
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/D3D12HeterogeneousMultiadapter.h
@@ -25,159 +25,161 @@ using Microsoft::WRL::ComPtr;
 class D3D12HeterogeneousMultiadapter : public DXSample
 {
 public:
-    D3D12HeterogeneousMultiadapter(int width, int height, LPCWSTR name);
+	D3D12HeterogeneousMultiadapter(int width, int height, LPCWSTR name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    static const bool AllowDrawDynamicWorkload = false;        // Allow the sample to change the number of triangles drawn, in an attempt to balance the workload between adapters.
-    static const bool AllowShaderDynamicWorkload = true;    // Allow the sample to change PS complexity (simulated), in an attempt to balance the workload between adapters.
+	static const bool AllowDrawDynamicWorkload = false;		// Allow the sample to change the number of triangles drawn, in an attempt to balance the workload between adapters.
+	static const bool AllowShaderDynamicWorkload = true;	// Allow the sample to change PS complexity (simulated), in an attempt to balance the workload between adapters.
 
-    static const UINT FrameCount = 3;
-    static const float ClearColor[4];
-    static const UINT MovingAverageFrameCount = 20;
-    static const UINT WindowTextUpdateFrequency = 20;    // Update the window title every x frames.
-    static const UINT MaxTriangleCount = 15000;            // The max number of triangles per frame.
-    static const float TriangleHalfWidth;                // The x and y offsets used by the triangle vertices.
-    static const float TriangleDepth;                    // The z offset used by the triangle vertices.
+	static const UINT FrameCount = 3;
+	static const float ClearColor[4];
+	static const UINT MovingAverageFrameCount = 20;
+	static const UINT WindowTextUpdateFrequency = 20;	// Update the window title every x frames.
+	static const UINT MaxTriangleCount = 15000;			// The max number of triangles per frame.
+	static const float TriangleHalfWidth;				// The x and y offsets used by the triangle vertices.
+	static const float TriangleDepth;					// The z offset used by the triangle vertices.
 
-    UINT m_frameIndex;
-    UINT m_triangleCount;
-    UINT m_psLoopCount;
-    UINT m_blurPSLoopCount;
-    UINT m_currentTimesIndex;
-    UINT64 m_drawTimes[MovingAverageFrameCount];
-    UINT64 m_blurTimes[MovingAverageFrameCount];
-    UINT64 m_drawTimeMovingAverage;
-    UINT64 m_blurTimeMovingAverage;
+	UINT m_frameIndex;
+	UINT m_triangleCount;
+	UINT m_psLoopCount;
+	UINT m_blurPSLoopCount;
+	UINT m_currentTimesIndex;
+	UINT64 m_drawTimes[MovingAverageFrameCount];
+	UINT64 m_blurTimes[MovingAverageFrameCount];
+	UINT64 m_drawTimeMovingAverage;
+	UINT64 m_blurTimeMovingAverage;
 
-    // Vertex definitions.
-    struct Vertex
-    {
-        XMFLOAT3 position;
-    };
+	// Vertex definitions.
+	struct Vertex
+	{
+		XMFLOAT3 position;
+	};
 
-    struct VertexPositionUV
-    {
-        XMFLOAT4 position;
-        XMFLOAT2 uv;
-    };
+	struct VertexPositionUV
+	{
+		XMFLOAT4 position;
+		XMFLOAT2 uv;
+	};
 
-    // Constant buffer definitions.
-    struct SceneConstantBuffer
-    {
-        XMFLOAT4 velocity;
-        XMFLOAT4 offset;
-        XMFLOAT4 color;
-        XMFLOAT4X4 projection;
+	// Constant buffer definitions.
+	struct SceneConstantBuffer
+	{
+		XMFLOAT4 velocity;
+		XMFLOAT4 offset;
+		XMFLOAT4 color;
+		XMFLOAT4X4 projection;
 
-        // Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
-        // to be array-indexed.
-        float padding[36];
-    };
+		// Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
+		// to be array-indexed.
+		float padding[36];
+	};
 
-    struct BlurConstantBufferData
-    {
-        XMFLOAT2 textureDimensions;
+	struct BlurConstantBufferData
+	{
+		XMFLOAT2 textureDimensions;
 
-        // Controls how much of the render target is blurred along X axis [0.0. 1.0]. 
-        // E.g. 1 = all of the RT is blurred, 0.5 = half of the RT is blurred, 0.0 = none of the RT is blurred
-        FLOAT offset;
+		// Controls how much of the render target is blurred along X axis [0.0. 1.0]. 
+		// E.g. 1 = all of the RT is blurred, 0.5 = half of the RT is blurred, 0.0 = none of the RT is blurred
+		FLOAT offset;
 
-        // Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
-        // to be array-indexed.
-        float padding[61];
-    };
+		// Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
+		// to be array-indexed.
+		float padding[61];
+	};
 
-    struct WorkloadConstantBufferData
-    {
-        UINT loopCount;
+	struct WorkloadConstantBufferData
+	{
+		UINT loopCount;
 
-        // Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
-        // to be array-indexed.
-        float padding[63];
-    };
+		// Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
+		// to be array-indexed.
+		float padding[63];
+	};
 
-    enum GraphicsAdapter
-    {
-        Primary, // Note: Not necessarily the OS's primary adapter (adapter enumerated at index 0).
-        Secondary,
-        GraphicsAdaptersCount
-    };
+	enum GraphicsAdapter
+	{
+		Primary, // Note: Not necessarily the OS's primary adapter (adapter enumerated at index 0).
+		Secondary,
+		GraphicsAdaptersCount
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    UINT m_rtvDescriptorSizes[GraphicsAdaptersCount];
-    UINT m_srvDescriptorSizes[GraphicsAdaptersCount];
-    DXGI_ADAPTER_DESC1 m_adapterDescs[GraphicsAdaptersCount];
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_devices[GraphicsAdaptersCount];
-    ComPtr<ID3D12CommandAllocator> m_directCommandAllocators[GraphicsAdaptersCount][FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_copyCommandAllocators[FrameCount];
-    ComPtr<ID3D12CommandQueue> m_directCommandQueues[GraphicsAdaptersCount];
-    ComPtr<ID3D12CommandQueue> m_copyCommandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12RootSignature> m_blurRootSignature;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12PipelineState> m_blurPipelineStates[2];
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeaps[GraphicsAdaptersCount];
-    ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_cbvSrvUavHeap;
-    ComPtr<ID3D12GraphicsCommandList> m_directCommandLists[GraphicsAdaptersCount];
-    ComPtr<ID3D12GraphicsCommandList> m_copyCommandList;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	UINT m_rtvDescriptorSizes[GraphicsAdaptersCount];
+	UINT m_srvDescriptorSizes[GraphicsAdaptersCount];
+	DXGI_ADAPTER_DESC1 m_adapterDescs[GraphicsAdaptersCount];
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_devices[GraphicsAdaptersCount];
+	ComPtr<ID3D12CommandAllocator> m_directCommandAllocators[GraphicsAdaptersCount][FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_copyCommandAllocators[FrameCount];
+	ComPtr<ID3D12CommandQueue> m_directCommandQueues[GraphicsAdaptersCount];
+	ComPtr<ID3D12CommandQueue> m_copyCommandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12RootSignature> m_blurRootSignature;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12PipelineState> m_blurPipelineStates[2];
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeaps[GraphicsAdaptersCount];
+	ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_cbvSrvUavHeap;
+	ComPtr<ID3D12GraphicsCommandList> m_directCommandLists[GraphicsAdaptersCount];
+	ComPtr<ID3D12GraphicsCommandList> m_copyCommandList;
 
-    // Synchronization objects.
-    ComPtr<ID3D12Fence> m_frameFence;
-    ComPtr<ID3D12Fence> m_renderFence;
-    ComPtr<ID3D12Fence> m_crossAdapterFences[GraphicsAdaptersCount];
-    UINT64 m_currentPresentFenceValue;
-    UINT64 m_currentRenderFenceValue;
-    UINT64 m_currentCrossAdapterFenceValue;
-    UINT64 m_frameFenceValues[FrameCount];
-    HANDLE m_fenceEvents[GraphicsAdaptersCount];
+	// Synchronization objects.
+	ComPtr<ID3D12Fence> m_frameFence;
+	ComPtr<ID3D12Fence> m_renderFence;
+	ComPtr<ID3D12Fence> m_crossAdapterFences[GraphicsAdaptersCount];
+	UINT64 m_currentPresentFenceValue;
+	UINT64 m_currentRenderFenceValue;
+	UINT64 m_currentCrossAdapterFenceValue;
+	UINT64 m_frameFenceValues[FrameCount];
+	HANDLE m_fenceEvents[GraphicsAdaptersCount];
 
-    // Asset objects.
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    ComPtr<ID3D12Resource> m_fullscreenQuadVertexBuffer;
-    ComPtr<ID3D12Resource> m_constantBuffer;
-    ComPtr<ID3D12Resource> m_workloadConstantBuffer;
-    ComPtr<ID3D12Resource> m_blurWorkloadConstantBuffer;
-    ComPtr<ID3D12Resource> m_blurConstantBuffer;
-    ComPtr<ID3D12Resource> m_depthStencil;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
-    D3D12_VERTEX_BUFFER_VIEW m_fullscreenQuadVertexBufferView;
-    std::vector<SceneConstantBuffer> m_constantBufferData;
-    SceneConstantBuffer* m_pCbvDataBegin;
-    BlurConstantBufferData* m_pBlurCbvDataBegin;
-    WorkloadConstantBufferData m_workloadConstantBufferData;
-    WorkloadConstantBufferData* m_pWorkloadCbvDataBegin;
-    WorkloadConstantBufferData m_blurWorkloadConstantBufferData;
-    WorkloadConstantBufferData* m_pBlurWorkloadCbvDataBegin;
-    ComPtr<ID3D12Heap> m_crossAdapterResourceHeaps[GraphicsAdaptersCount];
-    ComPtr<ID3D12Resource> m_crossAdapterResources[GraphicsAdaptersCount][FrameCount];
-    BOOL m_crossAdapterTextureSupport;
-    ComPtr<ID3D12Resource> m_secondaryAdapterTextures[FrameCount];            // Only used if cross adapter texture support is unavailable.
-    ComPtr<ID3D12Resource> m_renderTargets[GraphicsAdaptersCount][FrameCount];
-    ComPtr<ID3D12Resource> m_intermediateBlurRenderTarget;
-    ComPtr<ID3D12QueryHeap> m_timestampQueryHeaps[GraphicsAdaptersCount];
-    ComPtr<ID3D12Resource> m_timestampResultBuffers[GraphicsAdaptersCount];
-    UINT64 m_directCommandQueueTimestampFrequencies[GraphicsAdaptersCount];
+	// Asset objects.
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	ComPtr<ID3D12Resource> m_fullscreenQuadVertexBuffer;
+	ComPtr<ID3D12Resource> m_constantBuffer;
+	ComPtr<ID3D12Resource> m_workloadConstantBuffer;
+	ComPtr<ID3D12Resource> m_blurWorkloadConstantBuffer;
+	ComPtr<ID3D12Resource> m_blurConstantBuffer;
+	ComPtr<ID3D12Resource> m_depthStencil;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	D3D12_VERTEX_BUFFER_VIEW m_fullscreenQuadVertexBufferView;
+	std::vector<SceneConstantBuffer> m_constantBufferData;
+	SceneConstantBuffer* m_pCbvDataBegin;
+	BlurConstantBufferData* m_pBlurCbvDataBegin;
+	WorkloadConstantBufferData m_workloadConstantBufferData;
+	WorkloadConstantBufferData* m_pWorkloadCbvDataBegin;
+	WorkloadConstantBufferData m_blurWorkloadConstantBufferData;
+	WorkloadConstantBufferData* m_pBlurWorkloadCbvDataBegin;
+	ComPtr<ID3D12Heap> m_crossAdapterResourceHeaps[GraphicsAdaptersCount];
+	ComPtr<ID3D12Resource> m_crossAdapterResources[GraphicsAdaptersCount][FrameCount];
+	BOOL m_crossAdapterTextureSupport;
+	ComPtr<ID3D12Resource> m_secondaryAdapterTextures[FrameCount];			// Only used if cross adapter texture support is unavailable.
+	ComPtr<ID3D12Resource> m_renderTargets[GraphicsAdaptersCount][FrameCount];
+	ComPtr<ID3D12Resource> m_intermediateBlurRenderTarget;
+	ComPtr<ID3D12QueryHeap> m_timestampQueryHeaps[GraphicsAdaptersCount];
+	ComPtr<ID3D12Resource> m_timestampResultBuffers[GraphicsAdaptersCount];
+	UINT64 m_directCommandQueueTimestampFrequencies[GraphicsAdaptersCount];
 
-    HRESULT GetHardwareAdapters(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppPrimaryAdapter, _Outptr_result_maybenull_ IDXGIAdapter1** ppSecondaryAdapter);
-    void LoadPipeline();
-    void LoadAssets();
-    float GetRandomFloat(float min, float max);
-    void PopulateCommandLists();
-    void UpdateWindowTitle();
-    void WaitForGpu(GraphicsAdapter adapter);
-    void MoveToNextFrame();
+	HRESULT GetHardwareAdapters(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppPrimaryAdapter, _Outptr_result_maybenull_ IDXGIAdapter1** ppSecondaryAdapter);
+	void LoadPipeline();
+	void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
+	float GetRandomFloat(float min, float max);
+	void PopulateCommandLists();
+	void UpdateWindowTitle();
+	void WaitForGpu(GraphicsAdapter adapter);
+	void MoveToNextFrame();
 
-    static inline UINT Align(UINT size, UINT alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT)
-    {
-        return (size + alignment - 1) & ~(alignment - 1);
-    }
+	static inline UINT Align(UINT size, UINT alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT)
+	{
+		return (size + alignment - 1) & ~(alignment - 1);
+	}
 };

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/DXSample.cpp
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,59 +34,104 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
-    auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(windowText.c_str());
+	std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
+	auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/DXSample.h
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/DXSample.h
@@ -16,42 +16,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/Main.cpp
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12HeterogeneousMultiadapter sample(1200, 900, L"");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12HeterogeneousMultiadapter sample(1200, 900, L"");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/View.cpp
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/View.cpp
@@ -15,27 +15,27 @@
 using namespace Windows::Foundation;
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -44,20 +44,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -66,26 +66,26 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnClosed(CoreWindow^ /*sender*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/View.h
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/View.h
@@ -23,20 +23,20 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
+	DXSample* m_pSample;
+	bool m_windowClosed;
 };

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/ViewProvider.cpp
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/ViewProvider.h
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/blurShaders.hlsl
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/blurShaders.hlsl
@@ -11,23 +11,23 @@
 
 struct VSInput
 {
-    float4 position : POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : POSITION;
+	float2 uv : TEXCOORD;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 // A pass-through function for the texture coordinate data.
 PSInput VSSimpleBlur(VSInput input)
 {
-    PSInput output;
-    output.position = input.position;
-    output.uv = input.uv;
-    return output;
+	PSInput output;
+	output.position = input.position;
+	output.uv = input.uv;
+	return output;
 }
 
 static const float KernelOffsets[3] = { 0.0f, 1.3846153846f, 3.2307692308f };
@@ -40,81 +40,81 @@ SamplerState linearSampler : register(s1);
 
 cbuffer GaussianBlurConstantBuffer : register(b0)
 {
-    float2 textureDimensions;    // The render target width/height.
-    float blurXOffset;            // Controls how much of the render target is blurred along X axis [0.0. 1.0]. E.g. 1 = all of the RT is blurred, 0.5 = half of the RT is blurred, 0.0 = none of the RT is blurred.
+	float2 textureDimensions;	// The render target width/height.
+	float blurXOffset;			// Controls how much of the render target is blurred along X axis [0.0. 1.0]. E.g. 1 = all of the RT is blurred, 0.5 = half of the RT is blurred, 0.0 = none of the RT is blurred.
 };
 
 cbuffer WorkloadConstantBuffer : register(b1)
 {
-    uint loopCount;
+	uint loopCount;
 };
 
 // Simple gaussian blur in the vertical direction.
 float4 PSSimpleBlurV(PSInput input) : SV_TARGET
 {
-    float3 textureColor = float3(1.0f, 0.0f, 0.0f);
-    float2 uv = input.uv;
-    if (uv.x > (blurXOffset + 0.005f))
-    {
-        textureColor = tex.Sample(linearSampler, uv).xyz * BlurWeights[0];
-        for (int i = 1; i < 3; i++)
-        {
-            float2 normalizedOffset = float2(0.0f, KernelOffsets[i]) / textureDimensions.y;
-            textureColor += tex.Sample(linearSampler, uv + normalizedOffset).xyz * BlurWeights[i];
-            textureColor += tex.Sample(linearSampler, uv - normalizedOffset).xyz * BlurWeights[i];
-        }
-    }
-    else if (uv.x <= (blurXOffset - 0.005f))
-    {
-        textureColor = tex.Sample(pointSampler, uv).xyz;
-    }
+	float3 textureColor = float3(1.0f, 0.0f, 0.0f);
+	float2 uv = input.uv;
+	if (uv.x > (blurXOffset + 0.005f))
+	{
+		textureColor = tex.Sample(linearSampler, uv).xyz * BlurWeights[0];
+		for (int i = 1; i < 3; i++)
+		{
+			float2 normalizedOffset = float2(0.0f, KernelOffsets[i]) / textureDimensions.y;
+			textureColor += tex.Sample(linearSampler, uv + normalizedOffset).xyz * BlurWeights[i];
+			textureColor += tex.Sample(linearSampler, uv - normalizedOffset).xyz * BlurWeights[i];
+		}
+	}
+	else if (uv.x <= (blurXOffset - 0.005f))
+	{
+		textureColor = tex.Sample(pointSampler, uv).xyz;
+	}
 
-    // Artificially increase the workload to simulate a more complex shader.
-    const float3 textureColorOrig = textureColor;
-    for (uint i = 0; i < loopCount; i++)
-    {
-        textureColor += textureColorOrig;
-    }
+	// Artificially increase the workload to simulate a more complex shader.
+	const float3 textureColorOrig = textureColor;
+	for (uint i = 0; i < loopCount; i++)
+	{
+		textureColor += textureColorOrig;
+	}
 
-    if (loopCount > 0)
-    {
-        textureColor /= loopCount + 1;
-    }
+	if (loopCount > 0)
+	{
+		textureColor /= loopCount + 1;
+	}
 
-    return float4(textureColor, 1.0);
+	return float4(textureColor, 1.0);
 }
 
 // Simple gaussian blur in the horizontal direction.
 float4 PSSimpleBlurU(PSInput input) : SV_TARGET
 {
-    float3 textureColor = float3(1.0f, 0.0f, 0.0f);
-    float2 uv = input.uv;
-    if (uv.x > (blurXOffset + 0.005f))
-    {
-        textureColor = tex.Sample(linearSampler, uv).xyz * BlurWeights[0];
-        for (int i = 1; i < 3; i++)
-        {
-            float2 normalizedOffset = float2(KernelOffsets[i], 0.0f) / textureDimensions.x;
-            textureColor += tex.Sample(linearSampler, uv + normalizedOffset).xyz * BlurWeights[i];
-            textureColor += tex.Sample(linearSampler, uv - normalizedOffset).xyz * BlurWeights[i];
-        }
-    }
-    else if (uv.x <= (blurXOffset - 0.005f))
-    {
-        textureColor = tex.Sample(pointSampler, uv).xyz;
-    }
+	float3 textureColor = float3(1.0f, 0.0f, 0.0f);
+	float2 uv = input.uv;
+	if (uv.x > (blurXOffset + 0.005f))
+	{
+		textureColor = tex.Sample(linearSampler, uv).xyz * BlurWeights[0];
+		for (int i = 1; i < 3; i++)
+		{
+			float2 normalizedOffset = float2(KernelOffsets[i], 0.0f) / textureDimensions.x;
+			textureColor += tex.Sample(linearSampler, uv + normalizedOffset).xyz * BlurWeights[i];
+			textureColor += tex.Sample(linearSampler, uv - normalizedOffset).xyz * BlurWeights[i];
+		}
+	}
+	else if (uv.x <= (blurXOffset - 0.005f))
+	{
+		textureColor = tex.Sample(pointSampler, uv).xyz;
+	}
 
-    // Artificially increase the workload to simulate a more complex shader.
-    const float3 textureColorOrig = textureColor;
-    for (uint i = 0; i < loopCount; i++)
-    {
-        textureColor += textureColorOrig;
-    }
+	// Artificially increase the workload to simulate a more complex shader.
+	const float3 textureColorOrig = textureColor;
+	for (uint i = 0; i < loopCount; i++)
+	{
+		textureColor += textureColorOrig;
+	}
 
-    if (loopCount > 0)
-    {
-        textureColor /= loopCount + 1;
-    }
+	if (loopCount > 0)
+	{
+		textureColor /= loopCount + 1;
+	}
 
-    return float4(textureColor, 1.0);
+	return float4(textureColor, 1.0);
 }

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/d3dx12.h
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/shaders.hlsl
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/shaders.hlsl
@@ -11,49 +11,49 @@
 
 cbuffer SceneConstantBuffer : register(b0)
 {
-    float4 velocity;
-    float4 offset;
-    float4 color;
-    float4x4 projection;
+	float4 velocity;
+	float4 offset;
+	float4 color;
+	float4x4 projection;
 };
 
 cbuffer WorkloadConstantBuffer : register(b1)
 {
-    uint loopCount;
+	uint loopCount;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VShader(float4 position : POSITION)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = mul(position + offset, projection);
+	result.position = mul(position + offset, projection);
 
-    float intensity = saturate((4.0f - result.position.z) / 2.0f);
-    result.color = float4(color.xyz * intensity, 1.0f);
+	float intensity = saturate((4.0f - result.position.z) / 2.0f);
+	result.color = float4(color.xyz * intensity, 1.0f);
 
-    return result;
+	return result;
 }
 
 float4 PShader(PSInput input) : SV_TARGET
 {
-    float4 result = input.color;
+	float4 result = input.color;
 
-    // Artificially increase the workload to simulate a more complex shader.
-    for (uint i = 0; i < loopCount; i++)
-    {
-        result += input.color;
-    }
+	// Artificially increase the workload to simulate a more complex shader.
+	for (uint i = 0; i < loopCount; i++)
+	{
+		result += input.color;
+	}
 
-    if (loopCount > 0)
-    {
-        result /= loopCount + 1;
-    }
-    
-    return result;
+	if (loopCount > 0)
+	{
+		result /= loopCount + 1;
+	}
+	
+	return result;
 }

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/stdafx.h
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include "d3dx12.h"

--- a/Samples/UWP/D3D12LinkedGpus/src/D3DX12AffinityLayer/d3dx12.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/D3DX12AffinityLayer/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/CrossNodeResources.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/CrossNodeResources.cpp
@@ -21,237 +21,237 @@
 
 CrossNodeResources::CrossNodeResources(IDXGIFactory4* pFactory, ID3D12Device* pDevice)
 {
-    pFactory->QueryInterface(IID_PPV_ARGS(&m_factory));
-    pDevice->QueryInterface(IID_PPV_ARGS(&m_device));
+	pFactory->QueryInterface(IID_PPV_ARGS(&m_factory));
+	pDevice->QueryInterface(IID_PPV_ARGS(&m_device));
 
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 void CrossNodeResources::LoadPipeline()
 {
-    // Describe and create the command queues.
-    // Each GPU node needs its own command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queues.
+	// Each GPU node needs its own command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    std::vector<IUnknown*> ppQueues(Settings::BackBufferCount);
-    std::vector<UINT> creationNodes(Settings::BackBufferCount);
-    for (UINT n = 0; n < Settings::BackBufferCount; n++)
-    {
-        UINT nodeIndex = n % Settings::NodeCount;
-        creationNodes[n] = 1 << nodeIndex;
-        queueDesc.NodeMask = creationNodes[n];
+	std::vector<IUnknown*> ppQueues(Settings::BackBufferCount);
+	std::vector<UINT> creationNodes(Settings::BackBufferCount);
+	for (UINT n = 0; n < Settings::BackBufferCount; n++)
+	{
+		UINT nodeIndex = n % Settings::NodeCount;
+		creationNodes[n] = 1 << nodeIndex;
+		queueDesc.NodeMask = creationNodes[n];
 
-        if (!m_queues[nodeIndex])
-        {
-            ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_queues[nodeIndex])));
-        }
-        ppQueues[n] = m_queues[nodeIndex].Get();
-    }
+		if (!m_queues[nodeIndex])
+		{
+			ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_queues[nodeIndex])));
+		}
+		ppQueues[n] = m_queues[nodeIndex].Get();
+	}
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = Settings::BackBufferCount;
-    swapChainDesc.Width = Settings::Width;
-    swapChainDesc.Height = Settings::Height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = Settings::BackBufferCount;
+	swapChainDesc.Width = Settings::Width;
+	swapChainDesc.Height = Settings::Height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    // It is recommended to always use the tearing flag when it is available.
-    swapChainDesc.Flags = Settings::TearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
+	// It is recommended to always use the tearing flag when it is available.
+	swapChainDesc.Flags = Settings::TearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(m_factory->CreateSwapChainForCoreWindow(
-        ppQueues[0],        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(m_factory->CreateSwapChainForCoreWindow(
+		ppQueues[0],		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
+	ThrowIfFailed(swapChain.As(&m_swapChain));
 
-    if (Settings::NodeCount > 1)
-    {
-        // Set up the swap chain to allow back buffers to live on multiple GPU nodes.
-        ThrowIfFailed(m_swapChain->ResizeBuffers1(
-            swapChainDesc.BufferCount,
-            swapChainDesc.Width,
-            swapChainDesc.Height,
-            DXGI_FORMAT_R8G8B8A8_UNORM,
-            swapChainDesc.Flags,
-            creationNodes.data(),
-            ppQueues.data()));
-    }
+	if (Settings::NodeCount > 1)
+	{
+		// Set up the swap chain to allow back buffers to live on multiple GPU nodes.
+		ThrowIfFailed(m_swapChain->ResizeBuffers1(
+			swapChainDesc.BufferCount,
+			swapChainDesc.Width,
+			swapChainDesc.Height,
+			DXGI_FORMAT_R8G8B8A8_UNORM,
+			swapChainDesc.Flags,
+			creationNodes.data(),
+			ppQueues.data()));
+	}
 }
 
 void CrossNodeResources::LoadAssets()
 {
-    // Create the root signatures.
-    // Root signatures may be shared across GPU nodes.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signatures.
+	// Root signatures may be shared across GPU nodes.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        // Create a root signature for rendering the triangle scene.
-        {
-            CD3DX12_DESCRIPTOR_RANGE1 sceneRanges[1];
-            sceneRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		// Create a root signature for rendering the triangle scene.
+		{
+			CD3DX12_DESCRIPTOR_RANGE1 sceneRanges[1];
+			sceneRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
 
-            CD3DX12_ROOT_PARAMETER1 sceneRootParameters[2];
-            sceneRootParameters[0].InitAsDescriptorTable(1, &sceneRanges[0], D3D12_SHADER_VISIBILITY_VERTEX);
-            sceneRootParameters[1].InitAsConstants(1, 1, 0, D3D12_SHADER_VISIBILITY_VERTEX);
+			CD3DX12_ROOT_PARAMETER1 sceneRootParameters[2];
+			sceneRootParameters[0].InitAsDescriptorTable(1, &sceneRanges[0], D3D12_SHADER_VISIBILITY_VERTEX);
+			sceneRootParameters[1].InitAsConstants(1, 1, 0, D3D12_SHADER_VISIBILITY_VERTEX);
 
-            CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC sceneRootSignatureDesc;
-            sceneRootSignatureDesc.Init_1_1(_countof(sceneRootParameters), sceneRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+			CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC sceneRootSignatureDesc;
+			sceneRootSignatureDesc.Init_1_1(_countof(sceneRootParameters), sceneRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-            ComPtr<ID3DBlob> signature;
-            ComPtr<ID3DBlob> error;
-            ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&sceneRootSignatureDesc, featureData.HighestVersion, &signature, &error));
-            ThrowIfFailed(m_device->CreateRootSignature(Settings::SharedNodeMask, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_sceneRootSignature)));
-        }
+			ComPtr<ID3DBlob> signature;
+			ComPtr<ID3DBlob> error;
+			ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&sceneRootSignatureDesc, featureData.HighestVersion, &signature, &error));
+			ThrowIfFailed(m_device->CreateRootSignature(Settings::SharedNodeMask, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_sceneRootSignature)));
+		}
 
-        // Create a root signature for the post-process pass.
-        {
-            // We don't modify the SRV in the post-processing command list after
-            // SetGraphicsRootDescriptorTable is executed on the GPU so we can use the default
-            // range behavior: D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
-            CD3DX12_DESCRIPTOR_RANGE1 postRanges[2];
-            postRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, Settings::SceneHistoryCount, 0);
-            postRanges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
+		// Create a root signature for the post-process pass.
+		{
+			// We don't modify the SRV in the post-processing command list after
+			// SetGraphicsRootDescriptorTable is executed on the GPU so we can use the default
+			// range behavior: D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
+			CD3DX12_DESCRIPTOR_RANGE1 postRanges[2];
+			postRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, Settings::SceneHistoryCount, 0);
+			postRanges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
 
-            CD3DX12_ROOT_PARAMETER1 postRootParameters[3];
-            postRootParameters[0].InitAsDescriptorTable(1, &postRanges[0], D3D12_SHADER_VISIBILITY_PIXEL);
-            postRootParameters[1].InitAsDescriptorTable(1, &postRanges[1], D3D12_SHADER_VISIBILITY_PIXEL);
-            postRootParameters[2].InitAsConstants(2, 0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
+			CD3DX12_ROOT_PARAMETER1 postRootParameters[3];
+			postRootParameters[0].InitAsDescriptorTable(1, &postRanges[0], D3D12_SHADER_VISIBILITY_PIXEL);
+			postRootParameters[1].InitAsDescriptorTable(1, &postRanges[1], D3D12_SHADER_VISIBILITY_PIXEL);
+			postRootParameters[2].InitAsConstants(2, 0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
 
-            CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC postRootSignatureDesc;
-            postRootSignatureDesc.Init_1_1(_countof(postRootParameters), postRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+			CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC postRootSignatureDesc;
+			postRootSignatureDesc.Init_1_1(_countof(postRootParameters), postRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-            ComPtr<ID3DBlob> signature;
-            ComPtr<ID3DBlob> error;
-            ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&postRootSignatureDesc, featureData.HighestVersion, &signature, &error));
-            ThrowIfFailed(m_device->CreateRootSignature(Settings::SharedNodeMask, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_postRootSignature)));
-        }
-    }
+			ComPtr<ID3DBlob> signature;
+			ComPtr<ID3DBlob> error;
+			ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&postRootSignatureDesc, featureData.HighestVersion, &signature, &error));
+			ThrowIfFailed(m_device->CreateRootSignature(Settings::SharedNodeMask, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_postRootSignature)));
+		}
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    // Pipeline states may be shared across GPU nodes.
-    {
-        // Define the vertex input layout for the triangle scene.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+	// Create the pipeline state, which includes compiling and loading shaders.
+	// Pipeline states may be shared across GPU nodes.
+	{
+		// Define the vertex input layout for the triangle scene.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        // Describe and create the graphics pipeline state objects (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_sceneRootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_SceneVS, sizeof(g_SceneVS));
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_ScenePS, sizeof(g_ScenePS));
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
-        psoDesc.SampleDesc.Count = 1;
-        psoDesc.NodeMask = Settings::SharedNodeMask;
+		// Describe and create the graphics pipeline state objects (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_sceneRootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_SceneVS, sizeof(g_SceneVS));
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_ScenePS, sizeof(g_ScenePS));
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+		psoDesc.SampleDesc.Count = 1;
+		psoDesc.NodeMask = Settings::SharedNodeMask;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_scenePipelineState)));
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_scenePipelineState)));
 
-        // Define the vertex input layout for the post-process fullscreen quad.
-        D3D12_INPUT_ELEMENT_DESC postInputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+		// Define the vertex input layout for the post-process fullscreen quad.
+		D3D12_INPUT_ELEMENT_DESC postInputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        // Describe and create the PSO for the post-process pass.
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC postPsoDesc = {};
-        postPsoDesc.InputLayout = { postInputElementDescs, _countof(postInputElementDescs) };
-        postPsoDesc.pRootSignature = m_postRootSignature.Get();
-        postPsoDesc.VS = CD3DX12_SHADER_BYTECODE(g_PostVS, sizeof(g_PostVS));
-        postPsoDesc.PS = CD3DX12_SHADER_BYTECODE(g_PostPS, sizeof(g_PostPS));
-        postPsoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        postPsoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        postPsoDesc.DepthStencilState.DepthEnable = FALSE;
-        postPsoDesc.DepthStencilState.StencilEnable = FALSE;
-        postPsoDesc.SampleMask = UINT_MAX;
-        postPsoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        postPsoDesc.NumRenderTargets = 1;
-        postPsoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        postPsoDesc.SampleDesc.Count = 1;
-        postPsoDesc.NodeMask = Settings::SharedNodeMask;
+		// Describe and create the PSO for the post-process pass.
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC postPsoDesc = {};
+		postPsoDesc.InputLayout = { postInputElementDescs, _countof(postInputElementDescs) };
+		postPsoDesc.pRootSignature = m_postRootSignature.Get();
+		postPsoDesc.VS = CD3DX12_SHADER_BYTECODE(g_PostVS, sizeof(g_PostVS));
+		postPsoDesc.PS = CD3DX12_SHADER_BYTECODE(g_PostPS, sizeof(g_PostPS));
+		postPsoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		postPsoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		postPsoDesc.DepthStencilState.DepthEnable = FALSE;
+		postPsoDesc.DepthStencilState.StencilEnable = FALSE;
+		postPsoDesc.SampleMask = UINT_MAX;
+		postPsoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		postPsoDesc.NumRenderTargets = 1;
+		postPsoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		postPsoDesc.SampleDesc.Count = 1;
+		postPsoDesc.NodeMask = Settings::SharedNodeMask;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&postPsoDesc, IID_PPV_ARGS(&m_postPipelineState)));
-    }
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&postPsoDesc, IID_PPV_ARGS(&m_postPipelineState)));
+	}
 
-    // Create and map the constant buffers.
-    // Upload heaps live in system memory and can be made visible to all GPU nodes.
-    {
-        const UINT constantBufferDataSize = Settings::TriangleCount * Settings::SceneConstantBufferFrames * sizeof(SceneConstantBuffer);
+	// Create and map the constant buffers.
+	// Upload heaps live in system memory and can be made visible to all GPU nodes.
+	{
+		const UINT constantBufferDataSize = Settings::TriangleCount * Settings::SceneConstantBufferFrames * sizeof(SceneConstantBuffer);
 
-        D3D12_HEAP_PROPERTIES uploadHeapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
-        uploadHeapProps.VisibleNodeMask = Settings::SharedNodeMask;
+		D3D12_HEAP_PROPERTIES uploadHeapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+		uploadHeapProps.VisibleNodeMask = Settings::SharedNodeMask;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &uploadHeapProps,
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(constantBufferDataSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_sceneConstantBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&uploadHeapProps,
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(constantBufferDataSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_sceneConstantBuffer)));
 
-        // Map and initialize the constant buffer. We don't unmap this until the
-        // app closes. Keeping things mapped for the lifetime of the resource is okay.
-        ThrowIfFailed(m_sceneConstantBuffer->Map(0, nullptr, reinterpret_cast<void**>(&m_mappedConstantBuffer)));
-        ZeroMemory(m_mappedConstantBuffer, constantBufferDataSize);
-    }
+		// Map and initialize the constant buffer. We don't unmap this until the
+		// app closes. Keeping things mapped for the lifetime of the resource is okay.
+		ThrowIfFailed(m_sceneConstantBuffer->Map(0, nullptr, reinterpret_cast<void**>(&m_mappedConstantBuffer)));
+		ZeroMemory(m_mappedConstantBuffer, constantBufferDataSize);
+	}
 }
 
 void CrossNodeResources::UpdateConstantBuffer(UINT8* data, UINT dataSize, UINT64 frameId)
 {
-    UINT index = frameId % Settings::SceneConstantBufferFrames;
-    UINT offset = Settings::TriangleCount * index * sizeof(SceneConstantBuffer);
+	UINT index = frameId % Settings::SceneConstantBufferFrames;
+	UINT offset = Settings::TriangleCount * index * sizeof(SceneConstantBuffer);
 
-    memcpy(m_mappedConstantBuffer + offset, data, dataSize);
+	memcpy(m_mappedConstantBuffer + offset, data, dataSize);
 }
 
 void CrossNodeResources::ResizeSwapChain()
 {
-    DXGI_SWAP_CHAIN_DESC desc = {};
-    m_swapChain->GetDesc(&desc);
+	DXGI_SWAP_CHAIN_DESC desc = {};
+	m_swapChain->GetDesc(&desc);
 
-    if (Settings::NodeCount > 1)
-    {
-        std::vector<IUnknown*> ppQueues(Settings::BackBufferCount);
-        std::vector<UINT> creationNodes(Settings::BackBufferCount);
-        for (UINT n = 0; n < Settings::BackBufferCount; n++)
-        {
-            UINT nodeIndex = n % Settings::NodeCount;
-            creationNodes[n] = 1 << nodeIndex;
-            ppQueues[n] = m_queues[nodeIndex].Get();
-        }
+	if (Settings::NodeCount > 1)
+	{
+		std::vector<IUnknown*> ppQueues(Settings::BackBufferCount);
+		std::vector<UINT> creationNodes(Settings::BackBufferCount);
+		for (UINT n = 0; n < Settings::BackBufferCount; n++)
+		{
+			UINT nodeIndex = n % Settings::NodeCount;
+			creationNodes[n] = 1 << nodeIndex;
+			ppQueues[n] = m_queues[nodeIndex].Get();
+		}
 
-        ThrowIfFailed(m_swapChain->ResizeBuffers1(Settings::BackBufferCount, Settings::Width, Settings::Height, desc.BufferDesc.Format, desc.Flags, creationNodes.data(), ppQueues.data()));
-    }
-    else
-    {
-        ThrowIfFailed(m_swapChain->ResizeBuffers(Settings::BackBufferCount, Settings::Width, Settings::Height, desc.BufferDesc.Format, desc.Flags));
-    }
+		ThrowIfFailed(m_swapChain->ResizeBuffers1(Settings::BackBufferCount, Settings::Width, Settings::Height, desc.BufferDesc.Format, desc.Flags, creationNodes.data(), ppQueues.data()));
+	}
+	else
+	{
+		ThrowIfFailed(m_swapChain->ResizeBuffers(Settings::BackBufferCount, Settings::Width, Settings::Height, desc.BufferDesc.Format, desc.Flags));
+	}
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/CrossNodeResources.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/CrossNodeResources.h
@@ -18,57 +18,57 @@ using Microsoft::WRL::ComPtr;
 // Constant buffer definition.
 struct SceneConstantBuffer
 {
-    DirectX::XMFLOAT4 velocity;
-    DirectX::XMFLOAT4 offset;
-    DirectX::XMFLOAT4 color;
-    DirectX::XMMATRIX projection;
+	DirectX::XMFLOAT4 velocity;
+	DirectX::XMFLOAT4 offset;
+	DirectX::XMFLOAT4 color;
+	DirectX::XMMATRIX projection;
 
-    // Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
-    // to be array-indexed.
-    float padding[36];
+	// Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
+	// to be array-indexed.
+	float padding[36];
 };
 
 // Container for resources that are shareable across GPU nodes.
 class CrossNodeResources
 {
 public:
-    CrossNodeResources(IDXGIFactory4* pFactory, ID3D12Device* pDevice);
+	CrossNodeResources(IDXGIFactory4* pFactory, ID3D12Device* pDevice);
 
-    void LoadPipeline();
-    void LoadAssets();
+	void LoadPipeline();
+	void LoadAssets();
 
-    void UpdateConstantBuffer(UINT8* data, UINT dataSize, UINT64 frameId);
-    void ResizeSwapChain();
+	void UpdateConstantBuffer(UINT8* data, UINT dataSize, UINT64 frameId);
+	void ResizeSwapChain();
 
-    inline ID3D12Device* GetDevice()                             { return m_device.Get(); }
-    inline ID3D12CommandQueue* GetCommandQueue(UINT nodeIndex)   { return m_queues[nodeIndex].Get(); }
-    inline IDXGISwapChain3* GetSwapChain()                       { return m_swapChain.Get(); }
-    inline ID3D12RootSignature* GetSceneRootSignature()          { return m_sceneRootSignature.Get(); }
-    inline ID3D12PipelineState* GetScenePipelineState()          { return m_scenePipelineState.Get(); }
-    inline ID3D12RootSignature* GetPostRootSignature()           { return m_postRootSignature.Get(); }
-    inline ID3D12PipelineState* GetPostPipelineState()           { return m_postPipelineState.Get(); }
+	inline ID3D12Device* GetDevice()                             { return m_device.Get(); }
+	inline ID3D12CommandQueue* GetCommandQueue(UINT nodeIndex)   { return m_queues[nodeIndex].Get(); }
+	inline IDXGISwapChain3* GetSwapChain()                       { return m_swapChain.Get(); }
+	inline ID3D12RootSignature* GetSceneRootSignature()          { return m_sceneRootSignature.Get(); }
+	inline ID3D12PipelineState* GetScenePipelineState()          { return m_scenePipelineState.Get(); }
+	inline ID3D12RootSignature* GetPostRootSignature()           { return m_postRootSignature.Get(); }
+	inline ID3D12PipelineState* GetPostPipelineState()           { return m_postPipelineState.Get(); }
 
-    inline D3D12_GPU_VIRTUAL_ADDRESS GetSceneConstantBufferGpuVirtualAddress()
-    {
-        return m_sceneConstantBuffer->GetGPUVirtualAddress();
-    }
+	inline D3D12_GPU_VIRTUAL_ADDRESS GetSceneConstantBufferGpuVirtualAddress()
+	{
+		return m_sceneConstantBuffer->GetGPUVirtualAddress();
+	}
 
 private:
-    // Objects that are visible across all GPU nodes.
-    ComPtr<IDXGIFactory4> m_factory;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12RootSignature> m_sceneRootSignature;
-    ComPtr<ID3D12PipelineState> m_scenePipelineState;
-    ComPtr<ID3D12RootSignature> m_postRootSignature;
-    ComPtr<ID3D12PipelineState> m_postPipelineState;
+	// Objects that are visible across all GPU nodes.
+	ComPtr<IDXGIFactory4> m_factory;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12RootSignature> m_sceneRootSignature;
+	ComPtr<ID3D12PipelineState> m_scenePipelineState;
+	ComPtr<ID3D12RootSignature> m_postRootSignature;
+	ComPtr<ID3D12PipelineState> m_postPipelineState;
 
-    // We use an Upload heap for the constant buffers.
-    // Upload heaps reside in system memory and can be accessed by any available node.
-    ComPtr<ID3D12Resource> m_sceneConstantBuffer;
-    UINT8* m_mappedConstantBuffer;
+	// We use an Upload heap for the constant buffers.
+	// Upload heaps reside in system memory and can be accessed by any available node.
+	ComPtr<ID3D12Resource> m_sceneConstantBuffer;
+	UINT8* m_mappedConstantBuffer;
 
-    // The command queues are actually tied to specific GPU nodes, but are placed here
-    // for convenience since all queues are needed for swap chain creation and resizing.
-    ComPtr<ID3D12CommandQueue> m_queues[Settings::MaxNodeCount];
+	// The command queues are actually tied to specific GPU nodes, but are placed here
+	// for convenience since all queues are needed for swap chain creation and resizing.
+	ComPtr<ID3D12CommandQueue> m_queues[Settings::MaxNodeCount];
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/D3D12LinkedGpus.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/D3D12LinkedGpus.cpp
@@ -15,290 +15,290 @@
 using namespace DirectX;
 
 D3D12LinkedGpus::D3D12LinkedGpus(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_nodeIndex(0),
-    m_frameId(0),
-    m_simulatedGpuLoad(0x1000),
-    m_syncInterval(0),
-    m_windowVisible(true),
-    m_windowedMode(true)
+	DXSample(width, height, name),
+	m_nodeIndex(0),
+	m_frameId(0),
+	m_simulatedGpuLoad(0x1000),
+	m_syncInterval(0),
+	m_windowVisible(true),
+	m_windowedMode(true)
 {
-    m_sceneData.resize(Settings::TriangleCount);
+	m_sceneData.resize(Settings::TriangleCount);
 }
 
 void D3D12LinkedGpus::OnInit()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<ID3D12Device> device;
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<ID3D12Device> device;
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&device)
+			));
+	}
 
-    // Query capabilities of the device to configure the sample.
-    Settings::Initialize(device.Get(), m_width, m_height, m_tearingSupport);
+	// Query capabilities of the device to configure the sample.
+	Settings::Initialize(device.Get(), m_width, m_height, m_tearingSupport);
 
-    // Initialize resources for the sample.
-    m_crossNodeResources = std::make_shared<CrossNodeResources>(factory.Get(), device.Get());
+	// Initialize resources for the sample.
+	m_crossNodeResources = std::make_shared<CrossNodeResources>(factory.Get(), device.Get());
 
-    for (UINT n = 0; n < Settings::NodeCount; n++)
-    {
-        m_nodes[n] = std::make_shared<GpuNode>(n, m_crossNodeResources);
-    }
+	for (UINT n = 0; n < Settings::NodeCount; n++)
+	{
+		m_nodes[n] = std::make_shared<GpuNode>(n, m_crossNodeResources);
+	}
 
-    for (UINT n = 0; n < Settings::NodeCount; n++)
-    {
-        m_nodes[n]->LinkSharedResources(m_nodes, Settings::NodeCount);
-    }
+	for (UINT n = 0; n < Settings::NodeCount; n++)
+	{
+		m_nodes[n]->LinkSharedResources(m_nodes, Settings::NodeCount);
+	}
 
-    LoadSceneData();
-    UpdateWindowTitle();
+	LoadSceneData();
+	UpdateWindowTitle();
 }
 
 // Generate data for the scene triangles.
 void D3D12LinkedGpus::LoadSceneData()
 {
-    for (UINT n = 0; n < Settings::TriangleCount; n++)
-    {
-        m_sceneData[n].velocity = XMFLOAT4(GetRandomFloat(0.005f, 0.01f), 0.0f, 0.0f, 0.0f);
-        m_sceneData[n].offset = XMFLOAT4(GetRandomFloat(-6.0f, -1.5f), GetRandomFloat(-1.0f, 1.0f), GetRandomFloat(0.0f, 2.0f), 0.0f);
-        m_sceneData[n].color = XMFLOAT4(GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), 1.0f);
-        m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
-    }
+	for (UINT n = 0; n < Settings::TriangleCount; n++)
+	{
+		m_sceneData[n].velocity = XMFLOAT4(GetRandomFloat(0.005f, 0.01f), 0.0f, 0.0f, 0.0f);
+		m_sceneData[n].offset = XMFLOAT4(GetRandomFloat(-6.0f, -1.5f), GetRandomFloat(-1.0f, 1.0f), GetRandomFloat(0.0f, 2.0f), 0.0f);
+		m_sceneData[n].color = XMFLOAT4(GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), 1.0f);
+		m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
+	}
 }
 
 // Get a random float value between min and max.
 float D3D12LinkedGpus::GetRandomFloat(float min, float max)
 {
-    float scale = static_cast<float>(rand()) / RAND_MAX;
-    float range = max - min;
-    return scale * range + min;
+	float scale = static_cast<float>(rand()) / RAND_MAX;
+	float range = max - min;
+	return scale * range + min;
 }
 
 void D3D12LinkedGpus::UpdateWindowTitle()
 {
-    WCHAR nodeText[100];
-    if (Settings::NodeCount == 1)
-    {
-        swprintf_s(nodeText, L"Node Count = 1 | SyncInterval = %u | SimulatedLoad = %u", m_syncInterval, m_simulatedGpuLoad);
-    }
-    else
-    {
-        swprintf_s(
-            nodeText,
-            L"Node Count = %u | Cross Node Sharing Tier = %d | SyncInterval = %u | SimulatedLoad = %u",
-            Settings::NodeCount,
-            Settings::Tier2Support ? 2 : 1,
-            m_syncInterval,
-            m_simulatedGpuLoad);
-    }
-    SetCustomWindowText(nodeText);
+	WCHAR nodeText[100];
+	if (Settings::NodeCount == 1)
+	{
+		swprintf_s(nodeText, L"Node Count = 1 | SyncInterval = %u | SimulatedLoad = %u", m_syncInterval, m_simulatedGpuLoad);
+	}
+	else
+	{
+		swprintf_s(
+			nodeText,
+			L"Node Count = %u | Cross Node Sharing Tier = %d | SyncInterval = %u | SimulatedLoad = %u",
+			Settings::NodeCount,
+			Settings::Tier2Support ? 2 : 1,
+			m_syncInterval,
+			m_simulatedGpuLoad);
+	}
+	SetCustomWindowText(nodeText);
 }
 
 // Update frame-based values.
 void D3D12LinkedGpus::OnUpdate()
 {
-    for (UINT n = 0; n < Settings::TriangleCount; n++)
-    {
-        const float offsetBounds = 1.5f * m_aspectRatio;
-    
-        // Animate the triangles.
-        m_sceneData[n].offset.x += m_sceneData[n].velocity.x;
-        if (m_sceneData[n].offset.x > offsetBounds)
-        {
-            m_sceneData[n].velocity.x = GetRandomFloat(0.005f, 0.01f);
-            m_sceneData[n].offset.x = -offsetBounds;
-        }
-    }
+	for (UINT n = 0; n < Settings::TriangleCount; n++)
+	{
+		const float offsetBounds = 1.5f * m_aspectRatio;
+	
+		// Animate the triangles.
+		m_sceneData[n].offset.x += m_sceneData[n].velocity.x;
+		if (m_sceneData[n].offset.x > offsetBounds)
+		{
+			m_sceneData[n].velocity.x = GetRandomFloat(0.005f, 0.01f);
+			m_sceneData[n].offset.x = -offsetBounds;
+		}
+	}
 
-    m_nodes[m_nodeIndex]->OnUpdate(m_sceneData.data(), Settings::TriangleCount, m_frameId);
+	m_nodes[m_nodeIndex]->OnUpdate(m_sceneData.data(), Settings::TriangleCount, m_frameId);
 }
 
 // Render the scene.
 void D3D12LinkedGpus::OnRender()
 {
-    if (m_windowVisible)
-    {
-        auto currentNode = m_nodes[m_nodeIndex];
+	if (m_windowVisible)
+	{
+		auto currentNode = m_nodes[m_nodeIndex];
 
-        // Render and present the current frame.
-        currentNode->RenderScene(m_frameId, m_simulatedGpuLoad);
-        currentNode->RenderPost(m_frameId);
-        currentNode->Present(m_syncInterval, m_windowedMode);
+		// Render and present the current frame.
+		currentNode->RenderScene(m_frameId, m_simulatedGpuLoad);
+		currentNode->RenderPost(m_frameId);
+		currentNode->Present(m_syncInterval, m_windowedMode);
 
-        MoveToNextFrame();
-    }
+		MoveToNextFrame();
+	}
 }
 
 void D3D12LinkedGpus::OnSizeChanged(UINT width, UINT height, bool minimized)
 {
-    // Determine if the swap buffers and other resources need to be resized or not.
-    if ((width != m_width || height != m_height) && !minimized)
-    {
-        // Flush all current GPU commands.
-        WaitForGpus();
+	// Determine if the swap buffers and other resources need to be resized or not.
+	if ((width != m_width || height != m_height) && !minimized)
+	{
+		// Flush all current GPU commands.
+		WaitForGpus();
 
-        // Release buffers tied to the swap chain and update the global Settings
-        // for the new size.
-        for (UINT n = 0; n < Settings::NodeCount; n++)
-        {
-            m_nodes[n]->ReleaseBackBuffers();
-        }
-        Settings::OnSizeChanged(width, height);
+		// Release buffers tied to the swap chain and update the global Settings
+		// for the new size.
+		for (UINT n = 0; n < Settings::NodeCount; n++)
+		{
+			m_nodes[n]->ReleaseBackBuffers();
+		}
+		Settings::OnSizeChanged(width, height);
 
-        // Resize the swap chain to the desired dimensions.
-        m_crossNodeResources->ResizeSwapChain();
+		// Resize the swap chain to the desired dimensions.
+		m_crossNodeResources->ResizeSwapChain();
 
-        // Re-create and re-link render targets.
-        for (UINT n = 0; n < Settings::NodeCount; n++)
-        {
-            m_nodes[n]->LoadSizeDependentResources();
-        }
-        for (UINT n = 0; n < Settings::NodeCount; n++)
-        {
-            m_nodes[n]->LinkSharedResources(m_nodes, Settings::NodeCount);
-        }
+		// Re-create and re-link render targets.
+		for (UINT n = 0; n < Settings::NodeCount; n++)
+		{
+			m_nodes[n]->LoadSizeDependentResources();
+		}
+		for (UINT n = 0; n < Settings::NodeCount; n++)
+		{
+			m_nodes[n]->LinkSharedResources(m_nodes, Settings::NodeCount);
+		}
 
-        // Reset the node index and align the frameId so that assumptions in post-processing hold.
-        m_nodeIndex = m_crossNodeResources->GetSwapChain()->GetCurrentBackBufferIndex() % Settings::NodeCount;
-        m_frameId += (Settings::SceneHistoryCount - (m_frameId % Settings::SceneHistoryCount));
+		// Reset the node index and align the frameId so that assumptions in post-processing hold.
+		m_nodeIndex = m_crossNodeResources->GetSwapChain()->GetCurrentBackBufferIndex() % Settings::NodeCount;
+		m_frameId += (Settings::SceneHistoryCount - (m_frameId % Settings::SceneHistoryCount));
 
-        // Update the m_width, m_height, and m_aspectRatio member variables.
-        UpdateForSizeChange(width, height);
+		// Update the m_width, m_height, and m_aspectRatio member variables.
+		UpdateForSizeChange(width, height);
 
-        // Update the scene projection matrix.
-        for (UINT n = 0; n < Settings::TriangleCount; n++)
-        {
-            m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
-        }
-    }
+		// Update the scene projection matrix.
+		for (UINT n = 0; n < Settings::TriangleCount; n++)
+		{
+			m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
+		}
+	}
 
-    m_windowVisible = !minimized;
+	m_windowVisible = !minimized;
 }
 
 void D3D12LinkedGpus::OnKeyDown(UINT8 key)
 {
-    switch (key)
-    {
-    // Instrument the Space Bar to toggle between fullscreen states.
-    // The CoreWindow will fire a SizeChanged event once the window is in the
-    // fullscreen state. At that point, the IDXGISwapChain should be resized
-    // to match the new window size.
-    case VK_SPACE:
-    {
-        auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-        if (applicationView->IsFullScreenMode)
-        {
-            applicationView->ExitFullScreenMode();
-        }
-        else
-        {
-            applicationView->TryEnterFullScreenMode();
-        }
-        break;
-    }
+	switch (key)
+	{
+	// Instrument the Space Bar to toggle between fullscreen states.
+	// The CoreWindow will fire a SizeChanged event once the window is in the
+	// fullscreen state. At that point, the IDXGISwapChain should be resized
+	// to match the new window size.
+	case VK_SPACE:
+	{
+		auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+		if (applicationView->IsFullScreenMode)
+		{
+			applicationView->ExitFullScreenMode();
+		}
+		else
+		{
+			applicationView->TryEnterFullScreenMode();
+		}
+		break;
+	}
 
-    case VK_LEFT:
-    case VK_RIGHT:
-        m_syncInterval = (m_syncInterval > 0) ? 0 : 1;
-        UpdateWindowTitle();
-        break;
+	case VK_LEFT:
+	case VK_RIGHT:
+		m_syncInterval = (m_syncInterval > 0) ? 0 : 1;
+		UpdateWindowTitle();
+		break;
 
-    case VK_UP:
-        if (m_simulatedGpuLoad > 0)
-        {
-            if (m_simulatedGpuLoad < 0x80000)
-            {
-                m_simulatedGpuLoad <<= 1;
-            }
-        }
-        else
-        {
-            m_simulatedGpuLoad = 1;
-        }
-        UpdateWindowTitle();
-        break;
+	case VK_UP:
+		if (m_simulatedGpuLoad > 0)
+		{
+			if (m_simulatedGpuLoad < 0x80000)
+			{
+				m_simulatedGpuLoad <<= 1;
+			}
+		}
+		else
+		{
+			m_simulatedGpuLoad = 1;
+		}
+		UpdateWindowTitle();
+		break;
 
-    case VK_DOWN:
-        if (m_simulatedGpuLoad != 0)
-        {
-            m_simulatedGpuLoad >>= 1;
-        }
-        UpdateWindowTitle();
-        break;
-    }
+	case VK_DOWN:
+		if (m_simulatedGpuLoad != 0)
+		{
+			m_simulatedGpuLoad >>= 1;
+		}
+		UpdateWindowTitle();
+		break;
+	}
 }
 
 void D3D12LinkedGpus::OnDestroy()
 {
-    // Wait for the GPUs to be done with all their resources.
-    WaitForGpus();
+	// Wait for the GPUs to be done with all their resources.
+	WaitForGpus();
 }
 
 // Wait for pending GPU work to complete.
 void D3D12LinkedGpus::WaitForGpus()
 {
-    for (UINT n = 0; n < Settings::NodeCount; n++)
-    {
-        m_nodes[n]->WaitForGpu();
-    }
+	for (UINT n = 0; n < Settings::NodeCount; n++)
+	{
+		m_nodes[n]->WaitForGpu();
+	}
 }
 
 // Prepare to render the next frame.
 void D3D12LinkedGpus::MoveToNextFrame()
 {
-    UINT nextNode = m_crossNodeResources->GetSwapChain()->GetCurrentBackBufferIndex() % Settings::NodeCount;
+	UINT nextNode = m_crossNodeResources->GetSwapChain()->GetCurrentBackBufferIndex() % Settings::NodeCount;
 
-    if (Settings::NodeCount > 1 && nextNode == m_nodeIndex)
-    {
-        // If a WM_SIZE event was processed during Present, we will already be in the
-        // correct state. Do not update the node index or advance the node's frame.
-    }
-    else
-    {
-        // Advance the frame on the current node.
-        m_nodes[m_nodeIndex]->MoveToNextFrame();
+	if (Settings::NodeCount > 1 && nextNode == m_nodeIndex)
+	{
+		// If a WM_SIZE event was processed during Present, we will already be in the
+		// correct state. Do not update the node index or advance the node's frame.
+	}
+	else
+	{
+		// Advance the frame on the current node.
+		m_nodes[m_nodeIndex]->MoveToNextFrame();
 
-        // Advance to the next node.
-        m_nodeIndex = nextNode;
+		// Advance to the next node.
+		m_nodeIndex = nextNode;
 
-        m_frameId++;
-    }
+		m_frameId++;
+	}
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/D3D12LinkedGpus.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/D3D12LinkedGpus.h
@@ -32,33 +32,33 @@ using Microsoft::WRL::ComPtr;
 class D3D12LinkedGpus : public DXSample
 {
 public:
-    D3D12LinkedGpus(UINT width, UINT height, std::wstring name);
+	D3D12LinkedGpus(UINT width, UINT height, std::wstring name);
 
 protected:
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
-    virtual void OnKeyDown(UINT8 key);
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
+	virtual void OnKeyDown(UINT8 key);
+	virtual void OnDestroy();
 
 private:
-    // Data about each of the triangles in the scene.
-    std::vector<SceneConstantBuffer> m_sceneData;
+	// Data about each of the triangles in the scene.
+	std::vector<SceneConstantBuffer> m_sceneData;
 
-    std::shared_ptr<CrossNodeResources> m_crossNodeResources;
-    std::shared_ptr<GpuNode> m_nodes[Settings::MaxNodeCount];
+	std::shared_ptr<CrossNodeResources> m_crossNodeResources;
+	std::shared_ptr<GpuNode> m_nodes[Settings::MaxNodeCount];
 
-    UINT64 m_frameId;
-    UINT m_simulatedGpuLoad;
-    UINT m_nodeIndex;
-    UINT m_syncInterval;
-    bool m_windowVisible;
-    bool m_windowedMode;
+	UINT64 m_frameId;
+	UINT m_simulatedGpuLoad;
+	UINT m_nodeIndex;
+	UINT m_syncInterval;
+	bool m_windowVisible;
+	bool m_windowedMode;
 
-    void LoadSceneData();
-    float GetRandomFloat(float min, float max);
-    void UpdateWindowTitle();
-    void WaitForGpus();
-    void MoveToNextFrame();
+	void LoadSceneData();
+	float GetRandomFloat(float min, float max);
+	void UpdateWindowTitle();
+	void WaitForGpus();
+	void MoveToNextFrame();
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/DXSample.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/DXSample.cpp
@@ -52,33 +52,78 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
+
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+            }
+#if !defined(_XBOX_ONE)
+        }
+#endif
 
     *ppAdapter = adapter.Detach();
-}
+    }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/DXSample.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/DXSample.h
@@ -48,7 +48,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/Fence.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/Fence.h
@@ -18,133 +18,133 @@
 class Fence
 {
 public:
-    // Create a fence and associate it with the specified command queue for
-    // convenience in working with fences.
-    Fence(ID3D12CommandQueue* pQueue) :
-        m_currentFenceValue(0)
-    {
-        ThrowIfFailed(pQueue->QueryInterface(IID_PPV_ARGS(&m_queue)));
+	// Create a fence and associate it with the specified command queue for
+	// convenience in working with fences.
+	Fence(ID3D12CommandQueue* pQueue) :
+		m_currentFenceValue(0)
+	{
+		ThrowIfFailed(pQueue->QueryInterface(IID_PPV_ARGS(&m_queue)));
 
-        ComPtr<ID3D12Device> device;
-        ThrowIfFailed(m_queue->GetDevice(IID_PPV_ARGS(&device)));
+		ComPtr<ID3D12Device> device;
+		ThrowIfFailed(m_queue->GetDevice(IID_PPV_ARGS(&device)));
 
-        ThrowIfFailed(device->CreateFence(m_currentFenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		ThrowIfFailed(device->CreateFence(m_currentFenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
 
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
-    }
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
+	}
 
-    ~Fence()
-    {
-        if (m_fenceEvent)
-        {
-            CloseHandle(m_fenceEvent);
-            m_fenceEvent = nullptr;
-        }
-    }
+	~Fence()
+	{
+		if (m_fenceEvent)
+		{
+			CloseHandle(m_fenceEvent);
+			m_fenceEvent = nullptr;
+		}
+	}
 
-    // Drain the GPU command queue.
-    // (Blocks the calling CPU thread)
-    inline void FlushGpuQueue()
-    {
-        Signal();
-        CpuWait(m_currentFenceValue);
-    }
+	// Drain the GPU command queue.
+	// (Blocks the calling CPU thread)
+	inline void FlushGpuQueue()
+	{
+		Signal();
+		CpuWait(m_currentFenceValue);
+	}
 
-    // Issue a Signal command on the command queue.
-    // Use the current value of the fence or override it with your own value.
-    inline void Signal(UINT64 value = UnspecifiedFenceValue)
-    {
-        if (value == UnspecifiedFenceValue)
-        {
-            m_currentFenceValue++;
-        }
-        else
-        {
-            _ASSERT(value > m_currentFenceValue);
-            m_currentFenceValue = value;
-        }
+	// Issue a Signal command on the command queue.
+	// Use the current value of the fence or override it with your own value.
+	inline void Signal(UINT64 value = UnspecifiedFenceValue)
+	{
+		if (value == UnspecifiedFenceValue)
+		{
+			m_currentFenceValue++;
+		}
+		else
+		{
+			_ASSERT(value > m_currentFenceValue);
+			m_currentFenceValue = value;
+		}
 
-        ThrowIfFailed(m_queue->Signal(m_fence.Get(), m_currentFenceValue));
-    }
+		ThrowIfFailed(m_queue->Signal(m_fence.Get(), m_currentFenceValue));
+	}
 
-    // Instruct the GPU queue associated with this fence to wait for a value to be signaled.
-    // Use the current value of the fence or override it with your own value.
-    // (Does not block the calling CPU thread)
-    inline void GpuWait(UINT64 value = UnspecifiedFenceValue)
-    {
-        GpuWait(m_queue.Get(), this, value);
-    }
+	// Instruct the GPU queue associated with this fence to wait for a value to be signaled.
+	// Use the current value of the fence or override it with your own value.
+	// (Does not block the calling CPU thread)
+	inline void GpuWait(UINT64 value = UnspecifiedFenceValue)
+	{
+		GpuWait(m_queue.Get(), this, value);
+	}
 
-    // Instruct a GPU queue on a specific node to wait for a specific node's fence.
-    // Use the current value of the fence or override it with your own value.
-    // (Does not block the calling CPU thread)
-    inline static void GpuWait(ID3D12CommandQueue* pQueue, Fence* pFence, UINT64 value = UnspecifiedFenceValue)
-    {
-        if (value == UnspecifiedFenceValue)
-        {
-            value = pFence->m_currentFenceValue;
-        }
+	// Instruct a GPU queue on a specific node to wait for a specific node's fence.
+	// Use the current value of the fence or override it with your own value.
+	// (Does not block the calling CPU thread)
+	inline static void GpuWait(ID3D12CommandQueue* pQueue, Fence* pFence, UINT64 value = UnspecifiedFenceValue)
+	{
+		if (value == UnspecifiedFenceValue)
+		{
+			value = pFence->m_currentFenceValue;
+		}
 
-        ThrowIfFailed(pQueue->Wait(pFence->m_fence.Get(), value));
-    }
+		ThrowIfFailed(pQueue->Wait(pFence->m_fence.Get(), value));
+	}
 
 protected:
-    // Block the calling CPU thread until the GPU has signaled the specified fence.
-    inline void CpuWait(UINT64 fenceValue = UnspecifiedFenceValue)
-    {
-        if (fenceValue == UnspecifiedFenceValue)
-        {
-            fenceValue = m_currentFenceValue;
-        }
+	// Block the calling CPU thread until the GPU has signaled the specified fence.
+	inline void CpuWait(UINT64 fenceValue = UnspecifiedFenceValue)
+	{
+		if (fenceValue == UnspecifiedFenceValue)
+		{
+			fenceValue = m_currentFenceValue;
+		}
 
-        if (m_fence->GetCompletedValue() < fenceValue)
-        {
-            ThrowIfFailed(m_fence->SetEventOnCompletion(fenceValue, m_fenceEvent));
-            WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-        }
-    }
+		if (m_fence->GetCompletedValue() < fenceValue)
+		{
+			ThrowIfFailed(m_fence->SetEventOnCompletion(fenceValue, m_fenceEvent));
+			WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+		}
+	}
 
-    static const UINT64 UnspecifiedFenceValue = UINT64_MAX;
+	static const UINT64 UnspecifiedFenceValue = UINT64_MAX;
 
-    ComPtr<ID3D12Fence> m_fence;            // The D3D12 fence object.
-    ComPtr<ID3D12CommandQueue> m_queue;        // The command queue associated with this fence.
-    UINT64 m_currentFenceValue;                // The last value signaled by this fence.
-    HANDLE m_fenceEvent;                    // CPU-waitable event handle.
+	ComPtr<ID3D12Fence> m_fence;			// The D3D12 fence object.
+	ComPtr<ID3D12CommandQueue> m_queue;		// The command queue associated with this fence.
+	UINT64 m_currentFenceValue;				// The last value signaled by this fence.
+	HANDLE m_fenceEvent;					// CPU-waitable event handle.
 };
 
 class LinearFence : public Fence
 {
 public:
-    // This fence implementation manages a ring buffer of issued Signal events.
-    // The "Next" API instructs the Fence to move to the next slot in the ring buffer.
-    // If the next slot represents a fence value that has not yet been signaled by
-    // the GPU, then the CPU will wait until that fence is signaled before continuing.
-    // 
-    // In this sample, LinearFences are used to guard against premature resetting
-    // of command allocators and modifying of upload heaps that might currently be
-    // in use by the GPU.
-    LinearFence(ID3D12CommandQueue* pQueue, UINT count) :
-        Fence(pQueue),
-        m_signalIndex(0)
-    {
-        m_signalHistory.resize(count);
-    }
+	// This fence implementation manages a ring buffer of issued Signal events.
+	// The "Next" API instructs the Fence to move to the next slot in the ring buffer.
+	// If the next slot represents a fence value that has not yet been signaled by
+	// the GPU, then the CPU will wait until that fence is signaled before continuing.
+	// 
+	// In this sample, LinearFences are used to guard against premature resetting
+	// of command allocators and modifying of upload heaps that might currently be
+	// in use by the GPU.
+	LinearFence(ID3D12CommandQueue* pQueue, UINT count) :
+		Fence(pQueue),
+		m_signalIndex(0)
+	{
+		m_signalHistory.resize(count);
+	}
 
-    // If the oldest Signal event in the ring buffer has not yet been processed by
-    // the GPU, block the calling CPU thread until it is.
-    inline void Next()
-    {
-        m_signalHistory[m_signalIndex] = m_currentFenceValue;
-        m_signalIndex = (m_signalIndex + 1) % m_signalHistory.size();
+	// If the oldest Signal event in the ring buffer has not yet been processed by
+	// the GPU, block the calling CPU thread until it is.
+	inline void Next()
+	{
+		m_signalHistory[m_signalIndex] = m_currentFenceValue;
+		m_signalIndex = (m_signalIndex + 1) % m_signalHistory.size();
 
-        Fence::CpuWait(m_signalHistory[m_signalIndex]);
-    }
+		Fence::CpuWait(m_signalHistory[m_signalIndex]);
+	}
 
 private:
-    std::vector<UINT64> m_signalHistory;    // The history of signal events.
-    UINT m_signalIndex;                        // The index to the next slot in the signal history ring buffer.
+	std::vector<UINT64> m_signalHistory;	// The history of signal events.
+	UINT m_signalIndex;						// The index to the next slot in the signal history ring buffer.
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/GpuNode.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/GpuNode.cpp
@@ -13,652 +13,652 @@
 #include "GpuNode.h"
 
 GpuNode::GpuNode(UINT nodeIndex, std::shared_ptr<CrossNodeResources> crossNodeResources) :
-    m_frameIndex(0),
-    m_nodeIndex(nodeIndex),
-    m_nodeMask(1 << nodeIndex),
-    m_crossNodeResources(crossNodeResources),
-    m_sceneRenderTargetIndex(0)
+	m_frameIndex(0),
+	m_nodeIndex(nodeIndex),
+	m_nodeMask(1 << nodeIndex),
+	m_crossNodeResources(crossNodeResources),
+	m_sceneRenderTargetIndex(0)
 {
-    m_sceneCommandAllocators.resize(Settings::FrameCount);
-    m_postCommandAllocators.resize(Settings::FrameCount);
-    m_postRenderTargets.resize(Settings::BackBuffersPerNode);
+	m_sceneCommandAllocators.resize(Settings::FrameCount);
+	m_postCommandAllocators.resize(Settings::FrameCount);
+	m_postRenderTargets.resize(Settings::BackBuffersPerNode);
 
-    ThrowIfFailed(crossNodeResources->GetCommandQueue(nodeIndex)->QueryInterface(IID_PPV_ARGS(&m_graphicsQueue)));
-    m_sceneFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
-    m_postFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
+	ThrowIfFailed(crossNodeResources->GetCommandQueue(nodeIndex)->QueryInterface(IID_PPV_ARGS(&m_graphicsQueue)));
+	m_sceneFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
+	m_postFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
 
-    if (Settings::NodeCount > 1)
-    {
-        m_nodeSync = std::make_unique<NodeSynchronization>();
-    }
+	if (Settings::NodeCount > 1)
+	{
+		m_nodeSync = std::make_unique<NodeSynchronization>();
+	}
 
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 void GpuNode::LoadPipeline()
 {
-    auto pDevice = m_crossNodeResources->GetDevice();
+	auto pDevice = m_crossNodeResources->GetDevice();
 
-    // Scene descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        rtvHeapDesc.NodeMask = m_nodeMask;
-        ThrowIfFailed(pDevice->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_sceneRtvHeap)));
+	// Scene descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		rtvHeapDesc.NodeMask = m_nodeMask;
+		ThrowIfFailed(pDevice->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_sceneRtvHeap)));
 
-        // Describe and create a depth stencil view (DSV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
-        dsvHeapDesc.NumDescriptors = 1;
-        dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-        dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        dsvHeapDesc.NodeMask = m_nodeMask;
-        ThrowIfFailed(pDevice->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_sceneDsvHeap)));
+		// Describe and create a depth stencil view (DSV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
+		dsvHeapDesc.NumDescriptors = 1;
+		dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+		dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		dsvHeapDesc.NodeMask = m_nodeMask;
+		ThrowIfFailed(pDevice->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_sceneDsvHeap)));
 
-        // Describe and create a constant buffer view (CBV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
-        cbvHeapDesc.NumDescriptors = Settings::TriangleCount * Settings::SceneConstantBufferFrames;
-        cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        cbvHeapDesc.NodeMask = m_nodeMask;
-        ThrowIfFailed(pDevice->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_sceneCbvHeap)));
-    }
+		// Describe and create a constant buffer view (CBV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
+		cbvHeapDesc.NumDescriptors = Settings::TriangleCount * Settings::SceneConstantBufferFrames;
+		cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		cbvHeapDesc.NodeMask = m_nodeMask;
+		ThrowIfFailed(pDevice->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_sceneCbvHeap)));
+	}
 
-    // Post-process descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap for 
-        // the final output.
-        D3D12_DESCRIPTOR_HEAP_DESC postRtvHeapDesc = {};
-        postRtvHeapDesc.NumDescriptors = Settings::BackBuffersPerNode;
-        postRtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        postRtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        postRtvHeapDesc.NodeMask = m_nodeMask;
-        ThrowIfFailed(pDevice->CreateDescriptorHeap(&postRtvHeapDesc, IID_PPV_ARGS(&m_postRtvHeap)));
+	// Post-process descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap for 
+		// the final output.
+		D3D12_DESCRIPTOR_HEAP_DESC postRtvHeapDesc = {};
+		postRtvHeapDesc.NumDescriptors = Settings::BackBuffersPerNode;
+		postRtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		postRtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		postRtvHeapDesc.NodeMask = m_nodeMask;
+		ThrowIfFailed(pDevice->CreateDescriptorHeap(&postRtvHeapDesc, IID_PPV_ARGS(&m_postRtvHeap)));
 
-        // Describe and create a shader resource view (SRV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
-        srvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
-        srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        srvHeapDesc.NodeMask = m_nodeMask;
-        ThrowIfFailed(pDevice->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_postSrvHeap)));
+		// Describe and create a shader resource view (SRV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
+		srvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
+		srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		srvHeapDesc.NodeMask = m_nodeMask;
+		ThrowIfFailed(pDevice->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_postSrvHeap)));
 
-        // Describe and create a sampler descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
-        samplerHeapDesc.NumDescriptors = 1;
-        samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
-        samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        samplerHeapDesc.NodeMask = m_nodeMask;
-        ThrowIfFailed(pDevice->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_postSamplerHeap)));
-    }
+		// Describe and create a sampler descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
+		samplerHeapDesc.NumDescriptors = 1;
+		samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
+		samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		samplerHeapDesc.NodeMask = m_nodeMask;
+		ThrowIfFailed(pDevice->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_postSamplerHeap)));
+	}
 
-    // Create command allocators for each frame.
-    for (UINT n = 0; n < Settings::FrameCount; n++)
-    {
-        ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[n])));
-        ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_postCommandAllocators[n])));
-    }
+	// Create command allocators for each frame.
+	for (UINT n = 0; n < Settings::FrameCount; n++)
+	{
+		ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[n])));
+		ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_postCommandAllocators[n])));
+	}
 }
 
 void GpuNode::LoadAssets()
 {
-    auto pDevice = m_crossNodeResources->GetDevice();
+	auto pDevice = m_crossNodeResources->GetDevice();
 
-    // Single-use command allocator/list for resource initialization.
-    ComPtr<ID3D12CommandAllocator> commandAllocator;
-    ComPtr<ID3D12GraphicsCommandList> commandList;
+	// Single-use command allocator/list for resource initialization.
+	ComPtr<ID3D12CommandAllocator> commandAllocator;
+	ComPtr<ID3D12GraphicsCommandList> commandList;
 
-    ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator)));
-    ThrowIfFailed(pDevice->CreateCommandList(m_nodeMask, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
+	ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator)));
+	ThrowIfFailed(pDevice->CreateCommandList(m_nodeMask, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
 
-    // Create the command lists.
-    {
-        ThrowIfFailed(pDevice->CreateCommandList(
-            m_nodeMask,
-            D3D12_COMMAND_LIST_TYPE_DIRECT,
-            m_sceneCommandAllocators[m_frameIndex].Get(),
-            m_crossNodeResources->GetScenePipelineState(),
-            IID_PPV_ARGS(&m_sceneCommandList)));
+	// Create the command lists.
+	{
+		ThrowIfFailed(pDevice->CreateCommandList(
+			m_nodeMask,
+			D3D12_COMMAND_LIST_TYPE_DIRECT,
+			m_sceneCommandAllocators[m_frameIndex].Get(),
+			m_crossNodeResources->GetScenePipelineState(),
+			IID_PPV_ARGS(&m_sceneCommandList)));
 
-        ThrowIfFailed(pDevice->CreateCommandList(
-            m_nodeMask,
-            D3D12_COMMAND_LIST_TYPE_DIRECT,
-            m_postCommandAllocators[m_frameIndex].Get(),
-            m_crossNodeResources->GetPostPipelineState(),
-            IID_PPV_ARGS(&m_postCommandList)));
+		ThrowIfFailed(pDevice->CreateCommandList(
+			m_nodeMask,
+			D3D12_COMMAND_LIST_TYPE_DIRECT,
+			m_postCommandAllocators[m_frameIndex].Get(),
+			m_crossNodeResources->GetPostPipelineState(),
+			IID_PPV_ARGS(&m_postCommandList)));
 
-        // Command lists are created in the 'recording' state. We always call Reset
-        // as the first thing when populating command lists, so we need to close
-        // these here for the first frame.
-        ThrowIfFailed(m_sceneCommandList->Close());
-        ThrowIfFailed(m_postCommandList->Close());
-    }
+		// Command lists are created in the 'recording' state. We always call Reset
+		// as the first thing when populating command lists, so we need to close
+		// these here for the first frame.
+		ThrowIfFailed(m_sceneCommandList->Close());
+		ThrowIfFailed(m_postCommandList->Close());
+	}
 
-    ComPtr<ID3D12Resource> triangleVertexBufferUpload;
-    ComPtr<ID3D12Resource> quadVertexBufferUpload;
+	ComPtr<ID3D12Resource> triangleVertexBufferUpload;
+	ComPtr<ID3D12Resource> quadVertexBufferUpload;
 
-    // Create the triangle vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        SceneVertex vertices[] =
-        {
-            { { 0.0f, Settings::TriangleHalfWidth, Settings::TriangleDepth } },
-            { { Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } },
-            { { -Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } }
-        };
+	// Create the triangle vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		SceneVertex vertices[] =
+		{
+			{ { 0.0f, Settings::TriangleHalfWidth, Settings::TriangleDepth } },
+			{ { Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } },
+			{ { -Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } }
+		};
 
-        const UINT vertexBufferSize = sizeof(vertices);
+		const UINT vertexBufferSize = sizeof(vertices);
 
-        D3D12_HEAP_PROPERTIES heapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
-        heapProps.CreationNodeMask = m_nodeMask;
-        heapProps.VisibleNodeMask = m_nodeMask;
+		D3D12_HEAP_PROPERTIES heapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+		heapProps.CreationNodeMask = m_nodeMask;
+		heapProps.VisibleNodeMask = m_nodeMask;
 
-        ThrowIfFailed(pDevice->CreateCommittedResource(
-            &heapProps,
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_sceneVertexBuffer)));
+		ThrowIfFailed(pDevice->CreateCommittedResource(
+			&heapProps,
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_sceneVertexBuffer)));
 
-        D3D12_HEAP_PROPERTIES uploadHeapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
-        uploadHeapProps.CreationNodeMask = m_nodeMask;
-        uploadHeapProps.VisibleNodeMask = m_nodeMask;        // Upload heap is single-use and doesn't need to be shared.
+		D3D12_HEAP_PROPERTIES uploadHeapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+		uploadHeapProps.CreationNodeMask = m_nodeMask;
+		uploadHeapProps.VisibleNodeMask = m_nodeMask;		// Upload heap is single-use and doesn't need to be shared.
 
-        ThrowIfFailed(pDevice->CreateCommittedResource(
-            &uploadHeapProps,
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&triangleVertexBufferUpload)));
+		ThrowIfFailed(pDevice->CreateCommittedResource(
+			&uploadHeapProps,
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&triangleVertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(vertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(vertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(commandList.Get(), m_sceneVertexBuffer.Get(), triangleVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_sceneVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(commandList.Get(), m_sceneVertexBuffer.Get(), triangleVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_sceneVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_sceneVertexBufferView.BufferLocation = m_sceneVertexBuffer->GetGPUVirtualAddress();
-        m_sceneVertexBufferView.StrideInBytes = sizeof(SceneVertex);
-        m_sceneVertexBufferView.SizeInBytes = sizeof(vertices);
-    }
+		// Initialize the vertex buffer view.
+		m_sceneVertexBufferView.BufferLocation = m_sceneVertexBuffer->GetGPUVirtualAddress();
+		m_sceneVertexBufferView.StrideInBytes = sizeof(SceneVertex);
+		m_sceneVertexBufferView.SizeInBytes = sizeof(vertices);
+	}
 
-    // Create the quad vertex buffer.
-    {
-        // Define the geometry for a quad.
-        PostVertex vertices[] =
-        {
-            { { -1.0f, -1.0f, 0.0f },{ 0.0f, 1.0f } },    // Bottom Left
-            { { -1.0f, 1.0f, 0.0f },{ 0.0f, 0.0f } },    // Top Left
-            { { 1.0f, -1.0f, 0.0f },{ 1.0f, 1.0f } },    // Bottom Right
-            { { 1.0f, 1.0f, 0.0f },{ 1.0f, 0.0f } },    // Top Right
-        };
+	// Create the quad vertex buffer.
+	{
+		// Define the geometry for a quad.
+		PostVertex vertices[] =
+		{
+			{ { -1.0f, -1.0f, 0.0f },{ 0.0f, 1.0f } },	// Bottom Left
+			{ { -1.0f, 1.0f, 0.0f },{ 0.0f, 0.0f } },	// Top Left
+			{ { 1.0f, -1.0f, 0.0f },{ 1.0f, 1.0f } },	// Bottom Right
+			{ { 1.0f, 1.0f, 0.0f },{ 1.0f, 0.0f } },	// Top Right
+		};
 
-        const UINT vertexBufferSize = sizeof(vertices);
+		const UINT vertexBufferSize = sizeof(vertices);
 
-        D3D12_HEAP_PROPERTIES heapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
-        heapProps.CreationNodeMask = m_nodeMask;
-        heapProps.VisibleNodeMask = m_nodeMask;
+		D3D12_HEAP_PROPERTIES heapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+		heapProps.CreationNodeMask = m_nodeMask;
+		heapProps.VisibleNodeMask = m_nodeMask;
 
-        ThrowIfFailed(pDevice->CreateCommittedResource(
-            &heapProps,
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_postVertexBuffer)));
+		ThrowIfFailed(pDevice->CreateCommittedResource(
+			&heapProps,
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_postVertexBuffer)));
 
-        D3D12_HEAP_PROPERTIES uploadHeapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
-        uploadHeapProps.CreationNodeMask = m_nodeMask;
-        uploadHeapProps.VisibleNodeMask = m_nodeMask;        // Upload heap is single-use and doesn't need to be shared.
+		D3D12_HEAP_PROPERTIES uploadHeapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+		uploadHeapProps.CreationNodeMask = m_nodeMask;
+		uploadHeapProps.VisibleNodeMask = m_nodeMask;		// Upload heap is single-use and doesn't need to be shared.
 
-        ThrowIfFailed(pDevice->CreateCommittedResource(
-            &uploadHeapProps,
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&quadVertexBufferUpload)));
+		ThrowIfFailed(pDevice->CreateCommittedResource(
+			&uploadHeapProps,
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&quadVertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(vertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(vertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(commandList.Get(), m_postVertexBuffer.Get(), quadVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_postVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(commandList.Get(), m_postVertexBuffer.Get(), quadVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_postVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_postVertexBufferView.BufferLocation = m_postVertexBuffer->GetGPUVirtualAddress();
-        m_postVertexBufferView.StrideInBytes = sizeof(PostVertex);
-        m_postVertexBufferView.SizeInBytes = sizeof(vertices);
-    }
+		// Initialize the vertex buffer view.
+		m_postVertexBufferView.BufferLocation = m_postVertexBuffer->GetGPUVirtualAddress();
+		m_postVertexBufferView.StrideInBytes = sizeof(PostVertex);
+		m_postVertexBufferView.SizeInBytes = sizeof(vertices);
+	}
 
-    // Create constant buffer views.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_sceneCbvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create constant buffer views.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_sceneCbvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
-        cbvDesc.SizeInBytes = sizeof(SceneConstantBuffer);
-        cbvDesc.BufferLocation = m_crossNodeResources->GetSceneConstantBufferGpuVirtualAddress();
+		D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
+		cbvDesc.SizeInBytes = sizeof(SceneConstantBuffer);
+		cbvDesc.BufferLocation = m_crossNodeResources->GetSceneConstantBufferGpuVirtualAddress();
 
-        for (UINT frame = 0; frame < Settings::SceneConstantBufferFrames; frame++)
-        {
-            for (UINT n = 0; n < Settings::TriangleCount; n++)
-            {
-                pDevice->CreateConstantBufferView(&cbvDesc, cpuHandle);
+		for (UINT frame = 0; frame < Settings::SceneConstantBufferFrames; frame++)
+		{
+			for (UINT n = 0; n < Settings::TriangleCount; n++)
+			{
+				pDevice->CreateConstantBufferView(&cbvDesc, cpuHandle);
 
-                cpuHandle.Offset(Settings::CbvSrvDescriptorSize);
-                cbvDesc.BufferLocation += cbvDesc.SizeInBytes;
-            }
-        }
-    }
+				cpuHandle.Offset(Settings::CbvSrvDescriptorSize);
+				cbvDesc.BufferLocation += cbvDesc.SizeInBytes;
+			}
+		}
+	}
 
-    // Describe and create a sampler.
-    {
-        D3D12_SAMPLER_DESC samplerDesc = {};
-        samplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-        samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.MinLOD = 0;
-        samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
-        samplerDesc.MipLODBias = 0.0f;
-        samplerDesc.MaxAnisotropy = 1;
-        samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
+	// Describe and create a sampler.
+	{
+		D3D12_SAMPLER_DESC samplerDesc = {};
+		samplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.MinLOD = 0;
+		samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
+		samplerDesc.MipLODBias = 0.0f;
+		samplerDesc.MaxAnisotropy = 1;
+		samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
 
-        pDevice->CreateSampler(&samplerDesc, m_postSamplerHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		pDevice->CreateSampler(&samplerDesc, m_postSamplerHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    ThrowIfFailed(commandList->Close());
+	ThrowIfFailed(commandList->Close());
 
-    // Submit the initialization work to the GPU.
-    ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Submit the initialization work to the GPU.
+	ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Wait for the graphics queue to finish executing the commands.
-    Fence fence(m_graphicsQueue.Get());
-    fence.FlushGpuQueue();
+	// Wait for the graphics queue to finish executing the commands.
+	Fence fence(m_graphicsQueue.Get());
+	fence.FlushGpuQueue();
 
-    LoadSizeDependentResources();
+	LoadSizeDependentResources();
 }
 
 void GpuNode::LoadSizeDependentResources()
 {
-    auto pDevice = m_crossNodeResources->GetDevice();
-    auto pSwapChain = m_crossNodeResources->GetSwapChain();
+	auto pDevice = m_crossNodeResources->GetDevice();
+	auto pSwapChain = m_crossNodeResources->GetSwapChain();
 
-    // Single-use command allocator/list for resource initialization.
-    ComPtr<ID3D12CommandAllocator> commandAllocator;
-    ComPtr<ID3D12GraphicsCommandList> commandList;
+	// Single-use command allocator/list for resource initialization.
+	ComPtr<ID3D12CommandAllocator> commandAllocator;
+	ComPtr<ID3D12GraphicsCommandList> commandList;
 
-    ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator)));
-    ThrowIfFailed(pDevice->CreateCommandList(m_nodeMask, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
+	ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator)));
+	ThrowIfFailed(pDevice->CreateCommandList(m_nodeMask, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
 
-    // Create RTVs for back buffers assigned to this node.
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart());
-    for (UINT n = 0; n < Settings::BackBuffersPerNode; n++)
-    {
-        UINT backBufferIndex = (n * Settings::NodeCount) + m_nodeIndex;
+	// Create RTVs for back buffers assigned to this node.
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart());
+	for (UINT n = 0; n < Settings::BackBuffersPerNode; n++)
+	{
+		UINT backBufferIndex = (n * Settings::NodeCount) + m_nodeIndex;
 
-        // Create an RTV for the swap chain back buffer assigned to this node.
-        ThrowIfFailed(pSwapChain->GetBuffer(backBufferIndex, IID_PPV_ARGS(&m_postRenderTargets[n])));
+		// Create an RTV for the swap chain back buffer assigned to this node.
+		ThrowIfFailed(pSwapChain->GetBuffer(backBufferIndex, IID_PPV_ARGS(&m_postRenderTargets[n])));
 
-        pDevice->CreateRenderTargetView(m_postRenderTargets[n].Get(), nullptr, rtvHandle);
-        rtvHandle.Offset(Settings::RtvDescriptorSize);
-    }
+		pDevice->CreateRenderTargetView(m_postRenderTargets[n].Get(), nullptr, rtvHandle);
+		rtvHandle.Offset(Settings::RtvDescriptorSize);
+	}
 
-    m_frameIndex = 0;
-    m_sceneRenderTargetIndex = m_nodeIndex;
+	m_frameIndex = 0;
+	m_sceneRenderTargetIndex = m_nodeIndex;
 
-    // Create the render targets used to draw the scene.
-    // These will be sampled from during the post-processing step.
-    {
-        D3D12_RESOURCE_DESC renderTargetDesc = m_postRenderTargets[0]->GetDesc();
-        D3D12_RESOURCE_ALLOCATION_INFO info = pDevice->GetResourceAllocationInfo(m_nodeMask, 1, &renderTargetDesc);
-        const UINT64 alignedRenderTargetSize = AlignResource(info.SizeInBytes, info.Alignment);
+	// Create the render targets used to draw the scene.
+	// These will be sampled from during the post-processing step.
+	{
+		D3D12_RESOURCE_DESC renderTargetDesc = m_postRenderTargets[0]->GetDesc();
+		D3D12_RESOURCE_ALLOCATION_INFO info = pDevice->GetResourceAllocationInfo(m_nodeMask, 1, &renderTargetDesc);
+		const UINT64 alignedRenderTargetSize = AlignResource(info.SizeInBytes, info.Alignment);
 
-        D3D12_HEAP_DESC heapDesc = {};
-        heapDesc.SizeInBytes = alignedRenderTargetSize * Settings::SceneHistoryCount;
-        heapDesc.Alignment = info.Alignment;
-        heapDesc.Properties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT, m_nodeMask, Settings::SharedNodeMask);
-        heapDesc.Flags = D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES | D3D12_HEAP_FLAG_DENY_BUFFERS;
+		D3D12_HEAP_DESC heapDesc = {};
+		heapDesc.SizeInBytes = alignedRenderTargetSize * Settings::SceneHistoryCount;
+		heapDesc.Alignment = info.Alignment;
+		heapDesc.Properties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT, m_nodeMask, Settings::SharedNodeMask);
+		heapDesc.Flags = D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES | D3D12_HEAP_FLAG_DENY_BUFFERS;
 
-        ThrowIfFailed(pDevice->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_sceneRenderTargetHeap)));
+		ThrowIfFailed(pDevice->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_sceneRenderTargetHeap)));
 
-        CD3DX12_CLEAR_VALUE clearValue(DXGI_FORMAT_R8G8B8A8_UNORM, Settings::ClearColor);
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart());
-        CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_postSrvHeap->GetCPUDescriptorHandleForHeapStart());
+		CD3DX12_CLEAR_VALUE clearValue(DXGI_FORMAT_R8G8B8A8_UNORM, Settings::ClearColor);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart());
+		CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_postSrvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = 1;
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = 1;
 
-        D3D12_RESOURCE_BARRIER barriers[Settings::SceneHistoryCount];
+		D3D12_RESOURCE_BARRIER barriers[Settings::SceneHistoryCount];
 
-        for (UINT n = 0; n < Settings::SceneHistoryCount; n++)
-        {
-            // The post-processing pass expects that a previous post-processing pass has
-            // transitioned the next frame's dependencies into the COPY_DEST state.
-            // Since these resources were created with the PIXEL_SHADER_RESOURCE state,
-            // we need to transition them to COPY_DEST.
+		for (UINT n = 0; n < Settings::SceneHistoryCount; n++)
+		{
+			// The post-processing pass expects that a previous post-processing pass has
+			// transitioned the next frame's dependencies into the COPY_DEST state.
+			// Since these resources were created with the PIXEL_SHADER_RESOURCE state,
+			// we need to transition them to COPY_DEST.
 
-            UINT firstResource = (m_nodeIndex + Settings::SceneHistoryCount - (Settings::NodeCount - 1)) % Settings::SceneHistoryCount;
-            UINT lastResource = (m_nodeIndex + Settings::SceneHistoryCount - 1) % Settings::SceneHistoryCount;
-            bool initCopyDest = false;
-            if (firstResource <= lastResource)
-            {
-                initCopyDest = m_nodeSync && (firstResource <= n && n <= lastResource);
-            }
-            else
-            {
-                initCopyDest = m_nodeSync && (n <= lastResource || firstResource <= n);
-            }
+			UINT firstResource = (m_nodeIndex + Settings::SceneHistoryCount - (Settings::NodeCount - 1)) % Settings::SceneHistoryCount;
+			UINT lastResource = (m_nodeIndex + Settings::SceneHistoryCount - 1) % Settings::SceneHistoryCount;
+			bool initCopyDest = false;
+			if (firstResource <= lastResource)
+			{
+				initCopyDest = m_nodeSync && (firstResource <= n && n <= lastResource);
+			}
+			else
+			{
+				initCopyDest = m_nodeSync && (n <= lastResource || firstResource <= n);
+			}
 
-            ThrowIfFailed(pDevice->CreatePlacedResource(
-                m_sceneRenderTargetHeap.Get(),
-                alignedRenderTargetSize * n,
-                &renderTargetDesc,
-                initCopyDest ? D3D12_RESOURCE_STATE_COPY_DEST : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                &clearValue,
-                IID_PPV_ARGS(&m_sceneRenderTargets[n])));
+			ThrowIfFailed(pDevice->CreatePlacedResource(
+				m_sceneRenderTargetHeap.Get(),
+				alignedRenderTargetSize * n,
+				&renderTargetDesc,
+				initCopyDest ? D3D12_RESOURCE_STATE_COPY_DEST : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+				&clearValue,
+				IID_PPV_ARGS(&m_sceneRenderTargets[n])));
 
-            barriers[n] = CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, m_sceneRenderTargets[n].Get());
+			barriers[n] = CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, m_sceneRenderTargets[n].Get());
 
-            pDevice->CreateRenderTargetView(m_sceneRenderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(Settings::RtvDescriptorSize);
+			pDevice->CreateRenderTargetView(m_sceneRenderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(Settings::RtvDescriptorSize);
 
-            pDevice->CreateShaderResourceView(m_sceneRenderTargets[n].Get(), &srvDesc, srvHandle);
-            srvHandle.Offset(Settings::CbvSrvDescriptorSize);
-        }
+			pDevice->CreateShaderResourceView(m_sceneRenderTargets[n].Get(), &srvDesc, srvHandle);
+			srvHandle.Offset(Settings::CbvSrvDescriptorSize);
+		}
 
-        commandList->ResourceBarrier(_countof(barriers), barriers);
-    }
+		commandList->ResourceBarrier(_countof(barriers), barriers);
+	}
 
-    // Create the depth stencil and its view.
-    {
-        D3D12_HEAP_PROPERTIES heapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT, m_nodeMask, m_nodeMask);
-        D3D12_CLEAR_VALUE depthOptimizedClearValue = CD3DX12_CLEAR_VALUE(DXGI_FORMAT_D32_FLOAT, 1.0f, 0);
+	// Create the depth stencil and its view.
+	{
+		D3D12_HEAP_PROPERTIES heapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT, m_nodeMask, m_nodeMask);
+		D3D12_CLEAR_VALUE depthOptimizedClearValue = CD3DX12_CLEAR_VALUE(DXGI_FORMAT_D32_FLOAT, 1.0f, 0);
 
-        ThrowIfFailed(pDevice->CreateCommittedResource(
-            &heapProps,
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, Settings::Width, Settings::Height, 1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
-            D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            &depthOptimizedClearValue,
-            IID_PPV_ARGS(&m_sceneDepthStencil)
-            ));
+		ThrowIfFailed(pDevice->CreateCommittedResource(
+			&heapProps,
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, Settings::Width, Settings::Height, 1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
+			D3D12_RESOURCE_STATE_DEPTH_WRITE,
+			&depthOptimizedClearValue,
+			IID_PPV_ARGS(&m_sceneDepthStencil)
+			));
 
-        D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
-        depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
-        depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+		D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
+		depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
+		depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
 
-        pDevice->CreateDepthStencilView(m_sceneDepthStencil.Get(), &depthStencilDesc, m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		pDevice->CreateDepthStencilView(m_sceneDepthStencil.Get(), &depthStencilDesc, m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    ThrowIfFailed(commandList->Close());
+	ThrowIfFailed(commandList->Close());
 
-    // Submit the resource barrier changes to the GPU.
-    ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Submit the resource barrier changes to the GPU.
+	ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Wait for the graphics queue to finish executing the commands.
-    Fence fence(m_graphicsQueue.Get());
-    fence.FlushGpuQueue();
+	// Wait for the graphics queue to finish executing the commands.
+	Fence fence(m_graphicsQueue.Get());
+	fence.FlushGpuQueue();
 }
 
 // Get references to scene render targets and post-processing fences on other nodes.
 void GpuNode::LinkSharedResources(std::shared_ptr<GpuNode>* ppNodes, UINT nodeCount)
 {
-    if (m_nodeSync)
-    {
-        // We need to store a reference to the other nodes' render targets so that
-        // this node can copy rendered scenes to them.
-        for (UINT nodeIndex = 0; nodeIndex < nodeCount; nodeIndex++)
-        {
-            if (nodeIndex == m_nodeIndex)
-            {
-                // This node already has references to its own render targets.
-                continue;
-            }
+	if (m_nodeSync)
+	{
+		// We need to store a reference to the other nodes' render targets so that
+		// this node can copy rendered scenes to them.
+		for (UINT nodeIndex = 0; nodeIndex < nodeCount; nodeIndex++)
+		{
+			if (nodeIndex == m_nodeIndex)
+			{
+				// This node already has references to its own render targets.
+				continue;
+			}
 
-            for (UINT n = 0; n < Settings::SceneHistoryCount; n++)
-            {
-                ThrowIfFailed(ppNodes[nodeIndex]->m_sceneRenderTargets[n].As(&m_nodeSync->sceneRenderTargets[nodeIndex][n]));
-            }
+			for (UINT n = 0; n < Settings::SceneHistoryCount; n++)
+			{
+				ThrowIfFailed(ppNodes[nodeIndex]->m_sceneRenderTargets[n].As(&m_nodeSync->sceneRenderTargets[nodeIndex][n]));
+			}
 
-            // Cross-node copies are only done when all nodes are finished with their
-            // post-processing pass (which includes transitioning resources into the
-            // correct states so that they may be copied into).
-            // Keep a reference to the other nodes' fences so this node can wait to
-            // perform the copy until the resource barriers are correctly set.
-            m_nodeSync->postFences[nodeIndex] = ppNodes[nodeIndex]->m_postFence;
-        }
-    }
+			// Cross-node copies are only done when all nodes are finished with their
+			// post-processing pass (which includes transitioning resources into the
+			// correct states so that they may be copied into).
+			// Keep a reference to the other nodes' fences so this node can wait to
+			// perform the copy until the resource barriers are correctly set.
+			m_nodeSync->postFences[nodeIndex] = ppNodes[nodeIndex]->m_postFence;
+		}
+	}
 }
 
 void GpuNode::OnUpdate(SceneConstantBuffer* pBuffers, UINT bufferCount, UINT64 frameId)
 {
-    m_crossNodeResources->UpdateConstantBuffer(reinterpret_cast<UINT8*>(pBuffers), bufferCount * sizeof(SceneConstantBuffer), frameId);
+	m_crossNodeResources->UpdateConstantBuffer(reinterpret_cast<UINT8*>(pBuffers), bufferCount * sizeof(SceneConstantBuffer), frameId);
 }
 
 // Fill the command list with all the render commands and dependent state.
 void GpuNode::RenderScene(UINT64 frameId, UINT simulatedGpuLoad)
 {
-    UINT cbvDescriptorTableOffset = Settings::TriangleCount * (frameId % Settings::SceneConstantBufferFrames);
-    CD3DX12_GPU_DESCRIPTOR_HANDLE cbvHandle(m_sceneCbvHeap->GetGPUDescriptorHandleForHeapStart(), cbvDescriptorTableOffset, Settings::CbvSrvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart(), m_sceneRenderTargetIndex, Settings::RtvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
+	UINT cbvDescriptorTableOffset = Settings::TriangleCount * (frameId % Settings::SceneConstantBufferFrames);
+	CD3DX12_GPU_DESCRIPTOR_HANDLE cbvHandle(m_sceneCbvHeap->GetGPUDescriptorHandleForHeapStart(), cbvDescriptorTableOffset, Settings::CbvSrvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart(), m_sceneRenderTargetIndex, Settings::RtvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
 
-    m_sceneFence->Next();
+	m_sceneFence->Next();
 
-    // Record the rendering commands.
-    ThrowIfFailed(m_sceneCommandAllocators[m_frameIndex]->Reset());
-    ThrowIfFailed(m_sceneCommandList->Reset(m_sceneCommandAllocators[m_frameIndex].Get(), m_crossNodeResources->GetScenePipelineState()));
+	// Record the rendering commands.
+	ThrowIfFailed(m_sceneCommandAllocators[m_frameIndex]->Reset());
+	ThrowIfFailed(m_sceneCommandList->Reset(m_sceneCommandAllocators[m_frameIndex].Get(), m_crossNodeResources->GetScenePipelineState()));
 
-    // Set necessary state.
-    m_sceneCommandList->SetGraphicsRootSignature(m_crossNodeResources->GetSceneRootSignature());
-    m_sceneCommandList->SetGraphicsRoot32BitConstant(1, simulatedGpuLoad, 0);
-    
-    ID3D12DescriptorHeap* ppHeaps[] = { m_sceneCbvHeap.Get() };
-    m_sceneCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	// Set necessary state.
+	m_sceneCommandList->SetGraphicsRootSignature(m_crossNodeResources->GetSceneRootSignature());
+	m_sceneCommandList->SetGraphicsRoot32BitConstant(1, simulatedGpuLoad, 0);
+	
+	ID3D12DescriptorHeap* ppHeaps[] = { m_sceneCbvHeap.Get() };
+	m_sceneCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_sceneCommandList->RSSetViewports(1, &Settings::Viewport);
-    m_sceneCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
-    m_sceneCommandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
+	m_sceneCommandList->RSSetViewports(1, &Settings::Viewport);
+	m_sceneCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
+	m_sceneCommandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
 
-    // Record commands.
-    D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET);
-    m_sceneCommandList->ResourceBarrier(1, &barrier);
-    m_sceneCommandList->ClearRenderTargetView(rtvHandle, Settings::ClearColor, 0, nullptr);
-    m_sceneCommandList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
-    
-    m_sceneCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    m_sceneCommandList->IASetVertexBuffers(0, 1, &m_sceneVertexBufferView);
+	// Record commands.
+	D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET);
+	m_sceneCommandList->ResourceBarrier(1, &barrier);
+	m_sceneCommandList->ClearRenderTargetView(rtvHandle, Settings::ClearColor, 0, nullptr);
+	m_sceneCommandList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+	
+	m_sceneCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_sceneCommandList->IASetVertexBuffers(0, 1, &m_sceneVertexBufferView);
 
-    for (UINT m = 0; m < Settings::TriangleCount; m++)
-    {
-        m_sceneCommandList->SetGraphicsRootDescriptorTable(0, cbvHandle);
-        m_sceneCommandList->DrawInstanced(3, 1, 0, 0);
+	for (UINT m = 0; m < Settings::TriangleCount; m++)
+	{
+		m_sceneCommandList->SetGraphicsRootDescriptorTable(0, cbvHandle);
+		m_sceneCommandList->DrawInstanced(3, 1, 0, 0);
 
-        cbvHandle.Offset(Settings::CbvSrvDescriptorSize);
-    }
+		cbvHandle.Offset(Settings::CbvSrvDescriptorSize);
+	}
 
-    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barrier.Transition.StateAfter = m_nodeSync ? D3D12_RESOURCE_STATE_COPY_SOURCE : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-    m_sceneCommandList->ResourceBarrier(1, &barrier);
+	barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barrier.Transition.StateAfter = m_nodeSync ? D3D12_RESOURCE_STATE_COPY_SOURCE : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	m_sceneCommandList->ResourceBarrier(1, &barrier);
 
-    ThrowIfFailed(m_sceneCommandList->Close());
+	ThrowIfFailed(m_sceneCommandList->Close());
 
-    ID3D12CommandList* ppSceneCommandLists[] = { m_sceneCommandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppSceneCommandLists), ppSceneCommandLists);
+	ID3D12CommandList* ppSceneCommandLists[] = { m_sceneCommandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppSceneCommandLists), ppSceneCommandLists);
 
-    m_sceneFence->Signal();
+	m_sceneFence->Signal();
 }
 
 void GpuNode::RenderPost(UINT64 frameId)
 {
-    UINT backBufferIndex = m_crossNodeResources->GetSwapChain()->GetCurrentBackBufferIndex() / Settings::NodeCount;
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle = CD3DX12_CPU_DESCRIPTOR_HANDLE(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart(), backBufferIndex, Settings::RtvDescriptorSize);
+	UINT backBufferIndex = m_crossNodeResources->GetSwapChain()->GetCurrentBackBufferIndex() / Settings::NodeCount;
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle = CD3DX12_CPU_DESCRIPTOR_HANDLE(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart(), backBufferIndex, Settings::RtvDescriptorSize);
 
-    m_postFence->Next();
+	m_postFence->Next();
 
-    ThrowIfFailed(m_postCommandAllocators[m_frameIndex]->Reset());
-    ThrowIfFailed(m_postCommandList->Reset(m_postCommandAllocators[m_frameIndex].Get(), m_crossNodeResources->GetPostPipelineState()));
+	ThrowIfFailed(m_postCommandAllocators[m_frameIndex]->Reset());
+	ThrowIfFailed(m_postCommandList->Reset(m_postCommandAllocators[m_frameIndex].Get(), m_crossNodeResources->GetPostPipelineState()));
 
-    if (m_nodeSync)
-    {
-        // If the rendered scenes need to be copied across nodes, we need to wait
-        // until the other nodes are done with their post processing passes (which
-        // includes transitioning the state of the next render targets in the
-        // history to the COPY_DEST state).
-        if (frameId > 0)
-        {
-            for (UINT node = 0; node < Settings::NodeCount; node++)
-            {
-                if (node != m_nodeIndex)
-                {
-                    Fence::GpuWait(m_graphicsQueue.Get(), m_nodeSync->postFences[node].get());
-                }
-            }
-        }
+	if (m_nodeSync)
+	{
+		// If the rendered scenes need to be copied across nodes, we need to wait
+		// until the other nodes are done with their post processing passes (which
+		// includes transitioning the state of the next render targets in the
+		// history to the COPY_DEST state).
+		if (frameId > 0)
+		{
+			for (UINT node = 0; node < Settings::NodeCount; node++)
+			{
+				if (node != m_nodeIndex)
+				{
+					Fence::GpuWait(m_graphicsQueue.Get(), m_nodeSync->postFences[node].get());
+				}
+			}
+		}
 
-        // Copy the render target from the scene pass to all other nodes.
-        for (UINT n = 0; n < Settings::NodeCount; n++)
-        {
-            // We only keep references to the render targets that we need to copy to.
-            if (m_nodeSync->sceneRenderTargets[n][m_sceneRenderTargetIndex])
-            {
-                m_postCommandList->CopyResource(
-                    m_nodeSync->sceneRenderTargets[n][m_sceneRenderTargetIndex].Get(),
-                    m_sceneRenderTargets[m_sceneRenderTargetIndex].Get());
-            }
-        }
+		// Copy the render target from the scene pass to all other nodes.
+		for (UINT n = 0; n < Settings::NodeCount; n++)
+		{
+			// We only keep references to the render targets that we need to copy to.
+			if (m_nodeSync->sceneRenderTargets[n][m_sceneRenderTargetIndex])
+			{
+				m_postCommandList->CopyResource(
+					m_nodeSync->sceneRenderTargets[n][m_sceneRenderTargetIndex].Get(),
+					m_sceneRenderTargets[m_sceneRenderTargetIndex].Get());
+			}
+		}
 
-        // Transition all render target resources into the PIXEL_SHADER_RESOURCE
-        // state to prepare for rendering the post-process effect.
-        D3D12_RESOURCE_BARRIER barriers[Settings::MaxNodeCount];
+		// Transition all render target resources into the PIXEL_SHADER_RESOURCE
+		// state to prepare for rendering the post-process effect.
+		D3D12_RESOURCE_BARRIER barriers[Settings::MaxNodeCount];
 
-        for (UINT index = 0; index < Settings::NodeCount - 1; index++)
-        {
-            UINT offset = Settings::SceneHistoryCount - Settings::NodeCount + 1 + index;
-            UINT renderTargetIndex = (m_sceneRenderTargetIndex + offset) % Settings::SceneHistoryCount;
+		for (UINT index = 0; index < Settings::NodeCount - 1; index++)
+		{
+			UINT offset = Settings::SceneHistoryCount - Settings::NodeCount + 1 + index;
+			UINT renderTargetIndex = (m_sceneRenderTargetIndex + offset) % Settings::SceneHistoryCount;
 
-            barriers[index] = CD3DX12_RESOURCE_BARRIER::Transition(
-                m_sceneRenderTargets[renderTargetIndex].Get(),
-                D3D12_RESOURCE_STATE_COPY_DEST,
-                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
-        }
+			barriers[index] = CD3DX12_RESOURCE_BARRIER::Transition(
+				m_sceneRenderTargets[renderTargetIndex].Get(),
+				D3D12_RESOURCE_STATE_COPY_DEST,
+				D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+		}
 
-        barriers[Settings::NodeCount - 1] = CD3DX12_RESOURCE_BARRIER::Transition(
-            m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(),
-            D3D12_RESOURCE_STATE_COPY_SOURCE,
-            D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+		barriers[Settings::NodeCount - 1] = CD3DX12_RESOURCE_BARRIER::Transition(
+			m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(),
+			D3D12_RESOURCE_STATE_COPY_SOURCE,
+			D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
 
-        m_postCommandList->ResourceBarrier(Settings::NodeCount, barriers);
-    }
+		m_postCommandList->ResourceBarrier(Settings::NodeCount, barriers);
+	}
 
-    m_postCommandList->SetGraphicsRootSignature(m_crossNodeResources->GetPostRootSignature());
+	m_postCommandList->SetGraphicsRootSignature(m_crossNodeResources->GetPostRootSignature());
 
-    ID3D12DescriptorHeap* ppPostHeaps[] = { m_postSrvHeap.Get(), m_postSamplerHeap.Get() };
-    m_postCommandList->SetDescriptorHeaps(_countof(ppPostHeaps), ppPostHeaps);
+	ID3D12DescriptorHeap* ppPostHeaps[] = { m_postSrvHeap.Get(), m_postSamplerHeap.Get() };
+	m_postCommandList->SetDescriptorHeaps(_countof(ppPostHeaps), ppPostHeaps);
 
-    m_postCommandList->RSSetViewports(1, &Settings::Viewport);
-    m_postCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
+	m_postCommandList->RSSetViewports(1, &Settings::Viewport);
+	m_postCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
 
-    D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(m_postRenderTargets[backBufferIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET);
-    m_postCommandList->ResourceBarrier(1, &barrier);
+	D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(m_postRenderTargets[backBufferIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET);
+	m_postCommandList->ResourceBarrier(1, &barrier);
 
-    m_postCommandList->OMSetRenderTargets(1, &rtvHandle, false, nullptr);
+	m_postCommandList->OMSetRenderTargets(1, &rtvHandle, false, nullptr);
 
-    m_postCommandList->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-    m_postCommandList->IASetVertexBuffers(0, 1, &m_postVertexBufferView);
+	m_postCommandList->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+	m_postCommandList->IASetVertexBuffers(0, 1, &m_postVertexBufferView);
 
-    m_postCommandList->SetGraphicsRootDescriptorTable(0, m_postSrvHeap->GetGPUDescriptorHandleForHeapStart());
-    m_postCommandList->SetGraphicsRootDescriptorTable(1, m_postSamplerHeap->GetGPUDescriptorHandleForHeapStart());
-    m_postCommandList->SetGraphicsRoot32BitConstant(2, frameId % Settings::SceneHistoryCount, 0);
-    m_postCommandList->SetGraphicsRoot32BitConstant(2, static_cast<UINT>(min(frameId + 1, Settings::SceneHistoryCount)), 1);
+	m_postCommandList->SetGraphicsRootDescriptorTable(0, m_postSrvHeap->GetGPUDescriptorHandleForHeapStart());
+	m_postCommandList->SetGraphicsRootDescriptorTable(1, m_postSamplerHeap->GetGPUDescriptorHandleForHeapStart());
+	m_postCommandList->SetGraphicsRoot32BitConstant(2, frameId % Settings::SceneHistoryCount, 0);
+	m_postCommandList->SetGraphicsRoot32BitConstant(2, static_cast<UINT>(min(frameId + 1, Settings::SceneHistoryCount)), 1);
 
-    m_postCommandList->DrawInstanced(4, 1, 0, 0);
+	m_postCommandList->DrawInstanced(4, 1, 0, 0);
 
-    // Indicate that the back buffer will now be used to present.
-    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
+	// Indicate that the back buffer will now be used to present.
+	barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
 
-    D3D12_RESOURCE_BARRIER barriers[Settings::MaxNodeCount];
-    barriers[0] = barrier;
+	D3D12_RESOURCE_BARRIER barriers[Settings::MaxNodeCount];
+	barriers[0] = barrier;
 
-    if (m_nodeSync)
-    {
-        // Transition render target resources rendered by the next nodes into the
-        // COPY_DEST state to prepare them to be copied to during those nodes'
-        // post-process passes.
-        for (UINT offset = 1; offset < Settings::NodeCount; offset++)
-        {
-            UINT renderTargetIndex = (m_sceneRenderTargetIndex + offset) % Settings::SceneHistoryCount;
+	if (m_nodeSync)
+	{
+		// Transition render target resources rendered by the next nodes into the
+		// COPY_DEST state to prepare them to be copied to during those nodes'
+		// post-process passes.
+		for (UINT offset = 1; offset < Settings::NodeCount; offset++)
+		{
+			UINT renderTargetIndex = (m_sceneRenderTargetIndex + offset) % Settings::SceneHistoryCount;
 
-            barriers[offset] = CD3DX12_RESOURCE_BARRIER::Transition(
-                m_sceneRenderTargets[renderTargetIndex].Get(),
-                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_COPY_DEST);
-        }
-    }
+			barriers[offset] = CD3DX12_RESOURCE_BARRIER::Transition(
+				m_sceneRenderTargets[renderTargetIndex].Get(),
+				D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+				D3D12_RESOURCE_STATE_COPY_DEST);
+		}
+	}
 
-    m_postCommandList->ResourceBarrier(Settings::NodeCount, barriers);
+	m_postCommandList->ResourceBarrier(Settings::NodeCount, barriers);
 
-    ThrowIfFailed(m_postCommandList->Close());
+	ThrowIfFailed(m_postCommandList->Close());
 
-    ID3D12CommandList* ppPostCommandLists[] = { m_postCommandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppPostCommandLists), ppPostCommandLists);
+	ID3D12CommandList* ppPostCommandLists[] = { m_postCommandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppPostCommandLists), ppPostCommandLists);
 }
 
 void GpuNode::Present(UINT syncInterval, bool windowedMode)
 {
-    // When using sync interval 0, it is recommended to always pass the tearing
-    // flag when it is supported, even if not presenting to a fullscreen window.
-    // This flag cannot be used if the app is in "exclusive" fullscreen mode as
-    // a result of calling SetFullscreenState.
+	// When using sync interval 0, it is recommended to always pass the tearing
+	// flag when it is supported, even if not presenting to a fullscreen window.
+	// This flag cannot be used if the app is in "exclusive" fullscreen mode as
+	// a result of calling SetFullscreenState.
 
-    UINT presentFlags = (syncInterval == 0 && Settings::TearingSupport && windowedMode) ? DXGI_PRESENT_ALLOW_TEARING : 0;
+	UINT presentFlags = (syncInterval == 0 && Settings::TearingSupport && windowedMode) ? DXGI_PRESENT_ALLOW_TEARING : 0;
 
-    ThrowIfFailed(m_crossNodeResources->GetSwapChain()->Present(syncInterval, presentFlags));
+	ThrowIfFailed(m_crossNodeResources->GetSwapChain()->Present(syncInterval, presentFlags));
 }
 
 void GpuNode::ReleaseBackBuffers()
 {
-    // Release the resources holding references to the swap chain (requirement of
-    // IDXGISwapChain::ResizeBuffers).
+	// Release the resources holding references to the swap chain (requirement of
+	// IDXGISwapChain::ResizeBuffers).
 
-    for (UINT n = 0; n < Settings::BackBuffersPerNode; n++)
-    {
-        m_postRenderTargets[n].Reset();
-    }
+	for (UINT n = 0; n < Settings::BackBuffersPerNode; n++)
+	{
+		m_postRenderTargets[n].Reset();
+	}
 }
 
 void GpuNode::WaitForGpu()
 {
-    m_postFence->FlushGpuQueue();
+	m_postFence->FlushGpuQueue();
 }
 
 void GpuNode::MoveToNextFrame()
 {
-    m_postFence->Signal();
+	m_postFence->Signal();
 
-    m_frameIndex = (m_frameIndex + 1) % Settings::FrameCount;
+	m_frameIndex = (m_frameIndex + 1) % Settings::FrameCount;
 
-    // We render to every nth render target.
-    m_sceneRenderTargetIndex = (m_sceneRenderTargetIndex + Settings::NodeCount) % Settings::SceneHistoryCount;
+	// We render to every nth render target.
+	m_sceneRenderTargetIndex = (m_sceneRenderTargetIndex + Settings::NodeCount) % Settings::SceneHistoryCount;
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/GpuNode.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/GpuNode.h
@@ -21,84 +21,84 @@ using Microsoft::WRL::ComPtr;
 class GpuNode
 {
 public:
-    GpuNode(UINT nodeIndex, std::shared_ptr<CrossNodeResources> crossNodeResources);
-    void LoadPipeline();
-    void LoadAssets();
-    void LoadSizeDependentResources();
-    void LinkSharedResources(std::shared_ptr<GpuNode>* ppNodes, UINT nodeCount);
-    void OnUpdate(SceneConstantBuffer* pBuffers, UINT bufferCount, UINT64 frameId);
-    void RenderScene(UINT64 frameId, UINT simulatedGpuLoad);
-    void RenderPost(UINT64 frameId);
-    void Present(UINT syncInterval, bool windowedMode);
+	GpuNode(UINT nodeIndex, std::shared_ptr<CrossNodeResources> crossNodeResources);
+	void LoadPipeline();
+	void LoadAssets();
+	void LoadSizeDependentResources();
+	void LinkSharedResources(std::shared_ptr<GpuNode>* ppNodes, UINT nodeCount);
+	void OnUpdate(SceneConstantBuffer* pBuffers, UINT bufferCount, UINT64 frameId);
+	void RenderScene(UINT64 frameId, UINT simulatedGpuLoad);
+	void RenderPost(UINT64 frameId);
+	void Present(UINT syncInterval, bool windowedMode);
 
-    void ReleaseBackBuffers();
-    void WaitForGpu();
-    void MoveToNextFrame();
+	void ReleaseBackBuffers();
+	void WaitForGpu();
+	void MoveToNextFrame();
 
 private:
-    UINT m_frameIndex;
-    UINT m_nodeIndex;
-    UINT m_nodeMask;
+	UINT m_frameIndex;
+	UINT m_nodeIndex;
+	UINT m_nodeMask;
 
-    std::shared_ptr<CrossNodeResources> m_crossNodeResources;
+	std::shared_ptr<CrossNodeResources> m_crossNodeResources;
 
-    ComPtr<ID3D12CommandQueue> m_graphicsQueue;
-    std::vector<ComPtr<ID3D12CommandAllocator>> m_sceneCommandAllocators;
-    std::vector<ComPtr<ID3D12CommandAllocator>> m_postCommandAllocators;
-    ComPtr<ID3D12DescriptorHeap> m_sceneRtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_sceneDsvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_sceneCbvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_postRtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_postSrvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_postSamplerHeap;
+	ComPtr<ID3D12CommandQueue> m_graphicsQueue;
+	std::vector<ComPtr<ID3D12CommandAllocator>> m_sceneCommandAllocators;
+	std::vector<ComPtr<ID3D12CommandAllocator>> m_postCommandAllocators;
+	ComPtr<ID3D12DescriptorHeap> m_sceneRtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_sceneDsvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_sceneCbvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_postRtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_postSrvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_postSamplerHeap;
 
-    // Vertex definitions.
-    struct SceneVertex
-    {
-        DirectX::XMFLOAT3 position;
-    };
+	// Vertex definitions.
+	struct SceneVertex
+	{
+		DirectX::XMFLOAT3 position;
+	};
 
-    struct PostVertex
-    {
-        DirectX::XMFLOAT3 position;
-        DirectX::XMFLOAT2 uv;
-    };
+	struct PostVertex
+	{
+		DirectX::XMFLOAT3 position;
+		DirectX::XMFLOAT2 uv;
+	};
 
-    // Scene objects.
-    ComPtr<ID3D12Resource> m_sceneVertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_sceneVertexBufferView;
-    ComPtr<ID3D12GraphicsCommandList> m_sceneCommandList;
-    ComPtr<ID3D12Heap> m_sceneRenderTargetHeap;
-    ComPtr<ID3D12Resource> m_sceneDepthStencil;
+	// Scene objects.
+	ComPtr<ID3D12Resource> m_sceneVertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_sceneVertexBufferView;
+	ComPtr<ID3D12GraphicsCommandList> m_sceneCommandList;
+	ComPtr<ID3D12Heap> m_sceneRenderTargetHeap;
+	ComPtr<ID3D12Resource> m_sceneDepthStencil;
 
-    // The motion blur shader samples from the number of render targets specified by
-    // Settings::SceneHistoryCount. A copy of these render targets will exist on each
-    // node.
-    ComPtr<ID3D12Resource> m_sceneRenderTargets[Settings::SceneHistoryCount];
+	// The motion blur shader samples from the number of render targets specified by
+	// Settings::SceneHistoryCount. A copy of these render targets will exist on each
+	// node.
+	ComPtr<ID3D12Resource> m_sceneRenderTargets[Settings::SceneHistoryCount];
 
-    // The index of the current render target used in the scene pass.
-    // This value increases by Settings::NodeCount each frame.
-    UINT m_sceneRenderTargetIndex;
+	// The index of the current render target used in the scene pass.
+	// This value increases by Settings::NodeCount each frame.
+	UINT m_sceneRenderTargetIndex;
 
-    // Post-process objects.
-    ComPtr<ID3D12Resource> m_postVertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_postVertexBufferView;
-    ComPtr<ID3D12GraphicsCommandList> m_postCommandList;
-    std::vector<ComPtr<ID3D12Resource>> m_postRenderTargets;
+	// Post-process objects.
+	ComPtr<ID3D12Resource> m_postVertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_postVertexBufferView;
+	ComPtr<ID3D12GraphicsCommandList> m_postCommandList;
+	std::vector<ComPtr<ID3D12Resource>> m_postRenderTargets;
 
-    // Objects used to support synchronizing render target contents across GPU nodes.
-    struct NodeSynchronization
-    {
-        ComPtr<ID3D12Resource> sceneRenderTargets[Settings::MaxNodeCount][Settings::SceneHistoryCount];
-        std::shared_ptr<Fence> postFences[Settings::MaxNodeCount];
-    };
-    std::unique_ptr<NodeSynchronization> m_nodeSync;
+	// Objects used to support synchronizing render target contents across GPU nodes.
+	struct NodeSynchronization
+	{
+		ComPtr<ID3D12Resource> sceneRenderTargets[Settings::MaxNodeCount][Settings::SceneHistoryCount];
+		std::shared_ptr<Fence> postFences[Settings::MaxNodeCount];
+	};
+	std::unique_ptr<NodeSynchronization> m_nodeSync;
 
-    std::shared_ptr<LinearFence> m_sceneFence;
-    std::shared_ptr<LinearFence> m_postFence;
+	std::shared_ptr<LinearFence> m_sceneFence;
+	std::shared_ptr<LinearFence> m_postFence;
 
-    static inline UINT64 AlignResource(UINT64 size, UINT64 alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT)
-    {
-        return (size + alignment - 1) & ~(alignment - 1);
-    }
+	static inline UINT64 AlignResource(UINT64 size, UINT64 alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT)
+	{
+		return (size + alignment - 1) & ~(alignment - 1);
+	}
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/Main.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12LinkedGpus sample(1200, 900, L"");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12LinkedGpus sample(1200, 900, L"");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/Post.hlsli
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/Post.hlsli
@@ -11,14 +11,14 @@
 
 struct VSInput
 {
-    float4 position : POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : POSITION;
+	float2 uv : TEXCOORD;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 Texture2D g_renderTargets[6] : register(t0);
@@ -26,6 +26,6 @@ SamplerState g_sampler : register(s0);
 
 cbuffer ShaderConstants : register(b0)
 {
-    uint currentRenderTarget;
-    uint renderTargetCount;
+	uint currentRenderTarget;
+	uint renderTargetCount;
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/PostPS.hlsl
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/PostPS.hlsl
@@ -13,18 +13,18 @@
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    // This adds up to more than 1.0f, but creates a decent effect
-    // that doesn't make the triangles look too transparent.
-    float blurWeights[6] = { 0.80f, 0.25f, 0.15f, 0.075f, 0.025f, 0.0125f };
+	// This adds up to more than 1.0f, but creates a decent effect
+	// that doesn't make the triangles look too transparent.
+	float blurWeights[6] = { 0.80f, 0.25f, 0.15f, 0.075f, 0.025f, 0.0125f };
 
-    float4 result = float4(0.0f, 0.0f, 0.0f, 0.0f);
-    uint index = currentRenderTarget;
+	float4 result = float4(0.0f, 0.0f, 0.0f, 0.0f);
+	uint index = currentRenderTarget;
 
-    for (uint n = 0; n < renderTargetCount; n++)
-    {
-        result += blurWeights[n] * g_renderTargets[index].Sample(g_sampler, input.uv);
-        index = (index == 0) ? renderTargetCount - 1 : index - 1;
-    }
+	for (uint n = 0; n < renderTargetCount; n++)
+	{
+		result += blurWeights[n] * g_renderTargets[index].Sample(g_sampler, input.uv);
+		index = (index == 0) ? renderTargetCount - 1 : index - 1;
+	}
 
-    return saturate(result);
+	return saturate(result);
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/PostVS.hlsl
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/PostVS.hlsl
@@ -13,10 +13,10 @@
 
 PSInput VSMain(VSInput input)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = input.position;
-    result.uv = input.uv;
+	result.position = input.position;
+	result.uv = input.uv;
 
-    return result;
+	return result;
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/Scene.hlsli
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/Scene.hlsli
@@ -11,19 +11,19 @@
 
 cbuffer SceneConstantBuffer : register(b0)
 {
-    float4 velocity;
-    float4 offset;
-    float4 color;
-    float4x4 projection;
+	float4 velocity;
+	float4 offset;
+	float4 color;
+	float4x4 projection;
 };
 
 cbuffer SceneRootConstants : register(b1)
 {
-    uint simulatedGpuLoad;
+	uint simulatedGpuLoad;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/ScenePS.hlsl
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/ScenePS.hlsl
@@ -13,5 +13,5 @@
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/SceneVS.hlsl
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/SceneVS.hlsl
@@ -13,29 +13,29 @@
 
 PSInput VSMain(float4 position : POSITION)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = mul(position + offset, projection);
+	result.position = mul(position + offset, projection);
 
-    float intensity = saturate((4.0f - result.position.z) / 2.0f);
-    float4 c = float4(color.xyz * intensity, 1.0f);
+	float intensity = saturate((4.0f - result.position.z) / 2.0f);
+	float4 c = float4(color.xyz * intensity, 1.0f);
 
-    if (simulatedGpuLoad > 0)
-    {
-        float4 total = float4(0.0f, 0.0f, 0.0f, 0.0f);
+	if (simulatedGpuLoad > 0)
+	{
+		float4 total = float4(0.0f, 0.0f, 0.0f, 0.0f);
 
-        // Simulate additional workload on the GPU.
-        for (uint x = 0; x < simulatedGpuLoad; x++)
-        {
-            total += c;
-        }
+		// Simulate additional workload on the GPU.
+		for (uint x = 0; x < simulatedGpuLoad; x++)
+		{
+			total += c;
+		}
 
-        result.color = total / simulatedGpuLoad;
-    }
-    else
-    {
-        result.color = c;
-    }
+		result.color = total / simulatedGpuLoad;
+	}
+	else
+	{
+		result.color = c;
+	}
 
-    return result;
+	return result;
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/Settings.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/Settings.cpp
@@ -15,8 +15,8 @@
 
 using Microsoft::WRL::ComPtr;
 
-const float Settings::TriangleHalfWidth = 0.05f;    // The x and y offsets used by the triangle vertices.
-const float Settings::TriangleDepth = 1.0f;            // The z offset used by the triangle vertices.
+const float Settings::TriangleHalfWidth = 0.05f;	// The x and y offsets used by the triangle vertices.
+const float Settings::TriangleDepth = 1.0f;			// The z offset used by the triangle vertices.
 const float Settings::ClearColor[4] = { 0.0f, 0.2f, 0.4f, 1.0f };
 
 UINT Settings::NodeCount;
@@ -36,34 +36,34 @@ D3D12_RECT Settings::ScissorRect;
 
 void Settings::Initialize(ID3D12Device* pDevice, UINT width, UINT height, bool tearingSupport)
 {
-    NodeCount = pDevice->GetNodeCount();
-    _ASSERT(NodeCount <= MaxNodeCount);
+	NodeCount = pDevice->GetNodeCount();
+	_ASSERT(NodeCount <= MaxNodeCount);
 
-    BackBuffersPerNode = (NodeCount > 1) ? 1 : 2;
-    FrameCount = (NodeCount > 1) ? 1 : 2;
-    _ASSERT(FrameCount * NodeCount <= SceneConstantBufferFrames);
+	BackBuffersPerNode = (NodeCount > 1) ? 1 : 2;
+	FrameCount = (NodeCount > 1) ? 1 : 2;
+	_ASSERT(FrameCount * NodeCount <= SceneConstantBufferFrames);
 
-    D3D12_FEATURE_DATA_D3D12_OPTIONS featureOptions;
-    ThrowIfFailed(pDevice->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &featureOptions, sizeof(featureOptions)));
-    Tier2Support = (featureOptions.CrossNodeSharingTier == D3D12_CROSS_NODE_SHARING_TIER_2);
-    TearingSupport = tearingSupport;
+	D3D12_FEATURE_DATA_D3D12_OPTIONS featureOptions;
+	ThrowIfFailed(pDevice->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &featureOptions, sizeof(featureOptions)));
+	Tier2Support = (featureOptions.CrossNodeSharingTier == D3D12_CROSS_NODE_SHARING_TIER_2);
+	TearingSupport = tearingSupport;
 
-    RtvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    CbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	RtvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	CbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 
-    SharedNodeMask = (1 << NodeCount) - 1;
-    BackBufferCount = NodeCount * BackBuffersPerNode;
+	SharedNodeMask = (1 << NodeCount) - 1;
+	BackBufferCount = NodeCount * BackBuffersPerNode;
 
-    // We assume that each node will be assigned the same number of render targets.
-    _ASSERT(SceneHistoryCount % NodeCount == 0);
+	// We assume that each node will be assigned the same number of render targets.
+	_ASSERT(SceneHistoryCount % NodeCount == 0);
 
-    OnSizeChanged(width, height);
+	OnSizeChanged(width, height);
 }
 
 void Settings::OnSizeChanged(UINT width, UINT height)
 {
-    Width = width;
-    Height = height;
-    Viewport = CD3DX12_VIEWPORT(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 0.0f, 1.0f);
-    ScissorRect = CD3DX12_RECT(0, 0, static_cast<LONG>(width), static_cast<LONG>(height));
+	Width = width;
+	Height = height;
+	Viewport = CD3DX12_VIEWPORT(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 0.0f, 1.0f);
+	ScissorRect = CD3DX12_RECT(0, 0, static_cast<LONG>(width), static_cast<LONG>(height));
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/Settings.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/Settings.h
@@ -15,30 +15,30 @@
 // for the lifetime of the sample.
 struct Settings
 {
-    static void Initialize(ID3D12Device* pDevice, UINT width, UINT height, bool tearingSupport);
-    static void OnSizeChanged(UINT width, UINT height);
+	static void Initialize(ID3D12Device* pDevice, UINT width, UINT height, bool tearingSupport);
+	static void OnSizeChanged(UINT width, UINT height);
 
-    static const UINT MaxNodeCount = 2;
-    static UINT BackBuffersPerNode;
-    static UINT FrameCount;                                // The maximum number of frames that will be buffered on each node.
+	static const UINT MaxNodeCount = 2;
+	static UINT BackBuffersPerNode;
+	static UINT FrameCount;								// The maximum number of frames that will be buffered on each node.
 
-    static const UINT SceneHistoryCount = 6;            // The number of frames used in the motion blur effect.
-    static const UINT SceneConstantBufferFrames = 10;    // The number of frames that can be buffered in the constant buffer heap.
-    static const UINT TriangleCount = 1024;                // The number of triangles drawn per frame.
-    static const float TriangleHalfWidth;                // The x and y offsets used by the triangle vertices.
-    static const float TriangleDepth;                    // The z offset used by the triangle vertices.
-    static const float ClearColor[4];
+	static const UINT SceneHistoryCount = 6;			// The number of frames used in the motion blur effect.
+	static const UINT SceneConstantBufferFrames = 10;	// The number of frames that can be buffered in the constant buffer heap.
+	static const UINT TriangleCount = 1024;				// The number of triangles drawn per frame.
+	static const float TriangleHalfWidth;				// The x and y offsets used by the triangle vertices.
+	static const float TriangleDepth;					// The z offset used by the triangle vertices.
+	static const float ClearColor[4];
 
-    static UINT NodeCount;                                // The number of linked GPUs on the system.
-    static UINT SharedNodeMask;                            // The mask representing all GPUs on the system.
-    static bool Tier2Support;
-    static bool TearingSupport;
-    static UINT BackBufferCount;
-    static UINT RtvDescriptorSize;
-    static UINT CbvSrvDescriptorSize;
+	static UINT NodeCount;								// The number of linked GPUs on the system.
+	static UINT SharedNodeMask;							// The mask representing all GPUs on the system.
+	static bool Tier2Support;
+	static bool TearingSupport;
+	static UINT BackBufferCount;
+	static UINT RtvDescriptorSize;
+	static UINT CbvSrvDescriptorSize;
 
-    static UINT Width;
-    static UINT Height;
-    static D3D12_VIEWPORT Viewport;
-    static D3D12_RECT ScissorRect;
+	static UINT Width;
+	static UINT Height;
+	static D3D12_VIEWPORT Viewport;
+	static D3D12_RECT ScissorRect;
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/View.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/View.cpp
@@ -17,61 +17,61 @@ using namespace Windows::System;
 
 inline int ConvertToPixels(float dimension, float dpi)
 {
-    return static_cast<int>(dimension * dpi / 96.0f + 0.5f);
+	return static_cast<int>(dimension * dpi / 96.0f + 0.5f);
 }
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false),
-    m_windowResizing(false),
-    m_windowVisible(true),
-    m_logicalWidth(0),
-    m_logicalHeight(0)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false),
+	m_windowResizing(false),
+	m_windowVisible(true),
+	m_logicalWidth(0),
+	m_logicalHeight(0)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    m_logicalWidth = window->Bounds.Width;
-    m_logicalHeight = window->Bounds.Height;
+	m_logicalWidth = window->Bounds.Width;
+	m_logicalHeight = window->Bounds.Height;
 
     auto dispatcher = CoreWindow::GetForCurrentThread()->Dispatcher;
     dispatcher->AcceleratorKeyActivated +=
         ref new TypedEventHandler<CoreDispatcher^, AcceleratorKeyEventArgs^>(this, &View::OnAcceleratorKeyActivated);
 
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->SizeChanged += ref new TypedEventHandler<CoreWindow^, WindowSizeChangedEventArgs^>(this, &View::OnSizeChanged);
-    window->VisibilityChanged += ref new TypedEventHandler<CoreWindow^, VisibilityChangedEventArgs^>(this, &View::OnVisibilityChanged);
-    window->Closed += ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &View::OnClosed);
-    window->PointerMoved += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerMoved);
-    window->PointerPressed += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerPressed);
-    window->PointerReleased += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerReleased);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->SizeChanged += ref new TypedEventHandler<CoreWindow^, WindowSizeChangedEventArgs^>(this, &View::OnSizeChanged);
+	window->VisibilityChanged += ref new TypedEventHandler<CoreWindow^, VisibilityChangedEventArgs^>(this, &View::OnVisibilityChanged);
+	window->Closed += ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &View::OnClosed);
+	window->PointerMoved += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerMoved);
+	window->PointerPressed += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerPressed);
+	window->PointerReleased += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerReleased);
 
-    try
-    {
-        window->ResizeStarted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeStarted);
-        window->ResizeCompleted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeCompleted);
-    }
-    catch (Exception^ e)
-    {
-        // Requires Windows 10 Creators Update (10.0.15063) or later.
-    }
+	try
+	{
+		window->ResizeStarted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeStarted);
+		window->ResizeCompleted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeCompleted);
+	}
+	catch (Exception^ e)
+	{
+		// Requires Windows 10 Creators Update (10.0.15063) or later.
+	}
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 
-    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-    displayInformation->DpiChanged += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDpiChanged);
-    displayInformation->DisplayContentsInvalidated += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDisplayContentsInvalidated);
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	displayInformation->DpiChanged += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDpiChanged);
+	displayInformation->DisplayContentsInvalidated += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDisplayContentsInvalidated);
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -80,20 +80,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -102,15 +102,15 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
     if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnAcceleratorKeyActivated(CoreDispatcher^, AcceleratorKeyEventArgs^ args)
@@ -138,97 +138,97 @@ void View::OnAcceleratorKeyActivated(CoreDispatcher^, AcceleratorKeyEventArgs^ a
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnSizeChanged(CoreWindow^ /*window*/, WindowSizeChangedEventArgs^ args)
 {
-    m_logicalWidth = args->Size.Width;
-    m_logicalHeight = args->Size.Height;
+	m_logicalWidth = args->Size.Width;
+	m_logicalHeight = args->Size.Height;
 
-    if (!m_windowResizing)
-    {
-        UpdateWindowSize();
-    }
+	if (!m_windowResizing)
+	{
+		UpdateWindowSize();
+	}
 }
 
 void View::OnResizeStarted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
 {
-    m_windowResizing = true;
+	m_windowResizing = true;
 }
 
 void View::OnResizeCompleted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
 {
-    m_windowResizing = false;
-    UpdateWindowSize();
+	m_windowResizing = false;
+	UpdateWindowSize();
 }
 
 void View::OnDpiChanged(DisplayInformation^ /*sender*/, Object^ /*args*/)
 {
-    UpdateWindowSize();
+	UpdateWindowSize();
 }
 
 void View::OnVisibilityChanged(CoreWindow^ /*window*/, VisibilityChangedEventArgs^ args)
 {
-    m_windowVisible = args->Visible;
-    UpdateWindowSize();
+	m_windowVisible = args->Visible;
+	UpdateWindowSize();
 }
 
 void View::OnClosed(CoreWindow^ /*window*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }
 
 void View::OnPointerMoved(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
-    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-    float dpi = displayInformation->LogicalDpi;
-    m_pSample->OnMouseMove(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	float dpi = displayInformation->LogicalDpi;
+	m_pSample->OnMouseMove(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
 }
 
 void View::OnPointerPressed(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
-    // For simplicity, we only consider left button press here.
-    if(args->CurrentPoint->Properties->IsLeftButtonPressed)
-    {
-        DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-        float dpi = displayInformation->LogicalDpi;
-        m_pSample->OnLeftButtonDown(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
-    }
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonDown(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
 }
 
 void View::OnPointerReleased(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
-    // For simplicity, we only consider left button press here.
-    if(args->CurrentPoint->Properties->IsLeftButtonPressed)
-    {
-        DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-        float dpi = displayInformation->LogicalDpi;
-        m_pSample->OnLeftButtonUp(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
-    }
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonUp(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
 }
 
 void View::UpdateWindowSize()
 {
-    CoreWindow^ window = CoreWindow::GetForCurrentThread();
-    Windows::Foundation::Rect windowBounds = window->Bounds;
+	CoreWindow^ window = CoreWindow::GetForCurrentThread();
+	Windows::Foundation::Rect windowBounds = window->Bounds;
 
-    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-    float dpi = displayInformation->LogicalDpi;
-    
-    m_pSample->SetWindowBounds(
-        ConvertToPixels(windowBounds.Left, dpi),
-        ConvertToPixels(windowBounds.Top, dpi),
-        ConvertToPixels(windowBounds.Right, dpi),
-        ConvertToPixels(windowBounds.Bottom, dpi));
-        
-    m_pSample->OnSizeChanged(ConvertToPixels(m_logicalWidth, dpi), ConvertToPixels(m_logicalHeight, dpi), !m_windowVisible);
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	float dpi = displayInformation->LogicalDpi;
+	
+	m_pSample->SetWindowBounds(
+		ConvertToPixels(windowBounds.Left, dpi),
+		ConvertToPixels(windowBounds.Top, dpi),
+		ConvertToPixels(windowBounds.Right, dpi),
+		ConvertToPixels(windowBounds.Bottom, dpi));
+		
+	m_pSample->OnSizeChanged(ConvertToPixels(m_logicalWidth, dpi), ConvertToPixels(m_logicalHeight, dpi), !m_windowVisible);
 }
 
 void View::OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args)
 {
-    m_pSample->OnDisplayChanged();
+	m_pSample->OnDisplayChanged();
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/View.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/View.h
@@ -24,36 +24,36 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
     void OnAcceleratorKeyActivated(CoreDispatcher^, AcceleratorKeyEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ args);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ args);
-    void OnSizeChanged(CoreWindow^ window, WindowSizeChangedEventArgs^ args);
-    void OnResizeStarted(CoreWindow^ window, Object^ args);
-    void OnResizeCompleted(CoreWindow^ window, Object^ args);
-    void OnDpiChanged(DisplayInformation^ sender, Object^ args);
-    void OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args);
-    void OnClosed(CoreWindow^ window, CoreWindowEventArgs^ args);
-    void OnPointerMoved(CoreWindow^ window, PointerEventArgs^ args);
-    void OnPointerPressed(CoreWindow^ window, PointerEventArgs^ args);
-    void OnPointerReleased(CoreWindow^ window, PointerEventArgs^ args);
-    void OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args);
-    
-    void UpdateWindowSize();
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ args);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ args);
+	void OnSizeChanged(CoreWindow^ window, WindowSizeChangedEventArgs^ args);
+	void OnResizeStarted(CoreWindow^ window, Object^ args);
+	void OnResizeCompleted(CoreWindow^ window, Object^ args);
+	void OnDpiChanged(DisplayInformation^ sender, Object^ args);
+	void OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args);
+	void OnClosed(CoreWindow^ window, CoreWindowEventArgs^ args);
+	void OnPointerMoved(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerPressed(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerReleased(CoreWindow^ window, PointerEventArgs^ args);
+	void OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args);
+	
+	void UpdateWindowSize();
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
-    bool m_windowResizing;
-    bool m_windowVisible;
-    float m_logicalWidth;
-    float m_logicalHeight;
+	DXSample* m_pSample;
+	bool m_windowClosed;
+	bool m_windowResizing;
+	bool m_windowVisible;
+	float m_logicalWidth;
+	float m_logicalHeight;
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/ViewProvider.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/ViewProvider.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/d3dx12.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/D3D12LinkedGpusAffinity.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/D3D12LinkedGpusAffinity.cpp
@@ -21,991 +21,991 @@
 using namespace DirectX;
 
 D3D12LinkedGpusAffinity::D3D12LinkedGpusAffinity(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_frameId(0),
-    m_simulatedGpuLoad(0x1000),
-    m_syncInterval(0),
-    m_windowVisible(true),
-    m_windowedMode(true),
-    m_syncSceneRenderTargets(false)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_frameId(0),
+	m_simulatedGpuLoad(0x1000),
+	m_syncInterval(0),
+	m_windowVisible(true),
+	m_windowedMode(true),
+	m_syncSceneRenderTargets(false)
 {
-    m_sceneData.resize(Settings::TriangleCount);
+	m_sceneData.resize(Settings::TriangleCount);
 }
 
 void D3D12LinkedGpusAffinity::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 
-    UpdateWindowTitle();
+	UpdateWindowTitle();
 }
 
 void D3D12LinkedGpusAffinity::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<ID3D12Device> device;
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<ID3D12Device> device;
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&device)
+			));
+	}
 
-    ThrowIfFailed(D3DX12AffinityCreateLDADevice(device.Get(), &m_device));
+	ThrowIfFailed(D3DX12AffinityCreateLDADevice(device.Get(), &m_device));
 
-    // Query capabilities of the device to configure the sample.
-    Settings::Initialize(m_device.Get(), m_width, m_height);
+	// Query capabilities of the device to configure the sample.
+	Settings::Initialize(m_device.Get(), m_width, m_height);
 
-    // Initialize member variables dependent on the Settings.
-    m_syncSceneRenderTargets = (Settings::NodeCount > 1);
-    m_sceneRenderTargets.resize(Settings::SceneHistoryCount);
-    m_postRenderTargets.resize(Settings::BackBufferCount);
-    m_sceneCommandAllocators.resize(Settings::FrameCount);
-    m_postCommandAllocators.resize(Settings::FrameCount);
+	// Initialize member variables dependent on the Settings.
+	m_syncSceneRenderTargets = (Settings::NodeCount > 1);
+	m_sceneRenderTargets.resize(Settings::SceneHistoryCount);
+	m_postRenderTargets.resize(Settings::BackBufferCount);
+	m_sceneCommandAllocators.resize(Settings::FrameCount);
+	m_postCommandAllocators.resize(Settings::FrameCount);
 
-    // Describe and create the command queues.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queues.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_graphicsQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_graphicsQueue)));
 
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = Settings::BackBufferCount;
-    swapChainDesc.Width = Settings::Width;
-    swapChainDesc.Height = Settings::Height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
-    swapChainDesc.Flags = m_tearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = Settings::BackBufferCount;
+	swapChainDesc.Width = Settings::Width;
+	swapChainDesc.Height = Settings::Height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
+	swapChainDesc.Flags = m_tearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_graphicsQueue->GetChildObject(0),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
+		m_graphicsQueue->GetChildObject(0),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    DXGIXAffinityCreateLDASwapChain(swapChain.Get(), m_graphicsQueue.Get(), m_device.Get(), &m_swapChain);
+	DXGIXAffinityCreateLDASwapChain(swapChain.Get(), m_graphicsQueue.Get(), m_device.Get(), &m_swapChain);
 
-    // Scene descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_sceneRtvHeap)));
+	// Scene descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_sceneRtvHeap)));
 
-        // Describe and create a depth stencil view (DSV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
-        dsvHeapDesc.NumDescriptors = 1;
-        dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-        dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_sceneDsvHeap)));
+		// Describe and create a depth stencil view (DSV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
+		dsvHeapDesc.NumDescriptors = 1;
+		dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+		dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_sceneDsvHeap)));
 
-        // Describe and create a constant buffer view (CBV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
-        cbvHeapDesc.NumDescriptors = Settings::TriangleCount * Settings::SceneConstantBufferFrames;
-        cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_sceneCbvHeap)));
-    }
+		// Describe and create a constant buffer view (CBV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
+		cbvHeapDesc.NumDescriptors = Settings::TriangleCount * Settings::SceneConstantBufferFrames;
+		cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_sceneCbvHeap)));
+	}
 
-    // Post-process descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap for 
-        // the final output.
-        D3D12_DESCRIPTOR_HEAP_DESC postRtvHeapDesc = {};
-        postRtvHeapDesc.NumDescriptors = Settings::BackBufferCount;
-        postRtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        postRtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&postRtvHeapDesc, IID_PPV_ARGS(&m_postRtvHeap)));
+	// Post-process descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap for 
+		// the final output.
+		D3D12_DESCRIPTOR_HEAP_DESC postRtvHeapDesc = {};
+		postRtvHeapDesc.NumDescriptors = Settings::BackBufferCount;
+		postRtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		postRtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&postRtvHeapDesc, IID_PPV_ARGS(&m_postRtvHeap)));
 
-        // Describe and create a shader resource view (SRV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
-        srvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
-        srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_postSrvHeap)));
+		// Describe and create a shader resource view (SRV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
+		srvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
+		srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_postSrvHeap)));
 
-        // Describe and create a sampler descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
-        samplerHeapDesc.NumDescriptors = 1;
-        samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
-        samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_postSamplerHeap)));
-    }
+		// Describe and create a sampler descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
+		samplerHeapDesc.NumDescriptors = 1;
+		samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
+		samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_postSamplerHeap)));
+	}
 
-    // Create command allocators for each buffered frame.
-    for (UINT n = 0; n < Settings::FrameCount; n++)
-    {
-        ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[n])));
-        ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_postCommandAllocators[n])));
-    }
+	// Create command allocators for each buffered frame.
+	for (UINT n = 0; n < Settings::FrameCount; n++)
+	{
+		ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[n])));
+		ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_postCommandAllocators[n])));
+	}
 }
 
 // Generate data for the scene triangles.
 void D3D12LinkedGpusAffinity::LoadAssets()
 {
-    // Create the root signatures.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signatures.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        // Create a root signature for rendering the triangle scene.
-        {
-            CD3DX12_DESCRIPTOR_RANGE1 sceneRanges[1];
-            sceneRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		// Create a root signature for rendering the triangle scene.
+		{
+			CD3DX12_DESCRIPTOR_RANGE1 sceneRanges[1];
+			sceneRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
 
-            CD3DX12_ROOT_PARAMETER1 sceneRootParameters[2];
-            sceneRootParameters[0].InitAsDescriptorTable(1, &sceneRanges[0], D3D12_SHADER_VISIBILITY_VERTEX);
-            sceneRootParameters[1].InitAsConstants(1, 1, 0, D3D12_SHADER_VISIBILITY_VERTEX);
+			CD3DX12_ROOT_PARAMETER1 sceneRootParameters[2];
+			sceneRootParameters[0].InitAsDescriptorTable(1, &sceneRanges[0], D3D12_SHADER_VISIBILITY_VERTEX);
+			sceneRootParameters[1].InitAsConstants(1, 1, 0, D3D12_SHADER_VISIBILITY_VERTEX);
 
-            CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC sceneRootSignatureDesc;
-            sceneRootSignatureDesc.Init_1_1(_countof(sceneRootParameters), sceneRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+			CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC sceneRootSignatureDesc;
+			sceneRootSignatureDesc.Init_1_1(_countof(sceneRootParameters), sceneRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-            ComPtr<ID3DBlob> signature;
-            ComPtr<ID3DBlob> error;
-            ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&sceneRootSignatureDesc, featureData.HighestVersion, &signature, &error));
-            ThrowIfFailed(m_device->CreateRootSignature(Settings::SharedNodeMask, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_sceneRootSignature)));
-        }
+			ComPtr<ID3DBlob> signature;
+			ComPtr<ID3DBlob> error;
+			ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&sceneRootSignatureDesc, featureData.HighestVersion, &signature, &error));
+			ThrowIfFailed(m_device->CreateRootSignature(Settings::SharedNodeMask, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_sceneRootSignature)));
+		}
 
-        // Create a root signature for the post-process pass.
-        {
-            // We don't modify the SRV in the post-processing command list after
-            // SetGraphicsRootDescriptorTable is executed on the GPU so we can use the default
-            // range behavior: D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
-            CD3DX12_DESCRIPTOR_RANGE1 postRanges[2];
-            postRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, Settings::SceneHistoryCount, 0);
-            postRanges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
+		// Create a root signature for the post-process pass.
+		{
+			// We don't modify the SRV in the post-processing command list after
+			// SetGraphicsRootDescriptorTable is executed on the GPU so we can use the default
+			// range behavior: D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
+			CD3DX12_DESCRIPTOR_RANGE1 postRanges[2];
+			postRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, Settings::SceneHistoryCount, 0);
+			postRanges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
 
-            CD3DX12_ROOT_PARAMETER1 postRootParameters[3];
-            postRootParameters[0].InitAsDescriptorTable(1, &postRanges[0], D3D12_SHADER_VISIBILITY_PIXEL);
-            postRootParameters[1].InitAsDescriptorTable(1, &postRanges[1], D3D12_SHADER_VISIBILITY_PIXEL);
-            postRootParameters[2].InitAsConstants(2, 0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
+			CD3DX12_ROOT_PARAMETER1 postRootParameters[3];
+			postRootParameters[0].InitAsDescriptorTable(1, &postRanges[0], D3D12_SHADER_VISIBILITY_PIXEL);
+			postRootParameters[1].InitAsDescriptorTable(1, &postRanges[1], D3D12_SHADER_VISIBILITY_PIXEL);
+			postRootParameters[2].InitAsConstants(2, 0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
 
-            CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC postRootSignatureDesc;
-            postRootSignatureDesc.Init_1_1(_countof(postRootParameters), postRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+			CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC postRootSignatureDesc;
+			postRootSignatureDesc.Init_1_1(_countof(postRootParameters), postRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-            ComPtr<ID3DBlob> signature;
-            ComPtr<ID3DBlob> error;
-            ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&postRootSignatureDesc, featureData.HighestVersion, &signature, &error));
-            ThrowIfFailed(m_device->CreateRootSignature(Settings::SharedNodeMask, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_postRootSignature)));
-        }
-    }
+			ComPtr<ID3DBlob> signature;
+			ComPtr<ID3DBlob> error;
+			ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&postRootSignatureDesc, featureData.HighestVersion, &signature, &error));
+			ThrowIfFailed(m_device->CreateRootSignature(Settings::SharedNodeMask, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_postRootSignature)));
+		}
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        // Define the vertex input layout for the triangle scene.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		// Define the vertex input layout for the triangle scene.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        // Describe and create the graphics pipeline state objects (PSO).
-        D3DX12_AFFINITY_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_sceneRootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_SceneVS, sizeof(g_SceneVS));
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_ScenePS, sizeof(g_ScenePS));
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state objects (PSO).
+		D3DX12_AFFINITY_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_sceneRootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_SceneVS, sizeof(g_SceneVS));
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_ScenePS, sizeof(g_ScenePS));
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_scenePipelineState)));
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_scenePipelineState)));
 
-        // Define the vertex input layout for the post-process fullscreen quad.
-        D3D12_INPUT_ELEMENT_DESC postInputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+		// Define the vertex input layout for the post-process fullscreen quad.
+		D3D12_INPUT_ELEMENT_DESC postInputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        // Describe and create the PSO for the post-process pass.
-        D3DX12_AFFINITY_GRAPHICS_PIPELINE_STATE_DESC postPsoDesc = {};
-        postPsoDesc.InputLayout = { postInputElementDescs, _countof(postInputElementDescs) };
-        postPsoDesc.pRootSignature = m_postRootSignature.Get();
-        postPsoDesc.VS = CD3DX12_SHADER_BYTECODE(g_PostVS, sizeof(g_PostVS));
-        postPsoDesc.PS = CD3DX12_SHADER_BYTECODE(g_PostPS, sizeof(g_PostPS));
-        postPsoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        postPsoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        postPsoDesc.DepthStencilState.DepthEnable = FALSE;
-        postPsoDesc.DepthStencilState.StencilEnable = FALSE;
-        postPsoDesc.SampleMask = UINT_MAX;
-        postPsoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        postPsoDesc.NumRenderTargets = 1;
-        postPsoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        postPsoDesc.SampleDesc.Count = 1;
+		// Describe and create the PSO for the post-process pass.
+		D3DX12_AFFINITY_GRAPHICS_PIPELINE_STATE_DESC postPsoDesc = {};
+		postPsoDesc.InputLayout = { postInputElementDescs, _countof(postInputElementDescs) };
+		postPsoDesc.pRootSignature = m_postRootSignature.Get();
+		postPsoDesc.VS = CD3DX12_SHADER_BYTECODE(g_PostVS, sizeof(g_PostVS));
+		postPsoDesc.PS = CD3DX12_SHADER_BYTECODE(g_PostPS, sizeof(g_PostPS));
+		postPsoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		postPsoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		postPsoDesc.DepthStencilState.DepthEnable = FALSE;
+		postPsoDesc.DepthStencilState.StencilEnable = FALSE;
+		postPsoDesc.SampleMask = UINT_MAX;
+		postPsoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		postPsoDesc.NumRenderTargets = 1;
+		postPsoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		postPsoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&postPsoDesc, IID_PPV_ARGS(&m_postPipelineState)));
-    }
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&postPsoDesc, IID_PPV_ARGS(&m_postPipelineState)));
+	}
 
-    // Single-use command allocator/list for resource initialization.
-    ComPtr<CD3DX12AffinityCommandAllocator> commandAllocator;
-    ComPtr<CD3DX12AffinityGraphicsCommandList> commandList;
+	// Single-use command allocator/list for resource initialization.
+	ComPtr<CD3DX12AffinityCommandAllocator> commandAllocator;
+	ComPtr<CD3DX12AffinityGraphicsCommandList> commandList;
 
-    // Set the AffinityMask to Settings::SharedNodeMask to make the Affinity layer
-    // create n allocators and n command lists and execute the following setup commands
-    // on all GPU nodes.
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator), Settings::SharedNodeMask));
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList), Settings::SharedNodeMask));
+	// Set the AffinityMask to Settings::SharedNodeMask to make the Affinity layer
+	// create n allocators and n command lists and execute the following setup commands
+	// on all GPU nodes.
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator), Settings::SharedNodeMask));
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList), Settings::SharedNodeMask));
 
-    // Create command lists for the scene and post-processing passes.
-    {
-        ThrowIfFailed(m_device->CreateCommandList(
-            0,
-            D3D12_COMMAND_LIST_TYPE_DIRECT,
-            m_sceneCommandAllocators[m_frameIndex].Get(),
-            m_scenePipelineState.Get(),
-            IID_PPV_ARGS(&m_sceneCommandList)));
+	// Create command lists for the scene and post-processing passes.
+	{
+		ThrowIfFailed(m_device->CreateCommandList(
+			0,
+			D3D12_COMMAND_LIST_TYPE_DIRECT,
+			m_sceneCommandAllocators[m_frameIndex].Get(),
+			m_scenePipelineState.Get(),
+			IID_PPV_ARGS(&m_sceneCommandList)));
 
-        ThrowIfFailed(m_device->CreateCommandList(
-            0,
-            D3D12_COMMAND_LIST_TYPE_DIRECT,
-            m_postCommandAllocators[m_frameIndex].Get(),
-            m_postPipelineState.Get(),
-            IID_PPV_ARGS(&m_postCommandList)));
+		ThrowIfFailed(m_device->CreateCommandList(
+			0,
+			D3D12_COMMAND_LIST_TYPE_DIRECT,
+			m_postCommandAllocators[m_frameIndex].Get(),
+			m_postPipelineState.Get(),
+			IID_PPV_ARGS(&m_postCommandList)));
 
-        // Command lists are created in the 'recording' state. We always call Reset
-        // as the first thing when populating command lists, so we need to close
-        // these here for the first frame.
-        ThrowIfFailed(m_sceneCommandList->Close());
-        ThrowIfFailed(m_postCommandList->Close());
-    }
+		// Command lists are created in the 'recording' state. We always call Reset
+		// as the first thing when populating command lists, so we need to close
+		// these here for the first frame.
+		ThrowIfFailed(m_sceneCommandList->Close());
+		ThrowIfFailed(m_postCommandList->Close());
+	}
 
-    ComPtr<CD3DX12AffinityResource> triangleVertexBufferUpload;
-    ComPtr<CD3DX12AffinityResource> quadVertexBufferUpload;
+	ComPtr<CD3DX12AffinityResource> triangleVertexBufferUpload;
+	ComPtr<CD3DX12AffinityResource> quadVertexBufferUpload;
 
-    // Create the triangle vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        SceneVertex vertices[] =
-        {
-            { { 0.0f, Settings::TriangleHalfWidth, Settings::TriangleDepth } },
-            { { Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } },
-            { { -Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } }
-        };
+	// Create the triangle vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		SceneVertex vertices[] =
+		{
+			{ { 0.0f, Settings::TriangleHalfWidth, Settings::TriangleDepth } },
+			{ { Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } },
+			{ { -Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } }
+		};
 
-        const UINT vertexBufferSize = sizeof(vertices);
+		const UINT vertexBufferSize = sizeof(vertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_sceneVertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_sceneVertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&triangleVertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&triangleVertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(vertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(vertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(commandList.Get(), m_sceneVertexBuffer.Get(), triangleVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        commandList->ResourceBarrier(1, &CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(m_sceneVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(commandList.Get(), m_sceneVertexBuffer.Get(), triangleVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		commandList->ResourceBarrier(1, &CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(m_sceneVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_sceneVertexBufferView.BufferLocation = m_sceneVertexBuffer->GetGPUVirtualAddress();
-        m_sceneVertexBufferView.StrideInBytes = sizeof(SceneVertex);
-        m_sceneVertexBufferView.SizeInBytes = sizeof(vertices);
-    }
+		// Initialize the vertex buffer view.
+		m_sceneVertexBufferView.BufferLocation = m_sceneVertexBuffer->GetGPUVirtualAddress();
+		m_sceneVertexBufferView.StrideInBytes = sizeof(SceneVertex);
+		m_sceneVertexBufferView.SizeInBytes = sizeof(vertices);
+	}
 
-    // Create the quad vertex buffer.
-    {
-        // Define the geometry for a quad.
-        PostVertex vertices[] =
-        {
-            { { -1.0f, -1.0f, 0.0f }, { 0.0f, 1.0f } },    // Bottom Left
-            { { -1.0f, 1.0f, 0.0f }, { 0.0f, 0.0f } },    // Top Left
-            { { 1.0f, -1.0f, 0.0f }, { 1.0f, 1.0f } },    // Bottom Right
-            { { 1.0f, 1.0f, 0.0f }, { 1.0f, 0.0f } },    // Top Right
-        };
+	// Create the quad vertex buffer.
+	{
+		// Define the geometry for a quad.
+		PostVertex vertices[] =
+		{
+			{ { -1.0f, -1.0f, 0.0f }, { 0.0f, 1.0f } },	// Bottom Left
+			{ { -1.0f, 1.0f, 0.0f }, { 0.0f, 0.0f } },	// Top Left
+			{ { 1.0f, -1.0f, 0.0f }, { 1.0f, 1.0f } },	// Bottom Right
+			{ { 1.0f, 1.0f, 0.0f }, { 1.0f, 0.0f } },	// Top Right
+		};
 
-        const UINT vertexBufferSize = sizeof(vertices);
+		const UINT vertexBufferSize = sizeof(vertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_postVertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_postVertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&quadVertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&quadVertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(vertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(vertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(commandList.Get(), m_postVertexBuffer.Get(), quadVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        commandList->ResourceBarrier(1, &CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(m_postVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(commandList.Get(), m_postVertexBuffer.Get(), quadVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		commandList->ResourceBarrier(1, &CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(m_postVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_postVertexBufferView.BufferLocation = m_postVertexBuffer->GetGPUVirtualAddress();
-        m_postVertexBufferView.StrideInBytes = sizeof(PostVertex);
-        m_postVertexBufferView.SizeInBytes = sizeof(vertices);
-    }
+		// Initialize the vertex buffer view.
+		m_postVertexBufferView.BufferLocation = m_postVertexBuffer->GetGPUVirtualAddress();
+		m_postVertexBufferView.StrideInBytes = sizeof(PostVertex);
+		m_postVertexBufferView.SizeInBytes = sizeof(vertices);
+	}
 
-    // Create and map the constant buffers.
-    {
-        // UPLOAD heaps are not duplicated by the Affinity layer because:
-        //   1. they live in system memory
-        //   2. they are expected to contain data that will be read by all GPUs.
-        // All of our constant buffers change each frame, so the state of any one frame
-        // is only ever read by a single GPU. Therefore, we must ensure that a large
-        // enough resource is created to persist frame data for all GPUs to read from.
-        const UINT constantBufferDataSize = Settings::TriangleCount * Settings::SceneConstantBufferFrames * sizeof(SceneConstantBuffer);
+	// Create and map the constant buffers.
+	{
+		// UPLOAD heaps are not duplicated by the Affinity layer because:
+		//   1. they live in system memory
+		//   2. they are expected to contain data that will be read by all GPUs.
+		// All of our constant buffers change each frame, so the state of any one frame
+		// is only ever read by a single GPU. Therefore, we must ensure that a large
+		// enough resource is created to persist frame data for all GPUs to read from.
+		const UINT constantBufferDataSize = Settings::TriangleCount * Settings::SceneConstantBufferFrames * sizeof(SceneConstantBuffer);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(constantBufferDataSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_sceneConstantBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(constantBufferDataSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_sceneConstantBuffer)));
 
-        // Map and initialize the constant buffer. We don't unmap this until the
-        // app closes. Keeping things mapped for the lifetime of the resource is okay.
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_sceneConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_mappedConstantBuffer)));
-        ZeroMemory(m_mappedConstantBuffer, constantBufferDataSize);
+		// Map and initialize the constant buffer. We don't unmap this until the
+		// app closes. Keeping things mapped for the lifetime of the resource is okay.
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_sceneConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_mappedConstantBuffer)));
+		ZeroMemory(m_mappedConstantBuffer, constantBufferDataSize);
 
-        // Create constant buffer views. Because the Affinity layer does not duplicate
-        // UPLOAD heaps across nodes, the CBVs on each node will all point to the same
-        // range of system memory.
-        CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_sceneCbvHeap->GetCPUDescriptorHandleForHeapStart());
-        D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
-        cbvDesc.SizeInBytes = sizeof(SceneConstantBuffer);
-        cbvDesc.BufferLocation = m_sceneConstantBuffer->GetGPUVirtualAddress();
+		// Create constant buffer views. Because the Affinity layer does not duplicate
+		// UPLOAD heaps across nodes, the CBVs on each node will all point to the same
+		// range of system memory.
+		CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_sceneCbvHeap->GetCPUDescriptorHandleForHeapStart());
+		D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
+		cbvDesc.SizeInBytes = sizeof(SceneConstantBuffer);
+		cbvDesc.BufferLocation = m_sceneConstantBuffer->GetGPUVirtualAddress();
 
-        for (UINT frame = 0; frame < Settings::SceneConstantBufferFrames; frame++)
-        {
-            for (UINT n = 0; n < Settings::TriangleCount; n++)
-            {
-                m_device->CreateConstantBufferView(&cbvDesc, cpuHandle);
+		for (UINT frame = 0; frame < Settings::SceneConstantBufferFrames; frame++)
+		{
+			for (UINT n = 0; n < Settings::TriangleCount; n++)
+			{
+				m_device->CreateConstantBufferView(&cbvDesc, cpuHandle);
 
-                cpuHandle.Offset(Settings::CbvSrvDescriptorSize);
-                cbvDesc.BufferLocation += cbvDesc.SizeInBytes;
-            }
-        }
-    }
+				cpuHandle.Offset(Settings::CbvSrvDescriptorSize);
+				cbvDesc.BufferLocation += cbvDesc.SizeInBytes;
+			}
+		}
+	}
 
-    for (UINT n = 0; n < Settings::TriangleCount; n++)
-    {
-        m_sceneData[n].velocity = XMFLOAT4(GetRandomFloat(0.005f, 0.01f), 0.0f, 0.0f, 0.0f);
-        m_sceneData[n].offset = XMFLOAT4(GetRandomFloat(-6.0f, -1.5f), GetRandomFloat(-1.0f, 1.0f), GetRandomFloat(0.0f, 2.0f), 0.0f);
-        m_sceneData[n].color = XMFLOAT4(GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), 1.0f);
-        m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
-    }
+	for (UINT n = 0; n < Settings::TriangleCount; n++)
+	{
+		m_sceneData[n].velocity = XMFLOAT4(GetRandomFloat(0.005f, 0.01f), 0.0f, 0.0f, 0.0f);
+		m_sceneData[n].offset = XMFLOAT4(GetRandomFloat(-6.0f, -1.5f), GetRandomFloat(-1.0f, 1.0f), GetRandomFloat(0.0f, 2.0f), 0.0f);
+		m_sceneData[n].color = XMFLOAT4(GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), 1.0f);
+		m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
+	}
 
-    // Describe and create a sampler.
-    {
-        D3D12_SAMPLER_DESC samplerDesc = {};
-        samplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-        samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.MinLOD = 0;
-        samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
-        samplerDesc.MipLODBias = 0.0f;
-        samplerDesc.MaxAnisotropy = 1;
-        samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
+	// Describe and create a sampler.
+	{
+		D3D12_SAMPLER_DESC samplerDesc = {};
+		samplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.MinLOD = 0;
+		samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
+		samplerDesc.MipLODBias = 0.0f;
+		samplerDesc.MaxAnisotropy = 1;
+		samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
 
-        m_device->CreateSampler(&samplerDesc, m_postSamplerHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		m_device->CreateSampler(&samplerDesc, m_postSamplerHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    m_sceneFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
-    m_postFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
+	m_sceneFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
+	m_postFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
 
-    ThrowIfFailed(commandList->Close());
+	ThrowIfFailed(commandList->Close());
 
-    // Submit the initialization work to the GPU.
-    CD3DX12AffinityCommandList* ppCommandLists[] = { commandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Submit the initialization work to the GPU.
+	CD3DX12AffinityCommandList* ppCommandLists[] = { commandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Wait for the graphics queue to finish executing the commands.
-    Fence fence(m_graphicsQueue.Get());
-    fence.FlushGpuQueue();
+	// Wait for the graphics queue to finish executing the commands.
+	Fence fence(m_graphicsQueue.Get());
+	fence.FlushGpuQueue();
 
-    LoadSizeDependentResources();
+	LoadSizeDependentResources();
 }
 
 void D3D12LinkedGpusAffinity::LoadSizeDependentResources()
 {
-    // Single-use command allocator/list for resource initialization.
-    ComPtr<CD3DX12AffinityCommandAllocator> commandAllocator;
-    ComPtr<CD3DX12AffinityGraphicsCommandList> commandList;
+	// Single-use command allocator/list for resource initialization.
+	ComPtr<CD3DX12AffinityCommandAllocator> commandAllocator;
+	ComPtr<CD3DX12AffinityGraphicsCommandList> commandList;
 
-    // Set the AffinityMask to Settings::SharedNodeMask to make the Affinity layer
-    // create n allocators and n command lists and execute the following setup commands
-    // on all GPU nodes.
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator), Settings::SharedNodeMask));
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList), Settings::SharedNodeMask));
+	// Set the AffinityMask to Settings::SharedNodeMask to make the Affinity layer
+	// create n allocators and n command lists and execute the following setup commands
+	// on all GPU nodes.
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator), Settings::SharedNodeMask));
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList), Settings::SharedNodeMask));
 
-    // Create RTVs for swap chain back buffers.
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart());
-    for (UINT n = 0; n < Settings::BackBufferCount; n++)
-    {
-        ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_postRenderTargets[n])));
+	// Create RTVs for swap chain back buffers.
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart());
+	for (UINT n = 0; n < Settings::BackBufferCount; n++)
+	{
+		ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_postRenderTargets[n])));
 
-        m_device->CreateRenderTargetView(m_postRenderTargets[n].Get(), nullptr, rtvHandle);
-        rtvHandle.Offset(Settings::RtvDescriptorSize);
-    }
+		m_device->CreateRenderTargetView(m_postRenderTargets[n].Get(), nullptr, rtvHandle);
+		rtvHandle.Offset(Settings::RtvDescriptorSize);
+	}
 
-    m_frameIndex = 0;
-    m_sceneRenderTargetIndex = 0;
-    m_nodeIndex = 0;
+	m_frameIndex = 0;
+	m_sceneRenderTargetIndex = 0;
+	m_nodeIndex = 0;
 
-    // Create the render targets used to draw the scene.
-    // These will be sampled from during the post-processing step.
-    {
-        D3D12_RESOURCE_DESC renderTargetDesc = m_postRenderTargets[0]->GetDesc();
-        D3D12_RESOURCE_ALLOCATION_INFO info = m_device->GetResourceAllocationInfo(Settings::SharedNodeMask, 1, &renderTargetDesc);
-        const UINT64 alignedRenderTargetSize = AlignResource(info.SizeInBytes, info.Alignment);
+	// Create the render targets used to draw the scene.
+	// These will be sampled from during the post-processing step.
+	{
+		D3D12_RESOURCE_DESC renderTargetDesc = m_postRenderTargets[0]->GetDesc();
+		D3D12_RESOURCE_ALLOCATION_INFO info = m_device->GetResourceAllocationInfo(Settings::SharedNodeMask, 1, &renderTargetDesc);
+		const UINT64 alignedRenderTargetSize = AlignResource(info.SizeInBytes, info.Alignment);
 
-        D3D12_HEAP_DESC heapDesc = {};
-        heapDesc.SizeInBytes = alignedRenderTargetSize * Settings::SceneHistoryCount;
-        heapDesc.Alignment = info.Alignment;
-        heapDesc.Properties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
-        heapDesc.Flags = D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES | D3D12_HEAP_FLAG_DENY_BUFFERS;
+		D3D12_HEAP_DESC heapDesc = {};
+		heapDesc.SizeInBytes = alignedRenderTargetSize * Settings::SceneHistoryCount;
+		heapDesc.Alignment = info.Alignment;
+		heapDesc.Properties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+		heapDesc.Flags = D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES | D3D12_HEAP_FLAG_DENY_BUFFERS;
 
-        ThrowIfFailed(m_device->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_sceneRenderTargetHeap)));
+		ThrowIfFailed(m_device->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_sceneRenderTargetHeap)));
 
-        CD3DX12_CLEAR_VALUE clearValue(DXGI_FORMAT_R8G8B8A8_UNORM, Settings::ClearColor);
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart());
-        CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_postSrvHeap->GetCPUDescriptorHandleForHeapStart());
+		CD3DX12_CLEAR_VALUE clearValue(DXGI_FORMAT_R8G8B8A8_UNORM, Settings::ClearColor);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart());
+		CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_postSrvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = 1;
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = 1;
 
-        D3DX12_AFFINITY_RESOURCE_BARRIER barriers[Settings::SceneHistoryCount];
+		D3DX12_AFFINITY_RESOURCE_BARRIER barriers[Settings::SceneHistoryCount];
 
-        for (UINT sceneIndex = 0; sceneIndex < Settings::SceneHistoryCount; sceneIndex++)
-        {
-            ThrowIfFailed(m_device->CreatePlacedResource(
-                m_sceneRenderTargetHeap.Get(),
-                alignedRenderTargetSize * sceneIndex,
-                &renderTargetDesc,
-                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                &clearValue,
-                IID_PPV_ARGS(&m_sceneRenderTargets[sceneIndex])));
+		for (UINT sceneIndex = 0; sceneIndex < Settings::SceneHistoryCount; sceneIndex++)
+		{
+			ThrowIfFailed(m_device->CreatePlacedResource(
+				m_sceneRenderTargetHeap.Get(),
+				alignedRenderTargetSize * sceneIndex,
+				&renderTargetDesc,
+				D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+				&clearValue,
+				IID_PPV_ARGS(&m_sceneRenderTargets[sceneIndex])));
 
-            barriers[sceneIndex] = CD3DX12_AFFINITY_RESOURCE_BARRIER::Aliasing(nullptr, m_sceneRenderTargets[sceneIndex].Get());
+			barriers[sceneIndex] = CD3DX12_AFFINITY_RESOURCE_BARRIER::Aliasing(nullptr, m_sceneRenderTargets[sceneIndex].Get());
 
-            m_device->CreateRenderTargetView(m_sceneRenderTargets[sceneIndex].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(Settings::RtvDescriptorSize);
+			m_device->CreateRenderTargetView(m_sceneRenderTargets[sceneIndex].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(Settings::RtvDescriptorSize);
 
-            m_device->CreateShaderResourceView(m_sceneRenderTargets[sceneIndex].Get(), &srvDesc, srvHandle);
-            srvHandle.Offset(Settings::CbvSrvDescriptorSize);
-        }
+			m_device->CreateShaderResourceView(m_sceneRenderTargets[sceneIndex].Get(), &srvDesc, srvHandle);
+			srvHandle.Offset(Settings::CbvSrvDescriptorSize);
+		}
 
-        commandList->ResourceBarrier(_countof(barriers), barriers);
+		commandList->ResourceBarrier(_countof(barriers), barriers);
 
-        if (m_syncSceneRenderTargets)
-        {
-            // The post-processing pass expects that a previous post-processing pass has
-            // transitioned the next frame's dependencies into the COPY_DEST state.
-            // Since these resources were created with the PIXEL_SHADER_RESOURCE state,
-            // we need to transition them to COPY_DEST.
+		if (m_syncSceneRenderTargets)
+		{
+			// The post-processing pass expects that a previous post-processing pass has
+			// transitioned the next frame's dependencies into the COPY_DEST state.
+			// Since these resources were created with the PIXEL_SHADER_RESOURCE state,
+			// we need to transition them to COPY_DEST.
 
-            for (UINT nodeIndex = 0; nodeIndex < Settings::NodeCount; nodeIndex++)
-            {
-                D3DX12_AFFINITY_RESOURCE_BARRIER copyBarriers[Settings::MaxNodeCount];
-                UINT barrierIndex = 0;
+			for (UINT nodeIndex = 0; nodeIndex < Settings::NodeCount; nodeIndex++)
+			{
+				D3DX12_AFFINITY_RESOURCE_BARRIER copyBarriers[Settings::MaxNodeCount];
+				UINT barrierIndex = 0;
 
-                // The next commands added to the command list will only apply to the
-                // node selected.
-                commandList->SetAffinity(1 << nodeIndex);
+				// The next commands added to the command list will only apply to the
+				// node selected.
+				commandList->SetAffinity(1 << nodeIndex);
 
-                for (UINT index = 0; index < Settings::NodeCount - 1; index++)
-                {
-                    UINT offset = Settings::SceneHistoryCount - (Settings::NodeCount - 1) + index;
-                    UINT renderTargetIndex = (nodeIndex + offset) % Settings::SceneHistoryCount;
+				for (UINT index = 0; index < Settings::NodeCount - 1; index++)
+				{
+					UINT offset = Settings::SceneHistoryCount - (Settings::NodeCount - 1) + index;
+					UINT renderTargetIndex = (nodeIndex + offset) % Settings::SceneHistoryCount;
 
-                    copyBarriers[index] = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
-                        m_sceneRenderTargets[renderTargetIndex].Get(),
-                        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                        D3D12_RESOURCE_STATE_COPY_DEST);
-                }
-                commandList->ResourceBarrier(Settings::NodeCount - 1, copyBarriers);
-            }
+					copyBarriers[index] = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
+						m_sceneRenderTargets[renderTargetIndex].Get(),
+						D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+						D3D12_RESOURCE_STATE_COPY_DEST);
+				}
+				commandList->ResourceBarrier(Settings::NodeCount - 1, copyBarriers);
+			}
 
-            // The next commands added to the command list will apply to all nodes.
-            commandList->SetAffinity(Settings::SharedNodeMask);
-        }
-    }
+			// The next commands added to the command list will apply to all nodes.
+			commandList->SetAffinity(Settings::SharedNodeMask);
+		}
+	}
 
-    // Create the depth stencil and its view.
-    {
-        CD3DX12_HEAP_PROPERTIES heapProps(D3D12_HEAP_TYPE_DEFAULT);
-        CD3DX12_CLEAR_VALUE depthOptimizedClearValue(DXGI_FORMAT_D32_FLOAT, 1.0f, 0);
+	// Create the depth stencil and its view.
+	{
+		CD3DX12_HEAP_PROPERTIES heapProps(D3D12_HEAP_TYPE_DEFAULT);
+		CD3DX12_CLEAR_VALUE depthOptimizedClearValue(DXGI_FORMAT_D32_FLOAT, 1.0f, 0);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &heapProps,
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, Settings::Width, Settings::Height, 1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
-            D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            &depthOptimizedClearValue,
-            IID_PPV_ARGS(&m_sceneDepthStencil)
-            ));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&heapProps,
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, Settings::Width, Settings::Height, 1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
+			D3D12_RESOURCE_STATE_DEPTH_WRITE,
+			&depthOptimizedClearValue,
+			IID_PPV_ARGS(&m_sceneDepthStencil)
+			));
 
-        D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
-        depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
-        depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+		D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
+		depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
+		depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
 
-        m_device->CreateDepthStencilView(m_sceneDepthStencil.Get(), &depthStencilDesc, m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		m_device->CreateDepthStencilView(m_sceneDepthStencil.Get(), &depthStencilDesc, m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    ThrowIfFailed(commandList->Close());
+	ThrowIfFailed(commandList->Close());
 
-    // Submit the resource barrier changes to the GPU.
-    CD3DX12AffinityCommandList* ppCommandLists[] = { commandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Submit the resource barrier changes to the GPU.
+	CD3DX12AffinityCommandList* ppCommandLists[] = { commandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Wait for the graphics queue to finish executing the commands.
-    Fence fence(m_graphicsQueue.Get());
-    fence.FlushGpuQueue();
+	// Wait for the graphics queue to finish executing the commands.
+	Fence fence(m_graphicsQueue.Get());
+	fence.FlushGpuQueue();
 }
 
 // Get a random float value between min and max.
 float D3D12LinkedGpusAffinity::GetRandomFloat(float min, float max)
 {
-    float scale = static_cast<float>(rand()) / RAND_MAX;
-    float range = max - min;
-    return scale * range + min;
+	float scale = static_cast<float>(rand()) / RAND_MAX;
+	float range = max - min;
+	return scale * range + min;
 }
 
 void D3D12LinkedGpusAffinity::UpdateWindowTitle()
 {
-    WCHAR nodeText[100];
-    if (Settings::NodeCount == 1)
-    {
-        swprintf_s(nodeText, L"Node Count = 1 | SyncInterval = %u | SimulatedLoad = %u", m_syncInterval, m_simulatedGpuLoad);
-    }
-    else
-    {
-        swprintf_s(
-            nodeText,
-            L"Node Count = %u | Cross Node Sharing Tier = %d | SyncInterval = %u | SimulatedLoad = %u",
-            Settings::NodeCount,
-            Settings::Tier2Support ? 2 : 1,
-            m_syncInterval,
-            m_simulatedGpuLoad);
-    }
-    SetCustomWindowText(nodeText);
+	WCHAR nodeText[100];
+	if (Settings::NodeCount == 1)
+	{
+		swprintf_s(nodeText, L"Node Count = 1 | SyncInterval = %u | SimulatedLoad = %u", m_syncInterval, m_simulatedGpuLoad);
+	}
+	else
+	{
+		swprintf_s(
+			nodeText,
+			L"Node Count = %u | Cross Node Sharing Tier = %d | SyncInterval = %u | SimulatedLoad = %u",
+			Settings::NodeCount,
+			Settings::Tier2Support ? 2 : 1,
+			m_syncInterval,
+			m_simulatedGpuLoad);
+	}
+	SetCustomWindowText(nodeText);
 }
 
 // Update frame-based values.
 void D3D12LinkedGpusAffinity::OnUpdate()
 {
-    for (UINT n = 0; n < Settings::TriangleCount; n++)
-    {
-        const float offsetBounds = 1.5f * m_aspectRatio;
+	for (UINT n = 0; n < Settings::TriangleCount; n++)
+	{
+		const float offsetBounds = 1.5f * m_aspectRatio;
 
-        // Animate the triangles.
-        m_sceneData[n].offset.x += m_sceneData[n].velocity.x;
-        if (m_sceneData[n].offset.x > offsetBounds)
-        {
-            m_sceneData[n].velocity.x = GetRandomFloat(0.005f, 0.01f);
-            m_sceneData[n].offset.x = -offsetBounds;
-        }
-    }
+		// Animate the triangles.
+		m_sceneData[n].offset.x += m_sceneData[n].velocity.x;
+		if (m_sceneData[n].offset.x > offsetBounds)
+		{
+			m_sceneData[n].velocity.x = GetRandomFloat(0.005f, 0.01f);
+			m_sceneData[n].offset.x = -offsetBounds;
+		}
+	}
 
-    UINT index = m_frameId % Settings::SceneConstantBufferFrames;
-    UINT offset = Settings::TriangleCount * index * sizeof(SceneConstantBuffer);
+	UINT index = m_frameId % Settings::SceneConstantBufferFrames;
+	UINT offset = Settings::TriangleCount * index * sizeof(SceneConstantBuffer);
 
-    memcpy(m_mappedConstantBuffer + offset, m_sceneData.data(), Settings::TriangleCount * sizeof(SceneConstantBuffer));
+	memcpy(m_mappedConstantBuffer + offset, m_sceneData.data(), Settings::TriangleCount * sizeof(SceneConstantBuffer));
 }
 
 // Render the scene.
 void D3D12LinkedGpusAffinity::OnRender()
 {
-    if (m_windowVisible)
-    {
-        // Render and present the current frame.
-        RenderScene();
-        RenderPost();
+	if (m_windowVisible)
+	{
+		// Render and present the current frame.
+		RenderScene();
+		RenderPost();
 
-        // When using sync interval 0, it is recommended to always pass the tearing
-        // flag when it is supported, even if not presenting to a fullscreen window.
-        // This flag cannot be used if the app is in "exclusive" fullscreen mode as
-        // a result of calling SetFullscreenState.
+		// When using sync interval 0, it is recommended to always pass the tearing
+		// flag when it is supported, even if not presenting to a fullscreen window.
+		// This flag cannot be used if the app is in "exclusive" fullscreen mode as
+		// a result of calling SetFullscreenState.
 
-        UINT presentFlags = (m_syncInterval == 0 && m_tearingSupport && m_windowedMode) ? DXGI_PRESENT_ALLOW_TEARING : 0;
-        ThrowIfFailed(m_swapChain->Present(m_syncInterval, presentFlags));
+		UINT presentFlags = (m_syncInterval == 0 && m_tearingSupport && m_windowedMode) ? DXGI_PRESENT_ALLOW_TEARING : 0;
+		ThrowIfFailed(m_swapChain->Present(m_syncInterval, presentFlags));
 
-        MoveToNextFrame();
-    }
+		MoveToNextFrame();
+	}
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12LinkedGpusAffinity::RenderScene()
 {
-    UINT cbvDescriptorTableOffset = Settings::TriangleCount * (m_frameId % Settings::SceneConstantBufferFrames);
-    CD3DX12_GPU_DESCRIPTOR_HANDLE cbvHandle(m_sceneCbvHeap->GetGPUDescriptorHandleForHeapStart(), cbvDescriptorTableOffset, Settings::CbvSrvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart(), m_sceneRenderTargetIndex, Settings::RtvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
+	UINT cbvDescriptorTableOffset = Settings::TriangleCount * (m_frameId % Settings::SceneConstantBufferFrames);
+	CD3DX12_GPU_DESCRIPTOR_HANDLE cbvHandle(m_sceneCbvHeap->GetGPUDescriptorHandleForHeapStart(), cbvDescriptorTableOffset, Settings::CbvSrvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart(), m_sceneRenderTargetIndex, Settings::RtvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
 
-    m_sceneFence->Next();
+	m_sceneFence->Next();
 
-    // Record the rendering commands.
-    ThrowIfFailed(m_sceneCommandAllocators[m_frameIndex]->Reset());
-    ThrowIfFailed(m_sceneCommandList->Reset(m_sceneCommandAllocators[m_frameIndex].Get(), m_scenePipelineState.Get()));
+	// Record the rendering commands.
+	ThrowIfFailed(m_sceneCommandAllocators[m_frameIndex]->Reset());
+	ThrowIfFailed(m_sceneCommandList->Reset(m_sceneCommandAllocators[m_frameIndex].Get(), m_scenePipelineState.Get()));
 
-    // Set necessary state.
-    m_sceneCommandList->SetGraphicsRootSignature(m_sceneRootSignature.Get());
-    m_sceneCommandList->SetGraphicsRoot32BitConstant(1, m_simulatedGpuLoad, 0);
+	// Set necessary state.
+	m_sceneCommandList->SetGraphicsRootSignature(m_sceneRootSignature.Get());
+	m_sceneCommandList->SetGraphicsRoot32BitConstant(1, m_simulatedGpuLoad, 0);
 
-    CD3DX12AffinityDescriptorHeap* ppHeaps[] = { m_sceneCbvHeap.Get() };
-    m_sceneCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	CD3DX12AffinityDescriptorHeap* ppHeaps[] = { m_sceneCbvHeap.Get() };
+	m_sceneCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_sceneCommandList->RSSetViewports(1, &Settings::Viewport);
-    m_sceneCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
-    m_sceneCommandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
+	m_sceneCommandList->RSSetViewports(1, &Settings::Viewport);
+	m_sceneCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
+	m_sceneCommandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
 
-    // Record commands.
-    D3DX12_AFFINITY_RESOURCE_BARRIER barrier = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
-        m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(),
-        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-        D3D12_RESOURCE_STATE_RENDER_TARGET);
+	// Record commands.
+	D3DX12_AFFINITY_RESOURCE_BARRIER barrier = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
+		m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(),
+		D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+		D3D12_RESOURCE_STATE_RENDER_TARGET);
 
-    m_sceneCommandList->ResourceBarrier(1, &barrier);
-    m_sceneCommandList->ClearRenderTargetView(rtvHandle, Settings::ClearColor, 0, nullptr);
-    m_sceneCommandList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+	m_sceneCommandList->ResourceBarrier(1, &barrier);
+	m_sceneCommandList->ClearRenderTargetView(rtvHandle, Settings::ClearColor, 0, nullptr);
+	m_sceneCommandList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
 
-    m_sceneCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    m_sceneCommandList->IASetVertexBuffers(0, 1, &m_sceneVertexBufferView);
+	m_sceneCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_sceneCommandList->IASetVertexBuffers(0, 1, &m_sceneVertexBufferView);
 
-    for (UINT triangle = 0; triangle < Settings::TriangleCount; triangle++)
-    {
-        m_sceneCommandList->SetGraphicsRootDescriptorTable(0, cbvHandle);
-        m_sceneCommandList->DrawInstanced(3, 1, 0, 0);
+	for (UINT triangle = 0; triangle < Settings::TriangleCount; triangle++)
+	{
+		m_sceneCommandList->SetGraphicsRootDescriptorTable(0, cbvHandle);
+		m_sceneCommandList->DrawInstanced(3, 1, 0, 0);
 
-        cbvHandle.Offset(Settings::CbvSrvDescriptorSize);
-    }
+		cbvHandle.Offset(Settings::CbvSrvDescriptorSize);
+	}
 
-    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barrier.Transition.StateAfter = m_syncSceneRenderTargets ? D3D12_RESOURCE_STATE_COPY_SOURCE : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-    m_sceneCommandList->ResourceBarrier(1, &barrier);
+	barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barrier.Transition.StateAfter = m_syncSceneRenderTargets ? D3D12_RESOURCE_STATE_COPY_SOURCE : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	m_sceneCommandList->ResourceBarrier(1, &barrier);
 
-    ThrowIfFailed(m_sceneCommandList->Close());
+	ThrowIfFailed(m_sceneCommandList->Close());
 
-    CD3DX12AffinityCommandList* ppSceneCommandLists[] = { m_sceneCommandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppSceneCommandLists), ppSceneCommandLists);
+	CD3DX12AffinityCommandList* ppSceneCommandLists[] = { m_sceneCommandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppSceneCommandLists), ppSceneCommandLists);
 
-    m_sceneFence->Signal();
+	m_sceneFence->Signal();
 }
 
 void D3D12LinkedGpusAffinity::RenderPost()
 {
-    UINT backBufferIndex = m_swapChain->GetCurrentBackBufferIndex();
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart(), backBufferIndex, Settings::RtvDescriptorSize);
+	UINT backBufferIndex = m_swapChain->GetCurrentBackBufferIndex();
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart(), backBufferIndex, Settings::RtvDescriptorSize);
 
-    m_postFence->Next();
+	m_postFence->Next();
 
-    ThrowIfFailed(m_postCommandAllocators[m_frameIndex]->Reset());
-    ThrowIfFailed(m_postCommandList->Reset(m_postCommandAllocators[m_frameIndex].Get(), m_postPipelineState.Get()));
+	ThrowIfFailed(m_postCommandAllocators[m_frameIndex]->Reset());
+	ThrowIfFailed(m_postCommandList->Reset(m_postCommandAllocators[m_frameIndex].Get(), m_postPipelineState.Get()));
 
-    if (m_syncSceneRenderTargets)
-    {
-        // If the rendered scenes need to be copied across nodes, we need to wait
-        // until the other nodes are done with their post-processing passes (which
-        // includes transitioning the state of the next render targets in the
-        // history to the COPY_DEST state).
-        if (m_frameId > 0)
-        {
-            Fence::GpuWait(m_graphicsQueue.Get(), m_postFence.get());
-        }
+	if (m_syncSceneRenderTargets)
+	{
+		// If the rendered scenes need to be copied across nodes, we need to wait
+		// until the other nodes are done with their post-processing passes (which
+		// includes transitioning the state of the next render targets in the
+		// history to the COPY_DEST state).
+		if (m_frameId > 0)
+		{
+			Fence::GpuWait(m_graphicsQueue.Get(), m_postFence.get());
+		}
 
-        // Copy the render target from the scene pass to all other nodes.
-        m_postCommandList->BroadcastResource(m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(), m_nodeIndex, Settings::SharedNodeMask);
+		// Copy the render target from the scene pass to all other nodes.
+		m_postCommandList->BroadcastResource(m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(), m_nodeIndex, Settings::SharedNodeMask);
 
-        // Transition all render target resources into the PIXEL_SHADER_RESOURCE
-        // state to prepare for rendering the motion blur effect.
-        D3DX12_AFFINITY_RESOURCE_BARRIER barriers[Settings::MaxNodeCount];
+		// Transition all render target resources into the PIXEL_SHADER_RESOURCE
+		// state to prepare for rendering the motion blur effect.
+		D3DX12_AFFINITY_RESOURCE_BARRIER barriers[Settings::MaxNodeCount];
 
-        for (UINT index = 0; index < Settings::NodeCount - 1; index++)
-        {
-            UINT offset = Settings::SceneHistoryCount - Settings::NodeCount + 1 + index;
-            UINT renderTargetIndex = (m_sceneRenderTargetIndex + offset) % Settings::SceneHistoryCount;
+		for (UINT index = 0; index < Settings::NodeCount - 1; index++)
+		{
+			UINT offset = Settings::SceneHistoryCount - Settings::NodeCount + 1 + index;
+			UINT renderTargetIndex = (m_sceneRenderTargetIndex + offset) % Settings::SceneHistoryCount;
 
-            barriers[index] = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
-                m_sceneRenderTargets[renderTargetIndex].Get(),
-                D3D12_RESOURCE_STATE_COPY_DEST,
-                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
-        }
+			barriers[index] = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
+				m_sceneRenderTargets[renderTargetIndex].Get(),
+				D3D12_RESOURCE_STATE_COPY_DEST,
+				D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+		}
 
-        barriers[Settings::NodeCount - 1] = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
-            m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(),
-            D3D12_RESOURCE_STATE_COPY_SOURCE,
-            D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+		barriers[Settings::NodeCount - 1] = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
+			m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(),
+			D3D12_RESOURCE_STATE_COPY_SOURCE,
+			D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
 
-        m_postCommandList->ResourceBarrier(Settings::NodeCount, barriers);
-    }
+		m_postCommandList->ResourceBarrier(Settings::NodeCount, barriers);
+	}
 
-    m_postCommandList->SetGraphicsRootSignature(m_postRootSignature.Get());
+	m_postCommandList->SetGraphicsRootSignature(m_postRootSignature.Get());
 
-    CD3DX12AffinityDescriptorHeap* ppPostHeaps[] = { m_postSrvHeap.Get(), m_postSamplerHeap.Get() };
-    m_postCommandList->SetDescriptorHeaps(_countof(ppPostHeaps), ppPostHeaps);
+	CD3DX12AffinityDescriptorHeap* ppPostHeaps[] = { m_postSrvHeap.Get(), m_postSamplerHeap.Get() };
+	m_postCommandList->SetDescriptorHeaps(_countof(ppPostHeaps), ppPostHeaps);
 
-    m_postCommandList->RSSetViewports(1, &Settings::Viewport);
-    m_postCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
+	m_postCommandList->RSSetViewports(1, &Settings::Viewport);
+	m_postCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
 
-    D3DX12_AFFINITY_RESOURCE_BARRIER barrier = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
-        m_postRenderTargets[backBufferIndex].Get(),
-        D3D12_RESOURCE_STATE_PRESENT,
-        D3D12_RESOURCE_STATE_RENDER_TARGET);
+	D3DX12_AFFINITY_RESOURCE_BARRIER barrier = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
+		m_postRenderTargets[backBufferIndex].Get(),
+		D3D12_RESOURCE_STATE_PRESENT,
+		D3D12_RESOURCE_STATE_RENDER_TARGET);
 
-    m_postCommandList->ResourceBarrier(1, &barrier);
+	m_postCommandList->ResourceBarrier(1, &barrier);
 
-    m_postCommandList->OMSetRenderTargets(1, &rtvHandle, false, nullptr);
+	m_postCommandList->OMSetRenderTargets(1, &rtvHandle, false, nullptr);
 
-    m_postCommandList->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-    m_postCommandList->IASetVertexBuffers(0, 1, &m_postVertexBufferView);
+	m_postCommandList->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+	m_postCommandList->IASetVertexBuffers(0, 1, &m_postVertexBufferView);
 
-    m_postCommandList->SetGraphicsRootDescriptorTable(0, m_postSrvHeap->GetGPUDescriptorHandleForHeapStart());
-    m_postCommandList->SetGraphicsRootDescriptorTable(1, m_postSamplerHeap->GetGPUDescriptorHandleForHeapStart());
-    m_postCommandList->SetGraphicsRoot32BitConstant(2, m_frameId % Settings::SceneHistoryCount, 0);
-    m_postCommandList->SetGraphicsRoot32BitConstant(2, static_cast<UINT>(min(m_frameId + 1, Settings::SceneHistoryCount)), 1);
+	m_postCommandList->SetGraphicsRootDescriptorTable(0, m_postSrvHeap->GetGPUDescriptorHandleForHeapStart());
+	m_postCommandList->SetGraphicsRootDescriptorTable(1, m_postSamplerHeap->GetGPUDescriptorHandleForHeapStart());
+	m_postCommandList->SetGraphicsRoot32BitConstant(2, m_frameId % Settings::SceneHistoryCount, 0);
+	m_postCommandList->SetGraphicsRoot32BitConstant(2, static_cast<UINT>(min(m_frameId + 1, Settings::SceneHistoryCount)), 1);
 
-    m_postCommandList->DrawInstanced(4, 1, 0, 0);
+	m_postCommandList->DrawInstanced(4, 1, 0, 0);
 
-    // Indicate that the back buffer will now be used to present.
-    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
+	// Indicate that the back buffer will now be used to present.
+	barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
 
-    D3DX12_AFFINITY_RESOURCE_BARRIER barriers[Settings::MaxNodeCount];
-    barriers[0] = barrier;
+	D3DX12_AFFINITY_RESOURCE_BARRIER barriers[Settings::MaxNodeCount];
+	barriers[0] = barrier;
 
-    if (m_syncSceneRenderTargets)
-    {
-        // Transition render target resources rendered by the next nodes into the
-        // COPY_DEST state to prepare them to be copied to during those nodes'
-        // post-process passes.
-        for (UINT offset = 1; offset < Settings::NodeCount; offset++)
-        {
-            UINT renderTargetIndex = (m_sceneRenderTargetIndex + offset) % Settings::SceneHistoryCount;
+	if (m_syncSceneRenderTargets)
+	{
+		// Transition render target resources rendered by the next nodes into the
+		// COPY_DEST state to prepare them to be copied to during those nodes'
+		// post-process passes.
+		for (UINT offset = 1; offset < Settings::NodeCount; offset++)
+		{
+			UINT renderTargetIndex = (m_sceneRenderTargetIndex + offset) % Settings::SceneHistoryCount;
 
-            barriers[offset] = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
-                m_sceneRenderTargets[renderTargetIndex].Get(),
-                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_COPY_DEST);
-        }
-    }
+			barriers[offset] = CD3DX12_AFFINITY_RESOURCE_BARRIER::Transition(
+				m_sceneRenderTargets[renderTargetIndex].Get(),
+				D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+				D3D12_RESOURCE_STATE_COPY_DEST);
+		}
+	}
 
-    m_postCommandList->ResourceBarrier(Settings::NodeCount, barriers);
+	m_postCommandList->ResourceBarrier(Settings::NodeCount, barriers);
 
-    ThrowIfFailed(m_postCommandList->Close());
+	ThrowIfFailed(m_postCommandList->Close());
 
-    CD3DX12AffinityCommandList* ppPostCommandLists[] = { m_postCommandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppPostCommandLists), ppPostCommandLists);
+	CD3DX12AffinityCommandList* ppPostCommandLists[] = { m_postCommandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppPostCommandLists), ppPostCommandLists);
 }
 
 void D3D12LinkedGpusAffinity::OnSizeChanged(UINT width, UINT height, bool minimized)
 {
-    // Determine if the swap buffers and other resources need to be resized or not.
-    if ((width != m_width || height != m_height) && !minimized)
-    {
-        // Flush all current GPU commands.
-        WaitForGpus();
+	// Determine if the swap buffers and other resources need to be resized or not.
+	if ((width != m_width || height != m_height) && !minimized)
+	{
+		// Flush all current GPU commands.
+		WaitForGpus();
 
-        // Release buffers tied to the swap chain and update the global Settings
-        // for the new size.
-        for (UINT n = 0; n < Settings::BackBufferCount; n++)
-        {
-            m_postRenderTargets[n].Reset();
-        }
-        Settings::OnSizeChanged(width, height);
+		// Release buffers tied to the swap chain and update the global Settings
+		// for the new size.
+		for (UINT n = 0; n < Settings::BackBufferCount; n++)
+		{
+			m_postRenderTargets[n].Reset();
+		}
+		Settings::OnSizeChanged(width, height);
 
-        // Resize the swap chain to the desired dimensions.
-        DXGI_SWAP_CHAIN_DESC1 swapChainDesc;
-        ThrowIfFailed(m_swapChain->GetDesc1(&swapChainDesc));
-        ThrowIfFailed(m_swapChain->ResizeBuffers(Settings::BackBufferCount, width, height, swapChainDesc.Format, swapChainDesc.Flags));
+		// Resize the swap chain to the desired dimensions.
+		DXGI_SWAP_CHAIN_DESC1 swapChainDesc;
+		ThrowIfFailed(m_swapChain->GetDesc1(&swapChainDesc));
+		ThrowIfFailed(m_swapChain->ResizeBuffers(Settings::BackBufferCount, width, height, swapChainDesc.Format, swapChainDesc.Flags));
 
-        // Re-create render targets.
-        LoadSizeDependentResources();
+		// Re-create render targets.
+		LoadSizeDependentResources();
 
-        // Reset the node index and align the frameId so that assumptions in post-processing hold.
-        m_nodeIndex = m_swapChain->GetCurrentBackBufferIndex() % Settings::NodeCount;
-        m_frameId += (Settings::SceneHistoryCount - (m_frameId % Settings::SceneHistoryCount));
+		// Reset the node index and align the frameId so that assumptions in post-processing hold.
+		m_nodeIndex = m_swapChain->GetCurrentBackBufferIndex() % Settings::NodeCount;
+		m_frameId += (Settings::SceneHistoryCount - (m_frameId % Settings::SceneHistoryCount));
 
-        // Update the m_width, m_height, and m_aspectRatio member variables.
-        UpdateForSizeChange(width, height);
+		// Update the m_width, m_height, and m_aspectRatio member variables.
+		UpdateForSizeChange(width, height);
 
-        // Update the scene projection matrix.
-        for (UINT n = 0; n < Settings::TriangleCount; n++)
-        {
-            m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
-        }
-    }
+		// Update the scene projection matrix.
+		for (UINT n = 0; n < Settings::TriangleCount; n++)
+		{
+			m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
+		}
+	}
 
-    m_windowVisible = !minimized;
+	m_windowVisible = !minimized;
 }
 
 void D3D12LinkedGpusAffinity::OnKeyDown(UINT8 key)
 {
-    switch (key)
-    {
-    // Instrument the Space Bar to toggle between fullscreen states.
-    // The CoreWindow will fire a SizeChanged event once the window is in the
-    // fullscreen state. At that point, the IDXGISwapChain should be resized
-    // to match the new window size.
-    case VK_SPACE:
-    {
-        auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-        if (applicationView->IsFullScreenMode)
-        {
-            applicationView->ExitFullScreenMode();
-        }
-        else
-        {
-            applicationView->TryEnterFullScreenMode();
-        }
-        break;
-    }
+	switch (key)
+	{
+	// Instrument the Space Bar to toggle between fullscreen states.
+	// The CoreWindow will fire a SizeChanged event once the window is in the
+	// fullscreen state. At that point, the IDXGISwapChain should be resized
+	// to match the new window size.
+	case VK_SPACE:
+	{
+		auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+		if (applicationView->IsFullScreenMode)
+		{
+			applicationView->ExitFullScreenMode();
+		}
+		else
+		{
+			applicationView->TryEnterFullScreenMode();
+		}
+		break;
+	}
 
-    case VK_LEFT:
-    case VK_RIGHT:
-        m_syncInterval = (m_syncInterval > 0) ? 0 : 1;
-        UpdateWindowTitle();
-        break;
+	case VK_LEFT:
+	case VK_RIGHT:
+		m_syncInterval = (m_syncInterval > 0) ? 0 : 1;
+		UpdateWindowTitle();
+		break;
 
-    case VK_UP:
-        if (m_simulatedGpuLoad > 0)
-        {
-            if (m_simulatedGpuLoad < 0x80000)
-            {
-                m_simulatedGpuLoad <<= 1;
-            }
-        }
-        else
-        {
-            m_simulatedGpuLoad = 1;
-        }
-        UpdateWindowTitle();
-        break;
+	case VK_UP:
+		if (m_simulatedGpuLoad > 0)
+		{
+			if (m_simulatedGpuLoad < 0x80000)
+			{
+				m_simulatedGpuLoad <<= 1;
+			}
+		}
+		else
+		{
+			m_simulatedGpuLoad = 1;
+		}
+		UpdateWindowTitle();
+		break;
 
-    case VK_DOWN:
-        if (m_simulatedGpuLoad != 0)
-        {
-            m_simulatedGpuLoad >>= 1;
-        }
-        UpdateWindowTitle();
-        break;
-    }
+	case VK_DOWN:
+		if (m_simulatedGpuLoad != 0)
+		{
+			m_simulatedGpuLoad >>= 1;
+		}
+		UpdateWindowTitle();
+		break;
+	}
 }
 
 void D3D12LinkedGpusAffinity::OnDestroy()
 {
-    // Wait for the GPUs to be done with all their resources.
-    WaitForGpus();
+	// Wait for the GPUs to be done with all their resources.
+	WaitForGpus();
 }
 
 // Wait for pending GPU work to complete.
 void D3D12LinkedGpusAffinity::WaitForGpus()
 {
-    m_postFence->FlushGpuQueue();
+	m_postFence->FlushGpuQueue();
 }
 
 // Prepare to render the next frame.
 void D3D12LinkedGpusAffinity::MoveToNextFrame()
 {
-    UINT nextNode = m_swapChain->GetCurrentBackBufferIndex() % Settings::NodeCount;
+	UINT nextNode = m_swapChain->GetCurrentBackBufferIndex() % Settings::NodeCount;
 
-    if (Settings::NodeCount > 1 && nextNode == m_nodeIndex)
-    {
-        // If a WM_SIZE event was processed during Present, we will already be in the
-        // correct state. Do not update any indices.
-    }
-    else
-    {
-        m_postFence->Signal();
+	if (Settings::NodeCount > 1 && nextNode == m_nodeIndex)
+	{
+		// If a WM_SIZE event was processed during Present, we will already be in the
+		// correct state. Do not update any indices.
+	}
+	else
+	{
+		m_postFence->Signal();
 
-        // Advance to the next node.
-        m_device->SwitchToNextNode();
-        m_nodeIndex = m_device->GetActiveNodeIndex();
-        if (m_nodeIndex == 0)
-        {
-            m_frameIndex = (m_frameIndex + 1) % Settings::FrameCount;
-        }
+		// Advance to the next node.
+		m_device->SwitchToNextNode();
+		m_nodeIndex = m_device->GetActiveNodeIndex();
+		if (m_nodeIndex == 0)
+		{
+			m_frameIndex = (m_frameIndex + 1) % Settings::FrameCount;
+		}
 
-        m_sceneRenderTargetIndex = (m_sceneRenderTargetIndex + 1) % Settings::SceneHistoryCount;
+		m_sceneRenderTargetIndex = (m_sceneRenderTargetIndex + 1) % Settings::SceneHistoryCount;
 
-        m_frameId++;
-    }
+		m_frameId++;
+	}
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/D3D12LinkedGpusAffinity.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/D3D12LinkedGpusAffinity.h
@@ -32,109 +32,109 @@ using Microsoft::WRL::ComPtr;
 class D3D12LinkedGpusAffinity : public DXSample
 {
 public:
-    D3D12LinkedGpusAffinity(UINT width, UINT height, std::wstring name);
+	D3D12LinkedGpusAffinity(UINT width, UINT height, std::wstring name);
 
 protected:
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
-    virtual void OnKeyDown(UINT8 key);
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
+	virtual void OnKeyDown(UINT8 key);
+	virtual void OnDestroy();
 
 private:
-    ComPtr<CD3DX12AffinityDevice> m_device;
-    ComPtr<CDXGIAffinitySwapChain> m_swapChain;
-    ComPtr<CD3DX12AffinityCommandQueue> m_graphicsQueue;
-    std::vector<ComPtr<CD3DX12AffinityCommandAllocator>> m_sceneCommandAllocators;
-    std::vector<ComPtr<CD3DX12AffinityCommandAllocator>> m_postCommandAllocators;
-    ComPtr<CD3DX12AffinityDescriptorHeap> m_sceneRtvHeap;
-    ComPtr<CD3DX12AffinityDescriptorHeap> m_sceneDsvHeap;
-    ComPtr<CD3DX12AffinityDescriptorHeap> m_sceneCbvHeap;
-    ComPtr<CD3DX12AffinityDescriptorHeap> m_postRtvHeap;
-    ComPtr<CD3DX12AffinityDescriptorHeap> m_postSrvHeap;
-    ComPtr<CD3DX12AffinityDescriptorHeap> m_postSamplerHeap;
+	ComPtr<CD3DX12AffinityDevice> m_device;
+	ComPtr<CDXGIAffinitySwapChain> m_swapChain;
+	ComPtr<CD3DX12AffinityCommandQueue> m_graphicsQueue;
+	std::vector<ComPtr<CD3DX12AffinityCommandAllocator>> m_sceneCommandAllocators;
+	std::vector<ComPtr<CD3DX12AffinityCommandAllocator>> m_postCommandAllocators;
+	ComPtr<CD3DX12AffinityDescriptorHeap> m_sceneRtvHeap;
+	ComPtr<CD3DX12AffinityDescriptorHeap> m_sceneDsvHeap;
+	ComPtr<CD3DX12AffinityDescriptorHeap> m_sceneCbvHeap;
+	ComPtr<CD3DX12AffinityDescriptorHeap> m_postRtvHeap;
+	ComPtr<CD3DX12AffinityDescriptorHeap> m_postSrvHeap;
+	ComPtr<CD3DX12AffinityDescriptorHeap> m_postSamplerHeap;
 
-    // Objects used for rendering the scene.
-    ComPtr<CD3DX12AffinityGraphicsCommandList> m_sceneCommandList;
-    ComPtr<CD3DX12AffinityRootSignature> m_sceneRootSignature;
-    ComPtr<CD3DX12AffinityPipelineState> m_scenePipelineState;
-    ComPtr<CD3DX12AffinityResource> m_sceneVertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_sceneVertexBufferView;
-    ComPtr<CD3DX12AffinityResource> m_sceneConstantBuffer;
-    UINT8* m_mappedConstantBuffer;
-    ComPtr<CD3DX12AffinityHeap> m_sceneRenderTargetHeap;
-    std::vector<ComPtr<CD3DX12AffinityResource>> m_sceneRenderTargets;
-    ComPtr<CD3DX12AffinityResource> m_sceneDepthStencil;
+	// Objects used for rendering the scene.
+	ComPtr<CD3DX12AffinityGraphicsCommandList> m_sceneCommandList;
+	ComPtr<CD3DX12AffinityRootSignature> m_sceneRootSignature;
+	ComPtr<CD3DX12AffinityPipelineState> m_scenePipelineState;
+	ComPtr<CD3DX12AffinityResource> m_sceneVertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_sceneVertexBufferView;
+	ComPtr<CD3DX12AffinityResource> m_sceneConstantBuffer;
+	UINT8* m_mappedConstantBuffer;
+	ComPtr<CD3DX12AffinityHeap> m_sceneRenderTargetHeap;
+	std::vector<ComPtr<CD3DX12AffinityResource>> m_sceneRenderTargets;
+	ComPtr<CD3DX12AffinityResource> m_sceneDepthStencil;
 
-    // Objects used for post-processing.
-    ComPtr<CD3DX12AffinityGraphicsCommandList> m_postCommandList;
-    ComPtr<CD3DX12AffinityRootSignature> m_postRootSignature;
-    ComPtr<CD3DX12AffinityPipelineState> m_postPipelineState;
-    ComPtr<CD3DX12AffinityResource> m_postVertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_postVertexBufferView;
-    std::vector<ComPtr<CD3DX12AffinityResource>> m_postRenderTargets;
+	// Objects used for post-processing.
+	ComPtr<CD3DX12AffinityGraphicsCommandList> m_postCommandList;
+	ComPtr<CD3DX12AffinityRootSignature> m_postRootSignature;
+	ComPtr<CD3DX12AffinityPipelineState> m_postPipelineState;
+	ComPtr<CD3DX12AffinityResource> m_postVertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_postVertexBufferView;
+	std::vector<ComPtr<CD3DX12AffinityResource>> m_postRenderTargets;
 
-    // A fence to indicate when the scene pass is complete.
-    std::shared_ptr<LinearFence> m_sceneFence;
+	// A fence to indicate when the scene pass is complete.
+	std::shared_ptr<LinearFence> m_sceneFence;
 
-    // A fence to regulate submission of post-processing render passes.
-    // Up to 'Settings::FrameCount' command lists can be in flight on the node at once.
-    std::shared_ptr<LinearFence> m_postFence;
+	// A fence to regulate submission of post-processing render passes.
+	// Up to 'Settings::FrameCount' command lists can be in flight on the node at once.
+	std::shared_ptr<LinearFence> m_postFence;
 
-    // Vertex definitions.
-    struct SceneVertex
-    {
-        DirectX::XMFLOAT3 position;
-    };
+	// Vertex definitions.
+	struct SceneVertex
+	{
+		DirectX::XMFLOAT3 position;
+	};
 
-    struct PostVertex
-    {
-        DirectX::XMFLOAT3 position;
-        DirectX::XMFLOAT2 uv;
-    };
+	struct PostVertex
+	{
+		DirectX::XMFLOAT3 position;
+		DirectX::XMFLOAT2 uv;
+	};
 
-    // Constant buffer definition.
-    struct SceneConstantBuffer
-    {
-        DirectX::XMFLOAT4 velocity;
-        DirectX::XMFLOAT4 offset;
-        DirectX::XMFLOAT4 color;
-        DirectX::XMMATRIX projection;
+	// Constant buffer definition.
+	struct SceneConstantBuffer
+	{
+		DirectX::XMFLOAT4 velocity;
+		DirectX::XMFLOAT4 offset;
+		DirectX::XMFLOAT4 color;
+		DirectX::XMMATRIX projection;
 
-        // Constant buffers are 256-byte aligned. Add padding in the struct to allow
-        // multiple buffers to be array-indexed.
-        float padding[36];
-    };
+		// Constant buffers are 256-byte aligned. Add padding in the struct to allow
+		// multiple buffers to be array-indexed.
+		float padding[36];
+	};
 
-    // Data about each of the triangles in the scene.
-    std::vector<SceneConstantBuffer> m_sceneData;
+	// Data about each of the triangles in the scene.
+	std::vector<SceneConstantBuffer> m_sceneData;
 
-    UINT64 m_frameId;
-    UINT m_simulatedGpuLoad;
-    UINT m_nodeIndex;
-    UINT m_frameIndex;
-    UINT m_sceneRenderTargetIndex;
-    UINT m_syncInterval;
-    bool m_windowVisible;
-    bool m_windowedMode;
+	UINT64 m_frameId;
+	UINT m_simulatedGpuLoad;
+	UINT m_nodeIndex;
+	UINT m_frameIndex;
+	UINT m_sceneRenderTargetIndex;
+	UINT m_syncInterval;
+	bool m_windowVisible;
+	bool m_windowedMode;
 
-    // Additional work must be done to synchronize dependencies in the post-processing
-    // pass when rendering with multiple nodes.
-    bool m_syncSceneRenderTargets;
+	// Additional work must be done to synchronize dependencies in the post-processing
+	// pass when rendering with multiple nodes.
+	bool m_syncSceneRenderTargets;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void LoadSizeDependentResources();
-    float GetRandomFloat(float min, float max);
-    void UpdateWindowTitle();
-    void RenderScene();
-    void RenderPost();
-    void WaitForGpus();
-    void MoveToNextFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	void LoadSizeDependentResources();
+	float GetRandomFloat(float min, float max);
+	void UpdateWindowTitle();
+	void RenderScene();
+	void RenderPost();
+	void WaitForGpus();
+	void MoveToNextFrame();
 
-    static inline UINT64 AlignResource(UINT64 size, UINT64 alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT)
-    {
-        return (size + alignment - 1) & ~(alignment - 1);
-    }
+	static inline UINT64 AlignResource(UINT64 size, UINT64 alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT)
+	{
+		return (size + alignment - 1) & ~(alignment - 1);
+	}
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.cpp
@@ -52,33 +52,78 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
+
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+            }
+#if !defined(_XBOX_ONE)
+        }
+#endif
 
     *ppAdapter = adapter.Detach();
-}
+    }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.h
@@ -48,7 +48,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/Fence.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/Fence.h
@@ -20,139 +20,139 @@ using Microsoft::WRL::ComPtr;
 class Fence
 {
 public:
-    // Create a fence and associate it with the specified command queue for
-    // convenience in working with fences.
-    Fence(CD3DX12AffinityCommandQueue* pQueue) :
-        m_currentFenceValue(0)
-    {
-        ThrowIfFailed(pQueue->QueryInterface(IID_PPV_ARGS(&m_queue)));
+	// Create a fence and associate it with the specified command queue for
+	// convenience in working with fences.
+	Fence(CD3DX12AffinityCommandQueue* pQueue) :
+		m_currentFenceValue(0)
+	{
+		ThrowIfFailed(pQueue->QueryInterface(IID_PPV_ARGS(&m_queue)));
 
-        ComPtr<CD3DX12AffinityDevice> device;
-        ThrowIfFailed(m_queue->GetDevice(IID_PPV_ARGS(&device)));
+		ComPtr<CD3DX12AffinityDevice> device;
+		ThrowIfFailed(m_queue->GetDevice(IID_PPV_ARGS(&device)));
 
-        ThrowIfFailed(device->CreateFence(m_currentFenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		ThrowIfFailed(device->CreateFence(m_currentFenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
 
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
-    }
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
+	}
 
-    ~Fence()
-    {
-        if (m_fenceEvent)
-        {
-            CloseHandle(m_fenceEvent);
-            m_fenceEvent = nullptr;
-        }
-    }
+	~Fence()
+	{
+		if (m_fenceEvent)
+		{
+			CloseHandle(m_fenceEvent);
+			m_fenceEvent = nullptr;
+		}
+	}
 
-    // Drain the GPU command queue.
-    // (Blocks the calling CPU thread)
-    inline void FlushGpuQueue()
-    {
-        Signal();
-        m_queue->WaitForCompletion();
-    }
+	// Drain the GPU command queue.
+	// (Blocks the calling CPU thread)
+	inline void FlushGpuQueue()
+	{
+		Signal();
+		m_queue->WaitForCompletion();
+	}
 
-    // Issue a Signal command on the command queue.
-    // Use the current value of the fence or override it with your own value.
-    inline void Signal(UINT64 value = UnspecifiedFenceValue)
-    {
-        if (value == UnspecifiedFenceValue)
-        {
-            m_currentFenceValue++;
-        }
-        else
-        {
-            _ASSERT(value > m_currentFenceValue);
-            m_currentFenceValue = value;
-        }
+	// Issue a Signal command on the command queue.
+	// Use the current value of the fence or override it with your own value.
+	inline void Signal(UINT64 value = UnspecifiedFenceValue)
+	{
+		if (value == UnspecifiedFenceValue)
+		{
+			m_currentFenceValue++;
+		}
+		else
+		{
+			_ASSERT(value > m_currentFenceValue);
+			m_currentFenceValue = value;
+		}
 
-        ThrowIfFailed(m_queue->Signal(m_fence.Get(), m_currentFenceValue));
-    }
+		ThrowIfFailed(m_queue->Signal(m_fence.Get(), m_currentFenceValue));
+	}
 
-    // Instruct the GPU queue associated with this fence to wait for a value to be signaled.
-    // Use the current value of the fence or override it with your own value.
-    // (Does not block the calling CPU thread)
-    inline void GpuWait(UINT64 value = UnspecifiedFenceValue)
-    {
-        if (value == UnspecifiedFenceValue)
-        {
-            value = m_currentFenceValue;
-        }
+	// Instruct the GPU queue associated with this fence to wait for a value to be signaled.
+	// Use the current value of the fence or override it with your own value.
+	// (Does not block the calling CPU thread)
+	inline void GpuWait(UINT64 value = UnspecifiedFenceValue)
+	{
+		if (value == UnspecifiedFenceValue)
+		{
+			value = m_currentFenceValue;
+		}
 
-        ThrowIfFailed(m_queue->Wait(m_fence.Get(), value));
-    }
+		ThrowIfFailed(m_queue->Wait(m_fence.Get(), value));
+	}
 
-    // Instruct a GPU queue on the active node to wait for the fences on the other nodes.
-    // Use the current values of the fences or override them with your own value.
-    // (Does not block the calling CPU thread)
-    inline static void GpuWait(CD3DX12AffinityCommandQueue* pQueue, Fence* pFence, UINT64 value = UnspecifiedFenceValue)
-    {
-        if (value == UnspecifiedFenceValue)
-        {
-            value = pFence->m_currentFenceValue;
-        }
+	// Instruct a GPU queue on the active node to wait for the fences on the other nodes.
+	// Use the current values of the fences or override them with your own value.
+	// (Does not block the calling CPU thread)
+	inline static void GpuWait(CD3DX12AffinityCommandQueue* pQueue, Fence* pFence, UINT64 value = UnspecifiedFenceValue)
+	{
+		if (value == UnspecifiedFenceValue)
+		{
+			value = pFence->m_currentFenceValue;
+		}
 
-        pQueue->Wait(pFence->m_fence.Get(), value, true, Settings::SharedNodeMask);
-    }
+		pQueue->Wait(pFence->m_fence.Get(), value, true, Settings::SharedNodeMask);
+	}
 
 protected:
-    // Block the calling CPU thread until the GPU has signaled the specified fence.
-    inline void CpuWait(UINT64 fenceValue = UnspecifiedFenceValue)
-    {
-        if (fenceValue == UnspecifiedFenceValue)
-        {
-            fenceValue = m_currentFenceValue;
-        }
+	// Block the calling CPU thread until the GPU has signaled the specified fence.
+	inline void CpuWait(UINT64 fenceValue = UnspecifiedFenceValue)
+	{
+		if (fenceValue == UnspecifiedFenceValue)
+		{
+			fenceValue = m_currentFenceValue;
+		}
 
-        UINT nodeMask = 1 << m_fence->GetActiveNodeIndex();
-        if (m_fence->GetCompletedValue(nodeMask) < fenceValue)
-        {
-            ThrowIfFailed(m_fence->SetEventOnCompletion(fenceValue, m_fenceEvent));
-            WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-        }
-    }
+		UINT nodeMask = 1 << m_fence->GetActiveNodeIndex();
+		if (m_fence->GetCompletedValue(nodeMask) < fenceValue)
+		{
+			ThrowIfFailed(m_fence->SetEventOnCompletion(fenceValue, m_fenceEvent));
+			WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+		}
+	}
 
-    static const UINT64 UnspecifiedFenceValue = UINT64_MAX;
+	static const UINT64 UnspecifiedFenceValue = UINT64_MAX;
 
-    ComPtr<CD3DX12AffinityFence> m_fence;            // The D3D12 fence object.
-    ComPtr<CD3DX12AffinityCommandQueue> m_queue;    // The command queue associated with this fence.
-    UINT64 m_currentFenceValue;                        // The last value signaled by this fence.
-    HANDLE m_fenceEvent;                            // CPU-waitable event handle.
+	ComPtr<CD3DX12AffinityFence> m_fence;			// The D3D12 fence object.
+	ComPtr<CD3DX12AffinityCommandQueue> m_queue;	// The command queue associated with this fence.
+	UINT64 m_currentFenceValue;						// The last value signaled by this fence.
+	HANDLE m_fenceEvent;							// CPU-waitable event handle.
 };
 
 class LinearFence : public Fence
 {
 public:
-    // This fence implementation manages a ring buffer of issued Signal events.
-    // The "Next" API instructs the Fence to move to the next slot in the ring buffer.
-    // If the next slot represents a fence value that has not yet been signaled by
-    // the GPU, then the CPU will wait until that fence is signaled before continuing.
-    // 
-    // In this sample, LinearFences are used to guard against premature resetting
-    // of command allocators and modifying of upload heaps that might currently be
-    // in use by the GPU.
-    LinearFence(CD3DX12AffinityCommandQueue* pQueue, UINT count) :
-        Fence(pQueue),
-        m_signalIndex(0)
-    {
-        m_signalHistory.resize(count * pQueue->GetNodeCount());
-    }
+	// This fence implementation manages a ring buffer of issued Signal events.
+	// The "Next" API instructs the Fence to move to the next slot in the ring buffer.
+	// If the next slot represents a fence value that has not yet been signaled by
+	// the GPU, then the CPU will wait until that fence is signaled before continuing.
+	// 
+	// In this sample, LinearFences are used to guard against premature resetting
+	// of command allocators and modifying of upload heaps that might currently be
+	// in use by the GPU.
+	LinearFence(CD3DX12AffinityCommandQueue* pQueue, UINT count) :
+		Fence(pQueue),
+		m_signalIndex(0)
+	{
+		m_signalHistory.resize(count * pQueue->GetNodeCount());
+	}
 
-    // If the oldest Signal event in the ring buffer has not yet been processed by
-    // the GPU, block the calling CPU thread until it is.
-    inline void Next()
-    {
-        m_signalHistory[m_signalIndex] = m_currentFenceValue;
-        m_signalIndex = (m_signalIndex + 1) % m_signalHistory.size();
+	// If the oldest Signal event in the ring buffer has not yet been processed by
+	// the GPU, block the calling CPU thread until it is.
+	inline void Next()
+	{
+		m_signalHistory[m_signalIndex] = m_currentFenceValue;
+		m_signalIndex = (m_signalIndex + 1) % m_signalHistory.size();
 
-        Fence::CpuWait(m_signalHistory[m_signalIndex]);
-    }
+		Fence::CpuWait(m_signalHistory[m_signalIndex]);
+	}
 
 private:
-    std::vector<UINT64> m_signalHistory;    // The history of signal events.
-    UINT m_signalIndex;                        // The index to the next slot in the signal history ring buffer.
+	std::vector<UINT64> m_signalHistory;	// The history of signal events.
+	UINT m_signalIndex;						// The index to the next slot in the signal history ring buffer.
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/Main.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12LinkedGpusAffinity sample(1200, 900, L"");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12LinkedGpusAffinity sample(1200, 900, L"");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/Post.hlsli
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/Post.hlsli
@@ -11,14 +11,14 @@
 
 struct VSInput
 {
-    float4 position : POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : POSITION;
+	float2 uv : TEXCOORD;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 Texture2D g_renderTargets[6] : register(t0);
@@ -26,6 +26,6 @@ SamplerState g_sampler : register(s0);
 
 cbuffer ShaderConstants : register(b0)
 {
-    uint currentRenderTarget;
-    uint renderTargetCount;
+	uint currentRenderTarget;
+	uint renderTargetCount;
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/PostPS.hlsl
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/PostPS.hlsl
@@ -13,18 +13,18 @@
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    // This adds up to more than 1.0f, but creates a decent effect
-    // that doesn't make the triangles look too transparent.
-    float blurWeights[6] = { 0.80f, 0.25f, 0.15f, 0.075f, 0.025f, 0.0125f };
+	// This adds up to more than 1.0f, but creates a decent effect
+	// that doesn't make the triangles look too transparent.
+	float blurWeights[6] = { 0.80f, 0.25f, 0.15f, 0.075f, 0.025f, 0.0125f };
 
-    float4 result = float4(0.0f, 0.0f, 0.0f, 0.0f);
-    uint index = currentRenderTarget;
+	float4 result = float4(0.0f, 0.0f, 0.0f, 0.0f);
+	uint index = currentRenderTarget;
 
-    for (uint n = 0; n < renderTargetCount; n++)
-    {
-        result += blurWeights[n] * g_renderTargets[index].Sample(g_sampler, input.uv);
-        index = (index == 0) ? renderTargetCount - 1 : index - 1;
-    }
+	for (uint n = 0; n < renderTargetCount; n++)
+	{
+		result += blurWeights[n] * g_renderTargets[index].Sample(g_sampler, input.uv);
+		index = (index == 0) ? renderTargetCount - 1 : index - 1;
+	}
 
-    return saturate(result);
+	return saturate(result);
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/PostVS.hlsl
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/PostVS.hlsl
@@ -13,10 +13,10 @@
 
 PSInput VSMain(VSInput input)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = input.position;
-    result.uv = input.uv;
+	result.position = input.position;
+	result.uv = input.uv;
 
-    return result;
+	return result;
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/Scene.hlsli
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/Scene.hlsli
@@ -11,19 +11,19 @@
 
 cbuffer SceneConstantBuffer : register(b0)
 {
-    float4 velocity;
-    float4 offset;
-    float4 color;
-    float4x4 projection;
+	float4 velocity;
+	float4 offset;
+	float4 color;
+	float4x4 projection;
 };
 
 cbuffer SceneRootConstants : register(b1)
 {
-    uint simulatedGpuLoad;
+	uint simulatedGpuLoad;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/ScenePS.hlsl
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/ScenePS.hlsl
@@ -13,5 +13,5 @@
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/SceneVS.hlsl
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/SceneVS.hlsl
@@ -13,29 +13,29 @@
 
 PSInput VSMain(float4 position : POSITION)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = mul(position + offset, projection);
+	result.position = mul(position + offset, projection);
 
-    float intensity = saturate((4.0f - result.position.z) / 2.0f);
-    float4 c = float4(color.xyz * intensity, 1.0f);
+	float intensity = saturate((4.0f - result.position.z) / 2.0f);
+	float4 c = float4(color.xyz * intensity, 1.0f);
 
-    if (simulatedGpuLoad > 0)
-    {
-        float4 total = float4(0.0f, 0.0f, 0.0f, 0.0f);
+	if (simulatedGpuLoad > 0)
+	{
+		float4 total = float4(0.0f, 0.0f, 0.0f, 0.0f);
 
-        // Simulate additional workload on the GPU.
-        for (uint x = 0; x < simulatedGpuLoad; x++)
-        {
-            total += c;
-        }
+		// Simulate additional workload on the GPU.
+		for (uint x = 0; x < simulatedGpuLoad; x++)
+		{
+			total += c;
+		}
 
-        result.color = total / simulatedGpuLoad;
-    }
-    else
-    {
-        result.color = c;
-    }
+		result.color = total / simulatedGpuLoad;
+	}
+	else
+	{
+		result.color = c;
+	}
 
-    return result;
+	return result;
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/Settings.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/Settings.cpp
@@ -15,8 +15,8 @@
 
 using Microsoft::WRL::ComPtr;
 
-const float Settings::TriangleHalfWidth = 0.05f;    // The x and y offsets used by the triangle vertices.
-const float Settings::TriangleDepth = 1.0f;            // The z offset used by the triangle vertices.
+const float Settings::TriangleHalfWidth = 0.05f;	// The x and y offsets used by the triangle vertices.
+const float Settings::TriangleDepth = 1.0f;			// The z offset used by the triangle vertices.
 const float Settings::ClearColor[4] = { 0.0f, 0.2f, 0.4f, 1.0f };
 
 UINT Settings::NodeCount;
@@ -35,33 +35,33 @@ D3D12_RECT Settings::ScissorRect;
 
 void Settings::Initialize(CD3DX12AffinityDevice* pDevice, UINT width, UINT height)
 {
-    NodeCount = pDevice->GetNodeCount();
-    _ASSERT(NodeCount <= MaxNodeCount);
+	NodeCount = pDevice->GetNodeCount();
+	_ASSERT(NodeCount <= MaxNodeCount);
 
-    BackBuffersPerNode = (NodeCount > 1) ? 1 : 2;
-    FrameCount = (NodeCount > 1) ? 1 : 2;
-    _ASSERT(FrameCount * NodeCount <= SceneConstantBufferFrames);
+	BackBuffersPerNode = (NodeCount > 1) ? 1 : 2;
+	FrameCount = (NodeCount > 1) ? 1 : 2;
+	_ASSERT(FrameCount * NodeCount <= SceneConstantBufferFrames);
 
-    D3D12_FEATURE_DATA_D3D12_OPTIONS featureOptions;
-    ThrowIfFailed(pDevice->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &featureOptions, sizeof(featureOptions)));
-    Tier2Support = (featureOptions.CrossNodeSharingTier == D3D12_CROSS_NODE_SHARING_TIER_2);
+	D3D12_FEATURE_DATA_D3D12_OPTIONS featureOptions;
+	ThrowIfFailed(pDevice->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &featureOptions, sizeof(featureOptions)));
+	Tier2Support = (featureOptions.CrossNodeSharingTier == D3D12_CROSS_NODE_SHARING_TIER_2);
 
-    RtvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    CbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	RtvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	CbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 
-    SharedNodeMask = (1 << NodeCount) - 1;
-    BackBufferCount = NodeCount * BackBuffersPerNode;
+	SharedNodeMask = (1 << NodeCount) - 1;
+	BackBufferCount = NodeCount * BackBuffersPerNode;
 
-    // We assume that each node will be assigned the same number of render targets.
-    _ASSERT(SceneHistoryCount % NodeCount == 0);
+	// We assume that each node will be assigned the same number of render targets.
+	_ASSERT(SceneHistoryCount % NodeCount == 0);
 
-    OnSizeChanged(width, height);
+	OnSizeChanged(width, height);
 }
 
 void Settings::OnSizeChanged(UINT width, UINT height)
 {
-    Width = width;
-    Height = height;
-    Viewport = CD3DX12_VIEWPORT(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 0.0f, 1.0f);
-    ScissorRect = CD3DX12_RECT(0, 0, static_cast<LONG>(width), static_cast<LONG>(height));
+	Width = width;
+	Height = height;
+	Viewport = CD3DX12_VIEWPORT(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 0.0f, 1.0f);
+	ScissorRect = CD3DX12_RECT(0, 0, static_cast<LONG>(width), static_cast<LONG>(height));
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/Settings.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/Settings.h
@@ -15,29 +15,29 @@
 // for the lifetime of the sample.
 struct Settings
 {
-    static void Initialize(CD3DX12AffinityDevice* pDevice, UINT width, UINT height);
-    static void OnSizeChanged(UINT width, UINT height);
+	static void Initialize(CD3DX12AffinityDevice* pDevice, UINT width, UINT height);
+	static void OnSizeChanged(UINT width, UINT height);
 
-    static const UINT MaxNodeCount = 2;
-    static UINT BackBuffersPerNode;
-    static UINT FrameCount;                                // The maximum number of frames that will be buffered on each node.
+	static const UINT MaxNodeCount = 2;
+	static UINT BackBuffersPerNode;
+	static UINT FrameCount;								// The maximum number of frames that will be buffered on each node.
 
-    static const UINT SceneHistoryCount = 6;            // The number of frames used in the motion blur effect.
-    static const UINT SceneConstantBufferFrames = 10;    // The number of frames that can be buffered in the constant buffer heap.
-    static const UINT TriangleCount = 1024;                // The number of triangles drawn per frame.
-    static const float TriangleHalfWidth;                // The x and y offsets used by the triangle vertices.
-    static const float TriangleDepth;                    // The z offset used by the triangle vertices.
-    static const float ClearColor[4];
+	static const UINT SceneHistoryCount = 6;			// The number of frames used in the motion blur effect.
+	static const UINT SceneConstantBufferFrames = 10;	// The number of frames that can be buffered in the constant buffer heap.
+	static const UINT TriangleCount = 1024;				// The number of triangles drawn per frame.
+	static const float TriangleHalfWidth;				// The x and y offsets used by the triangle vertices.
+	static const float TriangleDepth;					// The z offset used by the triangle vertices.
+	static const float ClearColor[4];
 
-    static UINT NodeCount;                                // The number of linked GPUs on the system.
-    static UINT SharedNodeMask;                            // The mask representing all GPUs on the system.
-    static bool Tier2Support;
-    static UINT RtvDescriptorSize;
-    static UINT CbvSrvDescriptorSize;
-    static UINT BackBufferCount;
+	static UINT NodeCount;								// The number of linked GPUs on the system.
+	static UINT SharedNodeMask;							// The mask representing all GPUs on the system.
+	static bool Tier2Support;
+	static UINT RtvDescriptorSize;
+	static UINT CbvSrvDescriptorSize;
+	static UINT BackBufferCount;
 
-    static UINT Width;
-    static UINT Height;
-    static D3D12_VIEWPORT Viewport;
-    static D3D12_RECT ScissorRect;
+	static UINT Width;
+	static UINT Height;
+	static D3D12_VIEWPORT Viewport;
+	static D3D12_RECT ScissorRect;
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/View.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/View.cpp
@@ -17,61 +17,61 @@ using namespace Windows::System;
 
 inline int ConvertToPixels(float dimension, float dpi)
 {
-    return static_cast<int>(dimension * dpi / 96.0f + 0.5f);
+	return static_cast<int>(dimension * dpi / 96.0f + 0.5f);
 }
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false),
-    m_windowResizing(false),
-    m_windowVisible(true),
-    m_logicalWidth(0),
-    m_logicalHeight(0)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false),
+	m_windowResizing(false),
+	m_windowVisible(true),
+	m_logicalWidth(0),
+	m_logicalHeight(0)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    m_logicalWidth = window->Bounds.Width;
-    m_logicalHeight = window->Bounds.Height;
+	m_logicalWidth = window->Bounds.Width;
+	m_logicalHeight = window->Bounds.Height;
 
     auto dispatcher = CoreWindow::GetForCurrentThread()->Dispatcher;
     dispatcher->AcceleratorKeyActivated +=
         ref new TypedEventHandler<CoreDispatcher^, AcceleratorKeyEventArgs^>(this, &View::OnAcceleratorKeyActivated);
 
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->SizeChanged += ref new TypedEventHandler<CoreWindow^, WindowSizeChangedEventArgs^>(this, &View::OnSizeChanged);
-    window->VisibilityChanged += ref new TypedEventHandler<CoreWindow^, VisibilityChangedEventArgs^>(this, &View::OnVisibilityChanged);
-    window->Closed += ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &View::OnClosed);
-    window->PointerMoved += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerMoved);
-    window->PointerPressed += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerPressed);
-    window->PointerReleased += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerReleased);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->SizeChanged += ref new TypedEventHandler<CoreWindow^, WindowSizeChangedEventArgs^>(this, &View::OnSizeChanged);
+	window->VisibilityChanged += ref new TypedEventHandler<CoreWindow^, VisibilityChangedEventArgs^>(this, &View::OnVisibilityChanged);
+	window->Closed += ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &View::OnClosed);
+	window->PointerMoved += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerMoved);
+	window->PointerPressed += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerPressed);
+	window->PointerReleased += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerReleased);
 
-    try
-    {
-        window->ResizeStarted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeStarted);
-        window->ResizeCompleted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeCompleted);
-    }
-    catch (Exception^ e)
-    {
-        // Requires Windows 10 Creators Update (10.0.15063) or later.
-    }
+	try
+	{
+		window->ResizeStarted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeStarted);
+		window->ResizeCompleted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeCompleted);
+	}
+	catch (Exception^ e)
+	{
+		// Requires Windows 10 Creators Update (10.0.15063) or later.
+	}
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 
-    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-    displayInformation->DpiChanged += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDpiChanged);
-    displayInformation->DisplayContentsInvalidated += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDisplayContentsInvalidated);
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	displayInformation->DpiChanged += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDpiChanged);
+	displayInformation->DisplayContentsInvalidated += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDisplayContentsInvalidated);
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -80,20 +80,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -102,15 +102,15 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
     if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnAcceleratorKeyActivated(CoreDispatcher^, AcceleratorKeyEventArgs^ args)
@@ -138,97 +138,97 @@ void View::OnAcceleratorKeyActivated(CoreDispatcher^, AcceleratorKeyEventArgs^ a
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnSizeChanged(CoreWindow^ /*window*/, WindowSizeChangedEventArgs^ args)
 {
-    m_logicalWidth = args->Size.Width;
-    m_logicalHeight = args->Size.Height;
+	m_logicalWidth = args->Size.Width;
+	m_logicalHeight = args->Size.Height;
 
-    if (!m_windowResizing)
-    {
-        UpdateWindowSize();
-    }
+	if (!m_windowResizing)
+	{
+		UpdateWindowSize();
+	}
 }
 
 void View::OnResizeStarted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
 {
-    m_windowResizing = true;
+	m_windowResizing = true;
 }
 
 void View::OnResizeCompleted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
 {
-    m_windowResizing = false;
-    UpdateWindowSize();
+	m_windowResizing = false;
+	UpdateWindowSize();
 }
 
 void View::OnDpiChanged(DisplayInformation^ /*sender*/, Object^ /*args*/)
 {
-    UpdateWindowSize();
+	UpdateWindowSize();
 }
 
 void View::OnVisibilityChanged(CoreWindow^ /*window*/, VisibilityChangedEventArgs^ args)
 {
-    m_windowVisible = args->Visible;
-    UpdateWindowSize();
+	m_windowVisible = args->Visible;
+	UpdateWindowSize();
 }
 
 void View::OnClosed(CoreWindow^ /*window*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }
 
 void View::OnPointerMoved(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
-    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-    float dpi = displayInformation->LogicalDpi;
-    m_pSample->OnMouseMove(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	float dpi = displayInformation->LogicalDpi;
+	m_pSample->OnMouseMove(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
 }
 
 void View::OnPointerPressed(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
-    // For simplicity, we only consider left button press here.
-    if(args->CurrentPoint->Properties->IsLeftButtonPressed)
-    {
-        DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-        float dpi = displayInformation->LogicalDpi;
-        m_pSample->OnLeftButtonDown(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
-    }
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonDown(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
 }
 
 void View::OnPointerReleased(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
-    // For simplicity, we only consider left button press here.
-    if(args->CurrentPoint->Properties->IsLeftButtonPressed)
-    {
-        DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-        float dpi = displayInformation->LogicalDpi;
-        m_pSample->OnLeftButtonUp(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
-    }
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonUp(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
 }
 
 void View::UpdateWindowSize()
 {
-    CoreWindow^ window = CoreWindow::GetForCurrentThread();
-    Windows::Foundation::Rect windowBounds = window->Bounds;
+	CoreWindow^ window = CoreWindow::GetForCurrentThread();
+	Windows::Foundation::Rect windowBounds = window->Bounds;
 
-    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-    float dpi = displayInformation->LogicalDpi;
-    
-    m_pSample->SetWindowBounds(
-        ConvertToPixels(windowBounds.Left, dpi),
-        ConvertToPixels(windowBounds.Top, dpi),
-        ConvertToPixels(windowBounds.Right, dpi),
-        ConvertToPixels(windowBounds.Bottom, dpi));
-        
-    m_pSample->OnSizeChanged(ConvertToPixels(m_logicalWidth, dpi), ConvertToPixels(m_logicalHeight, dpi), !m_windowVisible);
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	float dpi = displayInformation->LogicalDpi;
+	
+	m_pSample->SetWindowBounds(
+		ConvertToPixels(windowBounds.Left, dpi),
+		ConvertToPixels(windowBounds.Top, dpi),
+		ConvertToPixels(windowBounds.Right, dpi),
+		ConvertToPixels(windowBounds.Bottom, dpi));
+		
+	m_pSample->OnSizeChanged(ConvertToPixels(m_logicalWidth, dpi), ConvertToPixels(m_logicalHeight, dpi), !m_windowVisible);
 }
 
 void View::OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args)
 {
-    m_pSample->OnDisplayChanged();
+	m_pSample->OnDisplayChanged();
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/View.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/View.h
@@ -24,36 +24,36 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
     void OnAcceleratorKeyActivated(CoreDispatcher^, AcceleratorKeyEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ args);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ args);
-    void OnSizeChanged(CoreWindow^ window, WindowSizeChangedEventArgs^ args);
-    void OnResizeStarted(CoreWindow^ window, Object^ args);
-    void OnResizeCompleted(CoreWindow^ window, Object^ args);
-    void OnDpiChanged(DisplayInformation^ sender, Object^ args);
-    void OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args);
-    void OnClosed(CoreWindow^ window, CoreWindowEventArgs^ args);
-    void OnPointerMoved(CoreWindow^ window, PointerEventArgs^ args);
-    void OnPointerPressed(CoreWindow^ window, PointerEventArgs^ args);
-    void OnPointerReleased(CoreWindow^ window, PointerEventArgs^ args);
-    void OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args);
-    
-    void UpdateWindowSize();
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ args);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ args);
+	void OnSizeChanged(CoreWindow^ window, WindowSizeChangedEventArgs^ args);
+	void OnResizeStarted(CoreWindow^ window, Object^ args);
+	void OnResizeCompleted(CoreWindow^ window, Object^ args);
+	void OnDpiChanged(DisplayInformation^ sender, Object^ args);
+	void OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args);
+	void OnClosed(CoreWindow^ window, CoreWindowEventArgs^ args);
+	void OnPointerMoved(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerPressed(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerReleased(CoreWindow^ window, PointerEventArgs^ args);
+	void OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args);
+	
+	void UpdateWindowSize();
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
-    bool m_windowResizing;
-    bool m_windowVisible;
-    float m_logicalWidth;
-    float m_logicalHeight;
+	DXSample* m_pSample;
+	bool m_windowClosed;
+	bool m_windowResizing;
+	bool m_windowVisible;
+	float m_logicalWidth;
+	float m_logicalHeight;
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/ViewProvider.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/ViewProvider.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/d3dx12.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/D3D12SingleGpu.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/D3D12SingleGpu.cpp
@@ -21,859 +21,859 @@
 using namespace DirectX;
 
 D3D12SingleGpu::D3D12SingleGpu(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_frameId(0),
-    m_simulatedGpuLoad(0x1000),
-    m_syncInterval(0),
-    m_windowVisible(true),
-    m_windowedMode(true)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_frameId(0),
+	m_simulatedGpuLoad(0x1000),
+	m_syncInterval(0),
+	m_windowVisible(true),
+	m_windowedMode(true)
 {
-    m_sceneData.resize(Settings::TriangleCount);
+	m_sceneData.resize(Settings::TriangleCount);
 }
 
 void D3D12SingleGpu::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 
-    UpdateWindowTitle();
+	UpdateWindowTitle();
 }
 
 void D3D12SingleGpu::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Query capabilities of the device to configure the sample.
-    Settings::Initialize(m_device.Get(), m_width, m_height);
+	// Query capabilities of the device to configure the sample.
+	Settings::Initialize(m_device.Get(), m_width, m_height);
 
-    // Initialize member variables dependent on the Settings.
-    m_sceneRenderTargets.resize(Settings::SceneHistoryCount);
-    m_postRenderTargets.resize(Settings::BackBufferCount);
-    m_sceneCommandAllocators.resize(Settings::FrameCount);
-    m_postCommandAllocators.resize(Settings::FrameCount);
+	// Initialize member variables dependent on the Settings.
+	m_sceneRenderTargets.resize(Settings::SceneHistoryCount);
+	m_postRenderTargets.resize(Settings::BackBufferCount);
+	m_sceneCommandAllocators.resize(Settings::FrameCount);
+	m_postCommandAllocators.resize(Settings::FrameCount);
 
-    // Describe and create the command queues.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queues.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_graphicsQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_graphicsQueue)));
 
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = Settings::BackBufferCount;
-    swapChainDesc.Width = Settings::Width;
-    swapChainDesc.Height = Settings::Height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
-    swapChainDesc.Flags = m_tearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = Settings::BackBufferCount;
+	swapChainDesc.Width = Settings::Width;
+	swapChainDesc.Height = Settings::Height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
+	swapChainDesc.Flags = m_tearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_graphicsQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
+		m_graphicsQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
+	ThrowIfFailed(swapChain.As(&m_swapChain));
 
-    // Scene descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_sceneRtvHeap)));
+	// Scene descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_sceneRtvHeap)));
 
-        // Describe and create a depth stencil view (DSV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
-        dsvHeapDesc.NumDescriptors = 1;
-        dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-        dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_sceneDsvHeap)));
+		// Describe and create a depth stencil view (DSV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
+		dsvHeapDesc.NumDescriptors = 1;
+		dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+		dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_sceneDsvHeap)));
 
-        // Describe and create a constant buffer view (CBV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
-        cbvHeapDesc.NumDescriptors = Settings::TriangleCount * Settings::SceneConstantBufferFrames;
-        cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_sceneCbvHeap)));
-    }
+		// Describe and create a constant buffer view (CBV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
+		cbvHeapDesc.NumDescriptors = Settings::TriangleCount * Settings::SceneConstantBufferFrames;
+		cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_sceneCbvHeap)));
+	}
 
-    // Post-process descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap for 
-        // the final output.
-        D3D12_DESCRIPTOR_HEAP_DESC postRtvHeapDesc = {};
-        postRtvHeapDesc.NumDescriptors = Settings::BackBufferCount;
-        postRtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        postRtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&postRtvHeapDesc, IID_PPV_ARGS(&m_postRtvHeap)));
+	// Post-process descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap for 
+		// the final output.
+		D3D12_DESCRIPTOR_HEAP_DESC postRtvHeapDesc = {};
+		postRtvHeapDesc.NumDescriptors = Settings::BackBufferCount;
+		postRtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		postRtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&postRtvHeapDesc, IID_PPV_ARGS(&m_postRtvHeap)));
 
-        // Describe and create a shader resource view (SRV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
-        srvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
-        srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_postSrvHeap)));
+		// Describe and create a shader resource view (SRV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
+		srvHeapDesc.NumDescriptors = Settings::SceneHistoryCount;
+		srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_postSrvHeap)));
 
-        // Describe and create a sampler descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
-        samplerHeapDesc.NumDescriptors = 1;
-        samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
-        samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_postSamplerHeap)));
-    }
+		// Describe and create a sampler descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
+		samplerHeapDesc.NumDescriptors = 1;
+		samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
+		samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_postSamplerHeap)));
+	}
 
-    // Create command allocators for each buffered frame.
-    for (UINT n = 0; n < Settings::FrameCount; n++)
-    {
-        ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[n])));
-        ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_postCommandAllocators[n])));
-    }
+	// Create command allocators for each buffered frame.
+	for (UINT n = 0; n < Settings::FrameCount; n++)
+	{
+		ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[n])));
+		ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_postCommandAllocators[n])));
+	}
 }
 
 // Generate data for the scene triangles.
 void D3D12SingleGpu::LoadAssets()
 {
-    // Create the root signatures.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signatures.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        // Create a root signature for rendering the triangle scene.
-        {
-            CD3DX12_DESCRIPTOR_RANGE1 sceneRanges[1];
-            sceneRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		// Create a root signature for rendering the triangle scene.
+		{
+			CD3DX12_DESCRIPTOR_RANGE1 sceneRanges[1];
+			sceneRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
 
-            CD3DX12_ROOT_PARAMETER1 sceneRootParameters[2];
-            sceneRootParameters[0].InitAsDescriptorTable(1, &sceneRanges[0], D3D12_SHADER_VISIBILITY_VERTEX);
-            sceneRootParameters[1].InitAsConstants(1, 1, 0, D3D12_SHADER_VISIBILITY_VERTEX);
+			CD3DX12_ROOT_PARAMETER1 sceneRootParameters[2];
+			sceneRootParameters[0].InitAsDescriptorTable(1, &sceneRanges[0], D3D12_SHADER_VISIBILITY_VERTEX);
+			sceneRootParameters[1].InitAsConstants(1, 1, 0, D3D12_SHADER_VISIBILITY_VERTEX);
 
-            CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC sceneRootSignatureDesc;
-            sceneRootSignatureDesc.Init_1_1(_countof(sceneRootParameters), sceneRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+			CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC sceneRootSignatureDesc;
+			sceneRootSignatureDesc.Init_1_1(_countof(sceneRootParameters), sceneRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-            ComPtr<ID3DBlob> signature;
-            ComPtr<ID3DBlob> error;
-            ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&sceneRootSignatureDesc, featureData.HighestVersion, &signature, &error));
-            ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_sceneRootSignature)));
-        }
+			ComPtr<ID3DBlob> signature;
+			ComPtr<ID3DBlob> error;
+			ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&sceneRootSignatureDesc, featureData.HighestVersion, &signature, &error));
+			ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_sceneRootSignature)));
+		}
 
-        // Create a root signature for the post-process pass.
-        {
-            // We don't modify the SRV in the post-processing command list after
-            // SetGraphicsRootDescriptorTable is executed on the GPU so we can use the default
-            // range behavior: D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
-            CD3DX12_DESCRIPTOR_RANGE1 postRanges[2];
-            postRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, Settings::SceneHistoryCount, 0);
-            postRanges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
+		// Create a root signature for the post-process pass.
+		{
+			// We don't modify the SRV in the post-processing command list after
+			// SetGraphicsRootDescriptorTable is executed on the GPU so we can use the default
+			// range behavior: D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
+			CD3DX12_DESCRIPTOR_RANGE1 postRanges[2];
+			postRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, Settings::SceneHistoryCount, 0);
+			postRanges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
 
-            CD3DX12_ROOT_PARAMETER1 postRootParameters[3];
-            postRootParameters[0].InitAsDescriptorTable(1, &postRanges[0], D3D12_SHADER_VISIBILITY_PIXEL);
-            postRootParameters[1].InitAsDescriptorTable(1, &postRanges[1], D3D12_SHADER_VISIBILITY_PIXEL);
-            postRootParameters[2].InitAsConstants(2, 0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
+			CD3DX12_ROOT_PARAMETER1 postRootParameters[3];
+			postRootParameters[0].InitAsDescriptorTable(1, &postRanges[0], D3D12_SHADER_VISIBILITY_PIXEL);
+			postRootParameters[1].InitAsDescriptorTable(1, &postRanges[1], D3D12_SHADER_VISIBILITY_PIXEL);
+			postRootParameters[2].InitAsConstants(2, 0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
 
-            CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC postRootSignatureDesc;
-            postRootSignatureDesc.Init_1_1(_countof(postRootParameters), postRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+			CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC postRootSignatureDesc;
+			postRootSignatureDesc.Init_1_1(_countof(postRootParameters), postRootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-            ComPtr<ID3DBlob> signature;
-            ComPtr<ID3DBlob> error;
-            ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&postRootSignatureDesc, featureData.HighestVersion, &signature, &error));
-            ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_postRootSignature)));
-        }
-    }
+			ComPtr<ID3DBlob> signature;
+			ComPtr<ID3DBlob> error;
+			ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&postRootSignatureDesc, featureData.HighestVersion, &signature, &error));
+			ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_postRootSignature)));
+		}
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        // Define the vertex input layout for the triangle scene.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		// Define the vertex input layout for the triangle scene.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        // Describe and create the graphics pipeline state objects (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_sceneRootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_SceneVS, sizeof(g_SceneVS));
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_ScenePS, sizeof(g_ScenePS));
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state objects (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_sceneRootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(g_SceneVS, sizeof(g_SceneVS));
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(g_ScenePS, sizeof(g_ScenePS));
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_scenePipelineState)));
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_scenePipelineState)));
 
-        // Define the vertex input layout for the post-process fullscreen quad.
-        D3D12_INPUT_ELEMENT_DESC postInputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+		// Define the vertex input layout for the post-process fullscreen quad.
+		D3D12_INPUT_ELEMENT_DESC postInputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        // Describe and create the PSO for the post-process pass.
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC postPsoDesc = {};
-        postPsoDesc.InputLayout = { postInputElementDescs, _countof(postInputElementDescs) };
-        postPsoDesc.pRootSignature = m_postRootSignature.Get();
-        postPsoDesc.VS = CD3DX12_SHADER_BYTECODE(g_PostVS, sizeof(g_PostVS));
-        postPsoDesc.PS = CD3DX12_SHADER_BYTECODE(g_PostPS, sizeof(g_PostPS));
-        postPsoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        postPsoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        postPsoDesc.DepthStencilState.DepthEnable = FALSE;
-        postPsoDesc.DepthStencilState.StencilEnable = FALSE;
-        postPsoDesc.SampleMask = UINT_MAX;
-        postPsoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        postPsoDesc.NumRenderTargets = 1;
-        postPsoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        postPsoDesc.SampleDesc.Count = 1;
+		// Describe and create the PSO for the post-process pass.
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC postPsoDesc = {};
+		postPsoDesc.InputLayout = { postInputElementDescs, _countof(postInputElementDescs) };
+		postPsoDesc.pRootSignature = m_postRootSignature.Get();
+		postPsoDesc.VS = CD3DX12_SHADER_BYTECODE(g_PostVS, sizeof(g_PostVS));
+		postPsoDesc.PS = CD3DX12_SHADER_BYTECODE(g_PostPS, sizeof(g_PostPS));
+		postPsoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		postPsoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		postPsoDesc.DepthStencilState.DepthEnable = FALSE;
+		postPsoDesc.DepthStencilState.StencilEnable = FALSE;
+		postPsoDesc.SampleMask = UINT_MAX;
+		postPsoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		postPsoDesc.NumRenderTargets = 1;
+		postPsoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		postPsoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&postPsoDesc, IID_PPV_ARGS(&m_postPipelineState)));
-    }
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&postPsoDesc, IID_PPV_ARGS(&m_postPipelineState)));
+	}
 
-    // Single-use command allocator/list for resource initialization.
-    ComPtr<ID3D12CommandAllocator> commandAllocator;
-    ComPtr<ID3D12GraphicsCommandList> commandList;
+	// Single-use command allocator/list for resource initialization.
+	ComPtr<ID3D12CommandAllocator> commandAllocator;
+	ComPtr<ID3D12GraphicsCommandList> commandList;
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator)));
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
 
-    // Create command lists for the scene and post-processing passes.
-    {
-        ThrowIfFailed(m_device->CreateCommandList(
-            0,
-            D3D12_COMMAND_LIST_TYPE_DIRECT,
-            m_sceneCommandAllocators[m_frameIndex].Get(),
-            m_scenePipelineState.Get(),
-            IID_PPV_ARGS(&m_sceneCommandList)));
+	// Create command lists for the scene and post-processing passes.
+	{
+		ThrowIfFailed(m_device->CreateCommandList(
+			0,
+			D3D12_COMMAND_LIST_TYPE_DIRECT,
+			m_sceneCommandAllocators[m_frameIndex].Get(),
+			m_scenePipelineState.Get(),
+			IID_PPV_ARGS(&m_sceneCommandList)));
 
-        ThrowIfFailed(m_device->CreateCommandList(
-            0,
-            D3D12_COMMAND_LIST_TYPE_DIRECT,
-            m_postCommandAllocators[m_frameIndex].Get(),
-            m_postPipelineState.Get(),
-            IID_PPV_ARGS(&m_postCommandList)));
+		ThrowIfFailed(m_device->CreateCommandList(
+			0,
+			D3D12_COMMAND_LIST_TYPE_DIRECT,
+			m_postCommandAllocators[m_frameIndex].Get(),
+			m_postPipelineState.Get(),
+			IID_PPV_ARGS(&m_postCommandList)));
 
-        // Command lists are created in the 'recording' state. We always call Reset
-        // as the first thing when populating command lists, so we need to close
-        // these here for the first frame.
-        ThrowIfFailed(m_sceneCommandList->Close());
-        ThrowIfFailed(m_postCommandList->Close());
-    }
+		// Command lists are created in the 'recording' state. We always call Reset
+		// as the first thing when populating command lists, so we need to close
+		// these here for the first frame.
+		ThrowIfFailed(m_sceneCommandList->Close());
+		ThrowIfFailed(m_postCommandList->Close());
+	}
 
-    ComPtr<ID3D12Resource> triangleVertexBufferUpload;
-    ComPtr<ID3D12Resource> quadVertexBufferUpload;
+	ComPtr<ID3D12Resource> triangleVertexBufferUpload;
+	ComPtr<ID3D12Resource> quadVertexBufferUpload;
 
-    // Create the triangle vertex buffer.
-    {
-        // Define the geometry for a triangle.
-        SceneVertex vertices[] =
-        {
-            { { 0.0f, Settings::TriangleHalfWidth, Settings::TriangleDepth } },
-            { { Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } },
-            { { -Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } }
-        };
+	// Create the triangle vertex buffer.
+	{
+		// Define the geometry for a triangle.
+		SceneVertex vertices[] =
+		{
+			{ { 0.0f, Settings::TriangleHalfWidth, Settings::TriangleDepth } },
+			{ { Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } },
+			{ { -Settings::TriangleHalfWidth, -Settings::TriangleHalfWidth, Settings::TriangleDepth } }
+		};
 
-        const UINT vertexBufferSize = sizeof(vertices);
+		const UINT vertexBufferSize = sizeof(vertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_sceneVertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_sceneVertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&triangleVertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&triangleVertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(vertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(vertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(commandList.Get(), m_sceneVertexBuffer.Get(), triangleVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_sceneVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(commandList.Get(), m_sceneVertexBuffer.Get(), triangleVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_sceneVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_sceneVertexBufferView.BufferLocation = m_sceneVertexBuffer->GetGPUVirtualAddress();
-        m_sceneVertexBufferView.StrideInBytes = sizeof(SceneVertex);
-        m_sceneVertexBufferView.SizeInBytes = sizeof(vertices);
-    }
+		// Initialize the vertex buffer view.
+		m_sceneVertexBufferView.BufferLocation = m_sceneVertexBuffer->GetGPUVirtualAddress();
+		m_sceneVertexBufferView.StrideInBytes = sizeof(SceneVertex);
+		m_sceneVertexBufferView.SizeInBytes = sizeof(vertices);
+	}
 
-    // Create the quad vertex buffer.
-    {
-        // Define the geometry for a quad.
-        PostVertex vertices[] =
-        {
-            { { -1.0f, -1.0f, 0.0f }, { 0.0f, 1.0f } },    // Bottom Left
-            { { -1.0f, 1.0f, 0.0f }, { 0.0f, 0.0f } },    // Top Left
-            { { 1.0f, -1.0f, 0.0f }, { 1.0f, 1.0f } },    // Bottom Right
-            { { 1.0f, 1.0f, 0.0f }, { 1.0f, 0.0f } },    // Top Right
-        };
+	// Create the quad vertex buffer.
+	{
+		// Define the geometry for a quad.
+		PostVertex vertices[] =
+		{
+			{ { -1.0f, -1.0f, 0.0f }, { 0.0f, 1.0f } },	// Bottom Left
+			{ { -1.0f, 1.0f, 0.0f }, { 0.0f, 0.0f } },	// Top Left
+			{ { 1.0f, -1.0f, 0.0f }, { 1.0f, 1.0f } },	// Bottom Right
+			{ { 1.0f, 1.0f, 0.0f }, { 1.0f, 0.0f } },	// Top Right
+		};
 
-        const UINT vertexBufferSize = sizeof(vertices);
+		const UINT vertexBufferSize = sizeof(vertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_postVertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_postVertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&quadVertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&quadVertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(vertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(vertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(commandList.Get(), m_postVertexBuffer.Get(), quadVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_postVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(commandList.Get(), m_postVertexBuffer.Get(), quadVertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_postVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_postVertexBufferView.BufferLocation = m_postVertexBuffer->GetGPUVirtualAddress();
-        m_postVertexBufferView.StrideInBytes = sizeof(PostVertex);
-        m_postVertexBufferView.SizeInBytes = sizeof(vertices);
-    }
+		// Initialize the vertex buffer view.
+		m_postVertexBufferView.BufferLocation = m_postVertexBuffer->GetGPUVirtualAddress();
+		m_postVertexBufferView.StrideInBytes = sizeof(PostVertex);
+		m_postVertexBufferView.SizeInBytes = sizeof(vertices);
+	}
 
-    // Create and map the constant buffers.
-    {
-        // UPLOAD heaps are not duplicated by the Affinity layer because:
-        //   1. they live in system memory
-        //   2. they are expected to contain data that will be read by all GPUs.
-        // All of our constant buffers change each frame, so the state of any one frame
-        // is only ever read by a single GPU. Therefore, we must ensure that a large
-        // enough resource is created to persist frame data for all GPUs to read from.
-        const UINT constantBufferDataSize = Settings::TriangleCount * Settings::SceneConstantBufferFrames * sizeof(SceneConstantBuffer);
+	// Create and map the constant buffers.
+	{
+		// UPLOAD heaps are not duplicated by the Affinity layer because:
+		//   1. they live in system memory
+		//   2. they are expected to contain data that will be read by all GPUs.
+		// All of our constant buffers change each frame, so the state of any one frame
+		// is only ever read by a single GPU. Therefore, we must ensure that a large
+		// enough resource is created to persist frame data for all GPUs to read from.
+		const UINT constantBufferDataSize = Settings::TriangleCount * Settings::SceneConstantBufferFrames * sizeof(SceneConstantBuffer);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(constantBufferDataSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_sceneConstantBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(constantBufferDataSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_sceneConstantBuffer)));
 
-        // Map and initialize the constant buffer. We don't unmap this until the
-        // app closes. Keeping things mapped for the lifetime of the resource is okay.
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_sceneConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_mappedConstantBuffer)));
-        ZeroMemory(m_mappedConstantBuffer, constantBufferDataSize);
+		// Map and initialize the constant buffer. We don't unmap this until the
+		// app closes. Keeping things mapped for the lifetime of the resource is okay.
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_sceneConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_mappedConstantBuffer)));
+		ZeroMemory(m_mappedConstantBuffer, constantBufferDataSize);
 
-        // Create constant buffer views.
-        CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_sceneCbvHeap->GetCPUDescriptorHandleForHeapStart());
-        D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
-        cbvDesc.SizeInBytes = sizeof(SceneConstantBuffer);
-        cbvDesc.BufferLocation = m_sceneConstantBuffer->GetGPUVirtualAddress();
+		// Create constant buffer views.
+		CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_sceneCbvHeap->GetCPUDescriptorHandleForHeapStart());
+		D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
+		cbvDesc.SizeInBytes = sizeof(SceneConstantBuffer);
+		cbvDesc.BufferLocation = m_sceneConstantBuffer->GetGPUVirtualAddress();
 
-        for (UINT frame = 0; frame < Settings::SceneConstantBufferFrames; frame++)
-        {
-            for (UINT n = 0; n < Settings::TriangleCount; n++)
-            {
-                m_device->CreateConstantBufferView(&cbvDesc, cpuHandle);
+		for (UINT frame = 0; frame < Settings::SceneConstantBufferFrames; frame++)
+		{
+			for (UINT n = 0; n < Settings::TriangleCount; n++)
+			{
+				m_device->CreateConstantBufferView(&cbvDesc, cpuHandle);
 
-                cpuHandle.Offset(Settings::CbvSrvDescriptorSize);
-                cbvDesc.BufferLocation += cbvDesc.SizeInBytes;
-            }
-        }
-    }
+				cpuHandle.Offset(Settings::CbvSrvDescriptorSize);
+				cbvDesc.BufferLocation += cbvDesc.SizeInBytes;
+			}
+		}
+	}
 
-    for (UINT n = 0; n < Settings::TriangleCount; n++)
-    {
-        m_sceneData[n].velocity = XMFLOAT4(GetRandomFloat(0.005f, 0.01f), 0.0f, 0.0f, 0.0f);
-        m_sceneData[n].offset = XMFLOAT4(GetRandomFloat(-6.0f, -1.5f), GetRandomFloat(-1.0f, 1.0f), GetRandomFloat(0.0f, 2.0f), 0.0f);
-        m_sceneData[n].color = XMFLOAT4(GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), 1.0f);
-        m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
-    }
+	for (UINT n = 0; n < Settings::TriangleCount; n++)
+	{
+		m_sceneData[n].velocity = XMFLOAT4(GetRandomFloat(0.005f, 0.01f), 0.0f, 0.0f, 0.0f);
+		m_sceneData[n].offset = XMFLOAT4(GetRandomFloat(-6.0f, -1.5f), GetRandomFloat(-1.0f, 1.0f), GetRandomFloat(0.0f, 2.0f), 0.0f);
+		m_sceneData[n].color = XMFLOAT4(GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), GetRandomFloat(0.4f, 0.9f), 1.0f);
+		m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
+	}
 
-    // Describe and create a sampler.
-    {
-        D3D12_SAMPLER_DESC samplerDesc = {};
-        samplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-        samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.MinLOD = 0;
-        samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
-        samplerDesc.MipLODBias = 0.0f;
-        samplerDesc.MaxAnisotropy = 1;
-        samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
+	// Describe and create a sampler.
+	{
+		D3D12_SAMPLER_DESC samplerDesc = {};
+		samplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		samplerDesc.MinLOD = 0;
+		samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
+		samplerDesc.MipLODBias = 0.0f;
+		samplerDesc.MaxAnisotropy = 1;
+		samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
 
-        m_device->CreateSampler(&samplerDesc, m_postSamplerHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		m_device->CreateSampler(&samplerDesc, m_postSamplerHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    m_sceneFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
-    m_postFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
+	m_sceneFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
+	m_postFence = std::make_shared<LinearFence>(m_graphicsQueue.Get(), Settings::FrameCount);
 
-    ThrowIfFailed(commandList->Close());
+	ThrowIfFailed(commandList->Close());
 
-    // Submit the initialization work to the GPU.
-    ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Submit the initialization work to the GPU.
+	ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Wait for the graphics queue to finish executing the commands.
-    Fence fence(m_graphicsQueue.Get());
-    fence.FlushGpuQueue();
+	// Wait for the graphics queue to finish executing the commands.
+	Fence fence(m_graphicsQueue.Get());
+	fence.FlushGpuQueue();
 
-    LoadSizeDependentResources();
+	LoadSizeDependentResources();
 }
 
 void D3D12SingleGpu::LoadSizeDependentResources()
 {
-    // Single-use command allocator/list for resource initialization.
-    ComPtr<ID3D12CommandAllocator> commandAllocator;
-    ComPtr<ID3D12GraphicsCommandList> commandList;
+	// Single-use command allocator/list for resource initialization.
+	ComPtr<ID3D12CommandAllocator> commandAllocator;
+	ComPtr<ID3D12GraphicsCommandList> commandList;
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator)));
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
 
-    // Create RTVs for swap chain back buffers.
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart());
-    for (UINT n = 0; n < Settings::BackBufferCount; n++)
-    {
-        ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_postRenderTargets[n])));
+	// Create RTVs for swap chain back buffers.
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart());
+	for (UINT n = 0; n < Settings::BackBufferCount; n++)
+	{
+		ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_postRenderTargets[n])));
 
-        m_device->CreateRenderTargetView(m_postRenderTargets[n].Get(), nullptr, rtvHandle);
-        rtvHandle.Offset(Settings::RtvDescriptorSize);
-    }
+		m_device->CreateRenderTargetView(m_postRenderTargets[n].Get(), nullptr, rtvHandle);
+		rtvHandle.Offset(Settings::RtvDescriptorSize);
+	}
 
-    m_frameIndex = 0;
-    m_sceneRenderTargetIndex = 0;
+	m_frameIndex = 0;
+	m_sceneRenderTargetIndex = 0;
 
-    // Create the render targets used to draw the scene.
-    // These will be sampled from during the post-processing step.
-    {
-        D3D12_RESOURCE_DESC renderTargetDesc = m_postRenderTargets[0]->GetDesc();
-        D3D12_RESOURCE_ALLOCATION_INFO info = m_device->GetResourceAllocationInfo(0, 1, &renderTargetDesc);
-        const UINT64 alignedRenderTargetSize = AlignResource(info.SizeInBytes, info.Alignment);
+	// Create the render targets used to draw the scene.
+	// These will be sampled from during the post-processing step.
+	{
+		D3D12_RESOURCE_DESC renderTargetDesc = m_postRenderTargets[0]->GetDesc();
+		D3D12_RESOURCE_ALLOCATION_INFO info = m_device->GetResourceAllocationInfo(0, 1, &renderTargetDesc);
+		const UINT64 alignedRenderTargetSize = AlignResource(info.SizeInBytes, info.Alignment);
 
-        D3D12_HEAP_DESC heapDesc = {};
-        heapDesc.SizeInBytes = alignedRenderTargetSize * Settings::SceneHistoryCount;
-        heapDesc.Alignment = info.Alignment;
-        heapDesc.Properties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
-        heapDesc.Flags = D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES | D3D12_HEAP_FLAG_DENY_BUFFERS;
+		D3D12_HEAP_DESC heapDesc = {};
+		heapDesc.SizeInBytes = alignedRenderTargetSize * Settings::SceneHistoryCount;
+		heapDesc.Alignment = info.Alignment;
+		heapDesc.Properties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+		heapDesc.Flags = D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES | D3D12_HEAP_FLAG_DENY_BUFFERS;
 
-        ThrowIfFailed(m_device->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_sceneRenderTargetHeap)));
+		ThrowIfFailed(m_device->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_sceneRenderTargetHeap)));
 
-        CD3DX12_CLEAR_VALUE clearValue(DXGI_FORMAT_R8G8B8A8_UNORM, Settings::ClearColor);
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart());
-        CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_postSrvHeap->GetCPUDescriptorHandleForHeapStart());
+		CD3DX12_CLEAR_VALUE clearValue(DXGI_FORMAT_R8G8B8A8_UNORM, Settings::ClearColor);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart());
+		CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_postSrvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = 1;
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = 1;
 
-        D3D12_RESOURCE_BARRIER barriers[Settings::SceneHistoryCount];
+		D3D12_RESOURCE_BARRIER barriers[Settings::SceneHistoryCount];
 
-        for (UINT sceneIndex = 0; sceneIndex < Settings::SceneHistoryCount; sceneIndex++)
-        {
-            ThrowIfFailed(m_device->CreatePlacedResource(
-                m_sceneRenderTargetHeap.Get(),
-                alignedRenderTargetSize * sceneIndex,
-                &renderTargetDesc,
-                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                &clearValue,
-                IID_PPV_ARGS(&m_sceneRenderTargets[sceneIndex])));
+		for (UINT sceneIndex = 0; sceneIndex < Settings::SceneHistoryCount; sceneIndex++)
+		{
+			ThrowIfFailed(m_device->CreatePlacedResource(
+				m_sceneRenderTargetHeap.Get(),
+				alignedRenderTargetSize * sceneIndex,
+				&renderTargetDesc,
+				D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+				&clearValue,
+				IID_PPV_ARGS(&m_sceneRenderTargets[sceneIndex])));
 
-            barriers[sceneIndex] = CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, m_sceneRenderTargets[sceneIndex].Get());
+			barriers[sceneIndex] = CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, m_sceneRenderTargets[sceneIndex].Get());
 
-            m_device->CreateRenderTargetView(m_sceneRenderTargets[sceneIndex].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(Settings::RtvDescriptorSize);
+			m_device->CreateRenderTargetView(m_sceneRenderTargets[sceneIndex].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(Settings::RtvDescriptorSize);
 
-            m_device->CreateShaderResourceView(m_sceneRenderTargets[sceneIndex].Get(), &srvDesc, srvHandle);
-            srvHandle.Offset(Settings::CbvSrvDescriptorSize);
-        }
+			m_device->CreateShaderResourceView(m_sceneRenderTargets[sceneIndex].Get(), &srvDesc, srvHandle);
+			srvHandle.Offset(Settings::CbvSrvDescriptorSize);
+		}
 
-        commandList->ResourceBarrier(_countof(barriers), barriers);
-    }
+		commandList->ResourceBarrier(_countof(barriers), barriers);
+	}
 
-    // Create the depth stencil and its view.
-    {
-        CD3DX12_HEAP_PROPERTIES heapProps(D3D12_HEAP_TYPE_DEFAULT);
-        CD3DX12_CLEAR_VALUE depthOptimizedClearValue(DXGI_FORMAT_D32_FLOAT, 1.0f, 0);
+	// Create the depth stencil and its view.
+	{
+		CD3DX12_HEAP_PROPERTIES heapProps(D3D12_HEAP_TYPE_DEFAULT);
+		CD3DX12_CLEAR_VALUE depthOptimizedClearValue(DXGI_FORMAT_D32_FLOAT, 1.0f, 0);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &heapProps,
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, Settings::Width, Settings::Height, 1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
-            D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            &depthOptimizedClearValue,
-            IID_PPV_ARGS(&m_sceneDepthStencil)
-            ));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&heapProps,
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, Settings::Width, Settings::Height, 1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
+			D3D12_RESOURCE_STATE_DEPTH_WRITE,
+			&depthOptimizedClearValue,
+			IID_PPV_ARGS(&m_sceneDepthStencil)
+			));
 
-        D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
-        depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
-        depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+		D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
+		depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
+		depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
 
-        m_device->CreateDepthStencilView(m_sceneDepthStencil.Get(), &depthStencilDesc, m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		m_device->CreateDepthStencilView(m_sceneDepthStencil.Get(), &depthStencilDesc, m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    ThrowIfFailed(commandList->Close());
+	ThrowIfFailed(commandList->Close());
 
-    // Submit the resource barrier changes to the GPU.
-    ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Submit the resource barrier changes to the GPU.
+	ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Wait for the graphics queue to finish executing the commands.
-    Fence fence(m_graphicsQueue.Get());
-    fence.FlushGpuQueue();
+	// Wait for the graphics queue to finish executing the commands.
+	Fence fence(m_graphicsQueue.Get());
+	fence.FlushGpuQueue();
 }
 
 // Get a random float value between min and max.
 float D3D12SingleGpu::GetRandomFloat(float min, float max)
 {
-    float scale = static_cast<float>(rand()) / RAND_MAX;
-    float range = max - min;
-    return scale * range + min;
+	float scale = static_cast<float>(rand()) / RAND_MAX;
+	float range = max - min;
+	return scale * range + min;
 }
 
 void D3D12SingleGpu::UpdateWindowTitle()
 {
-    WCHAR nodeText[100];
-    swprintf_s(nodeText, L"Node Count = 1 | SyncInterval = %u | SimulatedLoad = %u", m_syncInterval, m_simulatedGpuLoad);
-    SetCustomWindowText(nodeText);
+	WCHAR nodeText[100];
+	swprintf_s(nodeText, L"Node Count = 1 | SyncInterval = %u | SimulatedLoad = %u", m_syncInterval, m_simulatedGpuLoad);
+	SetCustomWindowText(nodeText);
 }
 
 // Update frame-based values.
 void D3D12SingleGpu::OnUpdate()
 {
-    for (UINT n = 0; n < Settings::TriangleCount; n++)
-    {
-        const float offsetBounds = 1.5f * m_aspectRatio;
+	for (UINT n = 0; n < Settings::TriangleCount; n++)
+	{
+		const float offsetBounds = 1.5f * m_aspectRatio;
 
-        // Animate the triangles.
-        m_sceneData[n].offset.x += m_sceneData[n].velocity.x;
-        if (m_sceneData[n].offset.x > offsetBounds)
-        {
-            m_sceneData[n].velocity.x = GetRandomFloat(0.005f, 0.01f);
-            m_sceneData[n].offset.x = -offsetBounds;
-        }
-    }
+		// Animate the triangles.
+		m_sceneData[n].offset.x += m_sceneData[n].velocity.x;
+		if (m_sceneData[n].offset.x > offsetBounds)
+		{
+			m_sceneData[n].velocity.x = GetRandomFloat(0.005f, 0.01f);
+			m_sceneData[n].offset.x = -offsetBounds;
+		}
+	}
 
-    UINT index = m_frameId % Settings::SceneConstantBufferFrames;
-    UINT offset = Settings::TriangleCount * index * sizeof(SceneConstantBuffer);
+	UINT index = m_frameId % Settings::SceneConstantBufferFrames;
+	UINT offset = Settings::TriangleCount * index * sizeof(SceneConstantBuffer);
 
-    memcpy(m_mappedConstantBuffer + offset, m_sceneData.data(), Settings::TriangleCount * sizeof(SceneConstantBuffer));
+	memcpy(m_mappedConstantBuffer + offset, m_sceneData.data(), Settings::TriangleCount * sizeof(SceneConstantBuffer));
 }
 
 // Render the scene.
 void D3D12SingleGpu::OnRender()
 {
-    if (m_windowVisible)
-    {
-        // Render and present the current frame.
-        RenderScene();
-        RenderPost();
+	if (m_windowVisible)
+	{
+		// Render and present the current frame.
+		RenderScene();
+		RenderPost();
 
-        // When using sync interval 0, it is recommended to always pass the tearing
-        // flag when it is supported, even if not presenting to a fullscreen window.
-        // This flag cannot be used if the app is in "exclusive" fullscreen mode as
-        // a result of calling SetFullscreenState.
+		// When using sync interval 0, it is recommended to always pass the tearing
+		// flag when it is supported, even if not presenting to a fullscreen window.
+		// This flag cannot be used if the app is in "exclusive" fullscreen mode as
+		// a result of calling SetFullscreenState.
 
-        UINT presentFlags = (m_syncInterval == 0 && m_tearingSupport && m_windowedMode) ? DXGI_PRESENT_ALLOW_TEARING : 0;
-        ThrowIfFailed(m_swapChain->Present(m_syncInterval, presentFlags));
+		UINT presentFlags = (m_syncInterval == 0 && m_tearingSupport && m_windowedMode) ? DXGI_PRESENT_ALLOW_TEARING : 0;
+		ThrowIfFailed(m_swapChain->Present(m_syncInterval, presentFlags));
 
-        MoveToNextFrame();
-    }
+		MoveToNextFrame();
+	}
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12SingleGpu::RenderScene()
 {
-    UINT cbvDescriptorTableOffset = Settings::TriangleCount * (m_frameId % Settings::SceneConstantBufferFrames);
-    CD3DX12_GPU_DESCRIPTOR_HANDLE cbvHandle(m_sceneCbvHeap->GetGPUDescriptorHandleForHeapStart(), cbvDescriptorTableOffset, Settings::CbvSrvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart(), m_sceneRenderTargetIndex, Settings::RtvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
+	UINT cbvDescriptorTableOffset = Settings::TriangleCount * (m_frameId % Settings::SceneConstantBufferFrames);
+	CD3DX12_GPU_DESCRIPTOR_HANDLE cbvHandle(m_sceneCbvHeap->GetGPUDescriptorHandleForHeapStart(), cbvDescriptorTableOffset, Settings::CbvSrvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_sceneRtvHeap->GetCPUDescriptorHandleForHeapStart(), m_sceneRenderTargetIndex, Settings::RtvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_sceneDsvHeap->GetCPUDescriptorHandleForHeapStart());
 
-    m_sceneFence->Next();
+	m_sceneFence->Next();
 
-    // Record the rendering commands.
-    ThrowIfFailed(m_sceneCommandAllocators[m_frameIndex]->Reset());
-    ThrowIfFailed(m_sceneCommandList->Reset(m_sceneCommandAllocators[m_frameIndex].Get(), m_scenePipelineState.Get()));
+	// Record the rendering commands.
+	ThrowIfFailed(m_sceneCommandAllocators[m_frameIndex]->Reset());
+	ThrowIfFailed(m_sceneCommandList->Reset(m_sceneCommandAllocators[m_frameIndex].Get(), m_scenePipelineState.Get()));
 
-    // Set necessary state.
-    m_sceneCommandList->SetGraphicsRootSignature(m_sceneRootSignature.Get());
-    m_sceneCommandList->SetGraphicsRoot32BitConstant(1, m_simulatedGpuLoad, 0);
+	// Set necessary state.
+	m_sceneCommandList->SetGraphicsRootSignature(m_sceneRootSignature.Get());
+	m_sceneCommandList->SetGraphicsRoot32BitConstant(1, m_simulatedGpuLoad, 0);
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_sceneCbvHeap.Get() };
-    m_sceneCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_sceneCbvHeap.Get() };
+	m_sceneCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_sceneCommandList->RSSetViewports(1, &Settings::Viewport);
-    m_sceneCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
-    m_sceneCommandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
+	m_sceneCommandList->RSSetViewports(1, &Settings::Viewport);
+	m_sceneCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
+	m_sceneCommandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
 
-    // Record commands.
-    D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(
-        m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(),
-        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-        D3D12_RESOURCE_STATE_RENDER_TARGET);
+	// Record commands.
+	D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(
+		m_sceneRenderTargets[m_sceneRenderTargetIndex].Get(),
+		D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+		D3D12_RESOURCE_STATE_RENDER_TARGET);
 
-    m_sceneCommandList->ResourceBarrier(1, &barrier);
-    m_sceneCommandList->ClearRenderTargetView(rtvHandle, Settings::ClearColor, 0, nullptr);
-    m_sceneCommandList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+	m_sceneCommandList->ResourceBarrier(1, &barrier);
+	m_sceneCommandList->ClearRenderTargetView(rtvHandle, Settings::ClearColor, 0, nullptr);
+	m_sceneCommandList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
 
-    m_sceneCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    m_sceneCommandList->IASetVertexBuffers(0, 1, &m_sceneVertexBufferView);
+	m_sceneCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_sceneCommandList->IASetVertexBuffers(0, 1, &m_sceneVertexBufferView);
 
-    for (UINT triangle = 0; triangle < Settings::TriangleCount; triangle++)
-    {
-        m_sceneCommandList->SetGraphicsRootDescriptorTable(0, cbvHandle);
-        m_sceneCommandList->DrawInstanced(3, 1, 0, 0);
+	for (UINT triangle = 0; triangle < Settings::TriangleCount; triangle++)
+	{
+		m_sceneCommandList->SetGraphicsRootDescriptorTable(0, cbvHandle);
+		m_sceneCommandList->DrawInstanced(3, 1, 0, 0);
 
-        cbvHandle.Offset(Settings::CbvSrvDescriptorSize);
-    }
+		cbvHandle.Offset(Settings::CbvSrvDescriptorSize);
+	}
 
-    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-    m_sceneCommandList->ResourceBarrier(1, &barrier);
+	barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	m_sceneCommandList->ResourceBarrier(1, &barrier);
 
-    ThrowIfFailed(m_sceneCommandList->Close());
+	ThrowIfFailed(m_sceneCommandList->Close());
 
-    ID3D12CommandList* ppSceneCommandLists[] = { m_sceneCommandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppSceneCommandLists), ppSceneCommandLists);
+	ID3D12CommandList* ppSceneCommandLists[] = { m_sceneCommandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppSceneCommandLists), ppSceneCommandLists);
 
-    m_sceneFence->Signal();
+	m_sceneFence->Signal();
 }
 
 void D3D12SingleGpu::RenderPost()
 {
-    UINT backBufferIndex = m_swapChain->GetCurrentBackBufferIndex();
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart(), backBufferIndex, Settings::RtvDescriptorSize);
+	UINT backBufferIndex = m_swapChain->GetCurrentBackBufferIndex();
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_postRtvHeap->GetCPUDescriptorHandleForHeapStart(), backBufferIndex, Settings::RtvDescriptorSize);
 
-    m_postFence->Next();
+	m_postFence->Next();
 
-    ThrowIfFailed(m_postCommandAllocators[m_frameIndex]->Reset());
-    ThrowIfFailed(m_postCommandList->Reset(m_postCommandAllocators[m_frameIndex].Get(), m_postPipelineState.Get()));
+	ThrowIfFailed(m_postCommandAllocators[m_frameIndex]->Reset());
+	ThrowIfFailed(m_postCommandList->Reset(m_postCommandAllocators[m_frameIndex].Get(), m_postPipelineState.Get()));
 
-    m_postCommandList->SetGraphicsRootSignature(m_postRootSignature.Get());
+	m_postCommandList->SetGraphicsRootSignature(m_postRootSignature.Get());
 
-    ID3D12DescriptorHeap* ppPostHeaps[] = { m_postSrvHeap.Get(), m_postSamplerHeap.Get() };
-    m_postCommandList->SetDescriptorHeaps(_countof(ppPostHeaps), ppPostHeaps);
+	ID3D12DescriptorHeap* ppPostHeaps[] = { m_postSrvHeap.Get(), m_postSamplerHeap.Get() };
+	m_postCommandList->SetDescriptorHeaps(_countof(ppPostHeaps), ppPostHeaps);
 
-    m_postCommandList->RSSetViewports(1, &Settings::Viewport);
-    m_postCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
+	m_postCommandList->RSSetViewports(1, &Settings::Viewport);
+	m_postCommandList->RSSetScissorRects(1, &Settings::ScissorRect);
 
-    D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(
-        m_postRenderTargets[backBufferIndex].Get(),
-        D3D12_RESOURCE_STATE_PRESENT,
-        D3D12_RESOURCE_STATE_RENDER_TARGET);
+	D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(
+		m_postRenderTargets[backBufferIndex].Get(),
+		D3D12_RESOURCE_STATE_PRESENT,
+		D3D12_RESOURCE_STATE_RENDER_TARGET);
 
-    m_postCommandList->ResourceBarrier(1, &barrier);
+	m_postCommandList->ResourceBarrier(1, &barrier);
 
-    m_postCommandList->OMSetRenderTargets(1, &rtvHandle, false, nullptr);
+	m_postCommandList->OMSetRenderTargets(1, &rtvHandle, false, nullptr);
 
-    m_postCommandList->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-    m_postCommandList->IASetVertexBuffers(0, 1, &m_postVertexBufferView);
+	m_postCommandList->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+	m_postCommandList->IASetVertexBuffers(0, 1, &m_postVertexBufferView);
 
-    m_postCommandList->SetGraphicsRootDescriptorTable(0, m_postSrvHeap->GetGPUDescriptorHandleForHeapStart());
-    m_postCommandList->SetGraphicsRootDescriptorTable(1, m_postSamplerHeap->GetGPUDescriptorHandleForHeapStart());
-    m_postCommandList->SetGraphicsRoot32BitConstant(2, m_frameId % Settings::SceneHistoryCount, 0);
-    m_postCommandList->SetGraphicsRoot32BitConstant(2, static_cast<UINT>(min(m_frameId + 1, Settings::SceneHistoryCount)), 1);
+	m_postCommandList->SetGraphicsRootDescriptorTable(0, m_postSrvHeap->GetGPUDescriptorHandleForHeapStart());
+	m_postCommandList->SetGraphicsRootDescriptorTable(1, m_postSamplerHeap->GetGPUDescriptorHandleForHeapStart());
+	m_postCommandList->SetGraphicsRoot32BitConstant(2, m_frameId % Settings::SceneHistoryCount, 0);
+	m_postCommandList->SetGraphicsRoot32BitConstant(2, static_cast<UINT>(min(m_frameId + 1, Settings::SceneHistoryCount)), 1);
 
-    m_postCommandList->DrawInstanced(4, 1, 0, 0);
+	m_postCommandList->DrawInstanced(4, 1, 0, 0);
 
-    // Indicate that the back buffer will now be used to present.
-    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
+	// Indicate that the back buffer will now be used to present.
+	barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
 
-    m_postCommandList->ResourceBarrier(1, &barrier);
+	m_postCommandList->ResourceBarrier(1, &barrier);
 
-    ThrowIfFailed(m_postCommandList->Close());
+	ThrowIfFailed(m_postCommandList->Close());
 
-    ID3D12CommandList* ppPostCommandLists[] = { m_postCommandList.Get() };
-    m_graphicsQueue->ExecuteCommandLists(_countof(ppPostCommandLists), ppPostCommandLists);
+	ID3D12CommandList* ppPostCommandLists[] = { m_postCommandList.Get() };
+	m_graphicsQueue->ExecuteCommandLists(_countof(ppPostCommandLists), ppPostCommandLists);
 }
 
 void D3D12SingleGpu::OnSizeChanged(UINT width, UINT height, bool minimized)
 {
-    // Determine if the swap buffers and other resources need to be resized or not.
-    if ((width != m_width || height != m_height) && !minimized)
-    {
-        // Flush all current GPU commands.
-        WaitForGpu();
+	// Determine if the swap buffers and other resources need to be resized or not.
+	if ((width != m_width || height != m_height) && !minimized)
+	{
+		// Flush all current GPU commands.
+		WaitForGpu();
 
-        // Release buffers tied to the swap chain and update the global Settings
-        // for the new size.
-        for (UINT n = 0; n < Settings::BackBufferCount; n++)
-        {
-            m_postRenderTargets[n].Reset();
-        }
-        Settings::OnSizeChanged(width, height);
+		// Release buffers tied to the swap chain and update the global Settings
+		// for the new size.
+		for (UINT n = 0; n < Settings::BackBufferCount; n++)
+		{
+			m_postRenderTargets[n].Reset();
+		}
+		Settings::OnSizeChanged(width, height);
 
-        // Resize the swap chain to the desired dimensions.
-        DXGI_SWAP_CHAIN_DESC1 swapChainDesc;
-        ThrowIfFailed(m_swapChain->GetDesc1(&swapChainDesc));
-        ThrowIfFailed(m_swapChain->ResizeBuffers(Settings::BackBufferCount, width, height, swapChainDesc.Format, swapChainDesc.Flags));
+		// Resize the swap chain to the desired dimensions.
+		DXGI_SWAP_CHAIN_DESC1 swapChainDesc;
+		ThrowIfFailed(m_swapChain->GetDesc1(&swapChainDesc));
+		ThrowIfFailed(m_swapChain->ResizeBuffers(Settings::BackBufferCount, width, height, swapChainDesc.Format, swapChainDesc.Flags));
 
-        // Re-create render targets.
-        LoadSizeDependentResources();
+		// Re-create render targets.
+		LoadSizeDependentResources();
 
-        // Align the frameId so that assumptions in post-processing hold.
-        m_frameId += (Settings::SceneHistoryCount - (m_frameId % Settings::SceneHistoryCount));
+		// Align the frameId so that assumptions in post-processing hold.
+		m_frameId += (Settings::SceneHistoryCount - (m_frameId % Settings::SceneHistoryCount));
 
-        // Update the m_width, m_height, and m_aspectRatio member variables.
-        UpdateForSizeChange(width, height);
+		// Update the m_width, m_height, and m_aspectRatio member variables.
+		UpdateForSizeChange(width, height);
 
-        // Update the scene projection matrix.
-        for (UINT n = 0; n < Settings::TriangleCount; n++)
-        {
-            m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
-        }
-    }
+		// Update the scene projection matrix.
+		for (UINT n = 0; n < Settings::TriangleCount; n++)
+		{
+			m_sceneData[n].projection = XMMatrixTranspose(XMMatrixPerspectiveFovLH(XM_PIDIV4, m_aspectRatio, 0.01f, 20.0f));
+		}
+	}
 
-    m_windowVisible = !minimized;
+	m_windowVisible = !minimized;
 }
 
 void D3D12SingleGpu::OnKeyDown(UINT8 key)
 {
-    switch (key)
-    {
-    // Instrument the Space Bar to toggle between fullscreen states.
-    // The CoreWindow will fire a SizeChanged event once the window is in the
-    // fullscreen state. At that point, the IDXGISwapChain should be resized
-    // to match the new window size.
-    case VK_SPACE:
-    {
-        auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-        if (applicationView->IsFullScreenMode)
-        {
-            applicationView->ExitFullScreenMode();
-        }
-        else
-        {
-            applicationView->TryEnterFullScreenMode();
-        }
-        break;
-    }
+	switch (key)
+	{
+	// Instrument the Space Bar to toggle between fullscreen states.
+	// The CoreWindow will fire a SizeChanged event once the window is in the
+	// fullscreen state. At that point, the IDXGISwapChain should be resized
+	// to match the new window size.
+	case VK_SPACE:
+	{
+		auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+		if (applicationView->IsFullScreenMode)
+		{
+			applicationView->ExitFullScreenMode();
+		}
+		else
+		{
+			applicationView->TryEnterFullScreenMode();
+		}
+		break;
+	}
 
-    case VK_LEFT:
-    case VK_RIGHT:
-        m_syncInterval = (m_syncInterval > 0) ? 0 : 1;
-        UpdateWindowTitle();
-        break;
+	case VK_LEFT:
+	case VK_RIGHT:
+		m_syncInterval = (m_syncInterval > 0) ? 0 : 1;
+		UpdateWindowTitle();
+		break;
 
-    case VK_UP:
-        if (m_simulatedGpuLoad > 0)
-        {
-            if (m_simulatedGpuLoad < 0x80000)
-            {
-                m_simulatedGpuLoad <<= 1;
-            }
-        }
-        else
-        {
-            m_simulatedGpuLoad = 1;
-        }
-        UpdateWindowTitle();
-        break;
+	case VK_UP:
+		if (m_simulatedGpuLoad > 0)
+		{
+			if (m_simulatedGpuLoad < 0x80000)
+			{
+				m_simulatedGpuLoad <<= 1;
+			}
+		}
+		else
+		{
+			m_simulatedGpuLoad = 1;
+		}
+		UpdateWindowTitle();
+		break;
 
-    case VK_DOWN:
-        if (m_simulatedGpuLoad != 0)
-        {
-            m_simulatedGpuLoad >>= 1;
-        }
-        UpdateWindowTitle();
-        break;
-    }
+	case VK_DOWN:
+		if (m_simulatedGpuLoad != 0)
+		{
+			m_simulatedGpuLoad >>= 1;
+		}
+		UpdateWindowTitle();
+		break;
+	}
 }
 
 void D3D12SingleGpu::OnDestroy()
 {
-    // Wait for the GPUs to be done with all their resources.
-    WaitForGpu();
+	// Wait for the GPUs to be done with all their resources.
+	WaitForGpu();
 }
 
 // Wait for pending GPU work to complete.
 void D3D12SingleGpu::WaitForGpu()
 {
-    m_postFence->FlushGpuQueue();
+	m_postFence->FlushGpuQueue();
 }
 
 // Prepare to render the next frame.
 void D3D12SingleGpu::MoveToNextFrame()
 {
-    m_postFence->Signal();
+	m_postFence->Signal();
 
-    // Advance to the next frame.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Advance to the next frame.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    m_sceneRenderTargetIndex = (m_sceneRenderTargetIndex + 1) % Settings::SceneHistoryCount;
+	m_sceneRenderTargetIndex = (m_sceneRenderTargetIndex + 1) % Settings::SceneHistoryCount;
 
-    m_frameId++;
+	m_frameId++;
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/D3D12SingleGpu.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/D3D12SingleGpu.h
@@ -22,104 +22,104 @@ using Microsoft::WRL::ComPtr;
 class D3D12SingleGpu : public DXSample
 {
 public:
-    D3D12SingleGpu(UINT width, UINT height, std::wstring name);
+	D3D12SingleGpu(UINT width, UINT height, std::wstring name);
 
 protected:
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
-    virtual void OnKeyDown(UINT8 key);
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
+	virtual void OnKeyDown(UINT8 key);
+	virtual void OnDestroy();
 
 private:
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12CommandQueue> m_graphicsQueue;
-    std::vector<ComPtr<ID3D12CommandAllocator>> m_sceneCommandAllocators;
-    std::vector<ComPtr<ID3D12CommandAllocator>> m_postCommandAllocators;
-    ComPtr<ID3D12DescriptorHeap> m_sceneRtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_sceneDsvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_sceneCbvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_postRtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_postSrvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_postSamplerHeap;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12CommandQueue> m_graphicsQueue;
+	std::vector<ComPtr<ID3D12CommandAllocator>> m_sceneCommandAllocators;
+	std::vector<ComPtr<ID3D12CommandAllocator>> m_postCommandAllocators;
+	ComPtr<ID3D12DescriptorHeap> m_sceneRtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_sceneDsvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_sceneCbvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_postRtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_postSrvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_postSamplerHeap;
 
-    // Objects used for rendering the scene.
-    ComPtr<ID3D12GraphicsCommandList> m_sceneCommandList;
-    ComPtr<ID3D12RootSignature> m_sceneRootSignature;
-    ComPtr<ID3D12PipelineState> m_scenePipelineState;
-    ComPtr<ID3D12Resource> m_sceneVertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_sceneVertexBufferView;
-    ComPtr<ID3D12Resource> m_sceneConstantBuffer;
-    UINT8* m_mappedConstantBuffer;
-    ComPtr<ID3D12Heap> m_sceneRenderTargetHeap;
-    std::vector<ComPtr<ID3D12Resource>> m_sceneRenderTargets;
-    ComPtr<ID3D12Resource> m_sceneDepthStencil;
+	// Objects used for rendering the scene.
+	ComPtr<ID3D12GraphicsCommandList> m_sceneCommandList;
+	ComPtr<ID3D12RootSignature> m_sceneRootSignature;
+	ComPtr<ID3D12PipelineState> m_scenePipelineState;
+	ComPtr<ID3D12Resource> m_sceneVertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_sceneVertexBufferView;
+	ComPtr<ID3D12Resource> m_sceneConstantBuffer;
+	UINT8* m_mappedConstantBuffer;
+	ComPtr<ID3D12Heap> m_sceneRenderTargetHeap;
+	std::vector<ComPtr<ID3D12Resource>> m_sceneRenderTargets;
+	ComPtr<ID3D12Resource> m_sceneDepthStencil;
 
-    // Objects used for post-processing.
-    ComPtr<ID3D12GraphicsCommandList> m_postCommandList;
-    ComPtr<ID3D12RootSignature> m_postRootSignature;
-    ComPtr<ID3D12PipelineState> m_postPipelineState;
-    ComPtr<ID3D12Resource> m_postVertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_postVertexBufferView;
-    std::vector<ComPtr<ID3D12Resource>> m_postRenderTargets;
+	// Objects used for post-processing.
+	ComPtr<ID3D12GraphicsCommandList> m_postCommandList;
+	ComPtr<ID3D12RootSignature> m_postRootSignature;
+	ComPtr<ID3D12PipelineState> m_postPipelineState;
+	ComPtr<ID3D12Resource> m_postVertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_postVertexBufferView;
+	std::vector<ComPtr<ID3D12Resource>> m_postRenderTargets;
 
-    // A fence to indicate when the scene pass is complete.
-    std::shared_ptr<LinearFence> m_sceneFence;
+	// A fence to indicate when the scene pass is complete.
+	std::shared_ptr<LinearFence> m_sceneFence;
 
-    // A fence to regulate submission of post-processing render passes.
-    // Up to 'Settings::FrameCount' command lists can be in flight on the node at once.
-    std::shared_ptr<LinearFence> m_postFence;
+	// A fence to regulate submission of post-processing render passes.
+	// Up to 'Settings::FrameCount' command lists can be in flight on the node at once.
+	std::shared_ptr<LinearFence> m_postFence;
 
-    // Vertex definitions.
-    struct SceneVertex
-    {
-        DirectX::XMFLOAT3 position;
-    };
+	// Vertex definitions.
+	struct SceneVertex
+	{
+		DirectX::XMFLOAT3 position;
+	};
 
-    struct PostVertex
-    {
-        DirectX::XMFLOAT3 position;
-        DirectX::XMFLOAT2 uv;
-    };
+	struct PostVertex
+	{
+		DirectX::XMFLOAT3 position;
+		DirectX::XMFLOAT2 uv;
+	};
 
-    // Constant buffer definition.
-    struct SceneConstantBuffer
-    {
-        DirectX::XMFLOAT4 velocity;
-        DirectX::XMFLOAT4 offset;
-        DirectX::XMFLOAT4 color;
-        DirectX::XMMATRIX projection;
+	// Constant buffer definition.
+	struct SceneConstantBuffer
+	{
+		DirectX::XMFLOAT4 velocity;
+		DirectX::XMFLOAT4 offset;
+		DirectX::XMFLOAT4 color;
+		DirectX::XMMATRIX projection;
 
-        // Constant buffers are 256-byte aligned. Add padding in the struct to allow
-        // multiple buffers to be array-indexed.
-        float padding[36];
-    };
+		// Constant buffers are 256-byte aligned. Add padding in the struct to allow
+		// multiple buffers to be array-indexed.
+		float padding[36];
+	};
 
-    // Data about each of the triangles in the scene.
-    std::vector<SceneConstantBuffer> m_sceneData;
+	// Data about each of the triangles in the scene.
+	std::vector<SceneConstantBuffer> m_sceneData;
 
-    UINT64 m_frameId;
-    UINT m_simulatedGpuLoad;
-    UINT m_frameIndex;
-    UINT m_sceneRenderTargetIndex;
-    UINT m_syncInterval;
-    bool m_windowVisible;
-    bool m_windowedMode;
+	UINT64 m_frameId;
+	UINT m_simulatedGpuLoad;
+	UINT m_frameIndex;
+	UINT m_sceneRenderTargetIndex;
+	UINT m_syncInterval;
+	bool m_windowVisible;
+	bool m_windowedMode;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void LoadSizeDependentResources();
-    float GetRandomFloat(float min, float max);
-    void UpdateWindowTitle();
-    void RenderScene();
-    void RenderPost();
-    void WaitForGpu();
-    void MoveToNextFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	void LoadSizeDependentResources();
+	float GetRandomFloat(float min, float max);
+	void UpdateWindowTitle();
+	void RenderScene();
+	void RenderPost();
+	void WaitForGpu();
+	void MoveToNextFrame();
 
-    static inline UINT64 AlignResource(UINT64 size, UINT64 alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT)
-    {
-        return (size + alignment - 1) & ~(alignment - 1);
-    }
+	static inline UINT64 AlignResource(UINT64 size, UINT64 alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT)
+	{
+		return (size + alignment - 1) & ~(alignment - 1);
+	}
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/DXSample.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/DXSample.cpp
@@ -52,33 +52,78 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
+
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+            }
+#if !defined(_XBOX_ONE)
+        }
+#endif
 
     *ppAdapter = adapter.Detach();
-}
+    }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/DXSample.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/DXSample.h
@@ -48,7 +48,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/Fence.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/Fence.h
@@ -20,138 +20,138 @@ using Microsoft::WRL::ComPtr;
 class Fence
 {
 public:
-    // Create a fence and associate it with the specified command queue for
-    // convenience in working with fences.
-    Fence(ID3D12CommandQueue* pQueue) :
-        m_currentFenceValue(0)
-    {
-        ThrowIfFailed(pQueue->QueryInterface(IID_PPV_ARGS(&m_queue)));
+	// Create a fence and associate it with the specified command queue for
+	// convenience in working with fences.
+	Fence(ID3D12CommandQueue* pQueue) :
+		m_currentFenceValue(0)
+	{
+		ThrowIfFailed(pQueue->QueryInterface(IID_PPV_ARGS(&m_queue)));
 
-        ComPtr<ID3D12Device> device;
-        ThrowIfFailed(m_queue->GetDevice(IID_PPV_ARGS(&device)));
+		ComPtr<ID3D12Device> device;
+		ThrowIfFailed(m_queue->GetDevice(IID_PPV_ARGS(&device)));
 
-        ThrowIfFailed(device->CreateFence(m_currentFenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		ThrowIfFailed(device->CreateFence(m_currentFenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
 
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
-    }
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
+	}
 
-    ~Fence()
-    {
-        if (m_fenceEvent)
-        {
-            CloseHandle(m_fenceEvent);
-            m_fenceEvent = nullptr;
-        }
-    }
+	~Fence()
+	{
+		if (m_fenceEvent)
+		{
+			CloseHandle(m_fenceEvent);
+			m_fenceEvent = nullptr;
+		}
+	}
 
-    // Drain the GPU command queue.
-    // (Blocks the calling CPU thread)
-    inline void FlushGpuQueue()
-    {
-        Signal();
-        CpuWait(m_currentFenceValue);
-    }
+	// Drain the GPU command queue.
+	// (Blocks the calling CPU thread)
+	inline void FlushGpuQueue()
+	{
+		Signal();
+		CpuWait(m_currentFenceValue);
+	}
 
-    // Issue a Signal command on the command queue.
-    // Use the current value of the fence or override it with your own value.
-    inline void Signal(UINT64 value = UnspecifiedFenceValue)
-    {
-        if (value == UnspecifiedFenceValue)
-        {
-            m_currentFenceValue++;
-        }
-        else
-        {
-            _ASSERT(value > m_currentFenceValue);
-            m_currentFenceValue = value;
-        }
+	// Issue a Signal command on the command queue.
+	// Use the current value of the fence or override it with your own value.
+	inline void Signal(UINT64 value = UnspecifiedFenceValue)
+	{
+		if (value == UnspecifiedFenceValue)
+		{
+			m_currentFenceValue++;
+		}
+		else
+		{
+			_ASSERT(value > m_currentFenceValue);
+			m_currentFenceValue = value;
+		}
 
-        ThrowIfFailed(m_queue->Signal(m_fence.Get(), m_currentFenceValue));
-    }
+		ThrowIfFailed(m_queue->Signal(m_fence.Get(), m_currentFenceValue));
+	}
 
-    // Instruct the GPU queue associated with this fence to wait for a value to be signaled.
-    // Use the current value of the fence or override it with your own value.
-    // (Does not block the calling CPU thread)
-    inline void GpuWait(UINT64 value = UnspecifiedFenceValue)
-    {
-        if (value == UnspecifiedFenceValue)
-        {
-            value = m_currentFenceValue;
-        }
+	// Instruct the GPU queue associated with this fence to wait for a value to be signaled.
+	// Use the current value of the fence or override it with your own value.
+	// (Does not block the calling CPU thread)
+	inline void GpuWait(UINT64 value = UnspecifiedFenceValue)
+	{
+		if (value == UnspecifiedFenceValue)
+		{
+			value = m_currentFenceValue;
+		}
 
-        ThrowIfFailed(m_queue->Wait(m_fence.Get(), value));
-    }
+		ThrowIfFailed(m_queue->Wait(m_fence.Get(), value));
+	}
 
-    // Instruct a GPU queue on the active node to wait for the fences on the other nodes.
-    // Use the current values of the fences or override them with your own value.
-    // (Does not block the calling CPU thread)
-    inline static void GpuWait(ID3D12CommandQueue* pQueue, Fence* pFence, UINT64 value = UnspecifiedFenceValue)
-    {
-        if (value == UnspecifiedFenceValue)
-        {
-            value = pFence->m_currentFenceValue;
-        }
+	// Instruct a GPU queue on the active node to wait for the fences on the other nodes.
+	// Use the current values of the fences or override them with your own value.
+	// (Does not block the calling CPU thread)
+	inline static void GpuWait(ID3D12CommandQueue* pQueue, Fence* pFence, UINT64 value = UnspecifiedFenceValue)
+	{
+		if (value == UnspecifiedFenceValue)
+		{
+			value = pFence->m_currentFenceValue;
+		}
 
-        pQueue->Wait(pFence->m_fence.Get(), value);
-    }
+		pQueue->Wait(pFence->m_fence.Get(), value);
+	}
 
 protected:
-    // Block the calling CPU thread until the GPU has signaled the specified fence.
-    inline void CpuWait(UINT64 fenceValue = UnspecifiedFenceValue)
-    {
-        if (fenceValue == UnspecifiedFenceValue)
-        {
-            fenceValue = m_currentFenceValue;
-        }
+	// Block the calling CPU thread until the GPU has signaled the specified fence.
+	inline void CpuWait(UINT64 fenceValue = UnspecifiedFenceValue)
+	{
+		if (fenceValue == UnspecifiedFenceValue)
+		{
+			fenceValue = m_currentFenceValue;
+		}
 
-        if (m_fence->GetCompletedValue() < fenceValue)
-        {
-            ThrowIfFailed(m_fence->SetEventOnCompletion(fenceValue, m_fenceEvent));
-            WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-        }
-    }
+		if (m_fence->GetCompletedValue() < fenceValue)
+		{
+			ThrowIfFailed(m_fence->SetEventOnCompletion(fenceValue, m_fenceEvent));
+			WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+		}
+	}
 
-    static const UINT64 UnspecifiedFenceValue = UINT64_MAX;
+	static const UINT64 UnspecifiedFenceValue = UINT64_MAX;
 
-    ComPtr<ID3D12Fence> m_fence;            // The D3D12 fence object.
-    ComPtr<ID3D12CommandQueue> m_queue;    // The command queue associated with this fence.
-    UINT64 m_currentFenceValue;                        // The last value signaled by this fence.
-    HANDLE m_fenceEvent;                            // CPU-waitable event handle.
+	ComPtr<ID3D12Fence> m_fence;			// The D3D12 fence object.
+	ComPtr<ID3D12CommandQueue> m_queue;	// The command queue associated with this fence.
+	UINT64 m_currentFenceValue;						// The last value signaled by this fence.
+	HANDLE m_fenceEvent;							// CPU-waitable event handle.
 };
 
 class LinearFence : public Fence
 {
 public:
-    // This fence implementation manages a ring buffer of issued Signal events.
-    // The "Next" API instructs the Fence to move to the next slot in the ring buffer.
-    // If the next slot represents a fence value that has not yet been signaled by
-    // the GPU, then the CPU will wait until that fence is signaled before continuing.
-    // 
-    // In this sample, LinearFences are used to guard against premature resetting
-    // of command allocators and modifying of upload heaps that might currently be
-    // in use by the GPU.
-    LinearFence(ID3D12CommandQueue* pQueue, UINT count) :
-        Fence(pQueue),
-        m_signalIndex(0)
-    {
-        m_signalHistory.resize(count);
-    }
+	// This fence implementation manages a ring buffer of issued Signal events.
+	// The "Next" API instructs the Fence to move to the next slot in the ring buffer.
+	// If the next slot represents a fence value that has not yet been signaled by
+	// the GPU, then the CPU will wait until that fence is signaled before continuing.
+	// 
+	// In this sample, LinearFences are used to guard against premature resetting
+	// of command allocators and modifying of upload heaps that might currently be
+	// in use by the GPU.
+	LinearFence(ID3D12CommandQueue* pQueue, UINT count) :
+		Fence(pQueue),
+		m_signalIndex(0)
+	{
+		m_signalHistory.resize(count);
+	}
 
-    // If the oldest Signal event in the ring buffer has not yet been processed by
-    // the GPU, block the calling CPU thread until it is.
-    inline void Next()
-    {
-        m_signalHistory[m_signalIndex] = m_currentFenceValue;
-        m_signalIndex = (m_signalIndex + 1) % m_signalHistory.size();
+	// If the oldest Signal event in the ring buffer has not yet been processed by
+	// the GPU, block the calling CPU thread until it is.
+	inline void Next()
+	{
+		m_signalHistory[m_signalIndex] = m_currentFenceValue;
+		m_signalIndex = (m_signalIndex + 1) % m_signalHistory.size();
 
-        Fence::CpuWait(m_signalHistory[m_signalIndex]);
-    }
+		Fence::CpuWait(m_signalHistory[m_signalIndex]);
+	}
 
 private:
-    std::vector<UINT64> m_signalHistory;    // The history of signal events.
-    UINT m_signalIndex;                        // The index to the next slot in the signal history ring buffer.
+	std::vector<UINT64> m_signalHistory;	// The history of signal events.
+	UINT m_signalIndex;						// The index to the next slot in the signal history ring buffer.
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/Main.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12SingleGpu sample(1200, 900, L"");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12SingleGpu sample(1200, 900, L"");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/Post.hlsli
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/Post.hlsli
@@ -11,14 +11,14 @@
 
 struct VSInput
 {
-    float4 position : POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : POSITION;
+	float2 uv : TEXCOORD;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 Texture2D g_renderTargets[6] : register(t0);
@@ -26,6 +26,6 @@ SamplerState g_sampler : register(s0);
 
 cbuffer ShaderConstants : register(b0)
 {
-    uint currentRenderTarget;
-    uint renderTargetCount;
+	uint currentRenderTarget;
+	uint renderTargetCount;
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/PostPS.hlsl
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/PostPS.hlsl
@@ -13,18 +13,18 @@
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    // This adds up to more than 1.0f, but creates a decent effect
-    // that doesn't make the triangles look too transparent.
-    float blurWeights[6] = { 0.80f, 0.25f, 0.15f, 0.075f, 0.025f, 0.0125f };
+	// This adds up to more than 1.0f, but creates a decent effect
+	// that doesn't make the triangles look too transparent.
+	float blurWeights[6] = { 0.80f, 0.25f, 0.15f, 0.075f, 0.025f, 0.0125f };
 
-    float4 result = float4(0.0f, 0.0f, 0.0f, 0.0f);
-    uint index = currentRenderTarget;
+	float4 result = float4(0.0f, 0.0f, 0.0f, 0.0f);
+	uint index = currentRenderTarget;
 
-    for (uint n = 0; n < renderTargetCount; n++)
-    {
-        result += blurWeights[n] * g_renderTargets[index].Sample(g_sampler, input.uv);
-        index = (index == 0) ? renderTargetCount - 1 : index - 1;
-    }
+	for (uint n = 0; n < renderTargetCount; n++)
+	{
+		result += blurWeights[n] * g_renderTargets[index].Sample(g_sampler, input.uv);
+		index = (index == 0) ? renderTargetCount - 1 : index - 1;
+	}
 
-    return saturate(result);
+	return saturate(result);
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/PostVS.hlsl
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/PostVS.hlsl
@@ -13,10 +13,10 @@
 
 PSInput VSMain(VSInput input)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = input.position;
-    result.uv = input.uv;
+	result.position = input.position;
+	result.uv = input.uv;
 
-    return result;
+	return result;
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/Scene.hlsli
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/Scene.hlsli
@@ -11,19 +11,19 @@
 
 cbuffer SceneConstantBuffer : register(b0)
 {
-    float4 velocity;
-    float4 offset;
-    float4 color;
-    float4x4 projection;
+	float4 velocity;
+	float4 offset;
+	float4 color;
+	float4x4 projection;
 };
 
 cbuffer SceneRootConstants : register(b1)
 {
-    uint simulatedGpuLoad;
+	uint simulatedGpuLoad;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/ScenePS.hlsl
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/ScenePS.hlsl
@@ -13,5 +13,5 @@
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/SceneVS.hlsl
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/SceneVS.hlsl
@@ -13,29 +13,29 @@
 
 PSInput VSMain(float4 position : POSITION)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = mul(position + offset, projection);
+	result.position = mul(position + offset, projection);
 
-    float intensity = saturate((4.0f - result.position.z) / 2.0f);
-    float4 c = float4(color.xyz * intensity, 1.0f);
+	float intensity = saturate((4.0f - result.position.z) / 2.0f);
+	float4 c = float4(color.xyz * intensity, 1.0f);
 
-    if (simulatedGpuLoad > 0)
-    {
-        float4 total = float4(0.0f, 0.0f, 0.0f, 0.0f);
+	if (simulatedGpuLoad > 0)
+	{
+		float4 total = float4(0.0f, 0.0f, 0.0f, 0.0f);
 
-        // Simulate additional workload on the GPU.
-        for (uint x = 0; x < simulatedGpuLoad; x++)
-        {
-            total += c;
-        }
+		// Simulate additional workload on the GPU.
+		for (uint x = 0; x < simulatedGpuLoad; x++)
+		{
+			total += c;
+		}
 
-        result.color = total / simulatedGpuLoad;
-    }
-    else
-    {
-        result.color = c;
-    }
+		result.color = total / simulatedGpuLoad;
+	}
+	else
+	{
+		result.color = c;
+	}
 
-    return result;
+	return result;
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/Settings.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/Settings.cpp
@@ -15,8 +15,8 @@
 
 using Microsoft::WRL::ComPtr;
 
-const float Settings::TriangleHalfWidth = 0.05f;    // The x and y offsets used by the triangle vertices.
-const float Settings::TriangleDepth = 1.0f;            // The z offset used by the triangle vertices.
+const float Settings::TriangleHalfWidth = 0.05f;	// The x and y offsets used by the triangle vertices.
+const float Settings::TriangleDepth = 1.0f;			// The z offset used by the triangle vertices.
 const float Settings::ClearColor[4] = { 0.0f, 0.2f, 0.4f, 1.0f };
 
 UINT Settings::FrameCount;
@@ -31,20 +31,20 @@ D3D12_RECT Settings::ScissorRect;
 
 void Settings::Initialize(ID3D12Device* pDevice, UINT width, UINT height)
 {
-    FrameCount = 2;
+	FrameCount = 2;
 
-    RtvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    CbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	RtvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	CbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 
-    BackBufferCount = 2;
+	BackBufferCount = 2;
 
-    OnSizeChanged(width, height);
+	OnSizeChanged(width, height);
 }
 
 void Settings::OnSizeChanged(UINT width, UINT height)
 {
-    Width = width;
-    Height = height;
-    Viewport = CD3DX12_VIEWPORT(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 0.0f, 1.0f);
-    ScissorRect = CD3DX12_RECT(0, 0, static_cast<LONG>(width), static_cast<LONG>(height));
+	Width = width;
+	Height = height;
+	Viewport = CD3DX12_VIEWPORT(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 0.0f, 1.0f);
+	ScissorRect = CD3DX12_RECT(0, 0, static_cast<LONG>(width), static_cast<LONG>(height));
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/Settings.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/Settings.h
@@ -15,24 +15,24 @@
 // for the lifetime of the sample.
 struct Settings
 {
-    static void Initialize(ID3D12Device* pDevice, UINT width, UINT height);
-    static void OnSizeChanged(UINT width, UINT height);
+	static void Initialize(ID3D12Device* pDevice, UINT width, UINT height);
+	static void OnSizeChanged(UINT width, UINT height);
 
-    static UINT FrameCount;                                // The maximum number of frames that will be buffered on each node.
+	static UINT FrameCount;								// The maximum number of frames that will be buffered on each node.
 
-    static const UINT SceneHistoryCount = 6;            // The number of frames used in the motion blur effect.
-    static const UINT SceneConstantBufferFrames = 10;    // The number of frames that can be buffered in the constant buffer heap.
-    static const UINT TriangleCount = 1024;                // The number of triangles drawn per frame.
-    static const float TriangleHalfWidth;                // The x and y offsets used by the triangle vertices.
-    static const float TriangleDepth;                    // The z offset used by the triangle vertices.
-    static const float ClearColor[4];
+	static const UINT SceneHistoryCount = 6;			// The number of frames used in the motion blur effect.
+	static const UINT SceneConstantBufferFrames = 10;	// The number of frames that can be buffered in the constant buffer heap.
+	static const UINT TriangleCount = 1024;				// The number of triangles drawn per frame.
+	static const float TriangleHalfWidth;				// The x and y offsets used by the triangle vertices.
+	static const float TriangleDepth;					// The z offset used by the triangle vertices.
+	static const float ClearColor[4];
 
-    static UINT RtvDescriptorSize;
-    static UINT CbvSrvDescriptorSize;
-    static UINT BackBufferCount;
+	static UINT RtvDescriptorSize;
+	static UINT CbvSrvDescriptorSize;
+	static UINT BackBufferCount;
 
-    static UINT Width;
-    static UINT Height;
-    static D3D12_VIEWPORT Viewport;
-    static D3D12_RECT ScissorRect;
+	static UINT Width;
+	static UINT Height;
+	static D3D12_VIEWPORT Viewport;
+	static D3D12_RECT ScissorRect;
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/View.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/View.cpp
@@ -17,61 +17,61 @@ using namespace Windows::System;
 
 inline int ConvertToPixels(float dimension, float dpi)
 {
-    return static_cast<int>(dimension * dpi / 96.0f + 0.5f);
+	return static_cast<int>(dimension * dpi / 96.0f + 0.5f);
 }
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false),
-    m_windowResizing(false),
-    m_windowVisible(true),
-    m_logicalWidth(0),
-    m_logicalHeight(0)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false),
+	m_windowResizing(false),
+	m_windowVisible(true),
+	m_logicalWidth(0),
+	m_logicalHeight(0)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    m_logicalWidth = window->Bounds.Width;
-    m_logicalHeight = window->Bounds.Height;
+	m_logicalWidth = window->Bounds.Width;
+	m_logicalHeight = window->Bounds.Height;
 
     auto dispatcher = CoreWindow::GetForCurrentThread()->Dispatcher;
     dispatcher->AcceleratorKeyActivated +=
         ref new TypedEventHandler<CoreDispatcher^, AcceleratorKeyEventArgs^>(this, &View::OnAcceleratorKeyActivated);
 
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->SizeChanged += ref new TypedEventHandler<CoreWindow^, WindowSizeChangedEventArgs^>(this, &View::OnSizeChanged);
-    window->VisibilityChanged += ref new TypedEventHandler<CoreWindow^, VisibilityChangedEventArgs^>(this, &View::OnVisibilityChanged);
-    window->Closed += ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &View::OnClosed);
-    window->PointerMoved += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerMoved);
-    window->PointerPressed += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerPressed);
-    window->PointerReleased += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerReleased);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->SizeChanged += ref new TypedEventHandler<CoreWindow^, WindowSizeChangedEventArgs^>(this, &View::OnSizeChanged);
+	window->VisibilityChanged += ref new TypedEventHandler<CoreWindow^, VisibilityChangedEventArgs^>(this, &View::OnVisibilityChanged);
+	window->Closed += ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &View::OnClosed);
+	window->PointerMoved += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerMoved);
+	window->PointerPressed += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerPressed);
+	window->PointerReleased += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerReleased);
 
-    try
-    {
-        window->ResizeStarted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeStarted);
-        window->ResizeCompleted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeCompleted);
-    }
-    catch (Exception^ e)
-    {
-        // Requires Windows 10 Creators Update (10.0.15063) or later.
-    }
+	try
+	{
+		window->ResizeStarted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeStarted);
+		window->ResizeCompleted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeCompleted);
+	}
+	catch (Exception^ e)
+	{
+		// Requires Windows 10 Creators Update (10.0.15063) or later.
+	}
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 
-    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-    displayInformation->DpiChanged += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDpiChanged);
-    displayInformation->DisplayContentsInvalidated += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDisplayContentsInvalidated);
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	displayInformation->DpiChanged += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDpiChanged);
+	displayInformation->DisplayContentsInvalidated += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDisplayContentsInvalidated);
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -80,20 +80,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -102,15 +102,15 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
     if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnAcceleratorKeyActivated(CoreDispatcher^, AcceleratorKeyEventArgs^ args)
@@ -138,97 +138,97 @@ void View::OnAcceleratorKeyActivated(CoreDispatcher^, AcceleratorKeyEventArgs^ a
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnSizeChanged(CoreWindow^ /*window*/, WindowSizeChangedEventArgs^ args)
 {
-    m_logicalWidth = args->Size.Width;
-    m_logicalHeight = args->Size.Height;
+	m_logicalWidth = args->Size.Width;
+	m_logicalHeight = args->Size.Height;
 
-    if (!m_windowResizing)
-    {
-        UpdateWindowSize();
-    }
+	if (!m_windowResizing)
+	{
+		UpdateWindowSize();
+	}
 }
 
 void View::OnResizeStarted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
 {
-    m_windowResizing = true;
+	m_windowResizing = true;
 }
 
 void View::OnResizeCompleted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
 {
-    m_windowResizing = false;
-    UpdateWindowSize();
+	m_windowResizing = false;
+	UpdateWindowSize();
 }
 
 void View::OnDpiChanged(DisplayInformation^ /*sender*/, Object^ /*args*/)
 {
-    UpdateWindowSize();
+	UpdateWindowSize();
 }
 
 void View::OnVisibilityChanged(CoreWindow^ /*window*/, VisibilityChangedEventArgs^ args)
 {
-    m_windowVisible = args->Visible;
-    UpdateWindowSize();
+	m_windowVisible = args->Visible;
+	UpdateWindowSize();
 }
 
 void View::OnClosed(CoreWindow^ /*window*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }
 
 void View::OnPointerMoved(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
-    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-    float dpi = displayInformation->LogicalDpi;
-    m_pSample->OnMouseMove(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	float dpi = displayInformation->LogicalDpi;
+	m_pSample->OnMouseMove(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
 }
 
 void View::OnPointerPressed(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
-    // For simplicity, we only consider left button press here.
-    if(args->CurrentPoint->Properties->IsLeftButtonPressed)
-    {
-        DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-        float dpi = displayInformation->LogicalDpi;
-        m_pSample->OnLeftButtonDown(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
-    }
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonDown(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
 }
 
 void View::OnPointerReleased(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
-    // For simplicity, we only consider left button press here.
-    if(args->CurrentPoint->Properties->IsLeftButtonPressed)
-    {
-        DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-        float dpi = displayInformation->LogicalDpi;
-        m_pSample->OnLeftButtonUp(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
-    }
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonUp(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
 }
 
 void View::UpdateWindowSize()
 {
-    CoreWindow^ window = CoreWindow::GetForCurrentThread();
-    Windows::Foundation::Rect windowBounds = window->Bounds;
+	CoreWindow^ window = CoreWindow::GetForCurrentThread();
+	Windows::Foundation::Rect windowBounds = window->Bounds;
 
-    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-    float dpi = displayInformation->LogicalDpi;
-    
-    m_pSample->SetWindowBounds(
-        ConvertToPixels(windowBounds.Left, dpi),
-        ConvertToPixels(windowBounds.Top, dpi),
-        ConvertToPixels(windowBounds.Right, dpi),
-        ConvertToPixels(windowBounds.Bottom, dpi));
-        
-    m_pSample->OnSizeChanged(ConvertToPixels(m_logicalWidth, dpi), ConvertToPixels(m_logicalHeight, dpi), !m_windowVisible);
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	float dpi = displayInformation->LogicalDpi;
+	
+	m_pSample->SetWindowBounds(
+		ConvertToPixels(windowBounds.Left, dpi),
+		ConvertToPixels(windowBounds.Top, dpi),
+		ConvertToPixels(windowBounds.Right, dpi),
+		ConvertToPixels(windowBounds.Bottom, dpi));
+		
+	m_pSample->OnSizeChanged(ConvertToPixels(m_logicalWidth, dpi), ConvertToPixels(m_logicalHeight, dpi), !m_windowVisible);
 }
 
 void View::OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args)
 {
-    m_pSample->OnDisplayChanged();
+	m_pSample->OnDisplayChanged();
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/View.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/View.h
@@ -24,36 +24,36 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
     void OnAcceleratorKeyActivated(CoreDispatcher^, AcceleratorKeyEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ args);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ args);
-    void OnSizeChanged(CoreWindow^ window, WindowSizeChangedEventArgs^ args);
-    void OnResizeStarted(CoreWindow^ window, Object^ args);
-    void OnResizeCompleted(CoreWindow^ window, Object^ args);
-    void OnDpiChanged(DisplayInformation^ sender, Object^ args);
-    void OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args);
-    void OnClosed(CoreWindow^ window, CoreWindowEventArgs^ args);
-    void OnPointerMoved(CoreWindow^ window, PointerEventArgs^ args);
-    void OnPointerPressed(CoreWindow^ window, PointerEventArgs^ args);
-    void OnPointerReleased(CoreWindow^ window, PointerEventArgs^ args);
-    void OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args);
-    
-    void UpdateWindowSize();
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ args);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ args);
+	void OnSizeChanged(CoreWindow^ window, WindowSizeChangedEventArgs^ args);
+	void OnResizeStarted(CoreWindow^ window, Object^ args);
+	void OnResizeCompleted(CoreWindow^ window, Object^ args);
+	void OnDpiChanged(DisplayInformation^ sender, Object^ args);
+	void OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args);
+	void OnClosed(CoreWindow^ window, CoreWindowEventArgs^ args);
+	void OnPointerMoved(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerPressed(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerReleased(CoreWindow^ window, PointerEventArgs^ args);
+	void OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args);
+	
+	void UpdateWindowSize();
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
-    bool m_windowResizing;
-    bool m_windowVisible;
-    float m_logicalWidth;
-    float m_logicalHeight;
+	DXSample* m_pSample;
+	bool m_windowClosed;
+	bool m_windowResizing;
+	bool m_windowVisible;
+	float m_logicalWidth;
+	float m_logicalHeight;
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/ViewProvider.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/ViewProvider.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/d3dx12.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12PipelineStateCache/src/BlitPixelShader.hlsl
+++ b/Samples/UWP/D3D12PipelineStateCache/src/BlitPixelShader.hlsl
@@ -13,10 +13,10 @@
 
 float4 Blit(float2 uv)
 {
-    return g_tex.Sample(g_samp, uv);
+	return g_tex.Sample(g_samp, uv);
 }
 
 float4 mainBlit(PSInput input) : SV_TARGET
 {
-    return Blit(input.uv);
+	return Blit(input.uv);
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/BlurPixelShader.hlsl
+++ b/Samples/UWP/D3D12PipelineStateCache/src/BlurPixelShader.hlsl
@@ -12,54 +12,54 @@
 #include "QuadVertexShader.hlsl"
 
 static const float weights[] = {
-    0.1061154f,
-    0.102850571f,
-    0.102850571f,
-    0.09364651f,
-    0.09364651f,
-    0.0801001f,
-    0.0801001f,
-    0.06436224f,
-    0.06436224f,
-    0.0485831723f,
-    0.0485831723f,
-    0.0344506279f,
-    0.0344506279f,
-    0.0229490642f,
-    0.0229490642f,
+	0.1061154f,
+	0.102850571f,
+	0.102850571f,
+	0.09364651f,
+	0.09364651f,
+	0.0801001f,
+	0.0801001f,
+	0.06436224f,
+	0.06436224f,
+	0.0485831723f,
+	0.0485831723f,
+	0.0344506279f,
+	0.0344506279f,
+	0.0229490642f,
+	0.0229490642f,
 };
 
 static const float2 offsets[] = {
-    float2(0.0f, 0.0f),
-    float2(0.00375f, 0.006250001f),
-    float2(-0.00375f, -0.006250001f),
-    float2(0.00875f, 0.01458333f),
-    float2(-0.00875f, -0.01458333f),
-    float2(0.01375f, 0.02291667f),
-    float2(-0.01375f, -0.02291667f),
-    float2(0.01875f, 0.03125f),
-    float2(-0.01875f, -0.03125f),
-    float2(0.02375f, 0.03958334f),
-    float2(-0.02375f, -0.03958334f),
-    float2(0.02875f, 0.04791667f),
-    float2(-0.02875f, -0.04791667f),
-    float2(0.03375f, 0.05625f),
-    float2(-0.03375f, -0.05625f),
+	float2(0.0f, 0.0f),
+	float2(0.00375f, 0.006250001f),
+	float2(-0.00375f, -0.006250001f),
+	float2(0.00875f, 0.01458333f),
+	float2(-0.00875f, -0.01458333f),
+	float2(0.01375f, 0.02291667f),
+	float2(-0.01375f, -0.02291667f),
+	float2(0.01875f, 0.03125f),
+	float2(-0.01875f, -0.03125f),
+	float2(0.02375f, 0.03958334f),
+	float2(-0.02375f, -0.03958334f),
+	float2(0.02875f, 0.04791667f),
+	float2(-0.02875f, -0.04791667f),
+	float2(0.03375f, 0.05625f),
+	float2(-0.03375f, -0.05625f),
 };
 
 float4 Blur(float2 uv)
 {
-    float4 color = float4(0.0f, 0.0f, 0.0f, 0.0f);
+	float4 color = float4(0.0f, 0.0f, 0.0f, 0.0f);
 
-    for (int i = 0; i < 15; i++)
-    {
-        color += g_tex.Sample(g_samp, uv + offsets[i]) * weights[i];
-    }
+	for (int i = 0; i < 15; i++)
+	{
+		color += g_tex.Sample(g_samp, uv + offsets[i]) * weights[i];
+	}
 
-    return color;
+	return color;
 }
 
 float4 mainBlur(PSInput input) : SV_TARGET
 {
-    return Blur(input.uv);
+	return Blur(input.uv);
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/D3D12PipelineStateCache.cpp
+++ b/Samples/UWP/D3D12PipelineStateCache/src/D3D12PipelineStateCache.cpp
@@ -15,662 +15,705 @@
 const float D3D12PipelineStateCache::IntermediateClearColor[4] = { 0.0f, 0.2f, 0.3f, 1.0f };
 
 D3D12PipelineStateCache::D3D12PipelineStateCache(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_psoLibrary(FrameCount, RootParameterUberShaderCB),
-    m_frameIndex(0),
-    m_swapChainEvent(0),
-    m_drawIndex(0),
-    m_maxDrawsPerFrame(256),
-    m_dynamicCB(sizeof(DrawConstantBuffer), m_maxDrawsPerFrame, FrameCount),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0),
-    m_srvDescriptorSize(0),
-    m_fenceValues{}
+	DXSample(width, height, name),
+	m_psoLibrary(FrameCount, RootParameterUberShaderCB),
+	m_frameIndex(0),
+	m_swapChainEvent(0),
+	m_drawIndex(0),
+	m_maxDrawsPerFrame(256),
+	m_dynamicCB(sizeof(DrawConstantBuffer), m_maxDrawsPerFrame, FrameCount),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0),
+	m_srvDescriptorSize(0),
+	m_fenceValues{}
 {
-    memset(m_enabledEffects, true, sizeof(m_enabledEffects));
+	memset(m_enabledEffects, true, sizeof(m_enabledEffects));
+
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
 }
 
 void D3D12PipelineStateCache::OnInit()
 {
-    UpdateWindowTextPso();
-    m_camera.Init({ 0.0f, 0.0f, 5.0f });
-    m_camera.SetMoveSpeed(1.0f);
+	UpdateWindowTextPso();
+	m_camera.Init({ 0.0f, 0.0f, 5.0f });
+	m_camera.SetMoveSpeed(1.0f);
 
-    m_projectionMatrix = m_camera.GetProjectionMatrix(0.8f, m_aspectRatio);
+	m_projectionMatrix = m_camera.GetProjectionMatrix(0.8f, m_aspectRatio);
 
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12PipelineStateCache::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter, true);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
-    NAME_D3D12_OBJECT(m_commandQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	NAME_D3D12_OBJECT(m_commandQueue);
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
-    swapChainDesc.Flags = DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
+	swapChainDesc.Flags = DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
-    m_swapChainEvent = m_swapChain->GetFrameLatencyWaitableObject();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	m_swapChainEvent = m_swapChain->GetFrameLatencyWaitableObject();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount + 1;    // A descriptor for each frame + 1 intermediate render target.
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount + 1;	// A descriptor for each frame + 1 intermediate render target.
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a shader resource view (SRV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
-        srvHeapDesc.NumDescriptors = 1;
-        srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
-        NAME_D3D12_OBJECT(m_srvHeap);
+		// Describe and create a shader resource view (SRV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
+		srvHeapDesc.NumDescriptors = 1;
+		srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
+		NAME_D3D12_OBJECT(m_srvHeap);
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-        m_srvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_srvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create RTVs and a command allocator for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
+		// Create RTVs and a command allocator for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-            NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
+			NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
 
-            ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
-        }
+			ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
+		}
 
-        D3D12_RESOURCE_DESC renderTargetDesc = m_renderTargets[0]->GetDesc();
+		D3D12_RESOURCE_DESC renderTargetDesc = m_renderTargets[0]->GetDesc();
 
-        D3D12_CLEAR_VALUE clearValue = {};
-        memcpy(clearValue.Color, IntermediateClearColor, sizeof(IntermediateClearColor));
-        clearValue.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+		D3D12_CLEAR_VALUE clearValue = {};
+		memcpy(clearValue.Color, IntermediateClearColor, sizeof(IntermediateClearColor));
+		clearValue.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
 
-        // Create an intermediate render target that is the same dimensions as the swap chain.
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &renderTargetDesc,
-            D3D12_RESOURCE_STATE_RENDER_TARGET,
-            &clearValue,
-            IID_PPV_ARGS(&m_intermediateRenderTarget)));
+		// Create an intermediate render target that is the same dimensions as the swap chain.
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&renderTargetDesc,
+			D3D12_RESOURCE_STATE_RENDER_TARGET,
+			&clearValue,
+			IID_PPV_ARGS(&m_intermediateRenderTarget)));
 
-        NAME_D3D12_OBJECT(m_intermediateRenderTarget);
+		NAME_D3D12_OBJECT(m_intermediateRenderTarget);
 
-        m_device->CreateRenderTargetView(m_intermediateRenderTarget.Get(), nullptr, rtvHandle);
-        rtvHandle.Offset(1, m_rtvDescriptorSize);
+		m_device->CreateRenderTargetView(m_intermediateRenderTarget.Get(), nullptr, rtvHandle);
+		rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-        // Create a SRV of the intermediate render target.
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Format = renderTargetDesc.Format;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = 1;
+		// Create a SRV of the intermediate render target.
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Format = renderTargetDesc.Format;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = 1;
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_srvHeap->GetCPUDescriptorHandleForHeapStart());
-        m_device->CreateShaderResourceView(m_intermediateRenderTarget.Get(), &srvDesc, srvHandle);
-    }
+		CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(m_srvHeap->GetCPUDescriptorHandleForHeapStart());
+		m_device->CreateShaderResourceView(m_intermediateRenderTarget.Get(), &srvDesc, srvHandle);
+	}
 }
 
 void D3D12PipelineStateCache::LoadAssets()
 {
-    // Create the root signature.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signature.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        // We don't modify the SRV in the command list after SetGraphicsRootDescriptorTable
-        // is executed on the GPU so we can use the default range behavior:
-        // D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[RootParametersCount];
-        ranges[RootParameterSRV].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
+		// We don't modify the SRV in the command list after SetGraphicsRootDescriptorTable
+		// is executed on the GPU so we can use the default range behavior:
+		// D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[RootParametersCount];
+		ranges[RootParameterSRV].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
 
-        CD3DX12_ROOT_PARAMETER1 rootParameters[RootParametersCount];
-        rootParameters[RootParameterUberShaderCB].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_ALL);
-        rootParameters[RootParameterCB].InitAsConstantBufferView(1, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_ALL);
-        rootParameters[RootParameterSRV].InitAsDescriptorTable(1, &ranges[RootParameterSRV], D3D12_SHADER_VISIBILITY_PIXEL);
+		CD3DX12_ROOT_PARAMETER1 rootParameters[RootParametersCount];
+		rootParameters[RootParameterUberShaderCB].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_ALL);
+		rootParameters[RootParameterCB].InitAsConstantBufferView(1, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_ALL);
+		rootParameters[RootParameterSRV].InitAsDescriptorTable(1, &ranges[RootParameterSRV], D3D12_SHADER_VISIBILITY_PIXEL);
 
-        D3D12_STATIC_SAMPLER_DESC sampler = {};
-        sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
-        sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.MipLODBias = 0;
-        sampler.MaxAnisotropy = 0;
-        sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
-        sampler.BorderColor = D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
-        sampler.MinLOD = 0.0f;
-        sampler.MaxLOD = 9999.0f;
-        sampler.ShaderRegister = 0;
-        sampler.RegisterSpace = 0;
-        sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+		D3D12_STATIC_SAMPLER_DESC sampler = {};
+		sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
+		sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.MipLODBias = 0;
+		sampler.MaxAnisotropy = 0;
+		sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
+		sampler.BorderColor = D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
+		sampler.MinLOD = 0.0f;
+		sampler.MaxLOD = 9999.0f;
+		sampler.ShaderRegister = 0;
+		sampler.RegisterSpace = 0;
+		sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &sampler, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &sampler, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-        NAME_D3D12_OBJECT(m_rootSignature);
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+		NAME_D3D12_OBJECT(m_rootSignature);
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), nullptr, IID_PPV_ARGS(&m_commandList)));
-    NAME_D3D12_OBJECT(m_commandList);
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), nullptr, IID_PPV_ARGS(&m_commandList)));
+	NAME_D3D12_OBJECT(m_commandList);
 
-    // Note: ComPtr's are CPU objects but this resource needs to stay in scope until
-    // the command list that references it has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resource is not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> vertexIndexBufferUpload;
+	// Note: ComPtr's are CPU objects but this resource needs to stay in scope until
+	// the command list that references it has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resource is not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> vertexIndexBufferUpload;
 
-    // Vertex and Index Buffer.
-    {
-        const VertexPositionColor cubeVertices[] = {
-            { { -1.0f, 1.0f, -1.0f, 1.0f }, { GetRandomColor(),GetRandomColor(), GetRandomColor() } },    // Back Top Left
-            { { 1.0f, 1.0f, -1.0f, 1.0f }, { GetRandomColor(), GetRandomColor(), GetRandomColor() } },    // Back Top Right
-            { { 1.0f, 1.0f, 1.0f, 1.0f }, { GetRandomColor(), GetRandomColor(), GetRandomColor() } },    // Front Top Right
-            { { -1.0f, 1.0f, 1.0f, 1.0f }, { GetRandomColor(), GetRandomColor(), GetRandomColor() } },    // Front Top Left
+	// Vertex and Index Buffer.
+	{
+		const VertexPositionColor cubeVertices[] = {
+			{ { -1.0f, 1.0f, -1.0f, 1.0f }, { GetRandomColor(),GetRandomColor(), GetRandomColor() } },	// Back Top Left
+			{ { 1.0f, 1.0f, -1.0f, 1.0f }, { GetRandomColor(), GetRandomColor(), GetRandomColor() } },	// Back Top Right
+			{ { 1.0f, 1.0f, 1.0f, 1.0f }, { GetRandomColor(), GetRandomColor(), GetRandomColor() } },	// Front Top Right
+			{ { -1.0f, 1.0f, 1.0f, 1.0f }, { GetRandomColor(), GetRandomColor(), GetRandomColor() } },	// Front Top Left
 
-            { { -1.0f, -1.0f, -1.0f, 1.0f }, { GetRandomColor(),GetRandomColor(), GetRandomColor() } },    // Back Bottom Left
-            { { 1.0f, -1.0f, -1.0f, 1.0f }, { GetRandomColor(),GetRandomColor(), GetRandomColor() } },    // Back Bottom Right
-            { { 1.0f, -1.0f, 1.0f, 1.0f }, { GetRandomColor(),GetRandomColor(), GetRandomColor() } },    // Front Bottom Right
-            { { -1.0f, -1.0f, 1.0f, 1.0f }, { GetRandomColor(),GetRandomColor(), GetRandomColor() } },    // Front Bottom Left
-        };
+			{ { -1.0f, -1.0f, -1.0f, 1.0f }, { GetRandomColor(),GetRandomColor(), GetRandomColor() } },	// Back Bottom Left
+			{ { 1.0f, -1.0f, -1.0f, 1.0f }, { GetRandomColor(),GetRandomColor(), GetRandomColor() } },	// Back Bottom Right
+			{ { 1.0f, -1.0f, 1.0f, 1.0f }, { GetRandomColor(),GetRandomColor(), GetRandomColor() } },	// Front Bottom Right
+			{ { -1.0f, -1.0f, 1.0f, 1.0f }, { GetRandomColor(),GetRandomColor(), GetRandomColor() } },	// Front Bottom Left
+		};
 
-        const UINT cubeIndices[] =
-        {
-            0, 1, 3,
-            1, 2, 3,
+		const UINT cubeIndices[] =
+		{
+			0, 1, 3,
+			1, 2, 3,
 
-            3, 2, 7,
-            6, 7, 2,
+			3, 2, 7,
+			6, 7, 2,
 
-            2, 1, 6,
-            5, 6, 1,
+			2, 1, 6,
+			5, 6, 1,
 
-            1, 0, 5,
-            4, 5, 0,
+			1, 0, 5,
+			4, 5, 0,
 
-            0, 3, 4,
-            7, 4, 3,
+			0, 3, 4,
+			7, 4, 3,
 
-            7, 6, 4,
-            5, 4, 6,
-        };
+			7, 6, 4,
+			5, 4, 6,
+		};
 
-        static const VertexPositionUV quadVertices[] =
-        {
-            { { -1.0f, -1.0f, 0.0f, 1.0f }, { 0.0f, 1.0f } },    // Bottom Left
-            { { -1.0f, 1.0f, 0.0f, 1.0f }, { 0.0f, 0.0f } },    // Top Left
-            { { 1.0f, -1.0f, 0.0f, 1.0f }, { 1.0f, 1.0f } },    // Bottom Right
-            { { 1.0f, 1.0f, 0.0f, 1.0f }, { 1.0f, 0.0f } },        // Top Right
-        };
+		static const VertexPositionUV quadVertices[] =
+		{
+			{ { -1.0f, -1.0f, 0.0f, 1.0f }, { 0.0f, 1.0f } },	// Bottom Left
+			{ { -1.0f, 1.0f, 0.0f, 1.0f }, { 0.0f, 0.0f } },	// Top Left
+			{ { 1.0f, -1.0f, 0.0f, 1.0f }, { 1.0f, 1.0f } },	// Bottom Right
+			{ { 1.0f, 1.0f, 0.0f, 1.0f }, { 1.0f, 0.0f } },		// Top Right
+		};
 
-        const UINT vertexIndexBufferSize = sizeof(cubeIndices) + sizeof(cubeVertices) + sizeof(quadVertices);
+		const UINT vertexIndexBufferSize = sizeof(cubeIndices) + sizeof(cubeVertices) + sizeof(quadVertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexIndexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexIndexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexIndexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexIndexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexIndexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&vertexIndexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexIndexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&vertexIndexBufferUpload)));
 
-        NAME_D3D12_OBJECT(m_vertexIndexBuffer);
+		NAME_D3D12_OBJECT(m_vertexIndexBuffer);
 
-        UINT8* mappedUploadHeap = nullptr;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(vertexIndexBufferUpload->Map(0, &readRange, reinterpret_cast<void**>(&mappedUploadHeap)));
+		UINT8* mappedUploadHeap = nullptr;
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(vertexIndexBufferUpload->Map(0, &readRange, reinterpret_cast<void**>(&mappedUploadHeap)));
 
-        // Fill in part of the upload heap with our index and vertex data.
-        UINT8* heapLocation = static_cast<UINT8*>(mappedUploadHeap);
-        memcpy(heapLocation, cubeVertices, sizeof(cubeVertices));
-        heapLocation += sizeof(cubeVertices);
-        memcpy(heapLocation, cubeIndices, sizeof(cubeIndices));
-        heapLocation += sizeof(cubeIndices);
-        memcpy(heapLocation, quadVertices, sizeof(quadVertices));
+		// Fill in part of the upload heap with our index and vertex data.
+		UINT8* heapLocation = static_cast<UINT8*>(mappedUploadHeap);
+		memcpy(heapLocation, cubeVertices, sizeof(cubeVertices));
+		heapLocation += sizeof(cubeVertices);
+		memcpy(heapLocation, cubeIndices, sizeof(cubeIndices));
+		heapLocation += sizeof(cubeIndices);
+		memcpy(heapLocation, quadVertices, sizeof(quadVertices));
 
-        // Pack the vertices and indices into their destination by copying from the upload heap.
-        m_commandList->CopyBufferRegion(m_vertexIndexBuffer.Get(), 0, vertexIndexBufferUpload.Get(), 0, vertexIndexBufferSize);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexIndexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER | D3D12_RESOURCE_STATE_INDEX_BUFFER));
+		// Pack the vertices and indices into their destination by copying from the upload heap.
+		m_commandList->CopyBufferRegion(m_vertexIndexBuffer.Get(), 0, vertexIndexBufferUpload.Get(), 0, vertexIndexBufferSize);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexIndexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER | D3D12_RESOURCE_STATE_INDEX_BUFFER));
 
-        // Create the index and vertex buffer views.
-        m_cubeVbv.BufferLocation = m_vertexIndexBuffer.Get()->GetGPUVirtualAddress();
-        m_cubeVbv.SizeInBytes = sizeof(cubeVertices);
-        m_cubeVbv.StrideInBytes = sizeof(VertexPositionColor);
+		// Create the index and vertex buffer views.
+		m_cubeVbv.BufferLocation = m_vertexIndexBuffer.Get()->GetGPUVirtualAddress();
+		m_cubeVbv.SizeInBytes = sizeof(cubeVertices);
+		m_cubeVbv.StrideInBytes = sizeof(VertexPositionColor);
 
-        m_cubeIbv.BufferLocation = m_cubeVbv.BufferLocation + sizeof(cubeVertices);
-        m_cubeIbv.SizeInBytes = sizeof(cubeIndices);
-        m_cubeIbv.Format = DXGI_FORMAT_R32_UINT;
+		m_cubeIbv.BufferLocation = m_cubeVbv.BufferLocation + sizeof(cubeVertices);
+		m_cubeIbv.SizeInBytes = sizeof(cubeIndices);
+		m_cubeIbv.Format = DXGI_FORMAT_R32_UINT;
 
-        m_quadVbv.BufferLocation = m_cubeIbv.BufferLocation + sizeof(cubeIndices);
-        m_quadVbv.SizeInBytes = sizeof(quadVertices);
-        m_quadVbv.StrideInBytes = sizeof(VertexPositionUV);
-    }
+		m_quadVbv.BufferLocation = m_cubeIbv.BufferLocation + sizeof(cubeIndices);
+		m_quadVbv.SizeInBytes = sizeof(quadVertices);
+		m_quadVbv.StrideInBytes = sizeof(VertexPositionUV);
+	}
 
-    // Create the constant buffer.
-    m_dynamicCB.Init(m_device.Get());
+	// Create the constant buffer.
+	m_dynamicCB.Init(m_device.Get());
 
-    // Close the command list and execute it to begin the vertex/index buffer copy
-    // into the default heap.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the vertex/index buffer copy
+	// into the default heap.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValues[m_frameIndex]++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValues[m_frameIndex]++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForGpu();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForGpu();
+	}
 
-    m_psoLibrary.Build(m_device.Get(), m_rootSignature.Get());
-    UpdateWindowTextPso();
+	m_psoLibrary.Build(m_device.Get(), m_rootSignature.Get());
+	UpdateWindowTextPso();
 }
 
 // Update frame-based values.
 void D3D12PipelineStateCache::OnUpdate()
 {
-    // Wait for the previous Present to complete.
-    WaitForSingleObjectEx(m_swapChainEvent, 100, FALSE);
+	// Wait for the previous Present to complete.
+	WaitForSingleObjectEx(m_swapChainEvent, 100, FALSE);
 
-    m_timer.Tick(NULL);
-    m_camera.Update(static_cast<float>(m_timer.GetElapsedSeconds()));
+	m_timer.Tick(NULL);
+	m_camera.Update(static_cast<float>(m_timer.GetElapsedSeconds()));
 }
 
 // Render the scene.
 void D3D12PipelineStateCache::OnRender()
 {
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+    try
+    {
+        PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
 
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+        // Record all the commands we need to render the scene into the command list.
+        PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+        // Execute the command list.
+        ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+        m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    PIXEndEvent(m_commandQueue.Get());
+        PIXEndEvent(m_commandQueue.Get());
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+        // Present the frame.
+        ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    m_drawIndex = 0;
-    m_psoLibrary.EndFrame();
+        m_drawIndex = 0;
+        m_psoLibrary.EndFrame();
 
-    MoveToNextFrame();
+        MoveToNextFrame();
+    }
+    catch (HrException& e)
+    {
+        if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
+        {
+            RestoreD3DResources();
+        }
+        else
+        {
+            throw;
+        }
+    }
 }
+
+// Release sample's D3D objects.
+void D3D12PipelineStateCache::ReleaseD3DResources()
+{
+    m_fence.Reset();
+    ResetComPtrArray(&m_renderTargets);
+    m_commandQueue.Reset();
+    m_swapChain.Reset();
+    m_device.Reset();
+}
+
+// Tears down D3D resources and reinitializes them.
+void D3D12PipelineStateCache::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
+    {
+        WaitForGpu();
+    }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
+}
+
 
 void D3D12PipelineStateCache::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForGpu();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForGpu();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12PipelineStateCache::OnKeyDown(UINT8 key)
 {
-    m_camera.OnKeyDown(key);
+	m_camera.OnKeyDown(key);
 }
 
 void D3D12PipelineStateCache::OnKeyUp(UINT8 key)
 {
-    m_camera.OnKeyUp(key);
-    
-    switch (key)
-    {
-    case 'C':
-        WaitForGpu();
-        m_psoLibrary.ClearPSOCache();
-        m_psoLibrary.Build(m_device.Get(), m_rootSignature.Get());
-        break;
+	m_camera.OnKeyUp(key);
+	
+	switch (key)
+	{
+	case 'C':
+		WaitForGpu();
+		m_psoLibrary.ClearPSOCache();
+		m_psoLibrary.Build(m_device.Get(), m_rootSignature.Get());
+		break;
 
-    case 'U':
-        m_psoLibrary.ToggleUberShader();
-        break;
+	case 'U':
+		m_psoLibrary.ToggleUberShader();
+		break;
 
-    case 'L':
-        m_psoLibrary.ToggleDiskLibrary();
-        break;
+	case 'L':
+		m_psoLibrary.ToggleDiskLibrary();
+		break;
 
-    case 'M':
-        m_psoLibrary.SwitchPSOCachingMechanism();
-        break;
+	case 'M':
+		m_psoLibrary.SwitchPSOCachingMechanism();
+		break;
 
-    case '1':
-        ToggleEffect(PostBlit);
-        break;
+	case '1':
+		ToggleEffect(PostBlit);
+		break;
 
-    case '2':
-        ToggleEffect(PostInvert);
-        break;
+	case '2':
+		ToggleEffect(PostInvert);
+		break;
 
-    case '3':
-        ToggleEffect(PostGrayScale);
-        break;
+	case '3':
+		ToggleEffect(PostGrayScale);
+		break;
 
-    case '4':
-        ToggleEffect(PostEdgeDetect);
-        break;
+	case '4':
+		ToggleEffect(PostEdgeDetect);
+		break;
 
-    case '5':
-        ToggleEffect(PostBlur);
-        break;
+	case '5':
+		ToggleEffect(PostBlur);
+		break;
 
-    case '6':
-        ToggleEffect(PostWarp);
-        break;
+	case '6':
+		ToggleEffect(PostWarp);
+		break;
 
-    case '7':
-        ToggleEffect(PostPixelate);
-        break;
+	case '7':
+		ToggleEffect(PostPixelate);
+		break;
 
-    case '8':
-        ToggleEffect(PostDistort);
-        break;
+	case '8':
+		ToggleEffect(PostDistort);
+		break;
 
-    case '9':
-        ToggleEffect(PostWave);
-        break;
+	case '9':
+		ToggleEffect(PostWave);
+		break;
 
-    default:
-        break;
-    }
+	default:
+		break;
+	}
 
-    UpdateWindowTextPso();
+	UpdateWindowTextPso();
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12PipelineStateCache::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated
-    // command lists have finished execution on the GPU; apps should use
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
+	// Command list allocators can only be reset when the associated
+	// command lists have finished execution on the GPU; apps should use
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command
-    // list, that command list can then be reset at any time and must be before
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), nullptr));
+	// However, when ExecuteCommandList() is called on a particular command
+	// list, that command list can then be reset at any time and must be before
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), nullptr));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
-    m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
+	m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE intermediateRtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSize);
-    CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_srvHeap->GetGPUDescriptorHandleForHeapStart());
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE intermediateRtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), FrameCount, m_rtvDescriptorSize);
+	CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_srvHeap->GetGPUDescriptorHandleForHeapStart());
 
-    m_commandList->OMSetRenderTargets(1, &intermediateRtvHandle, FALSE, nullptr);
+	m_commandList->OMSetRenderTargets(1, &intermediateRtvHandle, FALSE, nullptr);
 
-    // Record commands.
-    m_commandList->ClearRenderTargetView(intermediateRtvHandle, IntermediateClearColor, 0, nullptr);
+	// Record commands.
+	m_commandList->ClearRenderTargetView(intermediateRtvHandle, IntermediateClearColor, 0, nullptr);
 
-    // Draw the scene as normal into the intermediate buffer.
-    PIXBeginEvent(m_commandList.Get(), 0, L"Draw cube");
-    {
-        static float rot = 0.0f;
-        DrawConstantBuffer* drawCB = (DrawConstantBuffer*)m_dynamicCB.GetMappedMemory(m_drawIndex, m_frameIndex);
-        drawCB->worldViewProjection = XMMatrixTranspose(XMMatrixRotationY(rot) * XMMatrixRotationX(-rot) * m_camera.GetViewMatrix() * m_projectionMatrix);
+	// Draw the scene as normal into the intermediate buffer.
+	PIXBeginEvent(m_commandList.Get(), 0, L"Draw cube");
+	{
+		static float rot = 0.0f;
+		DrawConstantBuffer* drawCB = (DrawConstantBuffer*)m_dynamicCB.GetMappedMemory(m_drawIndex, m_frameIndex);
+		drawCB->worldViewProjection = XMMatrixTranspose(XMMatrixRotationY(rot) * XMMatrixRotationX(-rot) * m_camera.GetViewMatrix() * m_projectionMatrix);
 
-        rot += 0.01f;
+		rot += 0.01f;
 
-        m_commandList->IASetVertexBuffers(0, 1, &m_cubeVbv);
-        m_commandList->IASetIndexBuffer(&m_cubeIbv);
-        m_psoLibrary.SetPipelineState(m_device.Get(), m_rootSignature.Get(), m_commandList.Get(), BaseNormal3DRender, m_frameIndex);
+		m_commandList->IASetVertexBuffers(0, 1, &m_cubeVbv);
+		m_commandList->IASetIndexBuffer(&m_cubeIbv);
+		m_psoLibrary.SetPipelineState(m_device.Get(), m_rootSignature.Get(), m_commandList.Get(), BaseNormal3DRender, m_frameIndex);
 
-        m_commandList->SetGraphicsRootConstantBufferView(RootParameterCB, m_dynamicCB.GetGpuVirtualAddress(m_drawIndex, m_frameIndex));
-        m_commandList->DrawIndexedInstanced(36, 1, 0, 0, 0);
-        m_drawIndex++;
-    }
-    PIXEndEvent(m_commandList.Get());
+		m_commandList->SetGraphicsRootConstantBufferView(RootParameterCB, m_dynamicCB.GetGpuVirtualAddress(m_drawIndex, m_frameIndex));
+		m_commandList->DrawIndexedInstanced(36, 1, 0, 0, 0);
+		m_drawIndex++;
+	}
+	PIXEndEvent(m_commandList.Get());
 
-    // Set up the state for a fullscreen quad.
-    m_commandList->IASetVertexBuffers(0, 1, &m_quadVbv);
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+	// Set up the state for a fullscreen quad.
+	m_commandList->IASetVertexBuffers(0, 1, &m_quadVbv);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
 
-    // Indicate that the back buffer will be used as a render target and the
-    // intermediate render target will be used as a SRV.
-    D3D12_RESOURCE_BARRIER barriers[] = {
-        CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET),
-        CD3DX12_RESOURCE_BARRIER::Transition(m_intermediateRenderTarget.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE)
-    };
+	// Indicate that the back buffer will be used as a render target and the
+	// intermediate render target will be used as a SRV.
+	D3D12_RESOURCE_BARRIER barriers[] = {
+		CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET),
+		CD3DX12_RESOURCE_BARRIER::Transition(m_intermediateRenderTarget.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE)
+	};
 
-    m_commandList->ResourceBarrier(_countof(barriers), barriers);
-    m_commandList->SetGraphicsRootDescriptorTable(RootParameterSRV, m_srvHeap->GetGPUDescriptorHandleForHeapStart());
+	m_commandList->ResourceBarrier(_countof(barriers), barriers);
+	m_commandList->SetGraphicsRootDescriptorTable(RootParameterSRV, m_srvHeap->GetGPUDescriptorHandleForHeapStart());
 
-    const float black[] = { 0.0f, 0.0f, 0.0f, 0.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, black, 0, nullptr);
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	const float black[] = { 0.0f, 0.0f, 0.0f, 0.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, black, 0, nullptr);
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Draw some quads using the rendered scene with some effect shaders.
-    PIXBeginEvent(m_commandList.Get(), 0, L"Post-processing");
-    {
-        UINT quadCount = 0;
-        static const UINT quadsX = 3;
-        static const UINT quadsY = 3;
+	// Draw some quads using the rendered scene with some effect shaders.
+	PIXBeginEvent(m_commandList.Get(), 0, L"Post-processing");
+	{
+		UINT quadCount = 0;
+		static const UINT quadsX = 3;
+		static const UINT quadsY = 3;
 
-        // Cycle through all of the effects.
-        for (UINT i = PostBlit; i < EffectPipelineTypeCount; i++)
-        {
-            if (m_enabledEffects[i])
-            {
-                CD3DX12_VIEWPORT viewport(
-                    (quadCount % quadsX) * (m_viewport.Width / quadsX),
-                    (quadCount / quadsY) * (m_viewport.Height / quadsY),
-                    m_viewport.Width / quadsX,
-                    m_viewport.Height / quadsY);
+		// Cycle through all of the effects.
+		for (UINT i = PostBlit; i < EffectPipelineTypeCount; i++)
+		{
+			if (m_enabledEffects[i])
+			{
+				CD3DX12_VIEWPORT viewport(
+					(quadCount % quadsX) * (m_viewport.Width / quadsX),
+					(quadCount / quadsY) * (m_viewport.Height / quadsY),
+					m_viewport.Width / quadsX,
+					m_viewport.Height / quadsY);
 
-                PIXBeginEvent(m_commandList.Get(), 0, g_cEffectNames[i]);
-                m_commandList->RSSetViewports(1, &viewport);
-                m_psoLibrary.SetPipelineState(m_device.Get(), m_rootSignature.Get(), m_commandList.Get(), static_cast<EffectPipelineType>(i), m_frameIndex);
-                m_commandList->DrawInstanced(4, 1, 0, 0);
-                PIXEndEvent(m_commandList.Get());
-            }
+				PIXBeginEvent(m_commandList.Get(), 0, g_cEffectNames[i]);
+				m_commandList->RSSetViewports(1, &viewport);
+				m_psoLibrary.SetPipelineState(m_device.Get(), m_rootSignature.Get(), m_commandList.Get(), static_cast<EffectPipelineType>(i), m_frameIndex);
+				m_commandList->DrawInstanced(4, 1, 0, 0);
+				PIXEndEvent(m_commandList.Get());
+			}
 
-            quadCount++;
-        }
-    }
-    PIXEndEvent(m_commandList.Get());
+			quadCount++;
+		}
+	}
+	PIXEndEvent(m_commandList.Get());
 
-    // Revert resource states back to original values.
-    barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    barriers[0].Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
-    barriers[1].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-    barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	// Revert resource states back to original values.
+	barriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+	barriers[0].Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
+	barriers[1].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+	barriers[1].Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
 
-    m_commandList->ResourceBarrier(_countof(barriers), barriers);
+	m_commandList->ResourceBarrier(_countof(barriers), barriers);
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 void D3D12PipelineStateCache::ToggleEffect(EffectPipelineType type)
 {
-    if (m_enabledEffects[type])
-    {
-        // Wait until all frames using the shader are rendered before destroying
-        // the shader.
-        WaitForGpu();
+	if (m_enabledEffects[type])
+	{
+		// Wait until all frames using the shader are rendered before destroying
+		// the shader.
+		WaitForGpu();
 
-        m_psoLibrary.DestroyShader(type);
-    }
+		m_psoLibrary.DestroyShader(type);
+	}
 
-    m_enabledEffects[type] = !m_enabledEffects[type];
+	m_enabledEffects[type] = !m_enabledEffects[type];
 }
 
 void D3D12PipelineStateCache::UpdateWindowTextPso()
 {
-    std::wstringstream stringStream;
-    stringStream << L"  [Use Uber Shader: ";
-    stringStream << (m_psoLibrary.UberShadersEnabled() ? L"true]" : L"false]");
-    stringStream << L"   [Use DiskCache: ";
+	std::wstringstream stringStream;
+	stringStream << L"  [Use Uber Shader: ";
+	stringStream << (m_psoLibrary.UberShadersEnabled() ? L"true]" : L"false]");
+	stringStream << L"   [Use DiskCache: ";
 
-    if (m_psoLibrary.DiskCacheEnabled())
-    {
-        stringStream << L"true, ";
-        switch (m_psoLibrary.GetPSOCachingMechanism())
-        {
-        case PSOCachingMechanism::CachedBlobs:
-                stringStream << L"CachedBlobs]";
-                break;
-        case PSOCachingMechanism::PipelineLibraries:
-            stringStream << L"PipelineLibraries]";
-            break;
-        }
-    }
-    else
-    {
-        stringStream <<  L"false]";
-    }
+	if (m_psoLibrary.DiskCacheEnabled())
+	{
+		stringStream << L"true, ";
+		switch (m_psoLibrary.GetPSOCachingMechanism())
+		{
+		case PSOCachingMechanism::CachedBlobs:
+				stringStream << L"CachedBlobs]";
+				break;
+		case PSOCachingMechanism::PipelineLibraries:
+			stringStream << L"PipelineLibraries]";
+			break;
+		}
+	}
+	else
+	{
+		stringStream <<  L"false]";
+	}
 
-    SetCustomWindowText(stringStream.str().c_str());
+	SetCustomWindowText(stringStream.str().c_str());
 }
 
 // Wait for pending GPU work to complete.
 void D3D12PipelineStateCache::WaitForGpu()
 {
-    // Schedule a Signal command in the queue.
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
+	// Schedule a Signal command in the queue.
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
 
-    // Wait until the fence has been processed.
-    ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-    WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	// Wait until the fence has been processed.
+	ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+	WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
 
-    // Increment the fence value for the current frame.
-    m_fenceValues[m_frameIndex]++;
+	// Increment the fence value for the current frame.
+	m_fenceValues[m_frameIndex]++;
 }
 
 // Prepare to render the next frame.
 void D3D12PipelineStateCache::MoveToNextFrame()
 {
-    // Schedule a Signal command in the queue.
-    const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
+	// Schedule a Signal command in the queue.
+	const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
 
-    // Update the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Update the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-        WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+		WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	}
 
-    // Set the fence value for the next frame.
-    m_fenceValues[m_frameIndex] = currentFenceValue + 1;
+	// Set the fence value for the next frame.
+	m_fenceValues[m_frameIndex] = currentFenceValue + 1;
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/D3D12PipelineStateCache.h
+++ b/Samples/UWP/D3D12PipelineStateCache/src/D3D12PipelineStateCache.h
@@ -28,91 +28,93 @@ using Microsoft::WRL::ComPtr;
 class D3D12PipelineStateCache : public DXSample
 {
 public:
-    D3D12PipelineStateCache(UINT width, UINT height, std::wstring name);
+	D3D12PipelineStateCache(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
-    virtual void OnKeyDown(UINT8 key);
-    virtual void OnKeyUp(UINT8 key);
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
+	virtual void OnKeyDown(UINT8 key);
+	virtual void OnKeyUp(UINT8 key);
 
 private:
-    static const UINT FrameCount = 2;
-    static const float IntermediateClearColor[4];
+	static const UINT FrameCount = 2;
+	static const float IntermediateClearColor[4];
 
-    struct VertexPositionColor
-    {
-        XMFLOAT4 position;
-        XMFLOAT3 color;
-    };
+	struct VertexPositionColor
+	{
+		XMFLOAT4 position;
+		XMFLOAT3 color;
+	};
 
-    struct VertexPositionUV
-    {
-        XMFLOAT4 position;
-        XMFLOAT2 uv;
-    };
+	struct VertexPositionUV
+	{
+		XMFLOAT4 position;
+		XMFLOAT2 uv;
+	};
 
-    struct DrawConstantBuffer
-    {
-        XMMATRIX worldViewProjection;
-    };
+	struct DrawConstantBuffer
+	{
+		XMMATRIX worldViewProjection;
+	};
 
-    // Indices in the root parameter table.
-    enum RootParameters : UINT32
-    {
-        RootParameterUberShaderCB = 0,
-        RootParameterCB,
-        RootParameterSRV,
-        RootParametersCount
-    };
+	// Indices in the root parameter table.
+	enum RootParameters : UINT32
+	{
+		RootParameterUberShaderCB = 0,
+		RootParameterCB,
+		RootParameterSRV,
+		RootParametersCount
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12Resource> m_intermediateRenderTarget;
-    ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_srvHeap;
-    UINT m_rtvDescriptorSize;
-    UINT m_srvDescriptorSize;
-    UINT m_frameIndex;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12Resource> m_intermediateRenderTarget;
+	ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_srvHeap;
+	UINT m_rtvDescriptorSize;
+	UINT m_srvDescriptorSize;
+	UINT m_frameIndex;
 
-    // Asset objects.
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    ComPtr<ID3D12Resource> m_vertexIndexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_cubeVbv;
-    D3D12_VERTEX_BUFFER_VIEW m_quadVbv;
-    D3D12_INDEX_BUFFER_VIEW m_cubeIbv;
-    bool m_enabledEffects[EffectPipelineTypeCount];
+	// Asset objects.
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	ComPtr<ID3D12Resource> m_vertexIndexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_cubeVbv;
+	D3D12_VERTEX_BUFFER_VIEW m_quadVbv;
+	D3D12_INDEX_BUFFER_VIEW m_cubeIbv;
+	bool m_enabledEffects[EffectPipelineTypeCount];
 
-    // Synchronization objects.
-    HANDLE m_swapChainEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValues[FrameCount];
-    HANDLE m_fenceEvent;
+	// Synchronization objects.
+	HANDLE m_swapChainEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValues[FrameCount];
+	HANDLE m_fenceEvent;
 
-    UINT m_drawIndex;
-    UINT m_maxDrawsPerFrame;
+	UINT m_drawIndex;
+	UINT m_maxDrawsPerFrame;
 
-    SimpleCamera m_camera;
-    XMMATRIX m_projectionMatrix;
-    StepTimer m_timer;
-    PSOLibrary m_psoLibrary;
-    DynamicConstantBuffer m_dynamicCB;
+	SimpleCamera m_camera;
+	XMMATRIX m_projectionMatrix;
+	StepTimer m_timer;
+	PSOLibrary m_psoLibrary;
+	DynamicConstantBuffer m_dynamicCB;
 
-    inline float GetRandomColor() { return (rand() % 100) / 100.0f; }
+	inline float GetRandomColor() { return (rand() % 100) / 100.0f; }
 
-    void LoadPipeline();
-    void LoadAssets();
-    void PopulateCommandList();
-    void ToggleEffect(EffectPipelineType type);
-    void UpdateWindowTextPso();
-    void WaitForGpu();
-    void MoveToNextFrame();
+	void LoadPipeline();
+	void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
+	void PopulateCommandList();
+	void ToggleEffect(EffectPipelineType type);
+	void UpdateWindowTextPso();
+	void WaitForGpu();
+	void MoveToNextFrame();
 };

--- a/Samples/UWP/D3D12PipelineStateCache/src/DXSample.cpp
+++ b/Samples/UWP/D3D12PipelineStateCache/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,59 +34,104 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
-    auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(windowText.c_str());
+	std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
+	auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/DXSample.h
+++ b/Samples/UWP/D3D12PipelineStateCache/src/DXSample.h
@@ -16,42 +16,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/UWP/D3D12PipelineStateCache/src/DistortPixelShader.hlsl
+++ b/Samples/UWP/D3D12PipelineStateCache/src/DistortPixelShader.hlsl
@@ -13,22 +13,22 @@
 
 float4 Distort(float2 uv)
 {
-    // Calculate the distance of this pixel from the center.
-    float pixelDistance = distance(float2(0.5f, 0.5f), uv);
+	// Calculate the distance of this pixel from the center.
+	float pixelDistance = distance(float2(0.5f, 0.5f), uv);
 
-    // Weight the pixel by its distance.
-    float weight = 1.0f + pixelDistance;
+	// Weight the pixel by its distance.
+	float weight = 1.0f + pixelDistance;
 
-    float x = (uv.x - 0.5f) + 0.5f;
-    float y = (uv.y - 0.5f) + 0.5f;
+	float x = (uv.x - 0.5f) + 0.5f;
+	float y = (uv.y - 0.5f) + 0.5f;
 
-    x = pow(abs(x), weight);
-    y = pow(abs(y), weight);
+	x = pow(abs(x), weight);
+	y = pow(abs(y), weight);
 
-    return g_tex.Sample(g_samp, float2(x, y));
+	return g_tex.Sample(g_samp, float2(x, y));
 }
 
 float4 mainDistort(PSInput input) : SV_TARGET
 {
-    return Distort(input.uv);
+	return Distort(input.uv);
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/DynamicConstantBuffer.cpp
+++ b/Samples/UWP/D3D12PipelineStateCache/src/DynamicConstantBuffer.cpp
@@ -14,55 +14,55 @@
 
 static UINT Align(UINT location, UINT align = D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT)
 {
-    return (location + (align - 1)) & ~(align - 1);
+	return (location + (align - 1)) & ~(align - 1);
 }
 
 DynamicConstantBuffer::DynamicConstantBuffer(UINT constantSize, UINT maxDrawsPerFrame, UINT frameCount) :
-    m_alignedPerDrawConstantBufferSize(Align(constantSize)),    // Constant buffers must be aligned for hardware requirements.
-    m_maxDrawsPerFrame(maxDrawsPerFrame),
-    m_frameCount(frameCount),
-    m_constantBuffer(nullptr)
+	m_alignedPerDrawConstantBufferSize(Align(constantSize)),	// Constant buffers must be aligned for hardware requirements.
+	m_maxDrawsPerFrame(maxDrawsPerFrame),
+	m_frameCount(frameCount),
+	m_constantBuffer(nullptr)
 {
-    m_perFrameConstantBufferSize = m_alignedPerDrawConstantBufferSize * m_maxDrawsPerFrame;
+	m_perFrameConstantBufferSize = m_alignedPerDrawConstantBufferSize * m_maxDrawsPerFrame;
 }
 
 DynamicConstantBuffer::~DynamicConstantBuffer()
 {
-    m_constantBuffer->Unmap(0, nullptr);
+	m_constantBuffer->Unmap(0, nullptr);
 }
 
 void DynamicConstantBuffer::Init(ID3D12Device* pDevice)
 {
-    const UINT bufferSize = m_perFrameConstantBufferSize * m_frameCount;
+	const UINT bufferSize = m_perFrameConstantBufferSize * m_frameCount;
 
-    ThrowIfFailed(pDevice->CreateCommittedResource(
-        &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-        D3D12_HEAP_FLAG_NONE,
-        &CD3DX12_RESOURCE_DESC::Buffer(bufferSize),
-        D3D12_RESOURCE_STATE_GENERIC_READ,
-        nullptr,
-        IID_PPV_ARGS(&m_constantBuffer)
-        ));
+	ThrowIfFailed(pDevice->CreateCommittedResource(
+		&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+		D3D12_HEAP_FLAG_NONE,
+		&CD3DX12_RESOURCE_DESC::Buffer(bufferSize),
+		D3D12_RESOURCE_STATE_GENERIC_READ,
+		nullptr,
+		IID_PPV_ARGS(&m_constantBuffer)
+		));
 
-    NAME_D3D12_OBJECT(m_constantBuffer);
+	NAME_D3D12_OBJECT(m_constantBuffer);
 
-    CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-    ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pMappedConstantBuffer)));
+	CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+	ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pMappedConstantBuffer)));
 }
 
 void* DynamicConstantBuffer::GetMappedMemory(UINT drawIndex, UINT frameIndex)
 {
-    assert(drawIndex < m_maxDrawsPerFrame);
-    UINT constantBufferOffset = (frameIndex * m_perFrameConstantBufferSize) + (drawIndex * m_alignedPerDrawConstantBufferSize);
+	assert(drawIndex < m_maxDrawsPerFrame);
+	UINT constantBufferOffset = (frameIndex * m_perFrameConstantBufferSize) + (drawIndex * m_alignedPerDrawConstantBufferSize);
 
-    UINT8* temp = reinterpret_cast<UINT8*>(m_pMappedConstantBuffer);
-    temp += constantBufferOffset;
+	UINT8* temp = reinterpret_cast<UINT8*>(m_pMappedConstantBuffer);
+	temp += constantBufferOffset;
 
-    return temp;
+	return temp;
 }
 
 D3D12_GPU_VIRTUAL_ADDRESS DynamicConstantBuffer::GetGpuVirtualAddress(UINT drawIndex, UINT frameIndex)
 {
-    UINT constantBufferOffset = (frameIndex * m_perFrameConstantBufferSize) + (drawIndex * m_alignedPerDrawConstantBufferSize);
-    return m_constantBuffer->GetGPUVirtualAddress() + constantBufferOffset;
+	UINT constantBufferOffset = (frameIndex * m_perFrameConstantBufferSize) + (drawIndex * m_alignedPerDrawConstantBufferSize);
+	return m_constantBuffer->GetGPUVirtualAddress() + constantBufferOffset;
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/DynamicConstantBuffer.h
+++ b/Samples/UWP/D3D12PipelineStateCache/src/DynamicConstantBuffer.h
@@ -18,19 +18,19 @@ using namespace DirectX;
 class DynamicConstantBuffer
 {
 public:
-    DynamicConstantBuffer(UINT constantSize, UINT maxDrawsPerFrame, UINT frameCount);
-    ~DynamicConstantBuffer();
+	DynamicConstantBuffer(UINT constantSize, UINT maxDrawsPerFrame, UINT frameCount);
+	~DynamicConstantBuffer();
 
-    void Init(ID3D12Device* pDevice);
-    void* GetMappedMemory(UINT drawIndex, UINT frameIndex);
-    D3D12_GPU_VIRTUAL_ADDRESS GetGpuVirtualAddress(UINT drawIndex, UINT frameIndex);
+	void Init(ID3D12Device* pDevice);
+	void* GetMappedMemory(UINT drawIndex, UINT frameIndex);
+	D3D12_GPU_VIRTUAL_ADDRESS GetGpuVirtualAddress(UINT drawIndex, UINT frameIndex);
 
 private:
-    ComPtr<ID3D12Resource> m_constantBuffer;
-    void* m_pMappedConstantBuffer;
-    UINT  m_alignedPerDrawConstantBufferSize;
-    UINT  m_perFrameConstantBufferSize;
+	ComPtr<ID3D12Resource> m_constantBuffer;
+	void* m_pMappedConstantBuffer;
+	UINT  m_alignedPerDrawConstantBufferSize;
+	UINT  m_perFrameConstantBufferSize;
 
-    UINT m_frameCount;
-    UINT m_maxDrawsPerFrame;
+	UINT m_frameCount;
+	UINT m_maxDrawsPerFrame;
 };

--- a/Samples/UWP/D3D12PipelineStateCache/src/EdgeDetectPixelShader.hlsl
+++ b/Samples/UWP/D3D12PipelineStateCache/src/EdgeDetectPixelShader.hlsl
@@ -11,19 +11,19 @@
 
 #include "QuadVertexShader.hlsl"
 
-static const float threshold = 0.015f;    // What do we consider an edge?
-static const float edgeSize = 0.001f;    // The offest to look for neighboring pixels.
+static const float threshold = 0.015f;	// What do we consider an edge?
+static const float edgeSize = 0.001f;	// The offest to look for neighboring pixels.
 
 static const float2 samplePoints[9] = {
-    float2(-edgeSize, edgeSize),
-    float2(0.0f, edgeSize),
-    float2(edgeSize, edgeSize),
-    float2(-edgeSize, 0.0f),
-    float2(0.0f, 0.0f),
-    float2(edgeSize, edgeSize),
-    float2(-edgeSize, -edgeSize),
-    float2(0.0f, -edgeSize),
-    float2(edgeSize, -edgeSize),
+	float2(-edgeSize, edgeSize),
+	float2(0.0f, edgeSize),
+	float2(edgeSize, edgeSize),
+	float2(-edgeSize, 0.0f),
+	float2(0.0f, 0.0f),
+	float2(edgeSize, edgeSize),
+	float2(-edgeSize, -edgeSize),
+	float2(0.0f, -edgeSize),
+	float2(edgeSize, -edgeSize),
 };
 
 float4 EdgeDetect(float2 uv)

--- a/Samples/UWP/D3D12PipelineStateCache/src/GrayScalePixelShader.hlsl
+++ b/Samples/UWP/D3D12PipelineStateCache/src/GrayScalePixelShader.hlsl
@@ -13,14 +13,14 @@
 
 float4 GrayScale(float2 uv)
 {
-    float3 luminance = float3(0.21f, 0.72f, 0.07f);
-    float3 color = g_tex.Sample(g_samp, uv).xyz;
-    float output = dot(luminance, color);
+	float3 luminance = float3(0.21f, 0.72f, 0.07f);
+	float3 color = g_tex.Sample(g_samp, uv).xyz;
+	float output = dot(luminance, color);
 
-    return float4(output, output, output, 1.0f);
+	return float4(output, output, output, 1.0f);
 }
 
 float4 mainGray(PSInput input) : SV_TARGET
 {
-    return GrayScale(input.uv);
+	return GrayScale(input.uv);
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/InvertPixelShader.hlsl
+++ b/Samples/UWP/D3D12PipelineStateCache/src/InvertPixelShader.hlsl
@@ -13,10 +13,10 @@
 
 float4 InvertPixel(float2 uv)
 {
-    return float4(1.0f, 1.0f, 1.0f, 1.0f) - g_tex.Sample(g_samp, uv);
+	return float4(1.0f, 1.0f, 1.0f, 1.0f) - g_tex.Sample(g_samp, uv);
 }
 
 float4 mainInvert(PSInput input) : SV_TARGET
 {
-    return InvertPixel(input.uv);
+	return InvertPixel(input.uv);
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/Main.cpp
+++ b/Samples/UWP/D3D12PipelineStateCache/src/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12PipelineStateCache sample(1200, 900, L"");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12PipelineStateCache sample(1200, 900, L"");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/MemoryMappedFile.cpp
+++ b/Samples/UWP/D3D12PipelineStateCache/src/MemoryMappedFile.cpp
@@ -13,10 +13,10 @@
 #include "MemoryMappedFile.h"
 
 MemoryMappedFile::MemoryMappedFile() :
-    m_mapFile(INVALID_HANDLE_VALUE),
-    m_file(INVALID_HANDLE_VALUE),
-    m_mapAddress(nullptr),
-    m_currentFileSize(0)
+	m_mapFile(INVALID_HANDLE_VALUE),
+	m_file(INVALID_HANDLE_VALUE),
+	m_mapAddress(nullptr),
+	m_currentFileSize(0)
 {
 }
 
@@ -26,129 +26,129 @@ MemoryMappedFile::~MemoryMappedFile()
 
 void MemoryMappedFile::Init(std::wstring filename, UINT fileSize)
 {
-    m_filename = filename;
-    WIN32_FIND_DATA findFileData;
-    HANDLE handle = FindFirstFileEx(filename.c_str(), FindExInfoBasic, &findFileData, FindExSearchNameMatch, nullptr, 0);
-    bool found = handle != INVALID_HANDLE_VALUE;
+	m_filename = filename;
+	WIN32_FIND_DATA findFileData;
+	HANDLE handle = FindFirstFileEx(filename.c_str(), FindExInfoBasic, &findFileData, FindExSearchNameMatch, nullptr, 0);
+	bool found = handle != INVALID_HANDLE_VALUE;
 
-    if (found)
-    {
-        FindClose(handle);
-    }
+	if (found)
+	{
+		FindClose(handle);
+	}
 
-    m_file = CreateFile2(
-        filename.c_str(),
-        GENERIC_READ | GENERIC_WRITE,
-        0,
-        (found) ? OPEN_EXISTING : CREATE_NEW,
-        nullptr);
+	m_file = CreateFile2(
+		filename.c_str(),
+		GENERIC_READ | GENERIC_WRITE,
+		0,
+		(found) ? OPEN_EXISTING : CREATE_NEW,
+		nullptr);
 
-    if (m_file == INVALID_HANDLE_VALUE)
-    {
-        std::cerr << (L"m_file is invalid. Error %ld.\n", GetLastError());
-        std::cerr << (L"Target file is %s\n", filename.c_str());
-        return;
-    }
+	if (m_file == INVALID_HANDLE_VALUE)
+	{
+		std::cerr << (L"m_file is invalid. Error %ld.\n", GetLastError());
+		std::cerr << (L"Target file is %s\n", filename.c_str());
+		return;
+	}
 
-    LARGE_INTEGER realFileSize = {};
-    BOOL flag = GetFileSizeEx(m_file, &realFileSize);
-    if (!flag)
-    {
-        std::cerr << (L"\nError %ld occurred in GetFileSizeEx!", GetLastError());
-        assert(false);
-        return;
-    }
+	LARGE_INTEGER realFileSize = {};
+	BOOL flag = GetFileSizeEx(m_file, &realFileSize);
+	if (!flag)
+	{
+		std::cerr << (L"\nError %ld occurred in GetFileSizeEx!", GetLastError());
+		assert(false);
+		return;
+	}
 
-    assert(realFileSize.HighPart == 0);
-    m_currentFileSize = realFileSize.LowPart;
-    if (m_currentFileSize == 0)
-    {
-        // File mapping files with a size of 0 produces an error.
-        m_currentFileSize = DefaultFileSize;
-    }
-    else if(fileSize > m_currentFileSize)
-    {
-        // Grow to the specified size.
-        m_currentFileSize = fileSize;
-    }
+	assert(realFileSize.HighPart == 0);
+	m_currentFileSize = realFileSize.LowPart;
+	if (m_currentFileSize == 0)
+	{
+		// File mapping files with a size of 0 produces an error.
+		m_currentFileSize = DefaultFileSize;
+	}
+	else if(fileSize > m_currentFileSize)
+	{
+		// Grow to the specified size.
+		m_currentFileSize = fileSize;
+	}
 
-    m_mapFile = CreateFileMapping(m_file, nullptr, PAGE_READWRITE, 0, m_currentFileSize, nullptr);
+	m_mapFile = CreateFileMapping(m_file, nullptr, PAGE_READWRITE, 0, m_currentFileSize, nullptr);
 
-    if (m_mapFile == nullptr)
-    {
-        std::cerr << (L"m_mapFile is NULL: last error: %d\n", GetLastError());
-        assert(false);
-        return;
-    }
+	if (m_mapFile == nullptr)
+	{
+		std::cerr << (L"m_mapFile is NULL: last error: %d\n", GetLastError());
+		assert(false);
+		return;
+	}
 
-    m_mapAddress = MapViewOfFile(m_mapFile, FILE_MAP_ALL_ACCESS, 0, 0, m_currentFileSize);
+	m_mapAddress = MapViewOfFile(m_mapFile, FILE_MAP_ALL_ACCESS, 0, 0, m_currentFileSize);
 
-    if (m_mapAddress == nullptr)
-    {
-        std::cerr << (L"m_mapAddress is NULL: last error: %d\n", GetLastError());
-        assert(false);
-        return;
-    }
+	if (m_mapAddress == nullptr)
+	{
+		std::cerr << (L"m_mapAddress is NULL: last error: %d\n", GetLastError());
+		assert(false);
+		return;
+	}
 }
 
 void MemoryMappedFile::Destroy(bool deleteFile)
 {
-    if (m_mapAddress)
-    {
-        BOOL flag = UnmapViewOfFile(m_mapAddress);
-        if (!flag)
-        {
-            std::cerr << (L"\nError %ld occurred unmapping the view!", GetLastError());
-            assert(false);
-        }
+	if (m_mapAddress)
+	{
+		BOOL flag = UnmapViewOfFile(m_mapAddress);
+		if (!flag)
+		{
+			std::cerr << (L"\nError %ld occurred unmapping the view!", GetLastError());
+			assert(false);
+		}
 
-        m_mapAddress = nullptr;
+		m_mapAddress = nullptr;
 
-        flag = CloseHandle(m_mapFile);    // Close the file mapping object.
-        if (!flag)
-        {
-            std::cerr << (L"\nError %ld occurred closing the mapping object!", GetLastError());
-            assert(false);
-        }
+		flag = CloseHandle(m_mapFile);	// Close the file mapping object.
+		if (!flag)
+		{
+			std::cerr << (L"\nError %ld occurred closing the mapping object!", GetLastError());
+			assert(false);
+		}
 
-        flag = CloseHandle(m_file);        // Close the file itself.
-        if (!flag)
-        {
-            std::cerr << (L"\nError %ld occurred closing the file!", GetLastError());
-            assert(false);
-        }
-    }
+		flag = CloseHandle(m_file);		// Close the file itself.
+		if (!flag)
+		{
+			std::cerr << (L"\nError %ld occurred closing the file!", GetLastError());
+			assert(false);
+		}
+	}
 
-    if (deleteFile)
-    {
-        DeleteFile(m_filename.c_str());
-    }
+	if (deleteFile)
+	{
+		DeleteFile(m_filename.c_str());
+	}
 }
 
 void MemoryMappedFile::GrowMapping(UINT size)
 {
-    // Add space for the extra size at the beginning of the file.
-    size += sizeof(UINT);
+	// Add space for the extra size at the beginning of the file.
+	size += sizeof(UINT);
 
-    // Check the size.
-    if (size <= m_currentFileSize)
-    {
-        // Don't shrink.
-        return;
-    }
+	// Check the size.
+	if (size <= m_currentFileSize)
+	{
+		// Don't shrink.
+		return;
+	}
 
-    // Flush.
-    BOOL flag = FlushViewOfFile(m_mapAddress, 0);
-    if (!flag)
-    {
-        std::cerr << (L"\nError %ld occurred flushing the mapping object!", GetLastError());
-        assert(false);
-    }
+	// Flush.
+	BOOL flag = FlushViewOfFile(m_mapAddress, 0);
+	if (!flag)
+	{
+		std::cerr << (L"\nError %ld occurred flushing the mapping object!", GetLastError());
+		assert(false);
+	}
 
-    // Close the current mapping.
-    Destroy(false);
+	// Close the current mapping.
+	Destroy(false);
 
-    // Update the size and create a new mapping.
-    m_currentFileSize = size;
-    Init(m_filename, m_currentFileSize);
+	// Update the size and create a new mapping.
+	m_currentFileSize = size;
+	Init(m_filename, m_currentFileSize);
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/MemoryMappedFile.h
+++ b/Samples/UWP/D3D12PipelineStateCache/src/MemoryMappedFile.h
@@ -14,50 +14,50 @@
 class MemoryMappedFile
 {
 protected:
-    MemoryMappedFile();
-    ~MemoryMappedFile();
+	MemoryMappedFile();
+	~MemoryMappedFile();
 
-    void Init(std::wstring filename, UINT filesize = DefaultFileSize);
-    void Destroy(bool deleteFile);
-    void GrowMapping(UINT size);
+	void Init(std::wstring filename, UINT filesize = DefaultFileSize);
+	void Destroy(bool deleteFile);
+	void GrowMapping(UINT size);
 
-    void SetSize(UINT size)
-    {
-        if(m_mapAddress)
-        {
-            static_cast<UINT*>(m_mapAddress)[0] = size;
-        }
-    }
+	void SetSize(UINT size)
+	{
+		if(m_mapAddress)
+		{
+			static_cast<UINT*>(m_mapAddress)[0] = size;
+		}
+	}
 
-    UINT GetSize() const
-    {
-        if (m_mapAddress)
-        {
-            return static_cast<UINT*>(m_mapAddress)[0];
-        }
-        return 0;
-    }
+	UINT GetSize() const
+	{
+		if (m_mapAddress)
+		{
+			return static_cast<UINT*>(m_mapAddress)[0];
+		}
+		return 0;
+	}
 
-    void* GetData()
-    {
-        if (m_mapAddress)
-        {
-            // The actual data comes after the length.
-            return &static_cast<UINT*>(m_mapAddress)[1];
-        }
-        return nullptr;
-    }
+	void* GetData()
+	{
+		if (m_mapAddress)
+		{
+			// The actual data comes after the length.
+			return &static_cast<UINT*>(m_mapAddress)[1];
+		}
+		return nullptr;
+	}
 
 public:
-    bool IsMapped() const { return m_mapAddress != nullptr; }
-    
+	bool IsMapped() const { return m_mapAddress != nullptr; }
+	
 protected:
-    static const UINT DefaultFileSize = 64;
+	static const UINT DefaultFileSize = 64;
 
-    HANDLE m_mapFile;
-    HANDLE m_file;
-    LPVOID m_mapAddress;
-    std::wstring m_filename;
+	HANDLE m_mapFile;
+	HANDLE m_file;
+	LPVOID m_mapAddress;
+	std::wstring m_filename;
 
-    UINT m_currentFileSize;
+	UINT m_currentFileSize;
 };

--- a/Samples/UWP/D3D12PipelineStateCache/src/MemoryMappedPSOCache.cpp
+++ b/Samples/UWP/D3D12PipelineStateCache/src/MemoryMappedPSOCache.cpp
@@ -14,23 +14,23 @@
 
 void MemoryMappedPSOCache::Update(ID3DBlob* pBlob)
 {
-    if (pBlob)
-    {
-        assert(pBlob->GetBufferSize() <= UINT_MAX);    // Code below casts to UINT.
-        const UINT blobSize = static_cast<UINT>(pBlob->GetBufferSize());
-        if (blobSize > 0)
-        {
-            // Grow the file if needed.
-            const size_t neededSize = sizeof(UINT) + blobSize;
-            if (neededSize > m_currentFileSize)
-            {
-                MemoryMappedFile::GrowMapping(blobSize);
-            }
+	if (pBlob)
+	{
+		assert(pBlob->GetBufferSize() <= UINT_MAX);	// Code below casts to UINT.
+		const UINT blobSize = static_cast<UINT>(pBlob->GetBufferSize());
+		if (blobSize > 0)
+		{
+			// Grow the file if needed.
+			const size_t neededSize = sizeof(UINT) + blobSize;
+			if (neededSize > m_currentFileSize)
+			{
+				MemoryMappedFile::GrowMapping(blobSize);
+			}
 
-            // Save the size of the blob, and then the blob itself.
-            assert(neededSize <= m_currentFileSize);
-            MemoryMappedFile::SetSize(blobSize);
-            memcpy(GetCachedBlob(), pBlob->GetBufferPointer(), pBlob->GetBufferSize());
-        }
-    }
+			// Save the size of the blob, and then the blob itself.
+			assert(neededSize <= m_currentFileSize);
+			MemoryMappedFile::SetSize(blobSize);
+			memcpy(GetCachedBlob(), pBlob->GetBufferPointer(), pBlob->GetBufferSize());
+		}
+	}
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/MemoryMappedPSOCache.h
+++ b/Samples/UWP/D3D12PipelineStateCache/src/MemoryMappedPSOCache.h
@@ -17,10 +17,10 @@
 class MemoryMappedPSOCache : public MemoryMappedFile
 {
 public:
-    void Init(std::wstring filename) { MemoryMappedFile::Init(filename); }
-    void Destroy(bool deleteFile) { MemoryMappedFile::Destroy(deleteFile); }
-    void Update(ID3DBlob *pBlob);
+	void Init(std::wstring filename) { MemoryMappedFile::Init(filename); }
+	void Destroy(bool deleteFile) { MemoryMappedFile::Destroy(deleteFile); }
+	void Update(ID3DBlob *pBlob);
 
-    size_t GetCachedBlobSize() const { return GetSize(); }
-    void* GetCachedBlob() { return GetData(); }
+	size_t GetCachedBlobSize() const { return GetSize(); }
+	void* GetCachedBlob() { return GetData(); }
 };

--- a/Samples/UWP/D3D12PipelineStateCache/src/MemoryMappedPipelineLibrary.cpp
+++ b/Samples/UWP/D3D12PipelineStateCache/src/MemoryMappedPipelineLibrary.cpp
@@ -18,100 +18,100 @@ using Microsoft::WRL::ComPtr;
 
 bool MemoryMappedPipelineLibrary::Init(ID3D12Device* pDevice, std::wstring filename)
 {
-    // ID3D12PipelineLibrary usage requires OS and driver support.
-    //        - Pipeline Libraries require the ID3D12Device1 interface (OS support).
-    //        - All WDDM 2.1+ drivers are required to support Pipeline Libraries (driver support).
+	// ID3D12PipelineLibrary usage requires OS and driver support.
+	//		- Pipeline Libraries require the ID3D12Device1 interface (OS support).
+	//		- All WDDM 2.1+ drivers are required to support Pipeline Libraries (driver support).
 
 
-    // Note: Checking for Pipeline Library support is intended to be temporary during the transition period
-    // as customers update to the latest version of Windows 10 and drivers are updated to the latest driver model.
-    // All future versions of the OS and drivers will support Pipeline Libraries.
-    if (pDevice)
-    {
-        // Create the Pipeline Library.
-        ComPtr<ID3D12Device1> device1;
-        if (SUCCEEDED(pDevice->QueryInterface(IID_PPV_ARGS(&device1))))
-        {
-            // Init the memory mapped file.
-            MemoryMappedFile::Init(filename);
+	// Note: Checking for Pipeline Library support is intended to be temporary during the transition period
+	// as customers update to the latest version of Windows 10 and drivers are updated to the latest driver model.
+	// All future versions of the OS and drivers will support Pipeline Libraries.
+	if (pDevice)
+	{
+		// Create the Pipeline Library.
+		ComPtr<ID3D12Device1> device1;
+		if (SUCCEEDED(pDevice->QueryInterface(IID_PPV_ARGS(&device1))))
+		{
+			// Init the memory mapped file.
+			MemoryMappedFile::Init(filename);
 
-            // Create a Pipeline Library from the serialized blob.
-            // Note: The provided Library Blob must remain valid for the lifetime of the object returned - for efficiency, the data is not copied.
-            const HRESULT hr = device1->CreatePipelineLibrary(GetData(), GetSize(), IID_PPV_ARGS(&m_pipelineLibrary));
-            switch (hr)
-            {
-            case DXGI_ERROR_UNSUPPORTED: // The driver doesn't support Pipeline libraries. WDDM2.1 drivers must support it.
-                break;
+			// Create a Pipeline Library from the serialized blob.
+			// Note: The provided Library Blob must remain valid for the lifetime of the object returned - for efficiency, the data is not copied.
+			const HRESULT hr = device1->CreatePipelineLibrary(GetData(), GetSize(), IID_PPV_ARGS(&m_pipelineLibrary));
+			switch (hr)
+			{
+			case DXGI_ERROR_UNSUPPORTED: // The driver doesn't support Pipeline libraries. WDDM2.1 drivers must support it.
+				break;
 
-            case E_INVALIDARG: // The provided Library is corrupted or unrecognized.
-            case D3D12_ERROR_ADAPTER_NOT_FOUND: // The provided Library contains data for different hardware (Don't really need to clear the cache, could have a cache per adapter).
-            case D3D12_ERROR_DRIVER_VERSION_MISMATCH: // The provided Library contains data from an old driver or runtime. We need to re-create it.
-                MemoryMappedFile::Destroy(true);
-                MemoryMappedFile::Init(filename);
-                ThrowIfFailed(device1->CreatePipelineLibrary(GetData(), GetSize(), IID_PPV_ARGS(&m_pipelineLibrary)));
-                break;
+			case E_INVALIDARG: // The provided Library is corrupted or unrecognized.
+			case D3D12_ERROR_ADAPTER_NOT_FOUND: // The provided Library contains data for different hardware (Don't really need to clear the cache, could have a cache per adapter).
+			case D3D12_ERROR_DRIVER_VERSION_MISMATCH: // The provided Library contains data from an old driver or runtime. We need to re-create it.
+				MemoryMappedFile::Destroy(true);
+				MemoryMappedFile::Init(filename);
+				ThrowIfFailed(device1->CreatePipelineLibrary(GetData(), GetSize(), IID_PPV_ARGS(&m_pipelineLibrary)));
+				break;
 
-            default:
-                ThrowIfFailed(hr);
-            }
+			default:
+				ThrowIfFailed(hr);
+			}
 
-            if (m_pipelineLibrary)
-            {
-                NAME_D3D12_OBJECT(m_pipelineLibrary);
-            }
-        }
-    }
+			if (m_pipelineLibrary)
+			{
+				NAME_D3D12_OBJECT(m_pipelineLibrary);
+			}
+		}
+	}
 
-    return m_pipelineLibrary != nullptr;
+	return m_pipelineLibrary != nullptr;
 }
 
 void MemoryMappedPipelineLibrary::Destroy(bool deleteFile)
 {
-    // If we're not going to destroy the file, serialize the library to disk.
-    if (!deleteFile && m_pipelineLibrary)
-    {
-        // Important: An ID3D12PipelineLibrary object becomes undefined when the underlying memory, that was used to initalize it, changes.
+	// If we're not going to destroy the file, serialize the library to disk.
+	if (!deleteFile && m_pipelineLibrary)
+	{
+		// Important: An ID3D12PipelineLibrary object becomes undefined when the underlying memory, that was used to initalize it, changes.
 
-        assert(m_pipelineLibrary->GetSerializedSize() <= UINT_MAX);    // Code below casts to UINT.
-        const UINT librarySize = static_cast<UINT>(m_pipelineLibrary->GetSerializedSize());
-        if (librarySize > 0)
-        {
-            // Grow the file if needed.
-            const size_t neededSize = sizeof(UINT) + librarySize;
-            if (neededSize > m_currentFileSize)
-            {
-                // The file mapping is going to change thus it will invalidate the ID3D12PipelineLibrary object.
-                // Serialize the library contents to temporary memory first.
-                void* pTempData = new BYTE[librarySize];
-                if (pTempData)
-                {
-                    ThrowIfFailed(m_pipelineLibrary->Serialize(pTempData, librarySize));
+		assert(m_pipelineLibrary->GetSerializedSize() <= UINT_MAX);	// Code below casts to UINT.
+		const UINT librarySize = static_cast<UINT>(m_pipelineLibrary->GetSerializedSize());
+		if (librarySize > 0)
+		{
+			// Grow the file if needed.
+			const size_t neededSize = sizeof(UINT) + librarySize;
+			if (neededSize > m_currentFileSize)
+			{
+				// The file mapping is going to change thus it will invalidate the ID3D12PipelineLibrary object.
+				// Serialize the library contents to temporary memory first.
+				void* pTempData = new BYTE[librarySize];
+				if (pTempData)
+				{
+					ThrowIfFailed(m_pipelineLibrary->Serialize(pTempData, librarySize));
 
-                    // Now it's safe to grow the mapping.
-                    MemoryMappedFile::GrowMapping(librarySize);
+					// Now it's safe to grow the mapping.
+					MemoryMappedFile::GrowMapping(librarySize);
 
-                    // Save the size of the library and the library itself.
-                    memcpy(GetData(), pTempData, librarySize);
-                    MemoryMappedFile::SetSize(librarySize);
+					// Save the size of the library and the library itself.
+					memcpy(GetData(), pTempData, librarySize);
+					MemoryMappedFile::SetSize(librarySize);
 
-                    delete[] pTempData;
-                    pTempData = nullptr;
-                }
-            }
-            else
-            {
-                // The mapping didn't change, we can serialize directly to the mapped file.
-                // Save the size of the library and the library itself.
-                assert(neededSize <= m_currentFileSize);
-                ThrowIfFailed(m_pipelineLibrary->Serialize(GetData(), librarySize));
-                MemoryMappedFile::SetSize(librarySize);
-            }
+					delete[] pTempData;
+					pTempData = nullptr;
+				}
+			}
+			else
+			{
+				// The mapping didn't change, we can serialize directly to the mapped file.
+				// Save the size of the library and the library itself.
+				assert(neededSize <= m_currentFileSize);
+				ThrowIfFailed(m_pipelineLibrary->Serialize(GetData(), librarySize));
+				MemoryMappedFile::SetSize(librarySize);
+			}
 
-            // m_pipelineLibrary is now undefined because we just wrote to the mapped file, don't use it again.
-            // This is ok in this sample because we only write to the mapped file when the sample exits.
-        }
-    }
+			// m_pipelineLibrary is now undefined because we just wrote to the mapped file, don't use it again.
+			// This is ok in this sample because we only write to the mapped file when the sample exits.
+		}
+	}
 
-    MemoryMappedFile::Destroy(deleteFile);
-    m_pipelineLibrary = nullptr;
+	MemoryMappedFile::Destroy(deleteFile);
+	m_pipelineLibrary = nullptr;
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/MemoryMappedPipelineLibrary.h
+++ b/Samples/UWP/D3D12PipelineStateCache/src/MemoryMappedPipelineLibrary.h
@@ -18,11 +18,11 @@
 class MemoryMappedPipelineLibrary : public MemoryMappedFile
 {
 public:
-    bool Init(ID3D12Device* pDevice, std::wstring filename);
-    void Destroy(bool deleteFile);
-    
-    ID3D12PipelineLibrary* GetPipelineLibrary() { return m_pipelineLibrary.Get(); }
+	bool Init(ID3D12Device* pDevice, std::wstring filename);
+	void Destroy(bool deleteFile);
+	
+	ID3D12PipelineLibrary* GetPipelineLibrary() { return m_pipelineLibrary.Get(); }
 
 private:
-    Microsoft::WRL::ComPtr<ID3D12PipelineLibrary> m_pipelineLibrary;
+	Microsoft::WRL::ComPtr<ID3D12PipelineLibrary> m_pipelineLibrary;
 };

--- a/Samples/UWP/D3D12PipelineStateCache/src/PSOLibrary.cpp
+++ b/Samples/UWP/D3D12PipelineStateCache/src/PSOLibrary.cpp
@@ -15,374 +15,374 @@
 using namespace Microsoft::WRL::Wrappers;
 
 PSOLibrary::PSOLibrary(UINT frameCount, UINT cbvRootSignatureIndex) :
-    m_cbvRootSignatureIndex(cbvRootSignatureIndex),
-    m_maxDrawsPerFrame(256),
-    m_dynamicCB(sizeof(UberShaderConstantBuffer), m_maxDrawsPerFrame, frameCount),
-    m_flagsMutex(),
-    m_useUberShaders(true),
-    m_useDiskLibraries(true),
-    m_psoCachingMechanism(PSOCachingMechanism::PipelineLibraries),
-    m_drawIndex(0),
-    m_compiledPSOFlags{},
-    m_inflightPSOFlags{},
-    m_workerThreads{}
+	m_cbvRootSignatureIndex(cbvRootSignatureIndex),
+	m_maxDrawsPerFrame(256),
+	m_dynamicCB(sizeof(UberShaderConstantBuffer), m_maxDrawsPerFrame, frameCount),
+	m_flagsMutex(),
+	m_useUberShaders(true),
+	m_useDiskLibraries(true),
+	m_psoCachingMechanism(PSOCachingMechanism::PipelineLibraries),
+	m_drawIndex(0),
+	m_compiledPSOFlags{},
+	m_inflightPSOFlags{},
+	m_workerThreads{}
 {
-    m_cachePath = Windows::Storage::ApplicationData::Current->LocalCacheFolder->Path->Data();
-    m_cachePath += L"\\";
+	m_cachePath = Windows::Storage::ApplicationData::Current->LocalCacheFolder->Path->Data();
+	m_cachePath += L"\\";
 
-    m_flagsMutex = CreateMutex(nullptr, FALSE, nullptr);
+	m_flagsMutex = CreateMutex(nullptr, FALSE, nullptr);
 }
 
 PSOLibrary::~PSOLibrary()
 {
-    WaitForThreads();
+	WaitForThreads();
 
-    for (UINT i = 0; i < EffectPipelineTypeCount; i++)
-    {
-        m_diskCaches[i].Destroy(false);
-    }
+	for (UINT i = 0; i < EffectPipelineTypeCount; i++)
+	{
+		m_diskCaches[i].Destroy(false);
+	}
 
-    // The Pipeline Library is saved to disk on exit.
-    m_pipelineLibrary.Destroy(false);
+	// The Pipeline Library is saved to disk on exit.
+	m_pipelineLibrary.Destroy(false);
 }
 
 void PSOLibrary::WaitForThreads()
 {
-    for (auto& thread : m_workerThreads)
-    {
-        if (thread.threadHandle)
-        {
-            WaitForSingleObject(thread.threadHandle, INFINITE);
-            CloseHandle(thread.threadHandle);
-        }
-        thread.threadHandle = nullptr;
-    }
+	for (auto& thread : m_workerThreads)
+	{
+		if (thread.threadHandle)
+		{
+			WaitForSingleObject(thread.threadHandle, INFINITE);
+			CloseHandle(thread.threadHandle);
+		}
+		thread.threadHandle = nullptr;
+	}
 }
 
 void PSOLibrary::Build(ID3D12Device* pDevice, ID3D12RootSignature* pRootSignature)
 {
-    // Initialize all cache file mappings (file may be empty).
-    m_pipelineLibrariesSupported = m_pipelineLibrary.Init(pDevice, m_cachePath + g_cPipelineLibraryFileName);
-    for (UINT i = 0; i < EffectPipelineTypeCount; i++)
-    {
-        m_diskCaches[i].Init(m_cachePath + g_cCacheFileNames[i]);
-    }
+	// Initialize all cache file mappings (file may be empty).
+	m_pipelineLibrariesSupported = m_pipelineLibrary.Init(pDevice, m_cachePath + g_cPipelineLibraryFileName);
+	for (UINT i = 0; i < EffectPipelineTypeCount; i++)
+	{
+		m_diskCaches[i].Init(m_cachePath + g_cCacheFileNames[i]);
+	}
 
-    // Use Pipeline Libraries for PSO Caching, if available.
-    if (!m_pipelineLibrariesSupported)
-    {
-        // Fallback to Cached Blobs.
-        m_psoCachingMechanism = PSOCachingMechanism::CachedBlobs;
-    }
+	// Use Pipeline Libraries for PSO Caching, if available.
+	if (!m_pipelineLibrariesSupported)
+	{
+		// Fallback to Cached Blobs.
+		m_psoCachingMechanism = PSOCachingMechanism::CachedBlobs;
+	}
 
-    // Always compile the 3D shader and the Ubershader.
-    for (UINT i = 0; i < BaseEffectCount; i++)
-    {
-        m_workerThreads[i].pDevice = pDevice;
-        m_workerThreads[i].pRootSignature = pRootSignature;
-        m_workerThreads[i].type = EffectPipelineType(i);
-        m_workerThreads[i].pLibrary = this;
-        CompilePSO(&m_workerThreads[i]);
-    }
+	// Always compile the 3D shader and the Ubershader.
+	for (UINT i = 0; i < BaseEffectCount; i++)
+	{
+		m_workerThreads[i].pDevice = pDevice;
+		m_workerThreads[i].pRootSignature = pRootSignature;
+		m_workerThreads[i].type = EffectPipelineType(i);
+		m_workerThreads[i].pLibrary = this;
+		CompilePSO(&m_workerThreads[i]);
+	}
 
-    m_dynamicCB.Init(pDevice);
+	m_dynamicCB.Init(pDevice);
 }
 
 
 void PSOLibrary::SetPipelineState(
-    ID3D12Device* pDevice,
-    ID3D12RootSignature* pRootSignature,
-    ID3D12GraphicsCommandList* pCommandList,
-    _In_range_(0, EffectPipelineTypeCount-1) EffectPipelineType type,
-    UINT frameIndex)
+	ID3D12Device* pDevice,
+	ID3D12RootSignature* pRootSignature,
+	ID3D12GraphicsCommandList* pCommandList,
+	_In_range_(0, EffectPipelineTypeCount-1) EffectPipelineType type,
+	UINT frameIndex)
 {
-    assert(m_drawIndex < m_maxDrawsPerFrame);
+	assert(m_drawIndex < m_maxDrawsPerFrame);
 
-    bool isBuilt = false;
-    bool isInFlight = false;
+	bool isBuilt = false;
+	bool isInFlight = false;
 
-    {
-        // Take the lock to figure out if we need to build this thing or use an Uber shader.
-        auto lock = Mutex::Lock(m_flagsMutex);
+	{
+		// Take the lock to figure out if we need to build this thing or use an Uber shader.
+		auto lock = Mutex::Lock(m_flagsMutex);
 
-        isBuilt = m_compiledPSOFlags[type];
-        isInFlight = m_inflightPSOFlags[type];
-    }
+		isBuilt = m_compiledPSOFlags[type];
+		isInFlight = m_inflightPSOFlags[type];
+	}
 
-    if (type > BaseUberShader)
-    {
-        // If an effect hasn't been built yet.
-        if (!isBuilt && m_useUberShaders)
-        {
-            // Let the uber shader know what effect it should configure for.
-            UberShaderConstantBuffer* constantData = (UberShaderConstantBuffer*)m_dynamicCB.GetMappedMemory(m_drawIndex, frameIndex);
-            constantData->effectIndex = type;
-            pCommandList->SetGraphicsRootConstantBufferView(m_cbvRootSignatureIndex, m_dynamicCB.GetGpuVirtualAddress(m_drawIndex, frameIndex));
+	if (type > BaseUberShader)
+	{
+		// If an effect hasn't been built yet.
+		if (!isBuilt && m_useUberShaders)
+		{
+			// Let the uber shader know what effect it should configure for.
+			UberShaderConstantBuffer* constantData = (UberShaderConstantBuffer*)m_dynamicCB.GetMappedMemory(m_drawIndex, frameIndex);
+			constantData->effectIndex = type;
+			pCommandList->SetGraphicsRootConstantBufferView(m_cbvRootSignatureIndex, m_dynamicCB.GetGpuVirtualAddress(m_drawIndex, frameIndex));
 
-            // We don't want to double compile.
-            if (!isInFlight)
-            {
-                m_workerThreads[type].pDevice = pDevice;
-                m_workerThreads[type].pRootSignature = pRootSignature;
-                m_workerThreads[type].type = type;
-                m_workerThreads[type].pLibrary = this;
+			// We don't want to double compile.
+			if (!isInFlight)
+			{
+				m_workerThreads[type].pDevice = pDevice;
+				m_workerThreads[type].pRootSignature = pRootSignature;
+				m_workerThreads[type].type = type;
+				m_workerThreads[type].pLibrary = this;
 
-                // Compile the PSO on a background thread.
-                m_workerThreads[type].threadHandle = CreateThread(
-                    nullptr,
-                    0,
-                    reinterpret_cast<LPTHREAD_START_ROUTINE>(CompilePSO),
-                    reinterpret_cast<void*>(&m_workerThreads[type]),
-                    CREATE_SUSPENDED,
-                    nullptr);
+				// Compile the PSO on a background thread.
+				m_workerThreads[type].threadHandle = CreateThread(
+					nullptr,
+					0,
+					reinterpret_cast<LPTHREAD_START_ROUTINE>(CompilePSO),
+					reinterpret_cast<void*>(&m_workerThreads[type]),
+					CREATE_SUSPENDED,
+					nullptr);
 
-                if (!m_workerThreads[type].threadHandle)
-                {
-                    ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-                }
+				if (!m_workerThreads[type].threadHandle)
+				{
+					ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+				}
 
-                ResumeThread(m_workerThreads[type].threadHandle);
+				ResumeThread(m_workerThreads[type].threadHandle);
 
-                {
-                    auto lock = Mutex::Lock(m_flagsMutex);
+				{
+					auto lock = Mutex::Lock(m_flagsMutex);
 
-                    m_inflightPSOFlags[type] = true;
-                }
-            }
+					m_inflightPSOFlags[type] = true;
+				}
+			}
 
-            type = BaseUberShader;
-        }
-        else if (!isBuilt && !m_useUberShaders)
-        {
-            // When not using ubershaders this will take a long time and cause a hitch as the 
-            // CPU is stalled!
-            m_workerThreads[type].pDevice = pDevice;
-            m_workerThreads[type].pRootSignature = pRootSignature;
-            m_workerThreads[type].type = type;
-            m_workerThreads[type].pLibrary = this;
+			type = BaseUberShader;
+		}
+		else if (!isBuilt && !m_useUberShaders)
+		{
+			// When not using ubershaders this will take a long time and cause a hitch as the 
+			// CPU is stalled!
+			m_workerThreads[type].pDevice = pDevice;
+			m_workerThreads[type].pRootSignature = pRootSignature;
+			m_workerThreads[type].type = type;
+			m_workerThreads[type].pLibrary = this;
 
-            CompilePSO(&m_workerThreads[type]);
-        }
-    }
-    else
-    {
-        // We should always have the base shaders around.
-        assert(isBuilt);
-    }
+			CompilePSO(&m_workerThreads[type]);
+		}
+	}
+	else
+	{
+		// We should always have the base shaders around.
+		assert(isBuilt);
+	}
 
-    pCommandList->SetPipelineState(m_pipelineStates[type].Get());
+	pCommandList->SetPipelineState(m_pipelineStates[type].Get());
 
-    m_drawIndex++;
+	m_drawIndex++;
 }
 
 void PSOLibrary::CompilePSO(CompilePSOThreadData* pDataPackage)
 {
-    PSOLibrary* pLibrary = pDataPackage->pLibrary;
-    ID3D12Device* pDevice = pDataPackage->pDevice;
-    ID3D12RootSignature* pRootSignature = pDataPackage->pRootSignature;
-    EffectPipelineType type = pDataPackage->type;
-    bool useCache = false;
-    bool sleepToEmulateComplexCreatePSO = false;
+	PSOLibrary* pLibrary = pDataPackage->pLibrary;
+	ID3D12Device* pDevice = pDataPackage->pDevice;
+	ID3D12RootSignature* pRootSignature = pDataPackage->pRootSignature;
+	EffectPipelineType type = pDataPackage->type;
+	bool useCache = false;
+	bool sleepToEmulateComplexCreatePSO = false;
 
-    {
-        auto lock = Mutex::Lock(pLibrary->m_flagsMutex);
+	{
+		auto lock = Mutex::Lock(pLibrary->m_flagsMutex);
 
-        // When using the disk cache compilation should be extremely quick so don't sleep.
-        useCache = pLibrary->m_useDiskLibraries;
-    }
+		// When using the disk cache compilation should be extremely quick so don't sleep.
+		useCache = pLibrary->m_useDiskLibraries;
+	}
 
-    D3D12_GRAPHICS_PIPELINE_STATE_DESC baseDesc = {};
-    baseDesc.pRootSignature = pRootSignature;
-    baseDesc.SampleMask = UINT_MAX;
-    baseDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-    baseDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-    baseDesc.NumRenderTargets = 1;
-    baseDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-    baseDesc.SampleDesc.Count = 1;
-    baseDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-    baseDesc.DepthStencilState.DepthEnable = FALSE;
-    baseDesc.DepthStencilState.StencilEnable = FALSE;
+	D3D12_GRAPHICS_PIPELINE_STATE_DESC baseDesc = {};
+	baseDesc.pRootSignature = pRootSignature;
+	baseDesc.SampleMask = UINT_MAX;
+	baseDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+	baseDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+	baseDesc.NumRenderTargets = 1;
+	baseDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+	baseDesc.SampleDesc.Count = 1;
+	baseDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+	baseDesc.DepthStencilState.DepthEnable = FALSE;
+	baseDesc.DepthStencilState.StencilEnable = FALSE;
 
-    baseDesc.InputLayout = g_cEffectShaderData[type].inputLayout;
-    baseDesc.VS = g_cEffectShaderData[type].VS;
-    baseDesc.PS = g_cEffectShaderData[type].PS;
-    baseDesc.DS = g_cEffectShaderData[type].DS;
-    baseDesc.HS = g_cEffectShaderData[type].HS;
-    baseDesc.GS = g_cEffectShaderData[type].GS;
+	baseDesc.InputLayout = g_cEffectShaderData[type].inputLayout;
+	baseDesc.VS = g_cEffectShaderData[type].VS;
+	baseDesc.PS = g_cEffectShaderData[type].PS;
+	baseDesc.DS = g_cEffectShaderData[type].DS;
+	baseDesc.HS = g_cEffectShaderData[type].HS;
+	baseDesc.GS = g_cEffectShaderData[type].GS;
 
-    if (useCache && 
-        (pLibrary->m_psoCachingMechanism == PSOCachingMechanism::PipelineLibraries))
-    {
-        assert(pLibrary->m_pipelineLibrary.IsMapped());
-        ID3D12PipelineLibrary* pPipelineLibrary = pLibrary->m_pipelineLibrary.GetPipelineLibrary();
+	if (useCache && 
+		(pLibrary->m_psoCachingMechanism == PSOCachingMechanism::PipelineLibraries))
+	{
+		assert(pLibrary->m_pipelineLibrary.IsMapped());
+		ID3D12PipelineLibrary* pPipelineLibrary = pLibrary->m_pipelineLibrary.GetPipelineLibrary();
 
-        // Note: Load*Pipeline() will auto-name PSOs for you based on the provided name. However, this sample overrides those names.
-        HRESULT hr = pPipelineLibrary->LoadGraphicsPipeline(g_cEffectNames[type], &baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type]));
-        if (E_INVALIDARG == hr)
-        {
-            // A PSO with the specified name doesn’t exist, or the input desc doesn’t match the data in the library.
-            // Create the PSO and then store it in the library for next time.
-            ThrowIfFailed(pDevice->CreateGraphicsPipelineState(&baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type])));
+		// Note: Load*Pipeline() will auto-name PSOs for you based on the provided name. However, this sample overrides those names.
+		HRESULT hr = pPipelineLibrary->LoadGraphicsPipeline(g_cEffectNames[type], &baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type]));
+		if (E_INVALIDARG == hr)
+		{
+			// A PSO with the specified name doesn’t exist, or the input desc doesn’t match the data in the library.
+			// Create the PSO and then store it in the library for next time.
+			ThrowIfFailed(pDevice->CreateGraphicsPipelineState(&baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type])));
 
-            // Note: You don't need to pass StorePipeline() a name if the object is already named. If the name parameter is null, it will use the object's name.
-            hr = pPipelineLibrary->StorePipeline(g_cEffectNames[type], pLibrary->m_pipelineStates[type].Get());
-            if (E_INVALIDARG == hr)
-            {
-                // A PSO with the specified name already exists in the library.
-                // This shouldn't happen in this sample, but depending on how you name the PSOs collisions are possible.
-            }
-            else
-            {
-                ThrowIfFailed(hr);
-            }
+			// Note: You don't need to pass StorePipeline() a name if the object is already named. If the name parameter is null, it will use the object's name.
+			hr = pPipelineLibrary->StorePipeline(g_cEffectNames[type], pLibrary->m_pipelineStates[type].Get());
+			if (E_INVALIDARG == hr)
+			{
+				// A PSO with the specified name already exists in the library.
+				// This shouldn't happen in this sample, but depending on how you name the PSOs collisions are possible.
+			}
+			else
+			{
+				ThrowIfFailed(hr);
+			}
 
-            sleepToEmulateComplexCreatePSO = true;
-        }
-        else
-        {
-            ThrowIfFailed(hr);
-        }
-    }
-    else if (useCache && 
-        (pLibrary->m_psoCachingMechanism == PSOCachingMechanism::CachedBlobs))
-    {
-        // Read how long the cached shader blob is.
-        assert(pLibrary->m_diskCaches[type].IsMapped());
-        size_t size = pLibrary->m_diskCaches[type].GetCachedBlobSize();
+			sleepToEmulateComplexCreatePSO = true;
+		}
+		else
+		{
+			ThrowIfFailed(hr);
+		}
+	}
+	else if (useCache && 
+		(pLibrary->m_psoCachingMechanism == PSOCachingMechanism::CachedBlobs))
+	{
+		// Read how long the cached shader blob is.
+		assert(pLibrary->m_diskCaches[type].IsMapped());
+		size_t size = pLibrary->m_diskCaches[type].GetCachedBlobSize();
 
-        // If the size if 0 then this disk cache needs to be refreshed.
-        if (size == 0)
-        {
-            ThrowIfFailed(pDevice->CreateGraphicsPipelineState(&baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type])));
+		// If the size if 0 then this disk cache needs to be refreshed.
+		if (size == 0)
+		{
+			ThrowIfFailed(pDevice->CreateGraphicsPipelineState(&baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type])));
 
-            ComPtr<ID3DBlob> blob;
-            pLibrary->m_pipelineStates[type]->GetCachedBlob(&blob);
-            pLibrary->m_diskCaches[type].Update(blob.Get());
+			ComPtr<ID3DBlob> blob;
+			pLibrary->m_pipelineStates[type]->GetCachedBlob(&blob);
+			pLibrary->m_diskCaches[type].Update(blob.Get());
 
-            sleepToEmulateComplexCreatePSO = true;
-        }
-        else
-        {
-            // Read in the blob data from disk to avoid compiling it.
-            baseDesc.CachedPSO.pCachedBlob = pLibrary->m_diskCaches[type].GetCachedBlob();
-            baseDesc.CachedPSO.CachedBlobSizeInBytes = pLibrary->m_diskCaches[type].GetCachedBlobSize();
+			sleepToEmulateComplexCreatePSO = true;
+		}
+		else
+		{
+			// Read in the blob data from disk to avoid compiling it.
+			baseDesc.CachedPSO.pCachedBlob = pLibrary->m_diskCaches[type].GetCachedBlob();
+			baseDesc.CachedPSO.CachedBlobSizeInBytes = pLibrary->m_diskCaches[type].GetCachedBlobSize();
 
-            HRESULT hr = pDevice->CreateGraphicsPipelineState(&baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type]));
+			HRESULT hr = pDevice->CreateGraphicsPipelineState(&baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type]));
 
-            // If compilation fails the cache is probably stale. (old drivers etc.)
-            if (FAILED(hr))
-            {
-                baseDesc.CachedPSO = {};
-                ThrowIfFailed(pDevice->CreateGraphicsPipelineState(&baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type])));
+			// If compilation fails the cache is probably stale. (old drivers etc.)
+			if (FAILED(hr))
+			{
+				baseDesc.CachedPSO = {};
+				ThrowIfFailed(pDevice->CreateGraphicsPipelineState(&baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type])));
 
-                ComPtr<ID3DBlob> blob;
-                pLibrary->m_pipelineStates[type]->GetCachedBlob(&blob);
-                pLibrary->m_diskCaches[type].Update(blob.Get());
+				ComPtr<ID3DBlob> blob;
+				pLibrary->m_pipelineStates[type]->GetCachedBlob(&blob);
+				pLibrary->m_diskCaches[type].Update(blob.Get());
 
-                sleepToEmulateComplexCreatePSO = true;
-            }
-        }
-    }
-    else
-    {
-        ThrowIfFailed(pDevice->CreateGraphicsPipelineState(&baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type])));
+				sleepToEmulateComplexCreatePSO = true;
+			}
+		}
+	}
+	else
+	{
+		ThrowIfFailed(pDevice->CreateGraphicsPipelineState(&baseDesc, IID_PPV_ARGS(&pLibrary->m_pipelineStates[type])));
 
-        sleepToEmulateComplexCreatePSO = true;
-    }
+		sleepToEmulateComplexCreatePSO = true;
+	}
 
-    // The effects are very simple and should compile quickly so we'll sleep to emulate something more complex.
-    if (sleepToEmulateComplexCreatePSO && type > BaseUberShader)
-    {
-        Sleep(500);
-    }
+	// The effects are very simple and should compile quickly so we'll sleep to emulate something more complex.
+	if (sleepToEmulateComplexCreatePSO && type > BaseUberShader)
+	{
+		Sleep(500);
+	}
 
-    WCHAR name[50];
-    if (swprintf_s(name, L"m_pipelineStates[%s]", g_cEffectNames[type]) > 0)
-    {
-        SetName(pLibrary->m_pipelineStates[type].Get(), name);
-    }
+	WCHAR name[50];
+	if (swprintf_s(name, L"m_pipelineStates[%s]", g_cEffectNames[type]) > 0)
+	{
+		SetName(pLibrary->m_pipelineStates[type].Get(), name);
+	}
 
-    {
-        auto lock = Mutex::Lock(pLibrary->m_flagsMutex);
+	{
+		auto lock = Mutex::Lock(pLibrary->m_flagsMutex);
 
-        pLibrary->m_compiledPSOFlags[type] = true;
-        pLibrary->m_inflightPSOFlags[type] = false;
-    }
+		pLibrary->m_compiledPSOFlags[type] = true;
+		pLibrary->m_inflightPSOFlags[type] = false;
+	}
 }
 
 void PSOLibrary::EndFrame()
 {
-    m_drawIndex = 0;
+	m_drawIndex = 0;
 }
 
 void PSOLibrary::ClearPSOCache()
 {
-    WaitForThreads();
+	WaitForThreads();
 
-    for (size_t i = PostBlit; i < EffectPipelineTypeCount; i++)
-    {
-        if (m_pipelineStates[i])
-        {
-            m_pipelineStates[i] = nullptr;
-            m_compiledPSOFlags[i] = false;
-            m_inflightPSOFlags[i] = false;
-        }
-    }
+	for (size_t i = PostBlit; i < EffectPipelineTypeCount; i++)
+	{
+		if (m_pipelineStates[i])
+		{
+			m_pipelineStates[i] = nullptr;
+			m_compiledPSOFlags[i] = false;
+			m_inflightPSOFlags[i] = false;
+		}
+	}
 
-    // Clear the disk caches.
-    for (size_t i = 0; i < EffectPipelineTypeCount; i++)
-    {
-        m_diskCaches[i].Destroy(true);
-    }
+	// Clear the disk caches.
+	for (size_t i = 0; i < EffectPipelineTypeCount; i++)
+	{
+		m_diskCaches[i].Destroy(true);
+	}
 
-    m_pipelineLibrary.Destroy(true);
+	m_pipelineLibrary.Destroy(true);
 }
 
 void PSOLibrary::ToggleUberShader()
 {
-    m_useUberShaders = !m_useUberShaders;
+	m_useUberShaders = !m_useUberShaders;
 }
 
 void PSOLibrary::ToggleDiskLibrary()
 {
-    {
-        auto lock = Mutex::Lock(m_flagsMutex);
+	{
+		auto lock = Mutex::Lock(m_flagsMutex);
 
-        m_useDiskLibraries = !m_useDiskLibraries;
-    }
+		m_useDiskLibraries = !m_useDiskLibraries;
+	}
 
-    WaitForThreads();
+	WaitForThreads();
 }
 
 void PSOLibrary::SwitchPSOCachingMechanism()
 {
-    {
-        auto lock = Mutex::Lock(m_flagsMutex);
+	{
+		auto lock = Mutex::Lock(m_flagsMutex);
 
-        UINT newMechanism = static_cast<UINT>(m_psoCachingMechanism) + 1;
-        newMechanism = newMechanism % PSOCachingMechanism::PSOCachingMechanismCount;
+		UINT newMechanism = static_cast<UINT>(m_psoCachingMechanism) + 1;
+		newMechanism = newMechanism % PSOCachingMechanism::PSOCachingMechanismCount;
 
-        // Don't allow Pipeline Libraries if they're not available.
-        if (!m_pipelineLibrariesSupported && (newMechanism == PSOCachingMechanism::PipelineLibraries))
-        {
-            newMechanism++;
-            newMechanism = newMechanism % PSOCachingMechanism::PSOCachingMechanismCount;
-        }
-        
-        m_psoCachingMechanism = static_cast<PSOCachingMechanism>(newMechanism);
-    }
+		// Don't allow Pipeline Libraries if they're not available.
+		if (!m_pipelineLibrariesSupported && (newMechanism == PSOCachingMechanism::PipelineLibraries))
+		{
+			newMechanism++;
+			newMechanism = newMechanism % PSOCachingMechanism::PSOCachingMechanismCount;
+		}
+		
+		m_psoCachingMechanism = static_cast<PSOCachingMechanism>(newMechanism);
+	}
 
-    WaitForThreads();
+	WaitForThreads();
 }
 
 void PSOLibrary::DestroyShader(EffectPipelineType type)
 {
-    WaitForThreads();
+	WaitForThreads();
 
-    if (m_pipelineStates[type])
-    {
-        m_pipelineStates[type] = nullptr;
-        m_compiledPSOFlags[type] = false;
-        m_inflightPSOFlags[type] = false;
-    }
+	if (m_pipelineStates[type])
+	{
+		m_pipelineStates[type] = nullptr;
+		m_compiledPSOFlags[type] = false;
+		m_inflightPSOFlags[type] = false;
+	}
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/PSOLibrary.h
+++ b/Samples/UWP/D3D12PipelineStateCache/src/PSOLibrary.h
@@ -34,53 +34,53 @@ using namespace std;
 
 enum PSOCachingMechanism
 {
-    CachedBlobs,
+	CachedBlobs,
 
-    // Enables applications to explicitly group PSOs which are expected to share data. Recommended over Cached Blobs.
-    PipelineLibraries,
+	// Enables applications to explicitly group PSOs which are expected to share data. Recommended over Cached Blobs.
+	PipelineLibraries,
 
-    PSOCachingMechanismCount
+	PSOCachingMechanismCount
 };
 
 enum EffectPipelineType : UINT
 {
-    // These always get compiled at startup.
-    BaseNormal3DRender,
-    BaseUberShader,
+	// These always get compiled at startup.
+	BaseNormal3DRender,
+	BaseUberShader,
 
-    // These are compiled a la carte.
-    PostBlit,
-    PostInvert,
-    PostGrayScale,
-    PostEdgeDetect,
-    PostBlur,
-    PostWarp,
-    PostPixelate,
-    PostDistort,
-    PostWave,
-    EffectPipelineTypeCount
+	// These are compiled a la carte.
+	PostBlit,
+	PostInvert,
+	PostGrayScale,
+	PostEdgeDetect,
+	PostBlur,
+	PostWarp,
+	PostPixelate,
+	PostDistort,
+	PostWave,
+	EffectPipelineTypeCount
 };
 
 struct GraphicsShaderSet
 {
-    D3D12_INPUT_LAYOUT_DESC inputLayout;
-    D3D12_SHADER_BYTECODE VS;
-    D3D12_SHADER_BYTECODE PS;
-    D3D12_SHADER_BYTECODE DS;
-    D3D12_SHADER_BYTECODE HS;
-    D3D12_SHADER_BYTECODE GS;
+	D3D12_INPUT_LAYOUT_DESC inputLayout;
+	D3D12_SHADER_BYTECODE VS;
+	D3D12_SHADER_BYTECODE PS;
+	D3D12_SHADER_BYTECODE DS;
+	D3D12_SHADER_BYTECODE HS;
+	D3D12_SHADER_BYTECODE GS;
 };
 
 static const D3D12_INPUT_ELEMENT_DESC g_cSimpleInputElementDescs[] =
 {
-    { "POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-    { "COLOR", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+	{ "POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+	{ "COLOR", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
 };
 
 static const D3D12_INPUT_ELEMENT_DESC g_cQuadInputElementDescs[] =
 {
-    { "POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-    { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+	{ "POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+	{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
 };
 
 static const D3D12_INPUT_LAYOUT_DESC g_cForwardRenderInputLayout = { g_cSimpleInputElementDescs, _countof(g_cSimpleInputElementDescs) };
@@ -88,193 +88,193 @@ static const D3D12_INPUT_LAYOUT_DESC g_cQuadInputLayout = { g_cQuadInputElementD
 
 static const GraphicsShaderSet g_cEffectShaderData[EffectPipelineTypeCount] =
 {
-    {
-        g_cForwardRenderInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_SimpleVertexShader, sizeof(g_SimpleVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_SimplePixelShader, sizeof(g_SimplePixelShader)),
-        {},
-        {},
-        {},
-    },
-    {
-        g_cQuadInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_UberPixelShader, sizeof(g_UberPixelShader)),
-        {},
-        {},
-        {},
-    },
-    {
-        g_cQuadInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_BlitPixelShader, sizeof(g_BlitPixelShader)),
-        {},
-        {},
-        {},
-    },
-    {
-        g_cQuadInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_InvertPixelShader, sizeof(g_InvertPixelShader)),
-        {},
-        {},
-        {},
-    },
-    {
-        g_cQuadInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_GrayScalePixelShader, sizeof(g_GrayScalePixelShader)),
-        {},
-        {},
-        {},
-    },
-    {
-        g_cQuadInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_EdgeDetectPixelShader, sizeof(g_EdgeDetectPixelShader)),
-        {},
-        {},
-        {},
-    },
-    {
-        g_cQuadInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_BlurPixelShader, sizeof(g_BlurPixelShader)),
-        {},
-        {},
-        {},
-    },
-    {
-        g_cQuadInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_WarpPixelShader, sizeof(g_WarpPixelShader)),
-        {},
-        {},
-        {},
-    },
-    {
-        g_cQuadInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_PixelatePixelShader, sizeof(g_PixelatePixelShader)),
-        {},
-        {},
-        {},
-    },
-    {
-        g_cQuadInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_DistortPixelShader, sizeof(g_DistortPixelShader)),
-        {},
-        {},
-        {},
-    },
-    {
-        g_cQuadInputLayout,
-        CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
-        CD3DX12_SHADER_BYTECODE(g_WavePixelShader, sizeof(g_WavePixelShader)),
-        {},
-        {},
-        {},
-    },
+	{
+		g_cForwardRenderInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_SimpleVertexShader, sizeof(g_SimpleVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_SimplePixelShader, sizeof(g_SimplePixelShader)),
+		{},
+		{},
+		{},
+	},
+	{
+		g_cQuadInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_UberPixelShader, sizeof(g_UberPixelShader)),
+		{},
+		{},
+		{},
+	},
+	{
+		g_cQuadInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_BlitPixelShader, sizeof(g_BlitPixelShader)),
+		{},
+		{},
+		{},
+	},
+	{
+		g_cQuadInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_InvertPixelShader, sizeof(g_InvertPixelShader)),
+		{},
+		{},
+		{},
+	},
+	{
+		g_cQuadInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_GrayScalePixelShader, sizeof(g_GrayScalePixelShader)),
+		{},
+		{},
+		{},
+	},
+	{
+		g_cQuadInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_EdgeDetectPixelShader, sizeof(g_EdgeDetectPixelShader)),
+		{},
+		{},
+		{},
+	},
+	{
+		g_cQuadInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_BlurPixelShader, sizeof(g_BlurPixelShader)),
+		{},
+		{},
+		{},
+	},
+	{
+		g_cQuadInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_WarpPixelShader, sizeof(g_WarpPixelShader)),
+		{},
+		{},
+		{},
+	},
+	{
+		g_cQuadInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_PixelatePixelShader, sizeof(g_PixelatePixelShader)),
+		{},
+		{},
+		{},
+	},
+	{
+		g_cQuadInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_DistortPixelShader, sizeof(g_DistortPixelShader)),
+		{},
+		{},
+		{},
+	},
+	{
+		g_cQuadInputLayout,
+		CD3DX12_SHADER_BYTECODE(g_QuadVertexShader, sizeof(g_QuadVertexShader)),
+		CD3DX12_SHADER_BYTECODE(g_WavePixelShader, sizeof(g_WavePixelShader)),
+		{},
+		{},
+		{},
+	},
 };
 
 static const LPWCH g_cPipelineLibraryFileName = L"pipelineLibrary.cache";
 
 static const LPWCH g_cCacheFileNames[EffectPipelineTypeCount] =
 {
-    L"normal3dPSO.cache",
-    L"ubershaderPSO.cache",
-    L"blitEffectPSO.cache",
-    L"invertEffectPSO.cache",
-    L"grayscaleEffectPSO.cache",
-    L"edgeDetectEffectPSO.cache",
-    L"blurEffectPSO.cache",
-    L"warpEffectPSO.cache",
-    L"pixelateEffectPSO.cache",
-    L"distortEffectPSO.cache",
-    L"waveEffectPSO.cache",
+	L"normal3dPSO.cache",
+	L"ubershaderPSO.cache",
+	L"blitEffectPSO.cache",
+	L"invertEffectPSO.cache",
+	L"grayscaleEffectPSO.cache",
+	L"edgeDetectEffectPSO.cache",
+	L"blurEffectPSO.cache",
+	L"warpEffectPSO.cache",
+	L"pixelateEffectPSO.cache",
+	L"distortEffectPSO.cache",
+	L"waveEffectPSO.cache",
 };
 
 static const LPWCH g_cEffectNames[EffectPipelineTypeCount] =
 {
-    L"Normal 3D",
-    L"Generic post effect",
-    L"Blit",
-    L"Invert",
-    L"Grayscale",
-    L"Edge detect",
-    L"Blur",
-    L"Warp",
-    L"Pixelate",
-    L"Distort",
-    L"Wave",
+	L"Normal 3D",
+	L"Generic post effect",
+	L"Blit",
+	L"Invert",
+	L"Grayscale",
+	L"Edge detect",
+	L"Blur",
+	L"Warp",
+	L"Pixelate",
+	L"Distort",
+	L"Wave",
 };
 
 class PSOLibrary
 {
 public:
-    PSOLibrary(UINT frameCount, UINT cbvRootSignatureIndex);
-    ~PSOLibrary();
+	PSOLibrary(UINT frameCount, UINT cbvRootSignatureIndex);
+	~PSOLibrary();
 
-    void Build(ID3D12Device* pDevice, ID3D12RootSignature* pRootSignature);
+	void Build(ID3D12Device* pDevice, ID3D12RootSignature* pRootSignature);
 
-    void SetPipelineState(
-        ID3D12Device* pDevice,
-        ID3D12RootSignature* pRootSignature,
-        ID3D12GraphicsCommandList* pCommandList,
-        _In_range_(0, EffectPipelineTypeCount-1) EffectPipelineType type,
-        UINT frameIndex);
+	void SetPipelineState(
+		ID3D12Device* pDevice,
+		ID3D12RootSignature* pRootSignature,
+		ID3D12GraphicsCommandList* pCommandList,
+		_In_range_(0, EffectPipelineTypeCount-1) EffectPipelineType type,
+		UINT frameIndex);
 
-    void EndFrame();
-    void ClearPSOCache();
-    void ToggleUberShader();
-    void ToggleDiskLibrary();
-    void SwitchPSOCachingMechanism();
-    void DestroyShader(EffectPipelineType type);
+	void EndFrame();
+	void ClearPSOCache();
+	void ToggleUberShader();
+	void ToggleDiskLibrary();
+	void SwitchPSOCachingMechanism();
+	void DestroyShader(EffectPipelineType type);
 
-    bool UberShadersEnabled() { return m_useUberShaders; }
-    bool DiskCacheEnabled() { return m_useDiskLibraries; }
-    PSOCachingMechanism GetPSOCachingMechanism() { return m_psoCachingMechanism; }
+	bool UberShadersEnabled() { return m_useUberShaders; }
+	bool DiskCacheEnabled() { return m_useDiskLibraries; }
+	PSOCachingMechanism GetPSOCachingMechanism() { return m_psoCachingMechanism; }
 
 private:
-    static const UINT BaseEffectCount = 2;
+	static const UINT BaseEffectCount = 2;
 
-    struct CompilePSOThreadData
-    {
-        PSOLibrary* pLibrary;
-        ID3D12Device* pDevice;
-        ID3D12RootSignature* pRootSignature;
-        EffectPipelineType type;
+	struct CompilePSOThreadData
+	{
+		PSOLibrary* pLibrary;
+		ID3D12Device* pDevice;
+		ID3D12RootSignature* pRootSignature;
+		EffectPipelineType type;
 
-        HANDLE threadHandle;
-    };
+		HANDLE threadHandle;
+	};
 
-    // This will be used to tell the uber shader which effect to use.
-    struct UberShaderConstantBuffer
-    {
-        UINT32 effectIndex;
-    };
+	// This will be used to tell the uber shader which effect to use.
+	struct UberShaderConstantBuffer
+	{
+		UINT32 effectIndex;
+	};
 
-    static void CompilePSO(CompilePSOThreadData* pDataPackage);
-    void WaitForThreads();
+	static void CompilePSO(CompilePSOThreadData* pDataPackage);
+	void WaitForThreads();
 
-    ComPtr<ID3D12PipelineState> m_pipelineStates[EffectPipelineTypeCount];
-    bool m_compiledPSOFlags[EffectPipelineTypeCount];
-    bool m_inflightPSOFlags[EffectPipelineTypeCount];
-    MemoryMappedPSOCache m_diskCaches[EffectPipelineTypeCount];    // Cached blobs.
-    MemoryMappedPipelineLibrary m_pipelineLibrary; // Pipeline Library.
-    HANDLE m_flagsMutex;
-    CompilePSOThreadData m_workerThreads[EffectPipelineTypeCount];
+	ComPtr<ID3D12PipelineState> m_pipelineStates[EffectPipelineTypeCount];
+	bool m_compiledPSOFlags[EffectPipelineTypeCount];
+	bool m_inflightPSOFlags[EffectPipelineTypeCount];
+	MemoryMappedPSOCache m_diskCaches[EffectPipelineTypeCount];	// Cached blobs.
+	MemoryMappedPipelineLibrary m_pipelineLibrary; // Pipeline Library.
+	HANDLE m_flagsMutex;
+	CompilePSOThreadData m_workerThreads[EffectPipelineTypeCount];
 
-    bool m_useUberShaders;
-    bool m_useDiskLibraries;
-    bool m_pipelineLibrariesSupported;
-    PSOCachingMechanism m_psoCachingMechanism;
-    std::wstring m_cachePath;
+	bool m_useUberShaders;
+	bool m_useDiskLibraries;
+	bool m_pipelineLibrariesSupported;
+	PSOCachingMechanism m_psoCachingMechanism;
+	std::wstring m_cachePath;
 
-    UINT m_cbvRootSignatureIndex;
-    UINT m_maxDrawsPerFrame;
-    UINT m_drawIndex;
+	UINT m_cbvRootSignatureIndex;
+	UINT m_maxDrawsPerFrame;
+	UINT m_drawIndex;
 
-    DynamicConstantBuffer m_dynamicCB;
+	DynamicConstantBuffer m_dynamicCB;
 };

--- a/Samples/UWP/D3D12PipelineStateCache/src/PixelatePixelShader.hlsl
+++ b/Samples/UWP/D3D12PipelineStateCache/src/PixelatePixelShader.hlsl
@@ -13,13 +13,13 @@
 
 float4 Pixelate(float2 uv)
 {
-    uint2 var = uint2(uv.x * 100, uv.y * 100);
-    uv = float2((float)var.x / 100, (float)var.y / 100);
+	uint2 var = uint2(uv.x * 100, uv.y * 100);
+	uv = float2((float)var.x / 100, (float)var.y / 100);
 
-    return g_tex.Sample(g_samp, uv);
+	return g_tex.Sample(g_samp, uv);
 }
 
 float4 mainPixel(PSInput input) : SV_TARGET
 {
-    return Pixelate(input.uv);
+	return Pixelate(input.uv);
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/QuadVertexShader.hlsl
+++ b/Samples/UWP/D3D12PipelineStateCache/src/QuadVertexShader.hlsl
@@ -14,14 +14,14 @@
 
 struct VSInput
 {
-    float4 position : POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : POSITION;
+	float2 uv : TEXCOORD;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 Texture2D g_tex : register(t0);
@@ -29,11 +29,11 @@ SamplerState g_samp : register(s0);
 
 PSInput mainQuad(VSInput input)
 {
-    PSInput result;
-    result.position = input.position;
-    result.uv = input.uv;
+	PSInput result;
+	result.position = input.position;
+	result.uv = input.uv;
 
-    return result;
+	return result;
 }
 
 #endif

--- a/Samples/UWP/D3D12PipelineStateCache/src/SimpleCamera.cpp
+++ b/Samples/UWP/D3D12PipelineStateCache/src/SimpleCamera.cpp
@@ -13,163 +13,163 @@
 #include "SimpleCamera.h"
 
 SimpleCamera::SimpleCamera():
-    m_initialPosition(0, 0, 0),
-    m_position(m_initialPosition),
-    m_yaw(XM_PI),
-    m_pitch(0.0f),
-    m_lookDirection(0, 0, -1),
-    m_upDirection(0, 1, 0),
-    m_moveSpeed(20.0f),
-    m_turnSpeed(XM_PIDIV2),
-    m_keysPressed{}
+	m_initialPosition(0, 0, 0),
+	m_position(m_initialPosition),
+	m_yaw(XM_PI),
+	m_pitch(0.0f),
+	m_lookDirection(0, 0, -1),
+	m_upDirection(0, 1, 0),
+	m_moveSpeed(20.0f),
+	m_turnSpeed(XM_PIDIV2),
+	m_keysPressed{}
 {
 }
 
 void SimpleCamera::Init(XMFLOAT3 position)
 {
-    m_initialPosition = position;
-    Reset();
+	m_initialPosition = position;
+	Reset();
 }
 
 void SimpleCamera::SetMoveSpeed(float unitsPerSecond)
 {
-    m_moveSpeed = unitsPerSecond;
+	m_moveSpeed = unitsPerSecond;
 }
 
 void SimpleCamera::SetTurnSpeed(float radiansPerSecond)
 {
-    m_turnSpeed = radiansPerSecond;
+	m_turnSpeed = radiansPerSecond;
 }
 
 void SimpleCamera::Reset()
 {
-    m_position = m_initialPosition;
-    m_yaw = XM_PI;
-    m_pitch = 0.0f;
-    m_lookDirection = { 0, 0, -1 };
+	m_position = m_initialPosition;
+	m_yaw = XM_PI;
+	m_pitch = 0.0f;
+	m_lookDirection = { 0, 0, -1 };
 }
 
 void SimpleCamera::Update(float elapsedSeconds)
 {
-    // Calculate the move vector in camera space.
-    XMFLOAT3 move(0, 0, 0);
+	// Calculate the move vector in camera space.
+	XMFLOAT3 move(0, 0, 0);
 
-    if (m_keysPressed.a)
-        move.x -= 1.0f;
-    if (m_keysPressed.d)
-        move.x += 1.0f;
-    if (m_keysPressed.w)
-        move.z -= 1.0f;
-    if (m_keysPressed.s)
-        move.z += 1.0f;
+	if (m_keysPressed.a)
+		move.x -= 1.0f;
+	if (m_keysPressed.d)
+		move.x += 1.0f;
+	if (m_keysPressed.w)
+		move.z -= 1.0f;
+	if (m_keysPressed.s)
+		move.z += 1.0f;
 
-    if (fabs(move.x) > 0.1f && fabs(move.z) > 0.1f)
-    {
-        XMVECTOR vector = XMVector3Normalize(XMLoadFloat3(&move));
-        move.x = XMVectorGetX(vector);
-        move.z = XMVectorGetZ(vector);
-    }
+	if (fabs(move.x) > 0.1f && fabs(move.z) > 0.1f)
+	{
+		XMVECTOR vector = XMVector3Normalize(XMLoadFloat3(&move));
+		move.x = XMVectorGetX(vector);
+		move.z = XMVectorGetZ(vector);
+	}
 
-    float moveInterval = m_moveSpeed * elapsedSeconds;
-    float rotateInterval = m_turnSpeed * elapsedSeconds;
+	float moveInterval = m_moveSpeed * elapsedSeconds;
+	float rotateInterval = m_turnSpeed * elapsedSeconds;
 
-    if (m_keysPressed.left)
-        m_yaw += rotateInterval;
-    if (m_keysPressed.right)
-        m_yaw -= rotateInterval;
-    if (m_keysPressed.up)
-        m_pitch += rotateInterval;
-    if (m_keysPressed.down)
-        m_pitch -= rotateInterval;
+	if (m_keysPressed.left)
+		m_yaw += rotateInterval;
+	if (m_keysPressed.right)
+		m_yaw -= rotateInterval;
+	if (m_keysPressed.up)
+		m_pitch += rotateInterval;
+	if (m_keysPressed.down)
+		m_pitch -= rotateInterval;
 
-    // Prevent looking too far up or down.
-    m_pitch = min(m_pitch, XM_PIDIV4);
-    m_pitch = max(-XM_PIDIV4, m_pitch);
+	// Prevent looking too far up or down.
+	m_pitch = min(m_pitch, XM_PIDIV4);
+	m_pitch = max(-XM_PIDIV4, m_pitch);
 
-    // Move the camera in model space.
-    float x = move.x * -cosf(m_yaw) - move.z * sinf(m_yaw);
-    float z = move.x * sinf(m_yaw) - move.z * cosf(m_yaw);
-    m_position.x += x * moveInterval;
-    m_position.z += z * moveInterval;
+	// Move the camera in model space.
+	float x = move.x * -cosf(m_yaw) - move.z * sinf(m_yaw);
+	float z = move.x * sinf(m_yaw) - move.z * cosf(m_yaw);
+	m_position.x += x * moveInterval;
+	m_position.z += z * moveInterval;
 
-    // Determine the look direction.
-    float r = cosf(m_pitch);
-    m_lookDirection.x = r * sinf(m_yaw);
-    m_lookDirection.y = sinf(m_pitch);
-    m_lookDirection.z = r * cosf(m_yaw);
+	// Determine the look direction.
+	float r = cosf(m_pitch);
+	m_lookDirection.x = r * sinf(m_yaw);
+	m_lookDirection.y = sinf(m_pitch);
+	m_lookDirection.z = r * cosf(m_yaw);
 }
 
 XMMATRIX SimpleCamera::GetViewMatrix()
 {
-    return XMMatrixLookToRH(XMLoadFloat3(&m_position), XMLoadFloat3(&m_lookDirection), XMLoadFloat3(&m_upDirection));
+	return XMMatrixLookToRH(XMLoadFloat3(&m_position), XMLoadFloat3(&m_lookDirection), XMLoadFloat3(&m_upDirection));
 }
 
 XMMATRIX SimpleCamera::GetProjectionMatrix(float fov, float aspectRatio, float nearPlane, float farPlane)
 {
-    return XMMatrixPerspectiveFovRH(fov, aspectRatio, nearPlane, farPlane);
+	return XMMatrixPerspectiveFovRH(fov, aspectRatio, nearPlane, farPlane);
 }
 
 void SimpleCamera::OnKeyDown(WPARAM key)
 {
-    switch (key)
-    {
-    case 'W':
-        m_keysPressed.w = true;
-        break;
-    case 'A':
-        m_keysPressed.a = true;
-        break;
-    case 'S':
-        m_keysPressed.s = true;
-        break;
-    case 'D':
-        m_keysPressed.d = true;
-        break;
-    case VK_LEFT:
-        m_keysPressed.left = true;
-        break;
-    case VK_RIGHT:
-        m_keysPressed.right = true;
-        break;
-    case VK_UP:
-        m_keysPressed.up = true;
-        break;
-    case VK_DOWN:
-        m_keysPressed.down = true;
-        break;
-    case VK_ESCAPE:
-        Reset();
-        break;
-    }
+	switch (key)
+	{
+	case 'W':
+		m_keysPressed.w = true;
+		break;
+	case 'A':
+		m_keysPressed.a = true;
+		break;
+	case 'S':
+		m_keysPressed.s = true;
+		break;
+	case 'D':
+		m_keysPressed.d = true;
+		break;
+	case VK_LEFT:
+		m_keysPressed.left = true;
+		break;
+	case VK_RIGHT:
+		m_keysPressed.right = true;
+		break;
+	case VK_UP:
+		m_keysPressed.up = true;
+		break;
+	case VK_DOWN:
+		m_keysPressed.down = true;
+		break;
+	case VK_ESCAPE:
+		Reset();
+		break;
+	}
 }
 
 void SimpleCamera::OnKeyUp(WPARAM key)
 {
-    switch (key)
-    {
-    case 'W':
-        m_keysPressed.w = false;
-        break;
-    case 'A':
-        m_keysPressed.a = false;
-        break;
-    case 'S':
-        m_keysPressed.s = false;
-        break;
-    case 'D':
-        m_keysPressed.d = false;
-        break;
-    case VK_LEFT:
-        m_keysPressed.left = false;
-        break;
-    case VK_RIGHT:
-        m_keysPressed.right = false;
-        break;
-    case VK_UP:
-        m_keysPressed.up = false;
-        break;
-    case VK_DOWN:
-        m_keysPressed.down = false;
-        break;
-    }
+	switch (key)
+	{
+	case 'W':
+		m_keysPressed.w = false;
+		break;
+	case 'A':
+		m_keysPressed.a = false;
+		break;
+	case 'S':
+		m_keysPressed.s = false;
+		break;
+	case 'D':
+		m_keysPressed.d = false;
+		break;
+	case VK_LEFT:
+		m_keysPressed.left = false;
+		break;
+	case VK_RIGHT:
+		m_keysPressed.right = false;
+		break;
+	case VK_UP:
+		m_keysPressed.up = false;
+		break;
+	case VK_DOWN:
+		m_keysPressed.down = false;
+		break;
+	}
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/SimpleCamera.h
+++ b/Samples/UWP/D3D12PipelineStateCache/src/SimpleCamera.h
@@ -16,42 +16,42 @@ using namespace DirectX;
 class SimpleCamera
 {
 public:
-    SimpleCamera();
+	SimpleCamera();
 
-    void Init(XMFLOAT3 position);
-    void Update(float elapsedSeconds);
-    XMMATRIX GetViewMatrix();
-    XMMATRIX GetProjectionMatrix(float fov, float aspectRatio, float nearPlane = 1.0f, float farPlane = 1000.0f);
-    void SetMoveSpeed(float unitsPerSecond);
-    void SetTurnSpeed(float radiansPerSecond);
+	void Init(XMFLOAT3 position);
+	void Update(float elapsedSeconds);
+	XMMATRIX GetViewMatrix();
+	XMMATRIX GetProjectionMatrix(float fov, float aspectRatio, float nearPlane = 1.0f, float farPlane = 1000.0f);
+	void SetMoveSpeed(float unitsPerSecond);
+	void SetTurnSpeed(float radiansPerSecond);
 
-    void OnKeyDown(WPARAM key);
-    void OnKeyUp(WPARAM key);
+	void OnKeyDown(WPARAM key);
+	void OnKeyUp(WPARAM key);
 
 private:
-    void Reset();
+	void Reset();
 
-    struct KeysPressed
-    {
-        bool w;
-        bool a;
-        bool s;
-        bool d;
+	struct KeysPressed
+	{
+		bool w;
+		bool a;
+		bool s;
+		bool d;
 
-        bool left;
-        bool right;
-        bool up;
-        bool down;
-    };
+		bool left;
+		bool right;
+		bool up;
+		bool down;
+	};
 
-    XMFLOAT3 m_initialPosition;
-    XMFLOAT3 m_position;
-    float m_yaw;                // Relative to the +z axis.
-    float m_pitch;                // Relative to the xz plane.
-    XMFLOAT3 m_lookDirection;
-    XMFLOAT3 m_upDirection;
-    float m_moveSpeed;            // Speed at which the camera moves, in units per second.
-    float m_turnSpeed;            // Speed at which the camera turns, in radians per second.
+	XMFLOAT3 m_initialPosition;
+	XMFLOAT3 m_position;
+	float m_yaw;				// Relative to the +z axis.
+	float m_pitch;				// Relative to the xz plane.
+	XMFLOAT3 m_lookDirection;
+	XMFLOAT3 m_upDirection;
+	float m_moveSpeed;			// Speed at which the camera moves, in units per second.
+	float m_turnSpeed;			// Speed at which the camera turns, in radians per second.
 
-    KeysPressed m_keysPressed;
+	KeysPressed m_keysPressed;
 };

--- a/Samples/UWP/D3D12PipelineStateCache/src/SimplePixelShader.hlsl
+++ b/Samples/UWP/D3D12PipelineStateCache/src/SimplePixelShader.hlsl
@@ -13,5 +13,5 @@
 
 float4 main(PSInput input) : SV_TARGET
 {
-    return float4(input.color, 1.0f);
+	return float4(input.color, 1.0f);
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/SimpleVertexShader.hlsl
+++ b/Samples/UWP/D3D12PipelineStateCache/src/SimpleVertexShader.hlsl
@@ -11,27 +11,27 @@
 
 struct VSInput
 {
-    float4 position : POSITION;
-    float3 color : COLOR;
+	float4 position : POSITION;
+	float3 color : COLOR;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float3 color : COLOR;
+	float4 position : SV_POSITION;
+	float3 color : COLOR;
 };
 
 cbuffer PerDraw : register(b1)
 {
-    float4x4 worldViewProjection;
+	float4x4 worldViewProjection;
 };
 
 PSInput main(VSInput input) 
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = mul(input.position, worldViewProjection);
-    result.color = input.color;
+	result.position = mul(input.position, worldViewProjection);
+	result.color = input.color;
 
-    return result;
+	return result;
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/UberPixelShader.hlsl
+++ b/Samples/UWP/D3D12PipelineStateCache/src/UberPixelShader.hlsl
@@ -22,7 +22,7 @@
 
 cbuffer cb : register(b0)
 {
-    uint shaderType;
+	uint shaderType;
 };
 
 #define PostBlit 2
@@ -37,52 +37,52 @@ cbuffer cb : register(b0)
 
 float4 mainUber(PSInput input) : SV_TARGET
 {
-    float4 color = float4(0.0f, 0.0f, 0.0f, 1.0f);
+	float4 color = float4(0.0f, 0.0f, 0.0f, 1.0f);
 
-    [branch] switch (shaderType)
-    {
-    case PostBlit:
-        color = Blit(input.uv);
-        break;
+	[branch] switch (shaderType)
+	{
+	case PostBlit:
+		color = Blit(input.uv);
+		break;
 
-    case PostInvert:
-        color = InvertPixel(input.uv);
-        break;
+	case PostInvert:
+		color = InvertPixel(input.uv);
+		break;
 
-    case PostGrayScale:
-        color = GrayScale(input.uv);
-        break;
+	case PostGrayScale:
+		color = GrayScale(input.uv);
+		break;
 
-    case PostEdgeDetect:
-        color = EdgeDetect(input.uv);
-        break;
+	case PostEdgeDetect:
+		color = EdgeDetect(input.uv);
+		break;
 
-    case PostBlur:
-        color = Blur(input.uv);
-        break;
+	case PostBlur:
+		color = Blur(input.uv);
+		break;
 
-    case PostWarp:
-        color = Warp(input.uv);
-        break;
+	case PostWarp:
+		color = Warp(input.uv);
+		break;
 
-    case PostPixelate:
-        color = Pixelate(input.uv);
-        break;
+	case PostPixelate:
+		color = Pixelate(input.uv);
+		break;
 
-    case PostDistort:
-        color = Distort(input.uv);
-        break;
+	case PostDistort:
+		color = Distort(input.uv);
+		break;
 
-    case PostWave:
-        color = Wave(input.uv);
-        break;
+	case PostWave:
+		color = Wave(input.uv);
+		break;
 
-    default:
-        break;
-    }
+	default:
+		break;
+	}
 
-    // Indicate that the Uber shader is running.
-    color *= 0.4f;
+	// Indicate that the Uber shader is running.
+	color *= 0.4f;
 
-    return color;
+	return color;
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/View.cpp
+++ b/Samples/UWP/D3D12PipelineStateCache/src/View.cpp
@@ -15,27 +15,27 @@
 using namespace Windows::Foundation;
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -44,20 +44,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -66,26 +66,26 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnClosed(CoreWindow^ /*sender*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/View.h
+++ b/Samples/UWP/D3D12PipelineStateCache/src/View.h
@@ -23,20 +23,20 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
+	DXSample* m_pSample;
+	bool m_windowClosed;
 };

--- a/Samples/UWP/D3D12PipelineStateCache/src/ViewProvider.cpp
+++ b/Samples/UWP/D3D12PipelineStateCache/src/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/ViewProvider.h
+++ b/Samples/UWP/D3D12PipelineStateCache/src/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12PipelineStateCache/src/WarpPixelShader.hlsl
+++ b/Samples/UWP/D3D12PipelineStateCache/src/WarpPixelShader.hlsl
@@ -13,14 +13,14 @@
 
 float4 Warp(float2 uv)
 {
-    float2 dir = uv - float2(0.5f, 0.5f);
-    float len = length(dir) * 6.0f;
-    float2 newCoord = uv + dir * sin(pow(2.0f, len));
+	float2 dir = uv - float2(0.5f, 0.5f);
+	float len = length(dir) * 6.0f;
+	float2 newCoord = uv + dir * sin(pow(2.0f, len));
 
-    return g_tex.Sample(g_samp, newCoord);
+	return g_tex.Sample(g_samp, newCoord);
 }
 
 float4 mainWarp(PSInput input) : SV_TARGET
 {
-    return Warp(input.uv);
+	return Warp(input.uv);
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/WavePixelShader.hlsl
+++ b/Samples/UWP/D3D12PipelineStateCache/src/WavePixelShader.hlsl
@@ -13,14 +13,14 @@
 
 float4 Wave(float2 uv)
 {
-    float angle = distance(float2(0.5f, 0.5f), uv) * 50.0f;
-    uv.x = 0.5f + (uv.x - 0.5f) * cos(angle) - (uv.y - 0.5f) * sin(angle);
-    uv.y = 0.5f + (uv.x - 0.5f) * sin(angle) + (uv.y - 0.5f) * cos(angle);
+	float angle = distance(float2(0.5f, 0.5f), uv) * 50.0f;
+	uv.x = 0.5f + (uv.x - 0.5f) * cos(angle) - (uv.y - 0.5f) * sin(angle);
+	uv.y = 0.5f + (uv.x - 0.5f) * sin(angle) + (uv.y - 0.5f) * cos(angle);
 
-    return g_tex.Sample(g_samp, uv);
+	return g_tex.Sample(g_samp, uv);
 }
 
 float4 mainWave(PSInput input) : SV_TARGET
 {
-    return Wave(input.uv);
+	return Wave(input.uv);
 }

--- a/Samples/UWP/D3D12PipelineStateCache/src/d3dx12.h
+++ b/Samples/UWP/D3D12PipelineStateCache/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12PipelineStateCache/src/stdafx.h
+++ b/Samples/UWP/D3D12PipelineStateCache/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>

--- a/Samples/UWP/D3D12PredicationQueries/src/D3D12PredicationQueries.cpp
+++ b/Samples/UWP/D3D12PredicationQueries/src/D3D12PredicationQueries.cpp
@@ -13,586 +13,629 @@
 #include "D3D12PredicationQueries.h"
 
 D3D12PredicationQueries::D3D12PredicationQueries(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0),
-    m_cbvSrvDescriptorSize(0),
-    m_constantBufferData{},
-    m_fenceValues{}
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0),
+	m_cbvSrvDescriptorSize(0),
+	m_constantBufferData{},
+	m_fenceValues{}
 {
+#if !defined(_XBOX_ONE)
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
+#endif
 }
 
 void D3D12PredicationQueries::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12PredicationQueries::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter, true);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
-    NAME_D3D12_OBJECT(m_commandQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	NAME_D3D12_OBJECT(m_commandQueue);
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a depth stencil view (DSV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
-        dsvHeapDesc.NumDescriptors = 1;
-        dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-        dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
+		// Describe and create a depth stencil view (DSV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC dsvHeapDesc = {};
+		dsvHeapDesc.NumDescriptors = 1;
+		dsvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+		dsvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&dsvHeapDesc, IID_PPV_ARGS(&m_dsvHeap)));
 
-        // Describe and create a constant buffer view (CBV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
-        cbvHeapDesc.NumDescriptors = CbvCountPerFrame * FrameCount;
-        cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_cbvHeap)));
-        NAME_D3D12_OBJECT(m_cbvHeap);
+		// Describe and create a constant buffer view (CBV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
+		cbvHeapDesc.NumDescriptors = CbvCountPerFrame * FrameCount;
+		cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_cbvHeap)));
+		NAME_D3D12_OBJECT(m_cbvHeap);
 
-        // Describe and create a heap for occlusion queries.
-        D3D12_QUERY_HEAP_DESC queryHeapDesc = {};
-        queryHeapDesc.Count = 1;
-        queryHeapDesc.Type = D3D12_QUERY_HEAP_TYPE_OCCLUSION;
-        ThrowIfFailed(m_device->CreateQueryHeap(&queryHeapDesc, IID_PPV_ARGS(&m_queryHeap)));
+		// Describe and create a heap for occlusion queries.
+		D3D12_QUERY_HEAP_DESC queryHeapDesc = {};
+		queryHeapDesc.Count = 1;
+		queryHeapDesc.Type = D3D12_QUERY_HEAP_TYPE_OCCLUSION;
+		ThrowIfFailed(m_device->CreateQueryHeap(&queryHeapDesc, IID_PPV_ARGS(&m_queryHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-        m_cbvSrvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_cbvSrvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV and a command allocator for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
+		// Create a RTV and a command allocator for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-            NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
+			NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
 
-            ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
-        }
-    }
+			ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
+		}
+	}
 }
 
 // Load the sample assets.
 void D3D12PredicationQueries::LoadAssets()
 {
-    // Create a root signature consisting of a single CBV parameter.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create a root signature consisting of a single CBV parameter.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
-        CD3DX12_ROOT_PARAMETER1 rootParameters[1];
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
+		CD3DX12_ROOT_PARAMETER1 rootParameters[1];
 
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_VERTEX);
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_VERTEX);
 
-        // Allow input layout and deny uneccessary access to certain pipeline stages.
-        D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
-            D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_PIXEL_SHADER_ROOT_ACCESS;
+		// Allow input layout and deny uneccessary access to certain pipeline stages.
+		D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
+			D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_PIXEL_SHADER_ROOT_ACCESS;
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, rootSignatureFlags);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, rootSignatureFlags);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-        NAME_D3D12_OBJECT(m_rootSignature);
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+		NAME_D3D12_OBJECT(m_rootSignature);
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Enable alpha blending so we can visualize the occlusion query results.
-        CD3DX12_BLEND_DESC blendDesc(D3D12_DEFAULT);
-        blendDesc.RenderTarget[0] =
-        {
-            TRUE, FALSE,
-            D3D12_BLEND_SRC_ALPHA, D3D12_BLEND_INV_SRC_ALPHA, D3D12_BLEND_OP_ADD,
-            D3D12_BLEND_ONE, D3D12_BLEND_ZERO, D3D12_BLEND_OP_ADD,
-            D3D12_LOGIC_OP_NOOP,
-            D3D12_COLOR_WRITE_ENABLE_ALL,
-        };
+		// Enable alpha blending so we can visualize the occlusion query results.
+		CD3DX12_BLEND_DESC blendDesc(D3D12_DEFAULT);
+		blendDesc.RenderTarget[0] =
+		{
+			TRUE, FALSE,
+			D3D12_BLEND_SRC_ALPHA, D3D12_BLEND_INV_SRC_ALPHA, D3D12_BLEND_OP_ADD,
+			D3D12_BLEND_ONE, D3D12_BLEND_ZERO, D3D12_BLEND_OP_ADD,
+			D3D12_LOGIC_OP_NOOP,
+			D3D12_COLOR_WRITE_ENABLE_ALL,
+		};
 
-        // Describe and create the graphics pipeline state objects (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = blendDesc;
-        psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state objects (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = blendDesc;
+		psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-        NAME_D3D12_OBJECT(m_pipelineState);
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+		NAME_D3D12_OBJECT(m_pipelineState);
 
-        // Disable color writes and depth writes for the occlusion query's state.
-        psoDesc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0;
-        psoDesc.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ZERO;
+		// Disable color writes and depth writes for the occlusion query's state.
+		psoDesc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0;
+		psoDesc.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ZERO;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_queryState)));
-        NAME_D3D12_OBJECT(m_queryState);
-    }
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_queryState)));
+		NAME_D3D12_OBJECT(m_queryState);
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
-    NAME_D3D12_OBJECT(m_commandList);
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	NAME_D3D12_OBJECT(m_commandList);
 
-    // Note: ComPtr's are CPU objects but this resource needs to stay in scope until
-    // the command list that references it has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resource is not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> vertexBufferUpload;
+	// Note: ComPtr's are CPU objects but this resource needs to stay in scope until
+	// the command list that references it has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resource is not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> vertexBufferUpload;
 
-    // Create the vertex buffer.
-    {
-        // Create geometry for two quads and a bounding box for the occlusion query.
-        // Geometry will be rendered back-to-front to support transparency in the scene.
-        Vertex quadVertices[] =
-        {
-            // Far quad - in practice this would be a complex geometry.
-            { { -0.25f, -0.25f * m_aspectRatio, 0.5f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
-            { { -0.25f, 0.25f * m_aspectRatio, 0.5f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
-            { { 0.25f, -0.25f * m_aspectRatio, 0.5f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
-            { { 0.25f, 0.25f * m_aspectRatio, 0.5f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
+	// Create the vertex buffer.
+	{
+		// Create geometry for two quads and a bounding box for the occlusion query.
+		// Geometry will be rendered back-to-front to support transparency in the scene.
+		Vertex quadVertices[] =
+		{
+			// Far quad - in practice this would be a complex geometry.
+			{ { -0.25f, -0.25f * m_aspectRatio, 0.5f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
+			{ { -0.25f, 0.25f * m_aspectRatio, 0.5f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
+			{ { 0.25f, -0.25f * m_aspectRatio, 0.5f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
+			{ { 0.25f, 0.25f * m_aspectRatio, 0.5f }, { 1.0f, 1.0f, 1.0f, 1.0f } },
 
-            // Near quad.
-            { { -0.5f, -0.35f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 0.65f } },
-            { { -0.5f, 0.35f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 0.65f } },
-            { { 0.5f, -0.35f * m_aspectRatio, 0.0f }, { 1.0f, 1.0f, 0.0f, 0.65f } },
-            { { 0.5f, 0.35f * m_aspectRatio, 0.0f }, { 1.0f, 1.0f, 0.0f, 0.65f } },
+			// Near quad.
+			{ { -0.5f, -0.35f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 0.65f } },
+			{ { -0.5f, 0.35f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f, 0.0f, 0.65f } },
+			{ { 0.5f, -0.35f * m_aspectRatio, 0.0f }, { 1.0f, 1.0f, 0.0f, 0.65f } },
+			{ { 0.5f, 0.35f * m_aspectRatio, 0.0f }, { 1.0f, 1.0f, 0.0f, 0.65f } },
 
-            // Far quad bounding box used for occlusion query (offset slightly to avoid z-fighting).
-            { { -0.25f, -0.25f * m_aspectRatio, 0.4999f }, { 0.0f, 0.0f, 0.0f, 1.0f } },
-            { { -0.25f, 0.25f * m_aspectRatio, 0.4999f }, { 0.0f, 0.0f, 0.0f, 1.0f } },
-            { { 0.25f, -0.25f * m_aspectRatio, 0.4999f }, { 0.0f, 0.0f, 0.0f, 1.0f } },
-            { { 0.25f, 0.25f * m_aspectRatio, 0.4999f }, { 0.0f, 0.0f, 0.0f, 1.0f } },
-        };
+			// Far quad bounding box used for occlusion query (offset slightly to avoid z-fighting).
+			{ { -0.25f, -0.25f * m_aspectRatio, 0.4999f }, { 0.0f, 0.0f, 0.0f, 1.0f } },
+			{ { -0.25f, 0.25f * m_aspectRatio, 0.4999f }, { 0.0f, 0.0f, 0.0f, 1.0f } },
+			{ { 0.25f, -0.25f * m_aspectRatio, 0.4999f }, { 0.0f, 0.0f, 0.0f, 1.0f } },
+			{ { 0.25f, 0.25f * m_aspectRatio, 0.4999f }, { 0.0f, 0.0f, 0.0f, 1.0f } },
+		};
 
-        const UINT vertexBufferSize = sizeof(quadVertices);
+		const UINT vertexBufferSize = sizeof(quadVertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&vertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&vertexBufferUpload)));
 
-        NAME_D3D12_OBJECT(m_vertexBuffer);
+		NAME_D3D12_OBJECT(m_vertexBuffer);
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(quadVertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(quadVertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = sizeof(quadVertices);
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = sizeof(quadVertices);
+	}
 
-    // Create the constant buffers.
-    {
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(FrameCount * sizeof(m_constantBufferData)),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_constantBuffer)));
+	// Create the constant buffers.
+	{
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(FrameCount * sizeof(m_constantBufferData)),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_constantBuffer)));
 
-        NAME_D3D12_OBJECT(m_constantBuffer);
+		NAME_D3D12_OBJECT(m_constantBuffer);
 
-        // Map and initialize the constant buffer. We don't unmap this until the
-        // app closes. Keeping things mapped for the lifetime of the resource is okay.
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbvDataBegin)));
-        ZeroMemory(m_pCbvDataBegin, FrameCount * sizeof(m_constantBufferData));
+		// Map and initialize the constant buffer. We don't unmap this until the
+		// app closes. Keeping things mapped for the lifetime of the resource is okay.
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbvDataBegin)));
+		ZeroMemory(m_pCbvDataBegin, FrameCount * sizeof(m_constantBufferData));
 
-        // Create constant buffer views to access the upload buffer.
-        CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_cbvHeap->GetCPUDescriptorHandleForHeapStart());
-        D3D12_GPU_VIRTUAL_ADDRESS gpuAddress = m_constantBuffer->GetGPUVirtualAddress();
+		// Create constant buffer views to access the upload buffer.
+		CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_cbvHeap->GetCPUDescriptorHandleForHeapStart());
+		D3D12_GPU_VIRTUAL_ADDRESS gpuAddress = m_constantBuffer->GetGPUVirtualAddress();
 
-        D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
-        cbvDesc.SizeInBytes = sizeof(SceneConstantBuffer);
+		D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
+		cbvDesc.SizeInBytes = sizeof(SceneConstantBuffer);
 
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            cbvDesc.BufferLocation = gpuAddress;
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			cbvDesc.BufferLocation = gpuAddress;
 
-            m_device->CreateConstantBufferView(&cbvDesc, cpuHandle);
+			m_device->CreateConstantBufferView(&cbvDesc, cpuHandle);
 
-            cpuHandle.Offset(m_cbvSrvDescriptorSize);
-            gpuAddress += cbvDesc.SizeInBytes;
-            cbvDesc.BufferLocation = gpuAddress;
+			cpuHandle.Offset(m_cbvSrvDescriptorSize);
+			gpuAddress += cbvDesc.SizeInBytes;
+			cbvDesc.BufferLocation = gpuAddress;
 
-            m_device->CreateConstantBufferView(&cbvDesc, cpuHandle);
+			m_device->CreateConstantBufferView(&cbvDesc, cpuHandle);
 
-            cpuHandle.Offset(m_cbvSrvDescriptorSize);
-            gpuAddress += cbvDesc.SizeInBytes;
-        }
-    }
+			cpuHandle.Offset(m_cbvSrvDescriptorSize);
+			gpuAddress += cbvDesc.SizeInBytes;
+		}
+	}
 
-    // Create the depth stencil view.
-    {
-        D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
-        depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
-        depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
-        depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
+	// Create the depth stencil view.
+	{
+		D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
+		depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
+		depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+		depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
 
-        D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
-        depthOptimizedClearValue.Format = DXGI_FORMAT_D32_FLOAT;
-        depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
-        depthOptimizedClearValue.DepthStencil.Stencil = 0;
+		D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
+		depthOptimizedClearValue.Format = DXGI_FORMAT_D32_FLOAT;
+		depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
+		depthOptimizedClearValue.DepthStencil.Stencil = 0;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
-            D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            &depthOptimizedClearValue,
-            IID_PPV_ARGS(&m_depthStencil)
-            ));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
+			D3D12_RESOURCE_STATE_DEPTH_WRITE,
+			&depthOptimizedClearValue,
+			IID_PPV_ARGS(&m_depthStencil)
+			));
 
-        NAME_D3D12_OBJECT(m_depthStencil);
+		NAME_D3D12_OBJECT(m_depthStencil);
 
-        m_device->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-    }
+		m_device->CreateDepthStencilView(m_depthStencil.Get(), &depthStencilDesc, m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	}
 
-    // Create the query result buffer.
-    {
-        D3D12_RESOURCE_DESC queryResultDesc = CD3DX12_RESOURCE_DESC::Buffer(8);
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &queryResultDesc,
-            D3D12_RESOURCE_STATE_PREDICATION,
-            nullptr,
-            IID_PPV_ARGS(&m_queryResult)
-            ));
+	// Create the query result buffer.
+	{
+		D3D12_RESOURCE_DESC queryResultDesc = CD3DX12_RESOURCE_DESC::Buffer(8);
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&queryResultDesc,
+			D3D12_RESOURCE_STATE_PREDICATION,
+			nullptr,
+			IID_PPV_ARGS(&m_queryResult)
+			));
 
-        NAME_D3D12_OBJECT(m_queryResult);
-    }
+		NAME_D3D12_OBJECT(m_queryResult);
+	}
 
-    // Close the command list and execute it to begin the vertex buffer copy into
-    // the default heap.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the vertex buffer copy into
+	// the default heap.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValues[m_frameIndex]++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValues[m_frameIndex]++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForGpu();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForGpu();
+	}
 }
 
 // Update frame-based values.
 void D3D12PredicationQueries::OnUpdate()
 {
-    const float translationSpeed = 0.01f;
-    const float offsetBounds = 1.5f;
+	const float translationSpeed = 0.01f;
+	const float offsetBounds = 1.5f;
 
-    // Animate the near quad.
-    m_constantBufferData[1].offset.x += translationSpeed;
-    if (m_constantBufferData[1].offset.x > offsetBounds)
-    {
-        m_constantBufferData[1].offset.x = -offsetBounds;
-    }
+	// Animate the near quad.
+	m_constantBufferData[1].offset.x += translationSpeed;
+	if (m_constantBufferData[1].offset.x > offsetBounds)
+	{
+		m_constantBufferData[1].offset.x = -offsetBounds;
+	}
 
-    UINT cbvIndex = m_frameIndex * CbvCountPerFrame + 1;
-    UINT8* destination = m_pCbvDataBegin + (cbvIndex * sizeof(SceneConstantBuffer));
-    memcpy(destination, &m_constantBufferData[1], sizeof(SceneConstantBuffer));
+	UINT cbvIndex = m_frameIndex * CbvCountPerFrame + 1;
+	UINT8* destination = m_pCbvDataBegin + (cbvIndex * sizeof(SceneConstantBuffer));
+	memcpy(destination, &m_constantBufferData[1], sizeof(SceneConstantBuffer));
 }
 
 // Render the scene.
 void D3D12PredicationQueries::OnRender()
 {
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+    try
+    {
+        PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
 
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+        // Record all the commands we need to render the scene into the command list.
+        PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+        // Execute the command list.
+        ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+        m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    PIXEndEvent(m_commandQueue.Get());
+        PIXEndEvent(m_commandQueue.Get());
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+        // Present the frame.
+        ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    MoveToNextFrame();
+        MoveToNextFrame();
+    }
+    catch (HrException& e)
+    {
+        if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
+        {
+            RestoreD3DResources();
+        }
+        else
+        {
+            throw;
+        }
+    }
+}
+
+// Release sample's D3D objects.
+void D3D12PredicationQueries::ReleaseD3DResources()
+{
+    m_fence.Reset();
+    ResetComPtrArray(&m_renderTargets);
+    m_commandQueue.Reset();
+    m_swapChain.Reset();
+    m_device.Reset();
+}
+
+// Tears down D3D resources and reinitializes them.
+void D3D12PredicationQueries::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
+    {
+        WaitForGpu();
+    }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
 }
 
 void D3D12PredicationQueries::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForGpu();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForGpu();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12PredicationQueries::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_cbvHeap.Get() };
-    m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_cbvHeap.Get() };
+	m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(m_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    m_commandList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	m_commandList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
 
-    // Draw the quads and perform the occlusion query.
-    {
-        CD3DX12_GPU_DESCRIPTOR_HANDLE cbvFarQuad(m_cbvHeap->GetGPUDescriptorHandleForHeapStart(), m_frameIndex * CbvCountPerFrame, m_cbvSrvDescriptorSize);
-        CD3DX12_GPU_DESCRIPTOR_HANDLE cbvNearQuad(cbvFarQuad, m_cbvSrvDescriptorSize);
+	// Draw the quads and perform the occlusion query.
+	{
+		CD3DX12_GPU_DESCRIPTOR_HANDLE cbvFarQuad(m_cbvHeap->GetGPUDescriptorHandleForHeapStart(), m_frameIndex * CbvCountPerFrame, m_cbvSrvDescriptorSize);
+		CD3DX12_GPU_DESCRIPTOR_HANDLE cbvNearQuad(cbvFarQuad, m_cbvSrvDescriptorSize);
 
-        m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-        m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+		m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+		m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
 
-        // Draw the far quad conditionally based on the result of the occlusion query
-        // from the previous frame.
-        PIXBeginEvent(m_commandList.Get(), 0, L"Draw potentially occluded geometry");
-        m_commandList->SetGraphicsRootDescriptorTable(0, cbvFarQuad);
-        m_commandList->SetPredication(m_queryResult.Get(), 0, D3D12_PREDICATION_OP_EQUAL_ZERO);
-        m_commandList->DrawInstanced(4, 1, 0, 0);
-        PIXEndEvent(m_commandList.Get());
+		// Draw the far quad conditionally based on the result of the occlusion query
+		// from the previous frame.
+		PIXBeginEvent(m_commandList.Get(), 0, L"Draw potentially occluded geometry");
+		m_commandList->SetGraphicsRootDescriptorTable(0, cbvFarQuad);
+		m_commandList->SetPredication(m_queryResult.Get(), 0, D3D12_PREDICATION_OP_EQUAL_ZERO);
+		m_commandList->DrawInstanced(4, 1, 0, 0);
+		PIXEndEvent(m_commandList.Get());
 
-        // Disable predication and always draw the near quad.
-        PIXBeginEvent(m_commandList.Get(), 0, L"Draw animating geometry");
-        m_commandList->SetPredication(nullptr, 0, D3D12_PREDICATION_OP_EQUAL_ZERO);
-        m_commandList->SetGraphicsRootDescriptorTable(0, cbvNearQuad);
-        m_commandList->DrawInstanced(4, 1, 4, 0);
-        PIXEndEvent(m_commandList.Get());
+		// Disable predication and always draw the near quad.
+		PIXBeginEvent(m_commandList.Get(), 0, L"Draw animating geometry");
+		m_commandList->SetPredication(nullptr, 0, D3D12_PREDICATION_OP_EQUAL_ZERO);
+		m_commandList->SetGraphicsRootDescriptorTable(0, cbvNearQuad);
+		m_commandList->DrawInstanced(4, 1, 4, 0);
+		PIXEndEvent(m_commandList.Get());
 
-        // Run the occlusion query with the bounding box quad.
-        PIXBeginEvent(m_commandList.Get(), 0, L"Execute occlusion query");
-        m_commandList->SetGraphicsRootDescriptorTable(0, cbvFarQuad);
-        m_commandList->SetPipelineState(m_queryState.Get());
-        m_commandList->BeginQuery(m_queryHeap.Get(), D3D12_QUERY_TYPE_BINARY_OCCLUSION, 0);
-        m_commandList->DrawInstanced(4, 1, 8, 0);
-        m_commandList->EndQuery(m_queryHeap.Get(), D3D12_QUERY_TYPE_BINARY_OCCLUSION, 0);
-        PIXEndEvent(m_commandList.Get());
+		// Run the occlusion query with the bounding box quad.
+		PIXBeginEvent(m_commandList.Get(), 0, L"Execute occlusion query");
+		m_commandList->SetGraphicsRootDescriptorTable(0, cbvFarQuad);
+		m_commandList->SetPipelineState(m_queryState.Get());
+		m_commandList->BeginQuery(m_queryHeap.Get(), D3D12_QUERY_TYPE_BINARY_OCCLUSION, 0);
+		m_commandList->DrawInstanced(4, 1, 8, 0);
+		m_commandList->EndQuery(m_queryHeap.Get(), D3D12_QUERY_TYPE_BINARY_OCCLUSION, 0);
+		PIXEndEvent(m_commandList.Get());
 
-        // Resolve the occlusion query and store the results in the query result buffer
-        // to be used on the subsequent frame.
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_queryResult.Get(), D3D12_RESOURCE_STATE_PREDICATION, D3D12_RESOURCE_STATE_COPY_DEST));
-        m_commandList->ResolveQueryData(m_queryHeap.Get(), D3D12_QUERY_TYPE_BINARY_OCCLUSION, 0, 1, m_queryResult.Get(), 0);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_queryResult.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PREDICATION));
-    }
+		// Resolve the occlusion query and store the results in the query result buffer
+		// to be used on the subsequent frame.
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_queryResult.Get(), D3D12_RESOURCE_STATE_PREDICATION, D3D12_RESOURCE_STATE_COPY_DEST));
+		m_commandList->ResolveQueryData(m_queryHeap.Get(), D3D12_QUERY_TYPE_BINARY_OCCLUSION, 0, 1, m_queryResult.Get(), 0);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_queryResult.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PREDICATION));
+	}
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 // Wait for pending GPU work to complete.
 void D3D12PredicationQueries::WaitForGpu()
 {
-    // Schedule a Signal command in the queue.
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
+	// Schedule a Signal command in the queue.
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
 
-    // Wait until the fence has been processed.
-    ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-    WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	// Wait until the fence has been processed.
+	ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+	WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
 
-    // Increment the fence value for the current frame.
-    m_fenceValues[m_frameIndex]++;
+	// Increment the fence value for the current frame.
+	m_fenceValues[m_frameIndex]++;
 }
 
 // Prepare to render the next frame.
 void D3D12PredicationQueries::MoveToNextFrame()
 {
-    // Schedule a Signal command in the queue.
-    const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
+	// Schedule a Signal command in the queue.
+	const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
 
-    // Update the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Update the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-        WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+		WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	}
 
-    // Set the fence value for the next frame.
-    m_fenceValues[m_frameIndex] = currentFenceValue + 1;
+	// Set the fence value for the next frame.
+	m_fenceValues[m_frameIndex] = currentFenceValue + 1;
 }

--- a/Samples/UWP/D3D12PredicationQueries/src/D3D12PredicationQueries.h
+++ b/Samples/UWP/D3D12PredicationQueries/src/D3D12PredicationQueries.h
@@ -26,73 +26,75 @@ using Microsoft::WRL::ComPtr;
 class D3D12PredicationQueries : public DXSample
 {
 public:
-    D3D12PredicationQueries(UINT width, UINT height, std::wstring name);
+	D3D12PredicationQueries(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    static const UINT FrameCount = 2;
-    static const UINT CbvCountPerFrame = 2;
+	static const UINT FrameCount = 2;
+	static const UINT CbvCountPerFrame = 2;
 
-    // Vertex definition.
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT4 color;
-    };
+	// Vertex definition.
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT4 color;
+	};
 
-    // Constant buffer definition.
-    struct SceneConstantBuffer
-    {
-        XMFLOAT4 offset;
+	// Constant buffer definition.
+	struct SceneConstantBuffer
+	{
+		XMFLOAT4 offset;
 
-        // Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
-        // to be array-indexed.
-        FLOAT padding[60];
-    };
+		// Constant buffers are 256-byte aligned. Add padding in the struct to allow multiple buffers
+		// to be array-indexed.
+		FLOAT padding[60];
+	};
 
-    // Each geometry gets its own constant buffer.
-    SceneConstantBuffer m_constantBufferData[CbvCountPerFrame];
-    UINT8* m_pCbvDataBegin;
+	// Each geometry gets its own constant buffer.
+	SceneConstantBuffer m_constantBufferData[CbvCountPerFrame];
+	UINT8* m_pCbvDataBegin;
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_cbvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
-    ComPtr<ID3D12QueryHeap> m_queryHeap;
-    UINT m_rtvDescriptorSize;
-    UINT m_cbvSrvDescriptorSize;
-    UINT m_frameIndex;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_cbvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
+	ComPtr<ID3D12QueryHeap> m_queryHeap;
+	UINT m_rtvDescriptorSize;
+	UINT m_cbvSrvDescriptorSize;
+	UINT m_frameIndex;
 
-    // Synchronization objects.
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValues[FrameCount];
-    HANDLE m_fenceEvent;
+	// Synchronization objects.
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValues[FrameCount];
+	HANDLE m_fenceEvent;
 
-    // Asset objects.
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12PipelineState> m_queryState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    ComPtr<ID3D12Resource> m_constantBuffer;
-    ComPtr<ID3D12Resource> m_depthStencil;
-    ComPtr<ID3D12Resource> m_queryResult;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	// Asset objects.
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12PipelineState> m_queryState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	ComPtr<ID3D12Resource> m_constantBuffer;
+	ComPtr<ID3D12Resource> m_depthStencil;
+	ComPtr<ID3D12Resource> m_queryResult;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
 
-    void LoadPipeline();
-    void LoadAssets();
-    void PopulateCommandList();
-    void WaitForGpu();
-    void MoveToNextFrame();
+	void LoadPipeline();
+	void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
+	void PopulateCommandList();
+	void WaitForGpu();
+	void MoveToNextFrame();
 };

--- a/Samples/UWP/D3D12PredicationQueries/src/DXSample.cpp
+++ b/Samples/UWP/D3D12PredicationQueries/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,59 +34,104 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
-    auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(windowText.c_str());
+	std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
+	auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/UWP/D3D12PredicationQueries/src/DXSample.h
+++ b/Samples/UWP/D3D12PredicationQueries/src/DXSample.h
@@ -16,42 +16,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/UWP/D3D12PredicationQueries/src/Main.cpp
+++ b/Samples/UWP/D3D12PredicationQueries/src/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12PredicationQueries sample(1200, 900, L"");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12PredicationQueries sample(1200, 900, L"");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12PredicationQueries/src/View.cpp
+++ b/Samples/UWP/D3D12PredicationQueries/src/View.cpp
@@ -15,27 +15,27 @@
 using namespace Windows::Foundation;
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -44,20 +44,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -66,26 +66,26 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnClosed(CoreWindow^ /*sender*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }

--- a/Samples/UWP/D3D12PredicationQueries/src/View.h
+++ b/Samples/UWP/D3D12PredicationQueries/src/View.h
@@ -23,20 +23,20 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
+	DXSample* m_pSample;
+	bool m_windowClosed;
 };

--- a/Samples/UWP/D3D12PredicationQueries/src/ViewProvider.cpp
+++ b/Samples/UWP/D3D12PredicationQueries/src/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12PredicationQueries/src/ViewProvider.h
+++ b/Samples/UWP/D3D12PredicationQueries/src/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12PredicationQueries/src/d3dx12.h
+++ b/Samples/UWP/D3D12PredicationQueries/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12PredicationQueries/src/shaders.hlsl
+++ b/Samples/UWP/D3D12PredicationQueries/src/shaders.hlsl
@@ -11,26 +11,26 @@
 
 cbuffer SceneConstantBuffer : register(b0)
 {
-    float4 offset;
+	float4 offset;
 };
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VSMain(float4 position : POSITION, float4 color : COLOR)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position + offset;
-    result.color = color;
+	result.position = position + offset;
+	result.color = color;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return input.color;
+	return input.color;
 }

--- a/Samples/UWP/D3D12PredicationQueries/src/stdafx.h
+++ b/Samples/UWP/D3D12PredicationQueries/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>

--- a/Samples/UWP/D3D12ReservedResources/src/D3D12ReservedResources.cpp
+++ b/Samples/UWP/D3D12ReservedResources/src/D3D12ReservedResources.cpp
@@ -14,581 +14,581 @@
 #include <ppltasks.h>
 
 D3D12ReservedResources::D3D12ReservedResources(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0),
-    m_tilingSupport(false),
-    m_packedMipInfo(),
-    m_activeMip(0),
-    m_activeMipChanged(true),
-    m_fenceValues{}
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0),
+	m_tilingSupport(false),
+	m_packedMipInfo(),
+	m_activeMip(0),
+	m_activeMipChanged(true),
+	m_fenceValues{}
 {
-    UINT mipLevels = 0;
-    for (UINT w = TextureWidth, h = TextureHeight; w > 0 && h > 0; w >>= 1, h >>= 1)
-    {
-        mipLevels++;
-    }
-    m_activeMip = mipLevels - 1;    // Show the least detailed mip first.
-    m_mips.resize(mipLevels);
+	UINT mipLevels = 0;
+	for (UINT w = TextureWidth, h = TextureHeight; w > 0 && h > 0; w >>= 1, h >>= 1)
+	{
+		mipLevels++;
+	}
+	m_activeMip = mipLevels - 1;	// Show the least detailed mip first.
+	m_mips.resize(mipLevels);
 }
 
 void D3D12ReservedResources::OnInit()
 {
-    LoadPipeline();
-    if (m_tilingSupport)
-    {
-        LoadAssets();
-    }
+	LoadPipeline();
+	if (m_tilingSupport)
+	{
+		LoadAssets();
+	}
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12ReservedResources::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Check to see which support tier the GPU has for tiled resources.
-    D3D12_FEATURE_DATA_D3D12_OPTIONS options = {};
-    m_device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options));
-    m_tilingSupport = options.TiledResourcesTier != D3D12_TILED_RESOURCES_TIER_NOT_SUPPORTED;
-    if (!m_tilingSupport)
-    {
-        auto dialog = ref new Windows::UI::Popups::MessageDialog(
-            "Reserved resources are not supported by your GPU. "
-                "You will need to run the sample using a WARP adapter. "
-                "The sample will now exit.",
-            "Feature unavailable");
+	// Check to see which support tier the GPU has for tiled resources.
+	D3D12_FEATURE_DATA_D3D12_OPTIONS options = {};
+	m_device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options));
+	m_tilingSupport = options.TiledResourcesTier != D3D12_TILED_RESOURCES_TIER_NOT_SUPPORTED;
+	if (!m_tilingSupport)
+	{
+		auto dialog = ref new Windows::UI::Popups::MessageDialog(
+			"Reserved resources are not supported by your GPU. "
+				"You will need to run the sample using a WARP adapter. "
+				"The sample will now exit.",
+			"Feature unavailable");
 
-        concurrency::create_task(dialog->ShowAsync()).then([](Windows::UI::Popups::IUICommand^)
-        {
-            Windows::ApplicationModel::Core::CoreApplication::Exit();
-        });
-        return;
-    }
+		concurrency::create_task(dialog->ShowAsync()).then([](Windows::UI::Popups::IUICommand^)
+		{
+			Windows::ApplicationModel::Core::CoreApplication::Exit();
+		});
+		return;
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a shader resource view (SRV) heap for the reserved resource.
-        D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
-        srvHeapDesc.NumDescriptors = 1;
-        srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
+		// Describe and create a shader resource view (SRV) heap for the reserved resource.
+		D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
+		srvHeapDesc.NumDescriptors = 1;
+		srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV and a command allocator for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
+		// Create a RTV and a command allocator for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-            ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
-        }
-    }
+			ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
+		}
+	}
 }
 
 // Load the sample assets.
 void D3D12ReservedResources::LoadAssets()
 {
-    // Create the root signature.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signature.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        // We don't modify the SRV in the command list after SetGraphicsRootDescriptorTable
-        // is executed on the GPU so we can use the default range behavior:
-        // D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
+		// We don't modify the SRV in the command list after SetGraphicsRootDescriptorTable
+		// is executed on the GPU so we can use the default range behavior:
+		// D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
 
-        CD3DX12_ROOT_PARAMETER1 rootParameters[2];
-        rootParameters[0].InitAsConstants(1, 0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
-        rootParameters[1].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
+		CD3DX12_ROOT_PARAMETER1 rootParameters[2];
+		rootParameters[0].InitAsConstants(1, 0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
+		rootParameters[1].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
 
-        D3D12_STATIC_SAMPLER_DESC sampler = {};
-        sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-        sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-        sampler.MipLODBias = 0;
-        sampler.MaxAnisotropy = 0;
-        sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
-        sampler.BorderColor = D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
-        sampler.MinLOD = 0.0f;
-        sampler.MaxLOD = D3D12_FLOAT32_MAX;
-        sampler.ShaderRegister = 0;
-        sampler.RegisterSpace = 0;
-        sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+		D3D12_STATIC_SAMPLER_DESC sampler = {};
+		sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		sampler.MipLODBias = 0;
+		sampler.MaxAnisotropy = 0;
+		sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
+		sampler.BorderColor = D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
+		sampler.MinLOD = 0.0f;
+		sampler.MaxLOD = D3D12_FLOAT32_MAX;
+		sampler.ShaderRegister = 0;
+		sampler.RegisterSpace = 0;
+		sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &sampler, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &sampler, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
-        ComPtr<ID3DBlob> error;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
+		ComPtr<ID3DBlob> error;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, &error));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, &error));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, &error));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Describe and create the graphics pipeline state objects (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state objects (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-    }
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
 
-    // Note: ComPtr's are CPU objects but this resource needs to stay in scope until
-    // the command list that references it has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resource is not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> vertexBufferUpload;
+	// Note: ComPtr's are CPU objects but this resource needs to stay in scope until
+	// the command list that references it has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resource is not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> vertexBufferUpload;
 
-    // Create the vertex buffer.
-    {
-        // Create geometry for a quad.
-        Vertex quadVertices[] =
-        {
-            { { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f } },    // Bottom left.
-            { { -0.25f, 0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f } },    // Top left.
-            { { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 1.0f, 1.0f } },    // Bottom right.
-            { { 0.25f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f } },        // Top right.
-        };
+	// Create the vertex buffer.
+	{
+		// Create geometry for a quad.
+		Vertex quadVertices[] =
+		{
+			{ { -0.25f, -0.25f * m_aspectRatio, 0.0f }, { 0.0f, 1.0f } },	// Bottom left.
+			{ { -0.25f, 0.25f * m_aspectRatio, 0.0f }, { 0.0f, 0.0f } },	// Top left.
+			{ { 0.25f, -0.25f * m_aspectRatio, 0.0f }, { 1.0f, 1.0f } },	// Bottom right.
+			{ { 0.25f, 0.25f * m_aspectRatio, 0.0f }, { 1.0f, 0.0f } },		// Top right.
+		};
 
-        const UINT vertexBufferSize = sizeof(quadVertices);
+		const UINT vertexBufferSize = sizeof(quadVertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&vertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&vertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(quadVertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(quadVertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = sizeof(quadVertices);
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = sizeof(quadVertices);
+	}
 
-    // Create the reserved texture and map the low-resolution mips into it.
-    {
-        // Describe and create a reserved Texture2D. This resource has no backing texture
-        // when it is created. It will be mapped to a physical resource dynamically.
-        D3D12_RESOURCE_DESC reservedTextureDesc = {};
-        reservedTextureDesc.MipLevels = static_cast<UINT16>(m_mips.size());
-        reservedTextureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        reservedTextureDesc.Width = TextureWidth;
-        reservedTextureDesc.Height = TextureHeight;
-        reservedTextureDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
-        reservedTextureDesc.DepthOrArraySize = 1;
-        reservedTextureDesc.SampleDesc.Count = 1;
-        reservedTextureDesc.SampleDesc.Quality = 0;
-        reservedTextureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
-        reservedTextureDesc.Layout = D3D12_TEXTURE_LAYOUT_64KB_UNDEFINED_SWIZZLE;
+	// Create the reserved texture and map the low-resolution mips into it.
+	{
+		// Describe and create a reserved Texture2D. This resource has no backing texture
+		// when it is created. It will be mapped to a physical resource dynamically.
+		D3D12_RESOURCE_DESC reservedTextureDesc = {};
+		reservedTextureDesc.MipLevels = static_cast<UINT16>(m_mips.size());
+		reservedTextureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+		reservedTextureDesc.Width = TextureWidth;
+		reservedTextureDesc.Height = TextureHeight;
+		reservedTextureDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
+		reservedTextureDesc.DepthOrArraySize = 1;
+		reservedTextureDesc.SampleDesc.Count = 1;
+		reservedTextureDesc.SampleDesc.Quality = 0;
+		reservedTextureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+		reservedTextureDesc.Layout = D3D12_TEXTURE_LAYOUT_64KB_UNDEFINED_SWIZZLE;
 
-        ThrowIfFailed(m_device->CreateReservedResource(
-            &reservedTextureDesc,
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_reservedResource)));
+		ThrowIfFailed(m_device->CreateReservedResource(
+			&reservedTextureDesc,
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_reservedResource)));
 
-        // Describe and create a SRV for the resource.
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Format = reservedTextureDesc.Format;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = reservedTextureDesc.MipLevels;
-        m_device->CreateShaderResourceView(m_reservedResource.Get(), &srvDesc, m_srvHeap->GetCPUDescriptorHandleForHeapStart());
+		// Describe and create a SRV for the resource.
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Format = reservedTextureDesc.Format;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = reservedTextureDesc.MipLevels;
+		m_device->CreateShaderResourceView(m_reservedResource.Get(), &srvDesc, m_srvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create an upload heap big enough to fit the largest mip.
-        const UINT64 resourceSize = GetRequiredIntermediateSize(m_reservedResource.Get(), 0, 1);
+		// Create an upload heap big enough to fit the largest mip.
+		const UINT64 resourceSize = GetRequiredIntermediateSize(m_reservedResource.Get(), 0, 1);
 
-        // Create the GPU upload buffer.
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(resourceSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_uploadHeap)));
+		// Create the GPU upload buffer.
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(resourceSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_uploadHeap)));
 
-        // Get information about the tile layout for the resource.
-        //
-        // The GetResourceTiling method should always be used rather than manually
-        // calculating it since the tile information is dependent on the driver
-        // implementation.
+		// Get information about the tile layout for the resource.
+		//
+		// The GetResourceTiling method should always be used rather than manually
+		// calculating it since the tile information is dependent on the driver
+		// implementation.
 
-        UINT numTiles = 0;
-        D3D12_TILE_SHAPE tileShape = {};
-        UINT subresourceCount = reservedTextureDesc.MipLevels;
-        std::vector<D3D12_SUBRESOURCE_TILING> tilings(subresourceCount);
-        m_device->GetResourceTiling(m_reservedResource.Get(), &numTiles, &m_packedMipInfo, &tileShape, &subresourceCount, 0, &tilings[0]);
+		UINT numTiles = 0;
+		D3D12_TILE_SHAPE tileShape = {};
+		UINT subresourceCount = reservedTextureDesc.MipLevels;
+		std::vector<D3D12_SUBRESOURCE_TILING> tilings(subresourceCount);
+		m_device->GetResourceTiling(m_reservedResource.Get(), &numTiles, &m_packedMipInfo, &tileShape, &subresourceCount, 0, &tilings[0]);
 
-        UINT heapCount = m_packedMipInfo.NumStandardMips + (m_packedMipInfo.NumPackedMips > 0 ? 1 : 0);
-        for (UINT n = 0; n < m_mips.size(); n++)
-        {
-            if (n < m_packedMipInfo.NumStandardMips)
-            {
-                m_mips[n].heapIndex = n;
-                m_mips[n].packedMip = false;
-                m_mips[n].mapped = false;
-                m_mips[n].startCoordinate = CD3DX12_TILED_RESOURCE_COORDINATE(0, 0, 0, n);
-                m_mips[n].regionSize.Width = tilings[n].WidthInTiles;
-                m_mips[n].regionSize.Height = tilings[n].HeightInTiles;
-                m_mips[n].regionSize.Depth = tilings[n].DepthInTiles;
-                m_mips[n].regionSize.NumTiles = tilings[n].WidthInTiles * tilings[n].HeightInTiles * tilings[n].DepthInTiles;
-                m_mips[n].regionSize.UseBox = TRUE;
-            }
-            else
-            {
-                // All of the packed mips will go into the last heap.
-                m_mips[n].heapIndex = heapCount - 1;
-                m_mips[n].packedMip = true;
-                m_mips[n].mapped = false;
+		UINT heapCount = m_packedMipInfo.NumStandardMips + (m_packedMipInfo.NumPackedMips > 0 ? 1 : 0);
+		for (UINT n = 0; n < m_mips.size(); n++)
+		{
+			if (n < m_packedMipInfo.NumStandardMips)
+			{
+				m_mips[n].heapIndex = n;
+				m_mips[n].packedMip = false;
+				m_mips[n].mapped = false;
+				m_mips[n].startCoordinate = CD3DX12_TILED_RESOURCE_COORDINATE(0, 0, 0, n);
+				m_mips[n].regionSize.Width = tilings[n].WidthInTiles;
+				m_mips[n].regionSize.Height = tilings[n].HeightInTiles;
+				m_mips[n].regionSize.Depth = tilings[n].DepthInTiles;
+				m_mips[n].regionSize.NumTiles = tilings[n].WidthInTiles * tilings[n].HeightInTiles * tilings[n].DepthInTiles;
+				m_mips[n].regionSize.UseBox = TRUE;
+			}
+			else
+			{
+				// All of the packed mips will go into the last heap.
+				m_mips[n].heapIndex = heapCount - 1;
+				m_mips[n].packedMip = true;
+				m_mips[n].mapped = false;
 
-                // Mark all of the packed mips as having the same start coordinate and size.
-                m_mips[n].startCoordinate = CD3DX12_TILED_RESOURCE_COORDINATE(0, 0, 0, heapCount - 1);
-                m_mips[n].regionSize.NumTiles = m_packedMipInfo.NumTilesForPackedMips;
-                m_mips[n].regionSize.UseBox = FALSE;    // regionSize.Width/Height/Depth will be ignored.
-            }
-        }
+				// Mark all of the packed mips as having the same start coordinate and size.
+				m_mips[n].startCoordinate = CD3DX12_TILED_RESOURCE_COORDINATE(0, 0, 0, heapCount - 1);
+				m_mips[n].regionSize.NumTiles = m_packedMipInfo.NumTilesForPackedMips;
+				m_mips[n].regionSize.UseBox = FALSE;	// regionSize.Width/Height/Depth will be ignored.
+			}
+		}
 
-        // Describe and create heaps for the mips in the mip chain to be used by the
-        // reserved resource. The packed mips will all be stored in the same heap.
-        // 
-        // You could also put all of the mips in the same heap, but we do it this way
-        // in the sample to illustrate the ability to map tiles from multiple heaps
-        // into the same reserved resource.
+		// Describe and create heaps for the mips in the mip chain to be used by the
+		// reserved resource. The packed mips will all be stored in the same heap.
+		// 
+		// You could also put all of the mips in the same heap, but we do it this way
+		// in the sample to illustrate the ability to map tiles from multiple heaps
+		// into the same reserved resource.
 
-        m_heaps.resize(heapCount);
-        for (UINT n = 0; n < heapCount; n++)
-        {
-            const UINT heapSize = m_mips[n].regionSize.NumTiles * D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
+		m_heaps.resize(heapCount);
+		for (UINT n = 0; n < heapCount; n++)
+		{
+			const UINT heapSize = m_mips[n].regionSize.NumTiles * D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
 
-            CD3DX12_HEAP_DESC heapDesc(heapSize, D3D12_HEAP_TYPE_DEFAULT, 0, D3D12_HEAP_FLAG_DENY_BUFFERS | D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES);
-            ThrowIfFailed(m_device->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_heaps[n])));
-        }
+			CD3DX12_HEAP_DESC heapDesc(heapSize, D3D12_HEAP_TYPE_DEFAULT, 0, D3D12_HEAP_FLAG_DENY_BUFFERS | D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES);
+			ThrowIfFailed(m_device->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_heaps[n])));
+		}
 
-        UpdateTileMapping();
+		UpdateTileMapping();
 
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_reservedResource.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
-    }
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_reservedResource.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
+	}
 
-    // Close the command list and execute it to begin the vertex buffer copy into
-    // the default heap.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the vertex buffer copy into
+	// the default heap.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValues[m_frameIndex]++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValues[m_frameIndex]++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForGpu();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForGpu();
+	}
 }
 
 // Generate and upload the texture corresponding to the active mip level then
 // map it to the reserved resource.
 void D3D12ReservedResources::UpdateTileMapping()
 {
-    UINT firstSubresource = m_mips[m_activeMip].heapIndex;
-    UINT subresourceCount = m_mips[m_activeMip].packedMip ? m_packedMipInfo.NumPackedMips : 1;
+	UINT firstSubresource = m_mips[m_activeMip].heapIndex;
+	UINT subresourceCount = m_mips[m_activeMip].packedMip ? m_packedMipInfo.NumPackedMips : 1;
 
-    // Only update tile mappings if necessary.
-    if (!m_mips[firstSubresource].mapped)
-    {
-        // Generate the texture data for the active mip level.
-        // If the mip level corresponds to a packed mip, generate all the packed mips.
-        std::vector<UINT8> texture = GenerateTextureData(firstSubresource, subresourceCount);
+	// Only update tile mappings if necessary.
+	if (!m_mips[firstSubresource].mapped)
+	{
+		// Generate the texture data for the active mip level.
+		// If the mip level corresponds to a packed mip, generate all the packed mips.
+		std::vector<UINT8> texture = GenerateTextureData(firstSubresource, subresourceCount);
 
-        // Update the tile mappings on the reserved resource.
-        {
-            UINT updatedRegions = 0;
-            std::vector<D3D12_TILED_RESOURCE_COORDINATE> startCoordinates;
-            std::vector<D3D12_TILE_REGION_SIZE> regionSizes;
-            std::vector<D3D12_TILE_RANGE_FLAGS> rangeFlags;
-            std::vector<UINT> heapRangeStartOffsets;
-            std::vector<UINT> rangeTileCounts;
+		// Update the tile mappings on the reserved resource.
+		{
+			UINT updatedRegions = 0;
+			std::vector<D3D12_TILED_RESOURCE_COORDINATE> startCoordinates;
+			std::vector<D3D12_TILE_REGION_SIZE> regionSizes;
+			std::vector<D3D12_TILE_RANGE_FLAGS> rangeFlags;
+			std::vector<UINT> heapRangeStartOffsets;
+			std::vector<UINT> rangeTileCounts;
 
-            for (UINT n = 0; n < m_heaps.size(); n++)
-            {
-                if (!m_mips[n].mapped && n != firstSubresource)
-                {
-                    // Skip unchanged tile regions.
-                    continue;
-                }
+			for (UINT n = 0; n < m_heaps.size(); n++)
+			{
+				if (!m_mips[n].mapped && n != firstSubresource)
+				{
+					// Skip unchanged tile regions.
+					continue;
+				}
 
-                startCoordinates.push_back(m_mips[n].startCoordinate);
-                regionSizes.push_back(m_mips[n].regionSize);
+				startCoordinates.push_back(m_mips[n].startCoordinate);
+				regionSizes.push_back(m_mips[n].regionSize);
 
-                if (n == firstSubresource)
-                {
-                    // Map the currently active mip.
-                    rangeFlags.push_back(D3D12_TILE_RANGE_FLAG_NONE);
-                    m_mips[n].mapped = true;
-                }
-                else
-                {
-                    // Unmap the previously active mip.
-                    assert(m_mips[n].mapped);
+				if (n == firstSubresource)
+				{
+					// Map the currently active mip.
+					rangeFlags.push_back(D3D12_TILE_RANGE_FLAG_NONE);
+					m_mips[n].mapped = true;
+				}
+				else
+				{
+					// Unmap the previously active mip.
+					assert(m_mips[n].mapped);
 
-                    rangeFlags.push_back(D3D12_TILE_RANGE_FLAG_NULL);
-                    m_mips[n].mapped = false;
-                }
-                heapRangeStartOffsets.push_back(0);        // In this sample, each heap contains only one tile region.
-                rangeTileCounts.push_back(m_mips[n].regionSize.NumTiles);
+					rangeFlags.push_back(D3D12_TILE_RANGE_FLAG_NULL);
+					m_mips[n].mapped = false;
+				}
+				heapRangeStartOffsets.push_back(0);		// In this sample, each heap contains only one tile region.
+				rangeTileCounts.push_back(m_mips[n].regionSize.NumTiles);
 
-                updatedRegions++;
-            }
+				updatedRegions++;
+			}
 
-            m_commandQueue->UpdateTileMappings(
-                m_reservedResource.Get(),
-                updatedRegions,
-                &startCoordinates[0],
-                &regionSizes[0],
-                m_heaps[firstSubresource].Get(),
-                updatedRegions,
-                &rangeFlags[0],
-                &heapRangeStartOffsets[0],
-                &rangeTileCounts[0],
-                D3D12_TILE_MAPPING_FLAG_NONE
-                );
-        }
+			m_commandQueue->UpdateTileMappings(
+				m_reservedResource.Get(),
+				updatedRegions,
+				&startCoordinates[0],
+				&regionSizes[0],
+				m_heaps[firstSubresource].Get(),
+				updatedRegions,
+				&rangeFlags[0],
+				&heapRangeStartOffsets[0],
+				&rangeTileCounts[0],
+				D3D12_TILE_MAPPING_FLAG_NONE
+				);
+		}
 
-        // Upload the mip(s) to the GPU and copy them to the reserved resource.
-        {
-            UINT mipOffset = 0;
-            std::vector<D3D12_SUBRESOURCE_DATA> data(subresourceCount);
-            for (UINT n = 0; n < subresourceCount; n++)
-            {
-                UINT currentMip = firstSubresource + n;
+		// Upload the mip(s) to the GPU and copy them to the reserved resource.
+		{
+			UINT mipOffset = 0;
+			std::vector<D3D12_SUBRESOURCE_DATA> data(subresourceCount);
+			for (UINT n = 0; n < subresourceCount; n++)
+			{
+				UINT currentMip = firstSubresource + n;
 
-                data[n].pData = &texture[mipOffset];
-                data[n].RowPitch = (TextureWidth >> currentMip) * TexturePixelSizeInBytes;
-                data[n].SlicePitch = data[n].RowPitch * (TextureHeight >> currentMip);
+				data[n].pData = &texture[mipOffset];
+				data[n].RowPitch = (TextureWidth >> currentMip) * TexturePixelSizeInBytes;
+				data[n].SlicePitch = data[n].RowPitch * (TextureHeight >> currentMip);
 
-                mipOffset += static_cast<UINT>(data[n].SlicePitch);
-            }
+				mipOffset += static_cast<UINT>(data[n].SlicePitch);
+			}
 
-            UpdateSubresources(m_commandList.Get(), m_reservedResource.Get(), m_uploadHeap.Get(), 0, firstSubresource, subresourceCount, &data[0]);
-        }
-    }
+			UpdateSubresources(m_commandList.Get(), m_reservedResource.Get(), m_uploadHeap.Get(), 0, firstSubresource, subresourceCount, &data[0]);
+		}
+	}
 
-    m_activeMipChanged = false;
+	m_activeMipChanged = false;
 
-    WCHAR message[100];
-    swprintf_s(message, L"Mip Level: %d", m_activeMip);
-    SetCustomWindowText(message);
+	WCHAR message[100];
+	swprintf_s(message, L"Mip Level: %d", m_activeMip);
+	SetCustomWindowText(message);
 }
 
 // Generate a simple red and white checkerboard texture.
 std::vector<UINT8> D3D12ReservedResources::GenerateTextureData(UINT firstMip, UINT mipCount)
 {
-    // Determine the size of the data required by the mips(s).
-    UINT dataSize = (TextureWidth >> firstMip) * (TextureHeight >> firstMip) * TexturePixelSizeInBytes;
-    if (mipCount > 1)
-    {
-        // If generating more than 1 mip, double the size of the texture allocation
-        // (you will never need more than this).
-        dataSize *= 2;
-    }
-    std::vector<UINT8> data(dataSize);
-    UINT8* pData = &data[0];
+	// Determine the size of the data required by the mips(s).
+	UINT dataSize = (TextureWidth >> firstMip) * (TextureHeight >> firstMip) * TexturePixelSizeInBytes;
+	if (mipCount > 1)
+	{
+		// If generating more than 1 mip, double the size of the texture allocation
+		// (you will never need more than this).
+		dataSize *= 2;
+	}
+	std::vector<UINT8> data(dataSize);
+	UINT8* pData = &data[0];
 
-    UINT index = 0;
-    for (UINT n = 0; n < mipCount; n++)
-    {
-        const UINT currentMip = firstMip + n;
-        const UINT width = TextureWidth >> currentMip;
-        const UINT height = TextureHeight >> currentMip;
-        const UINT rowPitch = width * TexturePixelSizeInBytes;
-        const UINT cellPitch = max(rowPitch >> 3, TexturePixelSizeInBytes);    // The width of a cell in the checkboard texture.
-        const UINT cellHeight = max(height >> 3, 1);                        // The height of a cell in the checkerboard texture.
-        const UINT textureSize = rowPitch * height;
+	UINT index = 0;
+	for (UINT n = 0; n < mipCount; n++)
+	{
+		const UINT currentMip = firstMip + n;
+		const UINT width = TextureWidth >> currentMip;
+		const UINT height = TextureHeight >> currentMip;
+		const UINT rowPitch = width * TexturePixelSizeInBytes;
+		const UINT cellPitch = max(rowPitch >> 3, TexturePixelSizeInBytes);	// The width of a cell in the checkboard texture.
+		const UINT cellHeight = max(height >> 3, 1);						// The height of a cell in the checkerboard texture.
+		const UINT textureSize = rowPitch * height;
 
-        for (UINT m = 0; m < textureSize; m += TexturePixelSizeInBytes)
-        {
-            UINT x = m % rowPitch;
-            UINT y = m / rowPitch;
-            UINT i = x / cellPitch;
-            UINT j = y / cellHeight;
+		for (UINT m = 0; m < textureSize; m += TexturePixelSizeInBytes)
+		{
+			UINT x = m % rowPitch;
+			UINT y = m / rowPitch;
+			UINT i = x / cellPitch;
+			UINT j = y / cellHeight;
 
-            if (i % 2 == j % 2)
-            {
-                pData[index++] = 0xff;    // R
-                pData[index++] = 0x00;    // G
-                pData[index++] = 0x00;    // B
-                pData[index++] = 0xff;    // A
-            }
-            else
-            {
-                pData[index++] = 0xff;    // R
-                pData[index++] = 0xff;    // G
-                pData[index++] = 0xff;    // B
-                pData[index++] = 0xff;    // A
-            }
-        }
-    }
-    return data;
+			if (i % 2 == j % 2)
+			{
+				pData[index++] = 0xff;	// R
+				pData[index++] = 0x00;	// G
+				pData[index++] = 0x00;	// B
+				pData[index++] = 0xff;	// A
+			}
+			else
+			{
+				pData[index++] = 0xff;	// R
+				pData[index++] = 0xff;	// G
+				pData[index++] = 0xff;	// B
+				pData[index++] = 0xff;	// A
+			}
+		}
+	}
+	return data;
 }
 
 // Update frame-based values.
@@ -599,139 +599,139 @@ void D3D12ReservedResources::OnUpdate()
 // Render the scene.
 void D3D12ReservedResources::OnRender()
 {
-    if (m_tilingSupport)
-    {
-        // Record all the commands we need to render the scene into the command list.
-        PopulateCommandList();
+	if (m_tilingSupport)
+	{
+		// Record all the commands we need to render the scene into the command list.
+		PopulateCommandList();
 
-        // Execute the command list.
-        ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-        m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+		// Execute the command list.
+		ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+		m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-        // Present the frame.
-        ThrowIfFailed(m_swapChain->Present(1, 0));
+		// Present the frame.
+		ThrowIfFailed(m_swapChain->Present(1, 0));
 
-        MoveToNextFrame();
-    }
+		MoveToNextFrame();
+	}
 }
 
 void D3D12ReservedResources::OnDestroy()
 {
-    if (m_tilingSupport)
-    {
-        // Ensure that the GPU is no longer referencing resources that are about to be
-        // cleaned up by the destructor.
-        WaitForGpu();
+	if (m_tilingSupport)
+	{
+		// Ensure that the GPU is no longer referencing resources that are about to be
+		// cleaned up by the destructor.
+		WaitForGpu();
 
-        CloseHandle(m_fenceEvent);
-    }
+		CloseHandle(m_fenceEvent);
+	}
 }
 
 void D3D12ReservedResources::OnKeyDown(UINT8 key)
 {
-    switch (key)
-    {
-    case VK_LEFT:
-    case VK_UP:
-        if (m_activeMip != 0)
-        {
-            m_activeMip--;
-            m_activeMipChanged = true;
-        }
-        break;
+	switch (key)
+	{
+	case VK_LEFT:
+	case VK_UP:
+		if (m_activeMip != 0)
+		{
+			m_activeMip--;
+			m_activeMipChanged = true;
+		}
+		break;
 
-    case VK_RIGHT:
-    case VK_DOWN:
-        if (m_activeMip < m_mips.size() - 1)
-        {
-            m_activeMip++;
-            m_activeMipChanged = true;
-        }
-        break;
-    }
+	case VK_RIGHT:
+	case VK_DOWN:
+		if (m_activeMip < m_mips.size() - 1)
+		{
+			m_activeMip++;
+			m_activeMipChanged = true;
+		}
+		break;
+	}
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12ReservedResources::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
 
-    if (m_activeMipChanged)
-    {
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_reservedResource.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST));
-        UpdateTileMapping();
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_reservedResource.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
-    }
+	if (m_activeMipChanged)
+	{
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_reservedResource.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST));
+		UpdateTileMapping();
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_reservedResource.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
+	}
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
-    m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
+	m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_commandList->SetGraphicsRoot32BitConstant(0, m_activeMip, 0);
-    m_commandList->SetGraphicsRootDescriptorTable(1, m_srvHeap->GetGPUDescriptorHandleForHeapStart());
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	m_commandList->SetGraphicsRoot32BitConstant(0, m_activeMip, 0);
+	m_commandList->SetGraphicsRootDescriptorTable(1, m_srvHeap->GetGPUDescriptorHandleForHeapStart());
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-    m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
-    m_commandList->DrawInstanced(4, 1, 0, 0);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+	m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+	m_commandList->DrawInstanced(4, 1, 0, 0);
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 // Wait for pending GPU work to complete.
 void D3D12ReservedResources::WaitForGpu()
 {
-    // Schedule a Signal command in the queue.
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
+	// Schedule a Signal command in the queue.
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
 
-    // Wait until the fence has been processed.
-    ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-    WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	// Wait until the fence has been processed.
+	ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+	WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
 
-    // Increment the fence value for the current frame.
-    m_fenceValues[m_frameIndex]++;
+	// Increment the fence value for the current frame.
+	m_fenceValues[m_frameIndex]++;
 }
 
 // Prepare to render the next frame.
 void D3D12ReservedResources::MoveToNextFrame()
 {
-    // Schedule a Signal command in the queue.
-    const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
+	// Schedule a Signal command in the queue.
+	const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
 
-    // Update the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Update the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-        WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+		WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	}
 
-    // Set the fence value for the next frame.
-    m_fenceValues[m_frameIndex] = currentFenceValue + 1;
+	// Set the fence value for the next frame.
+	m_fenceValues[m_frameIndex] = currentFenceValue + 1;
 }

--- a/Samples/UWP/D3D12ReservedResources/src/D3D12ReservedResources.h
+++ b/Samples/UWP/D3D12ReservedResources/src/D3D12ReservedResources.h
@@ -25,75 +25,75 @@ using Microsoft::WRL::ComPtr;
 class D3D12ReservedResources : public DXSample
 {
 public:
-    D3D12ReservedResources(UINT width, UINT height, std::wstring name);
+	D3D12ReservedResources(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
-    virtual void OnKeyDown(UINT8 key);
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
+	virtual void OnKeyDown(UINT8 key);
 
 private:
-    static const UINT FrameCount = 2;
-    static const UINT TextureWidth = 256;
-    static const UINT TextureHeight = 256;
-    static const UINT TexturePixelSizeInBytes = 4;
+	static const UINT FrameCount = 2;
+	static const UINT TextureWidth = 256;
+	static const UINT TextureHeight = 256;
+	static const UINT TexturePixelSizeInBytes = 4;
 
-    // Vertex definition.
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT2 uv;
-    };
+	// Vertex definition.
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT2 uv;
+	};
 
-    // Information about the mips in the reserved resource.
-    struct MipInfo
-    {
-        UINT heapIndex;
-        bool packedMip;
-        bool mapped;
-        D3D12_TILED_RESOURCE_COORDINATE startCoordinate;
-        D3D12_TILE_REGION_SIZE regionSize;
-    };
+	// Information about the mips in the reserved resource.
+	struct MipInfo
+	{
+		UINT heapIndex;
+		bool packedMip;
+		bool mapped;
+		D3D12_TILED_RESOURCE_COORDINATE startCoordinate;
+		D3D12_TILE_REGION_SIZE regionSize;
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_srvHeap;
-    UINT m_rtvDescriptorSize;
-    UINT m_frameIndex;
-    bool m_tilingSupport;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_srvHeap;
+	UINT m_rtvDescriptorSize;
+	UINT m_frameIndex;
+	bool m_tilingSupport;
 
-    // Synchronization objects.
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValues[FrameCount];
-    HANDLE m_fenceEvent;
+	// Synchronization objects.
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValues[FrameCount];
+	HANDLE m_fenceEvent;
 
-    // Asset objects.
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
-    ComPtr<ID3D12Resource> m_uploadHeap;
-    ComPtr<ID3D12Resource> m_reservedResource;
-    std::vector<ComPtr<ID3D12Heap>> m_heaps;
-    std::vector<MipInfo> m_mips;
-    D3D12_PACKED_MIP_INFO m_packedMipInfo;
-    UINT m_activeMip;
-    bool m_activeMipChanged;
+	// Asset objects.
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	ComPtr<ID3D12Resource> m_uploadHeap;
+	ComPtr<ID3D12Resource> m_reservedResource;
+	std::vector<ComPtr<ID3D12Heap>> m_heaps;
+	std::vector<MipInfo> m_mips;
+	D3D12_PACKED_MIP_INFO m_packedMipInfo;
+	UINT m_activeMip;
+	bool m_activeMipChanged;
 
-    void LoadPipeline();
-    void LoadAssets();
-    std::vector<UINT8> GenerateTextureData(UINT firstMip, UINT lastMip);
-    void UpdateTileMapping();
-    void PopulateCommandList();
-    void WaitForGpu();
-    void MoveToNextFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	std::vector<UINT8> GenerateTextureData(UINT firstMip, UINT lastMip);
+	void UpdateTileMapping();
+	void PopulateCommandList();
+	void WaitForGpu();
+	void MoveToNextFrame();
 };

--- a/Samples/UWP/D3D12ReservedResources/src/DXSample.cpp
+++ b/Samples/UWP/D3D12ReservedResources/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,59 +34,104 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
-    auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(windowText.c_str());
+	std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
+	auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/UWP/D3D12ReservedResources/src/DXSample.h
+++ b/Samples/UWP/D3D12ReservedResources/src/DXSample.h
@@ -16,42 +16,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/UWP/D3D12ReservedResources/src/Main.cpp
+++ b/Samples/UWP/D3D12ReservedResources/src/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12ReservedResources sample(1200, 900, L"Use arrow keys to cycle through resources");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12ReservedResources sample(1200, 900, L"Use arrow keys to cycle through resources");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12ReservedResources/src/View.cpp
+++ b/Samples/UWP/D3D12ReservedResources/src/View.cpp
@@ -15,27 +15,27 @@
 using namespace Windows::Foundation;
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -44,20 +44,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -66,26 +66,26 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnClosed(CoreWindow^ /*sender*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }

--- a/Samples/UWP/D3D12ReservedResources/src/View.h
+++ b/Samples/UWP/D3D12ReservedResources/src/View.h
@@ -23,20 +23,20 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
+	DXSample* m_pSample;
+	bool m_windowClosed;
 };

--- a/Samples/UWP/D3D12ReservedResources/src/ViewProvider.cpp
+++ b/Samples/UWP/D3D12ReservedResources/src/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12ReservedResources/src/ViewProvider.h
+++ b/Samples/UWP/D3D12ReservedResources/src/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12ReservedResources/src/d3dx12.h
+++ b/Samples/UWP/D3D12ReservedResources/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12ReservedResources/src/shaders.hlsl
+++ b/Samples/UWP/D3D12ReservedResources/src/shaders.hlsl
@@ -11,13 +11,13 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 cbuffer RootConstants : register(b0)
 {
-    uint activeMip;
+	uint activeMip;
 }
 
 Texture2D g_texture : register(t0);
@@ -25,15 +25,15 @@ SamplerState g_sampler : register(s0);
 
 PSInput VSMain(float4 position : POSITION, float4 uv : TEXCOORD)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.uv = uv;
+	result.position = position;
+	result.uv = uv;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return g_texture.SampleLevel(g_sampler, input.uv, activeMip);
+	return g_texture.SampleLevel(g_sampler, input.uv, activeMip);
 }

--- a/Samples/UWP/D3D12Residency/src/D3D12Residency.cpp
+++ b/Samples/UWP/D3D12Residency/src/D3D12Residency.cpp
@@ -13,452 +13,452 @@
 #include "D3D12Residency.h"
 
 D3D12Residency::D3D12Residency(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0),
-    m_totalAllocations(0),
-    m_textureIndex(0),
-    m_cancel(false),
-    m_loadedTextureCount(0)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0),
+	m_totalAllocations(0),
+	m_textureIndex(0),
+	m_cancel(false),
+	m_loadedTextureCount(0)
 {
 }
 
 void D3D12Residency::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
-    LoadTexturesAsync();
+	LoadPipeline();
+	LoadAssets();
+	LoadTexturesAsync();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12Residency::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
 
-        ThrowIfFailed(warpAdapter.As(&m_adapter));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(warpAdapter.As(&m_adapter));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
 
-        ThrowIfFailed(hardwareAdapter.As(&m_adapter));
-    }
+		ThrowIfFailed(hardwareAdapter.As(&m_adapter));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a shader resource view (SRV) heap for the texture.
-        D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
-        srvHeapDesc.NumDescriptors = NumTextures;
-        srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
+		// Describe and create a shader resource view (SRV) heap for the texture.
+		D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
+		srvHeapDesc.NumDescriptors = NumTextures;
+		srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&srvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-        m_srvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_srvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
-        }
-    }
+		// Create a RTV for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
+		}
+	}
 
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
 }
 
 // Load the sample assets.
 void D3D12Residency::LoadAssets()
 {
-    // Create the root signature.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signature.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DESCRIPTORS_VOLATILE);
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DESCRIPTORS_VOLATILE);
 
-        CD3DX12_ROOT_PARAMETER1 rootParameters[1];
-        rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
+		CD3DX12_ROOT_PARAMETER1 rootParameters[1];
+		rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
 
-        CD3DX12_STATIC_SAMPLER_DESC sampler(0, D3D12_FILTER_MIN_MAG_MIP_POINT);
-        sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+		CD3DX12_STATIC_SAMPLER_DESC sampler(0, D3D12_FILTER_MIN_MAG_MIP_POINT);
+		sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &sampler, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &sampler, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Describe and create the graphics pipeline state object (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.SampleDesc.Count = 1;
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-    }
+		// Describe and create the graphics pipeline state object (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.SampleDesc.Count = 1;
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
 
-    // Note: ComPtr's are CPU objects but this resource needs to stay in scope until
-    // the command list that references it has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resource is not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> vertexBufferUpload;
+	// Note: ComPtr's are CPU objects but this resource needs to stay in scope until
+	// the command list that references it has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resource is not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> vertexBufferUpload;
 
-    // Create the vertex buffer.
-    {
-        // Define the geometry for a quad.
-        Vertex quadVertices[] =
-        {
-            { { -1.0f, -1.0f, 0.0f }, { 0.0f, 0.0f } },
-            { { -1.0f, 1.0f, 0.0f }, { 0.0f, 1.0f } },
-            { { 1.0f, -1.0f, 0.0f }, { 1.0f, 0.0f } },
-            { { 1.0f, 1.0f, 0.0f }, { 1.0f, 1.0f } },
-        };
+	// Create the vertex buffer.
+	{
+		// Define the geometry for a quad.
+		Vertex quadVertices[] =
+		{
+			{ { -1.0f, -1.0f, 0.0f }, { 0.0f, 0.0f } },
+			{ { -1.0f, 1.0f, 0.0f }, { 0.0f, 1.0f } },
+			{ { 1.0f, -1.0f, 0.0f }, { 1.0f, 0.0f } },
+			{ { 1.0f, 1.0f, 0.0f }, { 1.0f, 1.0f } },
+		};
 
-        const UINT vertexBufferSize = sizeof(quadVertices);
+		const UINT vertexBufferSize = sizeof(quadVertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&vertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&vertexBufferUpload)));
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(quadVertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(quadVertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = vertexBufferSize;
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = vertexBufferSize;
+	}
 
-    // Close the command list and execute it to begin the initial GPU setup.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the initial GPU setup.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValue = 1;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValue = 1;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        FlushGpu();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		FlushGpu();
+	}
 }
 
 // Create and upload textures asynchronously. When textures are uploaded, they may
 // then be used for rendering.
 void D3D12Residency::LoadTexturesAsync()
 {
-    // For this sample we will only track the residency of the textures.
-    // Other resources could also be tracked by adding them to the ResidencySets in the
-    // managed command lists.
-    m_residencyManager.Initialize(m_device.Get(), 0, m_adapter.Get(), MaxResidencyLatency);
-    m_loadedTextures.resize(NumTextures);
+	// For this sample we will only track the residency of the textures.
+	// Other resources could also be tracked by adding them to the ResidencySets in the
+	// managed command lists.
+	m_residencyManager.Initialize(m_device.Get(), 0, m_adapter.Get(), MaxResidencyLatency);
+	m_loadedTextures.resize(NumTextures);
 
-    // Initialize the queue of incomplete textures that will be loaded asynchronously.
-    for (UINT n = 0; n < NumTextures; n++)
-    {
-        auto pTexture = std::make_shared<ManagedTexture>();
-        pTexture->index = n;
-        m_incompleteTextures.push(pTexture);
-    }
+	// Initialize the queue of incomplete textures that will be loaded asynchronously.
+	for (UINT n = 0; n < NumTextures; n++)
+	{
+		auto pTexture = std::make_shared<ManagedTexture>();
+		pTexture->index = n;
+		m_incompleteTextures.push(pTexture);
+	}
 
-    // Async method that pulls textures out of the m_incompleteTextures queue,
-    // initializes them, and then moves them into the m_loadedTextures vector.
-    const auto& CreateAndUpload = [this]()
-    {
-        // Create a copy queue and associated resources to facilitate uploading textures.
-        D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-        queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-        queueDesc.Type = D3D12_COMMAND_LIST_TYPE_COPY;
+	// Async method that pulls textures out of the m_incompleteTextures queue,
+	// initializes them, and then moves them into the m_loadedTextures vector.
+	const auto& CreateAndUpload = [this]()
+	{
+		// Create a copy queue and associated resources to facilitate uploading textures.
+		D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+		queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+		queueDesc.Type = D3D12_COMMAND_LIST_TYPE_COPY;
 
-        ComPtr<ID3D12CommandQueue> copyQueue;
-        ComPtr<ID3D12CommandAllocator> commandAllocator;
-        ComPtr<ID3D12GraphicsCommandList> commandList;
-        std::shared_ptr<D3DX12Residency::ResidencySet> residencySet(m_residencyManager.CreateResidencySet());
-        ComPtr<ID3D12Fence> fence;
-        UINT64 fenceValue = 1;
-        HANDLE fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		ComPtr<ID3D12CommandQueue> copyQueue;
+		ComPtr<ID3D12CommandAllocator> commandAllocator;
+		ComPtr<ID3D12GraphicsCommandList> commandList;
+		std::shared_ptr<D3DX12Residency::ResidencySet> residencySet(m_residencyManager.CreateResidencySet());
+		ComPtr<ID3D12Fence> fence;
+		UINT64 fenceValue = 1;
+		HANDLE fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&copyQueue)));
-        ThrowIfFailed(m_device->CreateCommandAllocator(queueDesc.Type, IID_PPV_ARGS(&commandAllocator)));
-        ThrowIfFailed(m_device->CreateCommandList(0, queueDesc.Type, commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&commandList)));
-        ThrowIfFailed(commandList->Close());
-        ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&fence)));
+		ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&copyQueue)));
+		ThrowIfFailed(m_device->CreateCommandAllocator(queueDesc.Type, IID_PPV_ARGS(&commandAllocator)));
+		ThrowIfFailed(m_device->CreateCommandList(0, queueDesc.Type, commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&commandList)));
+		ThrowIfFailed(commandList->Close());
+		ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&fence)));
 
-        // Allocate the CPU-side memory backing the texture.
-        const UINT textureSize = TextureWidth * TextureHeight * TexturePixelSize;
-        std::vector<UINT8> textureData(textureSize);
-        UINT8* pData = textureData.data();
+		// Allocate the CPU-side memory backing the texture.
+		const UINT textureSize = TextureWidth * TextureHeight * TexturePixelSize;
+		std::vector<UINT8> textureData(textureSize);
+		UINT8* pData = textureData.data();
 
-        // Describe the texture.
-        D3D12_RESOURCE_DESC textureDesc = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R8G8B8A8_UNORM, TextureWidth, TextureHeight, 1, 1);
-        D3D12_RESOURCE_ALLOCATION_INFO info = m_device->GetResourceAllocationInfo(0, 1, &textureDesc);
+		// Describe the texture.
+		D3D12_RESOURCE_DESC textureDesc = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R8G8B8A8_UNORM, TextureWidth, TextureHeight, 1, 1);
+		D3D12_RESOURCE_ALLOCATION_INFO info = m_device->GetResourceAllocationInfo(0, 1, &textureDesc);
 
-        // Create a GPU upload buffer.
-        ComPtr<ID3D12Resource> textureUploadHeap;
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(info.SizeInBytes),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&textureUploadHeap)));
+		// Create a GPU upload buffer.
+		ComPtr<ID3D12Resource> textureUploadHeap;
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(info.SizeInBytes),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&textureUploadHeap)));
 
-        auto pTexture = GetNextIncompleteTexture();
+		auto pTexture = GetNextIncompleteTexture();
 
-        // Create and upload the next texture.
-        while (pTexture && !m_cancel)
-        {
-            // Create the backing resource for the texture and initialize the ManagedTexture.
-            ThrowIfFailed(m_device->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-                D3D12_HEAP_FLAG_NONE,
-                &textureDesc,
-                D3D12_RESOURCE_STATE_COMMON,
-                nullptr,
-                IID_PPV_ARGS(&pTexture->texture)));
+		// Create and upload the next texture.
+		while (pTexture && !m_cancel)
+		{
+			// Create the backing resource for the texture and initialize the ManagedTexture.
+			ThrowIfFailed(m_device->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+				D3D12_HEAP_FLAG_NONE,
+				&textureDesc,
+				D3D12_RESOURCE_STATE_COMMON,
+				nullptr,
+				IID_PPV_ARGS(&pTexture->texture)));
 
-            SetNameIndexed(pTexture->texture.Get(), L"texture", pTexture->index);
+			SetNameIndexed(pTexture->texture.Get(), L"texture", pTexture->index);
 
-            pTexture->trackingHandle.Initialize(pTexture->texture.Get(), info.SizeInBytes);
-            pTexture->size = info.SizeInBytes;
-            m_totalAllocations += info.SizeInBytes;
+			pTexture->trackingHandle.Initialize(pTexture->texture.Get(), info.SizeInBytes);
+			pTexture->size = info.SizeInBytes;
+			m_totalAllocations += info.SizeInBytes;
 
-            // Turn on residency tracking for this texture.
-            m_residencyManager.BeginTrackingObject(&pTexture->trackingHandle);
+			// Turn on residency tracking for this texture.
+			m_residencyManager.BeginTrackingObject(&pTexture->trackingHandle);
 
-            // Describe and create a SRV for the texture.
-            D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-            srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-            srvDesc.Format = textureDesc.Format;
-            srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-            srvDesc.Texture2D.MipLevels = 1;
+			// Describe and create a SRV for the texture.
+			D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+			srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+			srvDesc.Format = textureDesc.Format;
+			srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+			srvDesc.Texture2D.MipLevels = 1;
 
-            CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_srvHeap->GetCPUDescriptorHandleForHeapStart(), pTexture->index, m_srvDescriptorSize);
-            m_device->CreateShaderResourceView(pTexture->texture.Get(), &srvDesc, cpuHandle);
+			CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_srvHeap->GetCPUDescriptorHandleForHeapStart(), pTexture->index, m_srvDescriptorSize);
+			m_device->CreateShaderResourceView(pTexture->texture.Get(), &srvDesc, cpuHandle);
 
-            // Reclaim upload resources for initializing the current texture.
-            ThrowIfFailed(commandAllocator->Reset());
-            ThrowIfFailed(commandList->Reset(commandAllocator.Get(), m_pipelineState.Get()));
-            residencySet->Open();
+			// Reclaim upload resources for initializing the current texture.
+			ThrowIfFailed(commandAllocator->Reset());
+			ThrowIfFailed(commandList->Reset(commandAllocator.Get(), m_pipelineState.Get()));
+			residencySet->Open();
 
-            // Upload the texture data.
-            {
-                XMFLOAT3 hsv(static_cast<float>(pTexture->index) / (m_width >> 1), 0.75f, 0.85f);
-                XMFLOAT3 rgb;
-                XMStoreFloat3(&rgb, XMColorHSVToRGB(XMLoadFloat3(&hsv)));
-                UINT8 r = static_cast<UINT8>(rgb.x * 255.0f);
-                UINT8 g = static_cast<UINT8>(rgb.y * 255.0f);
-                UINT8 b = static_cast<UINT8>(rgb.z * 255.0f);
-                UINT8 a = 0xff;
+			// Upload the texture data.
+			{
+				XMFLOAT3 hsv(static_cast<float>(pTexture->index) / (m_width >> 1), 0.75f, 0.85f);
+				XMFLOAT3 rgb;
+				XMStoreFloat3(&rgb, XMColorHSVToRGB(XMLoadFloat3(&hsv)));
+				UINT8 r = static_cast<UINT8>(rgb.x * 255.0f);
+				UINT8 g = static_cast<UINT8>(rgb.y * 255.0f);
+				UINT8 b = static_cast<UINT8>(rgb.z * 255.0f);
+				UINT8 a = 0xff;
 
-                for (UINT n = 0; n < textureSize; n += TexturePixelSize)
-                {
-                    pData[n] = r;
-                    pData[n + 1] = g;
-                    pData[n + 2] = b;
-                    pData[n + 3] = a;
-                }
+				for (UINT n = 0; n < textureSize; n += TexturePixelSize)
+				{
+					pData[n] = r;
+					pData[n + 1] = g;
+					pData[n + 2] = b;
+					pData[n + 3] = a;
+				}
 
-                // Copy data to the intermediate upload heap and then schedule a copy
-                // from the upload heap to the texture resource.
-                D3D12_SUBRESOURCE_DATA textureData = {};
-                textureData.pData = pData;
-                textureData.RowPitch = TextureWidth * TexturePixelSize;
-                textureData.SlicePitch = textureData.RowPitch * TextureHeight;
+				// Copy data to the intermediate upload heap and then schedule a copy
+				// from the upload heap to the texture resource.
+				D3D12_SUBRESOURCE_DATA textureData = {};
+				textureData.pData = pData;
+				textureData.RowPitch = TextureWidth * TexturePixelSize;
+				textureData.SlicePitch = textureData.RowPitch * TextureHeight;
 
-                UpdateSubresources<1>(commandList.Get(), pTexture->texture.Get(), textureUploadHeap.Get(), 0, 0, 1, &textureData);
-            }
+				UpdateSubresources<1>(commandList.Get(), pTexture->texture.Get(), textureUploadHeap.Get(), 0, 0, 1, &textureData);
+			}
 
-            // Add this resource to the set of resources the command list needs resident.
-            residencySet->Insert(&pTexture->trackingHandle);
+			// Add this resource to the set of resources the command list needs resident.
+			residencySet->Insert(&pTexture->trackingHandle);
 
-            ThrowIfFailed(commandList->Close());
-            ThrowIfFailed(residencySet->Close());
+			ThrowIfFailed(commandList->Close());
+			ThrowIfFailed(residencySet->Close());
 
-            ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
-            D3DX12Residency::ResidencySet* ppResidencySets[] = { residencySet.get() };
+			ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
+			D3DX12Residency::ResidencySet* ppResidencySets[] = { residencySet.get() };
 
-            // Schedule the upload and wait for it to complete.
-            m_residencyManager.ExecuteCommandLists(copyQueue.Get(), ppCommandLists, ppResidencySets, _countof(ppCommandLists));
+			// Schedule the upload and wait for it to complete.
+			m_residencyManager.ExecuteCommandLists(copyQueue.Get(), ppCommandLists, ppResidencySets, _countof(ppCommandLists));
 
-            copyQueue->Signal(fence.Get(), fenceValue);
-            ThrowIfFailed(fence->SetEventOnCompletion(fenceValue, fenceEvent));
-            WaitForSingleObject(fenceEvent, INFINITE);
-            fenceValue++;
+			copyQueue->Signal(fence.Get(), fenceValue);
+			ThrowIfFailed(fence->SetEventOnCompletion(fenceValue, fenceEvent));
+			WaitForSingleObject(fenceEvent, INFINITE);
+			fenceValue++;
 
-            StoreCompletedTexture(pTexture);
-            pTexture = GetNextIncompleteTexture();
-        }
+			StoreCompletedTexture(pTexture);
+			pTexture = GetNextIncompleteTexture();
+		}
 
-        CloseHandle(fenceEvent);
-    };
+		CloseHandle(fenceEvent);
+	};
 
-    const UINT numThreads = MaxResidencyLatency + 1;
-    m_threads.resize(numThreads);
+	const UINT numThreads = MaxResidencyLatency + 1;
+	m_threads.resize(numThreads);
 
-    for (UINT n = 0; n < numThreads; n++)
-    {
-        m_threads[n] = std::async(std::launch::async, CreateAndUpload);
-    }
+	for (UINT n = 0; n < numThreads; n++)
+	{
+		m_threads[n] = std::async(std::launch::async, CreateAndUpload);
+	}
 }
 
 // Update frame-based values.
@@ -469,165 +469,165 @@ void D3D12Residency::OnUpdate()
 // Render the scene.
 void D3D12Residency::OnRender()
 {
-    std::shared_ptr<ManagedCommandList> pManagedCommandList;
+	std::shared_ptr<ManagedCommandList> pManagedCommandList;
 
-    if (m_commandListPool.empty() || m_commandListPool.front()->fenceValue > m_fence->GetCompletedValue())
-    {
-        pManagedCommandList = std::make_shared<ManagedCommandList>();
-        ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&pManagedCommandList->commandAllocator)));
-        ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, pManagedCommandList->commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&pManagedCommandList->commandList)));
-        pManagedCommandList->residencySet = std::shared_ptr<D3DX12Residency::ResidencySet>(m_residencyManager.CreateResidencySet());
-    }
-    else
-    {
-        pManagedCommandList = m_commandListPool.front();
-        m_commandListPool.pop();
+	if (m_commandListPool.empty() || m_commandListPool.front()->fenceValue > m_fence->GetCompletedValue())
+	{
+		pManagedCommandList = std::make_shared<ManagedCommandList>();
+		ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&pManagedCommandList->commandAllocator)));
+		ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, pManagedCommandList->commandAllocator.Get(), m_pipelineState.Get(), IID_PPV_ARGS(&pManagedCommandList->commandList)));
+		pManagedCommandList->residencySet = std::shared_ptr<D3DX12Residency::ResidencySet>(m_residencyManager.CreateResidencySet());
+	}
+	else
+	{
+		pManagedCommandList = m_commandListPool.front();
+		m_commandListPool.pop();
 
-        ThrowIfFailed(pManagedCommandList->commandAllocator->Reset());
-        ThrowIfFailed(pManagedCommandList->commandList->Reset(pManagedCommandList->commandAllocator.Get(), m_pipelineState.Get()));
-    }
+		ThrowIfFailed(pManagedCommandList->commandAllocator->Reset());
+		ThrowIfFailed(pManagedCommandList->commandList->Reset(pManagedCommandList->commandAllocator.Get(), m_pipelineState.Get()));
+	}
 
-    m_commandListPool.push(pManagedCommandList);
+	m_commandListPool.push(pManagedCommandList);
 
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList(pManagedCommandList);
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList(pManagedCommandList);
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { pManagedCommandList->commandList.Get() };
-    D3DX12Residency::ResidencySet* ppSets[] = { pManagedCommandList->residencySet.get() };
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { pManagedCommandList->commandList.Get() };
+	D3DX12Residency::ResidencySet* ppSets[] = { pManagedCommandList->residencySet.get() };
 
-    m_residencyManager.ExecuteCommandLists(m_commandQueue.Get(), ppCommandLists, ppSets, 1);
+	m_residencyManager.ExecuteCommandLists(m_commandQueue.Get(), ppCommandLists, ppSets, 1);
 
-    const UINT64 fence = m_fenceValue;
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
-    m_fenceValue++;
+	const UINT64 fence = m_fenceValue;
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
+	m_fenceValue++;
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Present the frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    pManagedCommandList->fenceValue = fence;
+	pManagedCommandList->fenceValue = fence;
 }
 
 void D3D12Residency::OnDestroy()
 {
-    // Cancel all of the texture loading threads and wait for them to exit.
-    m_cancel = true;
-    for (UINT n = 0; n < m_threads.size(); n++)
-    {
-        m_threads[n].wait();
-    }
+	// Cancel all of the texture loading threads and wait for them to exit.
+	m_cancel = true;
+	for (UINT n = 0; n < m_threads.size(); n++)
+	{
+		m_threads[n].wait();
+	}
 
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up.
-    FlushGpu();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up.
+	FlushGpu();
 
-    CloseHandle(m_fenceEvent);
-    m_residencyManager.Destroy();
+	CloseHandle(m_fenceEvent);
+	m_residencyManager.Destroy();
 }
 
 void D3D12Residency::PopulateCommandList(std::shared_ptr<ManagedCommandList> pManagedCommandList)
 {
-    DXGI_QUERY_VIDEO_MEMORY_INFO memoryInfo = {};
-    ThrowIfFailed(m_adapter->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &memoryInfo));
+	DXGI_QUERY_VIDEO_MEMORY_INFO memoryInfo = {};
+	ThrowIfFailed(m_adapter->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &memoryInfo));
 
-    WCHAR message[200];
-    swprintf_s(message, L"Total Allocated: %llu MB | Budget: %llu MB | Using: %llu MB", m_totalAllocations >> 20, memoryInfo.Budget >> 20, memoryInfo.CurrentUsage >> 20);
-    this->SetCustomWindowText(message);
+	WCHAR message[200];
+	swprintf_s(message, L"Total Allocated: %llu MB | Budget: %llu MB | Using: %llu MB", m_totalAllocations >> 20, memoryInfo.Budget >> 20, memoryInfo.CurrentUsage >> 20);
+	this->SetCustomWindowText(message);
 
-    auto commandList = pManagedCommandList->commandList;
-    ThrowIfFailed(pManagedCommandList->residencySet->Open());
+	auto commandList = pManagedCommandList->commandList;
+	ThrowIfFailed(pManagedCommandList->residencySet->Open());
 
-    // Set necessary state.
-    commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
-    commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
+	commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    commandList->SetGraphicsRootDescriptorTable(0, m_srvHeap->GetGPUDescriptorHandleForHeapStart());
-    commandList->RSSetViewports(1, &m_viewport);
-    commandList->RSSetScissorRects(1, &m_scissorRect);
+	commandList->SetGraphicsRootDescriptorTable(0, m_srvHeap->GetGPUDescriptorHandleForHeapStart());
+	commandList->RSSetViewports(1, &m_viewport);
+	commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
-    commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-    commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+	commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
 
-    // Draw each texture in a thin strip.
-    const UINT texturesPerRow = m_width >> 1;
-    D3D12_VIEWPORT movingViewport = m_viewport;
-    movingViewport.Width = 2.0f;
-    movingViewport.Height = floorf(m_height / ceilf(NumTextures / static_cast<float>(texturesPerRow)));
+	// Draw each texture in a thin strip.
+	const UINT texturesPerRow = m_width >> 1;
+	D3D12_VIEWPORT movingViewport = m_viewport;
+	movingViewport.Width = 2.0f;
+	movingViewport.Height = floorf(m_height / ceilf(NumTextures / static_cast<float>(texturesPerRow)));
 
-    // Only reference as much memory in this command list as the budget allows to
-    // be resident at any given time.
-    UINT64 memoryToUse = UINT64 (float(memoryInfo.Budget) * 0.95f);
-    UINT textureCount = LoadedTextureCount();
-    if (textureCount > 0)
-    {
-        UINT textureIndex = m_textureIndex;
-        UINT64 sizeUsed = 0;
+	// Only reference as much memory in this command list as the budget allows to
+	// be resident at any given time.
+	UINT64 memoryToUse = UINT64 (float(memoryInfo.Budget) * 0.95f);
+	UINT textureCount = LoadedTextureCount();
+	if (textureCount > 0)
+	{
+		UINT textureIndex = m_textureIndex;
+		UINT64 sizeUsed = 0;
 
-        // Draw as many textures as we have available up until we reach our memory
-        // usage budget for the command list.
-        do
-        {
-            auto pTexture = m_loadedTextures[textureIndex];
-            if (pTexture)
-            {
-                CD3DX12_GPU_DESCRIPTOR_HANDLE gpuHandle(m_srvHeap->GetGPUDescriptorHandleForHeapStart(), pTexture->index, m_srvDescriptorSize);
-                commandList->SetGraphicsRootDescriptorTable(0, gpuHandle);
+		// Draw as many textures as we have available up until we reach our memory
+		// usage budget for the command list.
+		do
+		{
+			auto pTexture = m_loadedTextures[textureIndex];
+			if (pTexture)
+			{
+				CD3DX12_GPU_DESCRIPTOR_HANDLE gpuHandle(m_srvHeap->GetGPUDescriptorHandleForHeapStart(), pTexture->index, m_srvDescriptorSize);
+				commandList->SetGraphicsRootDescriptorTable(0, gpuHandle);
 
-                // Indicate that this texture was used in the current command list.
-                pManagedCommandList->residencySet->Insert(&pTexture->trackingHandle);
-                sizeUsed += pTexture->size;
+				// Indicate that this texture was used in the current command list.
+				pManagedCommandList->residencySet->Insert(&pTexture->trackingHandle);
+				sizeUsed += pTexture->size;
 
-                // Position this quad on the render target.
-                UINT x = textureIndex % texturesPerRow;
-                UINT y = textureIndex / texturesPerRow;
-                movingViewport.TopLeftX = x * movingViewport.Width;
-                movingViewport.TopLeftY = y * movingViewport.Height;
-                commandList->RSSetViewports(1, &movingViewport);
-                commandList->DrawInstanced(4, 1, 0, 0);
-            }
+				// Position this quad on the render target.
+				UINT x = textureIndex % texturesPerRow;
+				UINT y = textureIndex / texturesPerRow;
+				movingViewport.TopLeftX = x * movingViewport.Width;
+				movingViewport.TopLeftY = y * movingViewport.Height;
+				commandList->RSSetViewports(1, &movingViewport);
+				commandList->DrawInstanced(4, 1, 0, 0);
+			}
 
-            textureIndex = (textureIndex + 1) % textureCount;
+			textureIndex = (textureIndex + 1) % textureCount;
 
-        } while (sizeUsed < memoryToUse && textureIndex != m_textureIndex);
+		} while (sizeUsed < memoryToUse && textureIndex != m_textureIndex);
 
-        // Once we have more textures loaded that we have budget to draw at a time,
-        // move the window of textures drawn.
-        if (textureIndex != m_textureIndex)
-        {
-            m_textureIndex = (m_textureIndex + 1) % textureCount;
-        }
-    }
+		// Once we have more textures loaded that we have budget to draw at a time,
+		// move the window of textures drawn.
+		if (textureIndex != m_textureIndex)
+		{
+			m_textureIndex = (m_textureIndex + 1) % textureCount;
+		}
+	}
 
-    // Indicate that the back buffer will now be used to present.
-    commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(commandList->Close());
-    ThrowIfFailed(pManagedCommandList->residencySet->Close());
+	ThrowIfFailed(commandList->Close());
+	ThrowIfFailed(pManagedCommandList->residencySet->Close());
 }
 
 void D3D12Residency::FlushGpu()
 {
-    // Signal and increment the fence value.
-    const UINT64 fence = m_fenceValue;
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
-    m_fenceValue++;
+	// Signal and increment the fence value.
+	const UINT64 fence = m_fenceValue;
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), fence));
+	m_fenceValue++;
 
-    // Wait until the fence has been completed.
-    if (m_fence->GetCompletedValue() < fence)
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
-        WaitForSingleObject(m_fenceEvent, INFINITE);
-    }
+	// Wait until the fence has been completed.
+	if (m_fence->GetCompletedValue() < fence)
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(fence, m_fenceEvent));
+		WaitForSingleObject(m_fenceEvent, INFINITE);
+	}
 }

--- a/Samples/UWP/D3D12Residency/src/D3D12Residency.h
+++ b/Samples/UWP/D3D12Residency/src/D3D12Residency.h
@@ -27,118 +27,118 @@ using Microsoft::WRL::ComPtr;
 class D3D12Residency : public DXSample
 {
 public:
-    D3D12Residency(UINT width, UINT height, std::wstring name);
+	D3D12Residency(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
 
 private:
-    static const UINT FrameCount = 3;
-    static const UINT TextureWidth = 512;
-    static const UINT TextureHeight = 512;
-    static const UINT TexturePixelSize = 4;    // The number of bytes used to represent a pixel in the texture.
+	static const UINT FrameCount = 3;
+	static const UINT TextureWidth = 512;
+	static const UINT TextureHeight = 512;
+	static const UINT TexturePixelSize = 4;	// The number of bytes used to represent a pixel in the texture.
 
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT2 uv;
-    };
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT2 uv;
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGIAdapter3> m_adapter;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_srvHeap;
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    UINT m_rtvDescriptorSize;
-    UINT m_srvDescriptorSize;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGIAdapter3> m_adapter;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_srvHeap;
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	UINT m_rtvDescriptorSize;
+	UINT m_srvDescriptorSize;
 
-    // App resources.
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	// App resources.
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
 
-    // Synchronization objects.
-    UINT m_frameIndex;
-    HANDLE m_fenceEvent;
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValue;
+	// Synchronization objects.
+	UINT m_frameIndex;
+	HANDLE m_fenceEvent;
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValue;
 
-    // Resource residency management.
-    static const UINT NumTextures = 1024 * 8;                // Should make for ~8GB of VRAM.
-    static const UINT CommandListSubmissionsPerFrame = 1;
-    static const UINT MaxResidencyLatency = FrameCount * CommandListSubmissionsPerFrame;
+	// Resource residency management.
+	static const UINT NumTextures = 1024 * 8;				// Should make for ~8GB of VRAM.
+	static const UINT CommandListSubmissionsPerFrame = 1;
+	static const UINT MaxResidencyLatency = FrameCount * CommandListSubmissionsPerFrame;
 
-    struct ManagedCommandList
-    {
-        ComPtr<ID3D12CommandAllocator> commandAllocator;
-        ComPtr<ID3D12GraphicsCommandList> commandList;
-        std::shared_ptr<D3DX12Residency::ResidencySet> residencySet;    // The set of resources that must be resident on the GPU to render this command list.
-        UINT64 fenceValue = 0;
-    };
+	struct ManagedCommandList
+	{
+		ComPtr<ID3D12CommandAllocator> commandAllocator;
+		ComPtr<ID3D12GraphicsCommandList> commandList;
+		std::shared_ptr<D3DX12Residency::ResidencySet> residencySet;	// The set of resources that must be resident on the GPU to render this command list.
+		UINT64 fenceValue = 0;
+	};
 
-    struct ManagedTexture
-    {
-        ComPtr<ID3D12Resource> texture;                        // The D3D12 texture resource that will be managed by the residency library.
-        D3DX12Residency::ManagedObject trackingHandle;        // The residency library works in units of ManagedObjects. They can be treated opaquely like a handle.
-        UINT64 size = 0;
-        UINT index = 0;
-    };
+	struct ManagedTexture
+	{
+		ComPtr<ID3D12Resource> texture;						// The D3D12 texture resource that will be managed by the residency library.
+		D3DX12Residency::ManagedObject trackingHandle;		// The residency library works in units of ManagedObjects. They can be treated opaquely like a handle.
+		UINT64 size = 0;
+		UINT index = 0;
+	};
 
-    UINT64 m_totalAllocations;
-    UINT m_textureIndex;
-    D3DX12Residency::ResidencyManager m_residencyManager;
-    std::queue<std::shared_ptr<ManagedCommandList>> m_commandListPool;
+	UINT64 m_totalAllocations;
+	UINT m_textureIndex;
+	D3DX12Residency::ResidencyManager m_residencyManager;
+	std::queue<std::shared_ptr<ManagedCommandList>> m_commandListPool;
 
-    // Thread and texture loading management.
-    std::vector<std::future<void>> m_threads;
-    bool m_cancel;
-    std::mutex m_mutex;
-    std::queue<std::shared_ptr<ManagedTexture>> m_incompleteTextures;    // Textures that are not initialized yet.
-    std::vector<std::shared_ptr<ManagedTexture>> m_loadedTextures;        // Textures that are ready to be used.
-    UINT m_loadedTextureCount;
+	// Thread and texture loading management.
+	std::vector<std::future<void>> m_threads;
+	bool m_cancel;
+	std::mutex m_mutex;
+	std::queue<std::shared_ptr<ManagedTexture>> m_incompleteTextures;	// Textures that are not initialized yet.
+	std::vector<std::shared_ptr<ManagedTexture>> m_loadedTextures;		// Textures that are ready to be used.
+	UINT m_loadedTextureCount;
 
-    inline std::shared_ptr<ManagedTexture> GetNextIncompleteTexture()
-    {
-        std::lock_guard<std::mutex> lock(m_mutex);
+	inline std::shared_ptr<ManagedTexture> GetNextIncompleteTexture()
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 
-        if (m_incompleteTextures.size() == 0)
-        {
-            return nullptr;
-        }
-        else
-        {
-            auto pTexture = m_incompleteTextures.front();
-            m_incompleteTextures.pop();
-            return pTexture;
-        }
-    }
+		if (m_incompleteTextures.size() == 0)
+		{
+			return nullptr;
+		}
+		else
+		{
+			auto pTexture = m_incompleteTextures.front();
+			m_incompleteTextures.pop();
+			return pTexture;
+		}
+	}
 
-    inline void StoreCompletedTexture(std::shared_ptr<ManagedTexture> pTexture)
-    {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        m_loadedTextures[pTexture->index] = pTexture;
-        m_loadedTextureCount++;
-    }
+	inline void StoreCompletedTexture(std::shared_ptr<ManagedTexture> pTexture)
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		m_loadedTextures[pTexture->index] = pTexture;
+		m_loadedTextureCount++;
+	}
 
-    inline UINT LoadedTextureCount()
-    {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        return m_loadedTextureCount;
-    }
+	inline UINT LoadedTextureCount()
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		return m_loadedTextureCount;
+	}
 
-    void LoadPipeline();
-    void LoadAssets();
-    void LoadTexturesAsync();
-    void PopulateCommandList(std::shared_ptr<ManagedCommandList> pManagedCommandList);
-    void FlushGpu();
+	void LoadPipeline();
+	void LoadAssets();
+	void LoadTexturesAsync();
+	void PopulateCommandList(std::shared_ptr<ManagedCommandList> pManagedCommandList);
+	void FlushGpu();
 };

--- a/Samples/UWP/D3D12Residency/src/DXSample.cpp
+++ b/Samples/UWP/D3D12Residency/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,59 +34,104 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
-    auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(windowText.c_str());
+	std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
+	auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/UWP/D3D12Residency/src/DXSample.h
+++ b/Samples/UWP/D3D12Residency/src/DXSample.h
@@ -16,42 +16,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/UWP/D3D12Residency/src/Main.cpp
+++ b/Samples/UWP/D3D12Residency/src/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12Residency sample(1200, 900, L"");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12Residency sample(1200, 900, L"");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12Residency/src/View.cpp
+++ b/Samples/UWP/D3D12Residency/src/View.cpp
@@ -15,27 +15,27 @@
 using namespace Windows::Foundation;
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -44,20 +44,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -66,26 +66,26 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnClosed(CoreWindow^ /*sender*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }

--- a/Samples/UWP/D3D12Residency/src/View.h
+++ b/Samples/UWP/D3D12Residency/src/View.h
@@ -23,20 +23,20 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
+	DXSample* m_pSample;
+	bool m_windowClosed;
 };

--- a/Samples/UWP/D3D12Residency/src/ViewProvider.cpp
+++ b/Samples/UWP/D3D12Residency/src/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12Residency/src/ViewProvider.h
+++ b/Samples/UWP/D3D12Residency/src/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12Residency/src/d3dx12.h
+++ b/Samples/UWP/D3D12Residency/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12Residency/src/d3dx12Residency.h
+++ b/Samples/UWP/D3D12Residency/src/d3dx12Residency.h
@@ -12,14 +12,14 @@
 #pragma once
 namespace D3DX12Residency
 {
-    __declspec(selectany) INT64 g_ResidencyManagerUniqueID = 0;
+	__declspec(selectany) INT64 g_ResidencyManagerUniqueID = 0;
 
 #if 0
 #define RESIDENCY_CHECK(x) \
-    if((x) == false) { DebugBreak(); }
+	if((x) == false) { DebugBreak(); }
 
 #define RESIDENCY_CHECK_RESULT(x) \
-    if((x) != S_OK) { DebugBreak(); }
+	if((x) != S_OK) { DebugBreak(); }
 #else
 #define RESIDENCY_CHECK(x)
 #define RESIDENCY_CHECK_RESULT(x) x
@@ -30,1486 +30,1486 @@ namespace D3DX12Residency
 #define RESIDENCY_MIN(x,y) ((x) < (y) ? (x) : (y))
 #define RESIDENCY_MAX(x,y) ((x) > (y) ? (x) : (y))
 
-    // This size can be tuned to your app in order to save space
+	// This size can be tuned to your app in order to save space
 #define MAX_NUM_CONCURRENT_CMD_LISTS 32
 
-    namespace Internal
-    {
-        class CriticalSection
-        {
-            friend class ScopedLock;
-        public:
-            CriticalSection()
-            {
-                InitializeCriticalSectionAndSpinCount(&CS, 8);
-            }
-
-            ~CriticalSection()
-            {
-                DeleteCriticalSection(&CS);
-            }
-
-        private:
-            CRITICAL_SECTION CS;
-        };
-
-        class ScopedLock
-        {
-        public:
-
-            ScopedLock() : pCS(nullptr) {};
-            ScopedLock(CriticalSection* pCSIn) : pCS(pCSIn)
-            {
-                if (pCS)
-                {
-                    EnterCriticalSection(&pCS->CS);
-                }
-            };
-
-            ~ScopedLock()
-            {
-                if (pCS)
-                {
-                    LeaveCriticalSection(&pCS->CS);
-                }
-            }
-
-        private:
-
-            CriticalSection* pCS;
-        };
-
-        // One per Residency Manager
-        class SyncManager
-        {
-        public:
-            SyncManager()
-            {
-                for (UINT32 i = 0; i < ARRAYSIZE(AvailableCommandLists); i++)
-                {
-                    AvailableCommandLists[i] = false;
-                }
-            }
-
-            Internal::CriticalSection MaskCriticalSection;
-
-            static const UINT32 sUnsetValue = UINT32(-1);
-            // Represents which command lists are currently open for recording
-            bool AvailableCommandLists[MAX_NUM_CONCURRENT_CMD_LISTS];
-        };
-
-        //Forward Declaration
-        class ResidencyManagerInternal;
-    }
-
-    // Used to track meta data for each object the app potentially wants
-    // to make resident or evict.
-    class ManagedObject
-    {
-    public:
-        enum class RESIDENCY_STATUS
-        {
-            RESIDENT,
-            EVICTED
-        };
-
-        ManagedObject() :
-            pUnderlying(nullptr),
-            Size(0),
-            ResidencyStatus(RESIDENCY_STATUS::RESIDENT),
-            LastGPUSyncPoint(0),
-            LastUsedTimestamp(0)
-        {
-            memset(CommandListsUsedOn, 0, sizeof(CommandListsUsedOn));
-        }
-
-        void Initialize(ID3D12Pageable* pUnderlyingIn, UINT64 ObjectSize, UINT64 InitialGPUSyncPoint = 0)
-        {
-            RESIDENCY_CHECK(pUnderlying == nullptr);
-            pUnderlying = pUnderlyingIn;
-            Size = ObjectSize;
-            LastGPUSyncPoint = InitialGPUSyncPoint;
-        }
-
-        inline bool IsInitialized() { return pUnderlying != nullptr; }
-
-        // Wether the object is resident or not
-        RESIDENCY_STATUS ResidencyStatus;
-
-        // The underlying D3D Object being tracked
-        ID3D12Pageable* pUnderlying;
-        // The size of the D3D Object in bytes
-        UINT64 Size;
-
-        UINT64 LastGPUSyncPoint;
-        UINT64 LastUsedTimestamp;
-
-        // This is used to track which open command lists this resource is currently used on.
-        bool CommandListsUsedOn[MAX_NUM_CONCURRENT_CMD_LISTS];
-
-        // Linked list entry
-        LIST_ENTRY ListEntry;
-    };
-
-    // This represents a set of objects which are referenced by a command list i.e. every time a resource
-    // is bound for rendering, clearing, copy etc. the set must be updated to ensure the it is resident 
-    // for execution.
-    class ResidencySet
-    {
-        friend class ResidencyManager;
-        friend class Internal::ResidencyManagerInternal;
-    public:
-
-        static const UINT32 InvalidIndex = (UINT32)-1;
-
-        ResidencySet() :
-            CommandListIndex(InvalidIndex),
-            MaxResidencySetSize(0),
-            CurrentSetSize(0),
-            ppSet(nullptr),
-            IsOpen(false),
-            OutOfMemory(false),
-            pSyncManager(nullptr)
-        {
-        };
-
-        ~ResidencySet()
-        {
-            delete[](ppSet);
-        }
-
-        // Returns true if the object was inserted, false otherwise
-        inline bool Insert(ManagedObject* pObject)
-        {
-            RESIDENCY_CHECK(IsOpen);
-            RESIDENCY_CHECK(CommandListIndex != InvalidIndex);
-
-            // If we haven't seen this object on this command list mark it
-            if (pObject->CommandListsUsedOn[CommandListIndex] == false)
-            {
-                pObject->CommandListsUsedOn[CommandListIndex] = true;
-                if (ppSet == nullptr || CurrentSetSize >= MaxResidencySetSize)
-                {
-                    Realloc();
-                }
-                if (ppSet == nullptr)
-                {
-                    OutOfMemory = true;
-                    return false;
-                }
-
-                ppSet[CurrentSetSize++] = pObject;
-
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-
-        HRESULT Open()
-        {
-            Internal::ScopedLock Lock(&pSyncManager->MaskCriticalSection);
-
-            // It's invalid to open a set that is already open
-            if (IsOpen)
-            {
-                return E_INVALIDARG;
-            }
-
-            RESIDENCY_CHECK(CommandListIndex == InvalidIndex);
-
-            bool CommandlistAvailable = false;
-            // Find the first available command list by bitscanning
-            for (UINT32 i = 0; i < ARRAYSIZE(pSyncManager->AvailableCommandLists); i++)
-            {
-                if (pSyncManager->AvailableCommandLists[i] == false)
-                {
-                    CommandListIndex = i;
-                    pSyncManager->AvailableCommandLists[i] = true;
-                    CommandlistAvailable = true;
-                    break;
-                }
-            }
-
-            if (CommandlistAvailable == false)
-            {
-                // There are too many open residency sets, consider using less or increasing the value of MAX_NUM_CONCURRENT_CMD_LISTS
-                RESIDENCY_CHECK(false);
-                return E_OUTOFMEMORY;
-            }
-
-            CurrentSetSize = 0;
-
-            IsOpen = true;
-            OutOfMemory = false;
-            return S_OK;
-        }
-
-        HRESULT Close()
-        {
-            if (IsOpen == false)
-            {
-                return E_INVALIDARG;
-            }
-
-            if (OutOfMemory == true)
-            {
-                return E_OUTOFMEMORY;
-            }
-
-            for (INT32 i = 0; i < CurrentSetSize; i++)
-            {
-                Remove(ppSet[i]);
-            }
-
-            ReturnCommandListReservation();
-
-            IsOpen = false;
-
-            return S_OK;
-        }
-
-    private:
-
-        inline void Remove(ManagedObject* pObject)
-        {
-            pObject->CommandListsUsedOn[CommandListIndex] = false;
-        }
-
-        inline void ReturnCommandListReservation()
-        {
-            Internal::ScopedLock Lock(&pSyncManager->MaskCriticalSection);
-
-            pSyncManager->AvailableCommandLists[CommandListIndex] = false;
-
-            CommandListIndex = ResidencySet::InvalidIndex;
-
-            IsOpen = false;
-        }
-
-        void Initialize(Internal::SyncManager* pSyncManagerIn)
-        {
-            pSyncManager = pSyncManagerIn;
-        }
-
-        bool Initialize(Internal::SyncManager* pSyncManagerIn, UINT32 MaxSize)
-        {
-            pSyncManager = pSyncManagerIn;
-            MaxResidencySetSize = MaxSize;
-
-            ppSet = new ManagedObject*[MaxResidencySetSize];
-
-            return ppSet != nullptr;
-        }
-
-        inline void Realloc()
-        {
-            MaxResidencySetSize = (MaxResidencySetSize == 0) ? 4096 : INT32(MaxResidencySetSize + (MaxResidencySetSize / 2.0f));
-            ManagedObject** ppNewAlloc = new ManagedObject*[MaxResidencySetSize];
-
-            if (ppSet && ppNewAlloc)
-            {
-                memcpy(ppNewAlloc, ppSet, CurrentSetSize * sizeof(ManagedObject*));
-                delete[](ppSet);
-            }
-
-            ppSet = ppNewAlloc;
-        }
-
-        UINT32 CommandListIndex;
-
-        ManagedObject** ppSet;
-        INT32 MaxResidencySetSize;
-        INT32 CurrentSetSize;
-
-        bool IsOpen;
-        bool OutOfMemory;
-
-        Internal::SyncManager* pSyncManager;
-    };
-
-    namespace Internal
-    {
-        /* List Helpers */
-        inline void InitializeListHead(LIST_ENTRY* pHead)
-        {
-            pHead->Flink = pHead->Blink = pHead;
-        }
-
-        inline void InsertHeadList(LIST_ENTRY* pHead, LIST_ENTRY* pEntry)
-        {
-            pEntry->Blink = pHead;
-            pEntry->Flink = pHead->Flink;
-
-            pHead->Flink->Blink = pEntry;
-            pHead->Flink = pEntry;
-        }
-
-        inline void InsertTailList(LIST_ENTRY* pHead, LIST_ENTRY* pEntry)
-        {
-            pEntry->Flink = pHead;
-            pEntry->Blink = pHead->Blink;
-
-            pHead->Blink->Flink = pEntry;
-            pHead->Blink = pEntry;
-        }
-
-        inline void RemoveEntryList(LIST_ENTRY* pEntry)
-        {
-            pEntry->Blink->Flink = pEntry->Flink;
-            pEntry->Flink->Blink = pEntry->Blink;
-        }
-
-        inline LIST_ENTRY* RemoveHeadList(LIST_ENTRY* pHead)
-        {
-            LIST_ENTRY* pEntry = pHead->Flink;
-            Internal::RemoveEntryList(pEntry);
-            return pEntry;
-        }
-
-        inline LIST_ENTRY* RemoveTailList(LIST_ENTRY* pHead)
-        {
-            LIST_ENTRY* pEntry = pHead->Blink;
-            Internal::RemoveEntryList(pEntry);
-            return pEntry;
-        }
-
-        inline bool IsListEmpty(LIST_ENTRY* pEntry)
-        {
-            return pEntry->Flink == pEntry;
-        }
-
-        struct Fence
-        {
-            Fence(UINT64 StartingValue) : pFence(nullptr), FenceValue(StartingValue)
-            {
-                Internal::InitializeListHead(&ListEntry);
-            };
-
-            HRESULT Initialize(ID3D12Device* pDevice)
-            {
-                HRESULT hr = pDevice->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&pFence));
-                RESIDENCY_CHECK_RESULT(hr);
-
-                return hr;
-            }
-
-            void Destroy()
-            {
-                if (pFence)
-                {
-                    pFence->Release();
-                    pFence = nullptr;
-                }
-            }
-
-            HRESULT GPUWait(ID3D12CommandQueue* pQueue)
-            {
-                HRESULT hr = pQueue->Wait(pFence, FenceValue);
-                RESIDENCY_CHECK_RESULT(hr);
-                return hr;
-            }
-
-            HRESULT GPUSignal(ID3D12CommandQueue* pQueue)
-            {
-                HRESULT hr = pQueue->Signal(pFence, FenceValue);
-                RESIDENCY_CHECK_RESULT(hr);
-                return hr;
-            }
-
-            inline void Increment()
-            {
-                FenceValue++;
-            }
-
-            ID3D12Fence* pFence;
-            UINT64 FenceValue;
-            LIST_ENTRY ListEntry;
-        };
-
-        // Represents a time on a particular queue that a resource was used
-        struct QueueSyncPoint
-        {
-            QueueSyncPoint() : pFence(nullptr), LastUsedValue(0) {};
-
-            inline bool IsCompleted() { return LastUsedValue <= pFence->pFence->GetCompletedValue(); }
-
-            inline void WaitForCompletion(HANDLE Event)
-            {
-                RESIDENCY_CHECK_RESULT(pFence->pFence->SetEventOnCompletion(LastUsedValue, Event));
-                RESIDENCY_CHECK_RESULT(WaitForSingleObject(Event, INFINITE));
-            }
-
-            Fence* pFence;
-            UINT64 LastUsedValue;
-        };
-
-        struct DeviceWideSyncPoint
-        {
-            DeviceWideSyncPoint(UINT32 NumQueues, UINT64 Generation) :
-                GenerationID(Generation), NumQueueSyncPoints(NumQueues) {};
-
-            // Create the whole structure in one allocation for locality
-            static DeviceWideSyncPoint* CreateSyncPoint(UINT32 NumQueues, UINT64 Generation)
-            {
-                DeviceWideSyncPoint* pSyncPoint = nullptr;
-                const SIZE_T Size = sizeof(DeviceWideSyncPoint) + (sizeof(QueueSyncPoint) * (NumQueues - 1));
-
-                BYTE* pAlloc = new BYTE[Size];
-                if (pAlloc && Size >= sizeof(DeviceWideSyncPoint))
-                {
-                    pSyncPoint = new (pAlloc) DeviceWideSyncPoint(NumQueues, Generation);
-                }
-
-                return pSyncPoint;
-            }
-
-            // A device wide fence is completed if all of the queues that were active at that point are completed
-            inline bool IsCompleted()
-            {
-                for (UINT32 i = 0; i < NumQueueSyncPoints; i++)
-                {
-                    if (pQueueSyncPoints[i].IsCompleted() == false)
-                    {
-                        return false;
-                    }
-                }
-                return true;
-            }
-
-            inline void WaitForCompletion(HANDLE Event)
-            {
-                for (UINT32 i = 0; i < NumQueueSyncPoints; i++)
-                {
-                    if (pQueueSyncPoints[i].IsCompleted() == false)
-                    {
-                        pQueueSyncPoints[i].WaitForCompletion(Event);
-                    }
-                }
-            }
-
-            const UINT64 GenerationID;
-            const UINT32 NumQueueSyncPoints;
-            LIST_ENTRY ListEntry;
-            // NumQueueSyncPoints QueueSyncPoints will be placed below here
-            QueueSyncPoint pQueueSyncPoints[1];
-        };
-
-        // A Least Recently Used Cache. Tracks all of the objects requested by the app so that objects
-        // that aren't used freqently can get evicted to help the app stay under buget.
-        class LRUCache
-        {
-        public:
-            LRUCache() :
-                NumResidentObjects(0),
-                NumEvictedObjects(0),
-                ResidentSize(0)
-            {
-                Internal::InitializeListHead(&ResidentObjectListHead);
-                Internal::InitializeListHead(&EvictedObjectListHead);
-            };
-
-            void Insert(ManagedObject* pObject)
-            {
-                if (pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT)
-                {
-                    Internal::InsertHeadList(&ResidentObjectListHead, &pObject->ListEntry);
-                    NumResidentObjects++;
-                    ResidentSize += pObject->Size;
-                }
-                else
-                {
-                    Internal::InsertHeadList(&EvictedObjectListHead, &pObject->ListEntry);
-                    NumEvictedObjects++;
-                }
-            }
-
-            void Remove(ManagedObject* pObject)
-            {
-                Internal::RemoveEntryList(&pObject->ListEntry);
-                if (pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT)
-                {
-                    NumResidentObjects--;
-                    ResidentSize -= pObject->Size;
-                }
-                else
-                {
-                    NumEvictedObjects--;
-                }
-            }
-
-            // When an object is used by the GPU we move it to the end of the list.
-            // This way things closer to the head of the list are the objects which
-            // are stale and better candidates for eviction
-            void ObjectReferenced(ManagedObject* pObject)
-            {
-                RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT);
-
-                Internal::RemoveEntryList(&pObject->ListEntry);
-                Internal::InsertTailList(&ResidentObjectListHead, &pObject->ListEntry);
-            }
-
-            void MakeResident(ManagedObject* pObject)
-            {
-                RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::EVICTED);
-
-                pObject->ResidencyStatus = ManagedObject::RESIDENCY_STATUS::RESIDENT;
-                Internal::RemoveEntryList(&pObject->ListEntry);
-                Internal::InsertTailList(&ResidentObjectListHead, &pObject->ListEntry);
-
-                NumEvictedObjects--;
-                NumResidentObjects++;
-                ResidentSize += pObject->Size;
-            }
-
-            void Evict(ManagedObject* pObject)
-            {
-                RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT);
-
-                pObject->ResidencyStatus = ManagedObject::RESIDENCY_STATUS::EVICTED;
-                Internal::RemoveEntryList(&pObject->ListEntry);
-                Internal::InsertTailList(&EvictedObjectListHead, &pObject->ListEntry);
-
-                NumResidentObjects--;
-                ResidentSize -= pObject->Size;
-                NumEvictedObjects++;
-            }
-
-            // Evict all of the resident objects used in sync points up to the specficied one (inclusive)
-            void TrimToSyncPointInclusive(INT64 CurrentUsage, INT64 CurrentBudget, ID3D12Pageable** EvictionList, UINT32& NumObjectsToEvict, UINT64 SyncPoint)
-            {
-                NumObjectsToEvict = 0;
-
-                LIST_ENTRY* pResourceEntry = ResidentObjectListHead.Flink;
-                while (pResourceEntry != &ResidentObjectListHead)
-                {
-                    ManagedObject* pObject = CONTAINING_RECORD(pResourceEntry, ManagedObject, ListEntry);
-
-                    if (pObject->LastGPUSyncPoint > SyncPoint || CurrentUsage < CurrentBudget)
-                    {
-                        break;
-                    }
-
-                    RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT);
-
-                    EvictionList[NumObjectsToEvict++] = pObject->pUnderlying;
-                    Evict(pObject);
-
-                    CurrentUsage -= pObject->Size;
-
-                    pResourceEntry = ResidentObjectListHead.Flink;
-                }
-            }
-
-            // Trim all objects which are older than the specified time
-            void TrimAgedAllocations(DeviceWideSyncPoint* MaxSyncPoint, ID3D12Pageable** EvictionList, UINT32& NumObjectsToEvict, UINT64 CurrentTimeStamp, UINT64 MinDelta)
-            {
-                LIST_ENTRY* pResourceEntry = ResidentObjectListHead.Flink;
-                while (pResourceEntry != &ResidentObjectListHead)
-                {
-                    ManagedObject* pObject = CONTAINING_RECORD(pResourceEntry, ManagedObject, ListEntry);
-
-                    if ((MaxSyncPoint && pObject->LastGPUSyncPoint >= MaxSyncPoint->GenerationID) || // Only trim allocations done on the GPU
-                        CurrentTimeStamp - pObject->LastUsedTimestamp <= MinDelta) // Don't evict things which have been used recently
-                    {
-                        break;
-                    }
-
-                    RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT);
-                    EvictionList[NumObjectsToEvict++] = pObject->pUnderlying;
-                    Evict(pObject);
-
-                    pResourceEntry = ResidentObjectListHead.Flink;
-                }
-            }
-
-            ManagedObject* GetResidentListHead()
-            {
-                if (IsListEmpty(&ResidentObjectListHead))
-                {
-                    return nullptr;
-                }
-                return CONTAINING_RECORD(ResidentObjectListHead.Flink, ManagedObject, ListEntry);
-            }
-
-            LIST_ENTRY ResidentObjectListHead;
-            LIST_ENTRY EvictedObjectListHead;
-
-            UINT32 NumResidentObjects;
-            UINT32 NumEvictedObjects;
-
-            UINT64 ResidentSize;
-        };
-
-        class ResidencyManagerInternal
-        {
-        public:
-            ResidencyManagerInternal(SyncManager* pSyncManagerIn) :
-                Device(nullptr),
-                AsyncThreadFence(1),
-                CompletionEvent(INVALID_HANDLE_VALUE),
-                AsyncThreadWorkCompletionEvent(INVALID_HANDLE_VALUE),
-                Adapter(nullptr),
-                AsyncWorkEvent(INVALID_HANDLE_VALUE),
-                AsyncWorkThread(INVALID_HANDLE_VALUE),
-                FinishAsyncWork(false),
-                cStartEvicted(false),
-                CurrentSyncPointGeneration(0),
-                NumQueuesSeen(0),
-                NodeIndex(0),
-                CurrentAsyncWorkloadHead(0),
-                CurrentAsyncWorkloadTail(0),
-                cMinEvictionGracePeriod(1.0f),
-                cMaxEvictionGracePeriod(60.0f),
-                cTrimPercentageMemoryUsageThreshold(0.7f),
-                AsyncWorkQueue(nullptr),
-                MaxSoftwareQueueLatency(6),
-                AsyncWorkQueueSize(7),
-                pSyncManager(pSyncManagerIn)
-            {
-                Internal::InitializeListHead(&QueueFencesListHead);
-                Internal::InitializeListHead(&InFlightSyncPointsHead);
-
-                ResidencyManagerUniqueID = InterlockedIncrement64(&g_ResidencyManagerUniqueID);
-            };
-
-            // NOTE: DeviceNodeIndex is an index not a mask. The majority of D3D12 uses bit masks to identify a GPU node whereas DXGI uses 0 based indices.
-            HRESULT Initialize(ID3D12Device* ParentDevice, UINT DeviceNodeIndex, IDXGIAdapter3* ParentAdapter, UINT32 MaxLatency)
-            {
-                Device = ParentDevice;
-                NodeIndex = DeviceNodeIndex;
-                Adapter = ParentAdapter;
-                MaxSoftwareQueueLatency = MaxLatency;
-
-                AsyncWorkQueueSize = MaxLatency + 1;
-                AsyncWorkQueue = new AsyncWorkload[AsyncWorkQueueSize];
-
-                if (AsyncWorkQueue == nullptr)
-                {
-                    return E_OUTOFMEMORY;
-                }
-
-                LARGE_INTEGER Frequency;
-                QueryPerformanceFrequency(&Frequency);
-
-                // Calculate how many QPC ticks are equivalent to the given time in seconds
-                MinEvictionGracePeriodTicks = UINT64(Frequency.QuadPart * cMinEvictionGracePeriod);
-                MaxEvictionGracePeriodTicks = UINT64(Frequency.QuadPart * cMaxEvictionGracePeriod);
-
-                HRESULT hr = S_OK;
-                hr = AsyncThreadFence.Initialize(Device);
-
-                if (SUCCEEDED(hr))
-                {
-                    CompletionEvent = CreateEvent(nullptr, false, false, nullptr);
-                    if (CompletionEvent == INVALID_HANDLE_VALUE)
-                    {
-                        hr = HRESULT_FROM_WIN32(GetLastError());
-                    }
-                }
-
-                if (SUCCEEDED(hr))
-                {
-                    AsyncThreadWorkCompletionEvent = CreateEvent(nullptr, false, false, nullptr);
-                    if (AsyncThreadWorkCompletionEvent == INVALID_HANDLE_VALUE)
-                    {
-                        hr = HRESULT_FROM_WIN32(GetLastError());
-                    }
-                }
-
-                if (SUCCEEDED(hr))
-                {
-                    AsyncWorkEvent = CreateEvent(nullptr, true, false, nullptr);
-                    if (AsyncWorkEvent == INVALID_HANDLE_VALUE)
-                    {
-                        hr = HRESULT_FROM_WIN32(GetLastError());
-                    }
-                }
+	namespace Internal
+	{
+		class CriticalSection
+		{
+			friend class ScopedLock;
+		public:
+			CriticalSection()
+			{
+				InitializeCriticalSectionAndSpinCount(&CS, 8);
+			}
+
+			~CriticalSection()
+			{
+				DeleteCriticalSection(&CS);
+			}
+
+		private:
+			CRITICAL_SECTION CS;
+		};
+
+		class ScopedLock
+		{
+		public:
+
+			ScopedLock() : pCS(nullptr) {};
+			ScopedLock(CriticalSection* pCSIn) : pCS(pCSIn)
+			{
+				if (pCS)
+				{
+					EnterCriticalSection(&pCS->CS);
+				}
+			};
+
+			~ScopedLock()
+			{
+				if (pCS)
+				{
+					LeaveCriticalSection(&pCS->CS);
+				}
+			}
+
+		private:
+
+			CriticalSection* pCS;
+		};
+
+		// One per Residency Manager
+		class SyncManager
+		{
+		public:
+			SyncManager()
+			{
+				for (UINT32 i = 0; i < ARRAYSIZE(AvailableCommandLists); i++)
+				{
+					AvailableCommandLists[i] = false;
+				}
+			}
+
+			Internal::CriticalSection MaskCriticalSection;
+
+			static const UINT32 sUnsetValue = UINT32(-1);
+			// Represents which command lists are currently open for recording
+			bool AvailableCommandLists[MAX_NUM_CONCURRENT_CMD_LISTS];
+		};
+
+		//Forward Declaration
+		class ResidencyManagerInternal;
+	}
+
+	// Used to track meta data for each object the app potentially wants
+	// to make resident or evict.
+	class ManagedObject
+	{
+	public:
+		enum class RESIDENCY_STATUS
+		{
+			RESIDENT,
+			EVICTED
+		};
+
+		ManagedObject() :
+			pUnderlying(nullptr),
+			Size(0),
+			ResidencyStatus(RESIDENCY_STATUS::RESIDENT),
+			LastGPUSyncPoint(0),
+			LastUsedTimestamp(0)
+		{
+			memset(CommandListsUsedOn, 0, sizeof(CommandListsUsedOn));
+		}
+
+		void Initialize(ID3D12Pageable* pUnderlyingIn, UINT64 ObjectSize, UINT64 InitialGPUSyncPoint = 0)
+		{
+			RESIDENCY_CHECK(pUnderlying == nullptr);
+			pUnderlying = pUnderlyingIn;
+			Size = ObjectSize;
+			LastGPUSyncPoint = InitialGPUSyncPoint;
+		}
+
+		inline bool IsInitialized() { return pUnderlying != nullptr; }
+
+		// Wether the object is resident or not
+		RESIDENCY_STATUS ResidencyStatus;
+
+		// The underlying D3D Object being tracked
+		ID3D12Pageable* pUnderlying;
+		// The size of the D3D Object in bytes
+		UINT64 Size;
+
+		UINT64 LastGPUSyncPoint;
+		UINT64 LastUsedTimestamp;
+
+		// This is used to track which open command lists this resource is currently used on.
+		bool CommandListsUsedOn[MAX_NUM_CONCURRENT_CMD_LISTS];
+
+		// Linked list entry
+		LIST_ENTRY ListEntry;
+	};
+
+	// This represents a set of objects which are referenced by a command list i.e. every time a resource
+	// is bound for rendering, clearing, copy etc. the set must be updated to ensure the it is resident 
+	// for execution.
+	class ResidencySet
+	{
+		friend class ResidencyManager;
+		friend class Internal::ResidencyManagerInternal;
+	public:
+
+		static const UINT32 InvalidIndex = (UINT32)-1;
+
+		ResidencySet() :
+			CommandListIndex(InvalidIndex),
+			MaxResidencySetSize(0),
+			CurrentSetSize(0),
+			ppSet(nullptr),
+			IsOpen(false),
+			OutOfMemory(false),
+			pSyncManager(nullptr)
+		{
+		};
+
+		~ResidencySet()
+		{
+			delete[](ppSet);
+		}
+
+		// Returns true if the object was inserted, false otherwise
+		inline bool Insert(ManagedObject* pObject)
+		{
+			RESIDENCY_CHECK(IsOpen);
+			RESIDENCY_CHECK(CommandListIndex != InvalidIndex);
+
+			// If we haven't seen this object on this command list mark it
+			if (pObject->CommandListsUsedOn[CommandListIndex] == false)
+			{
+				pObject->CommandListsUsedOn[CommandListIndex] = true;
+				if (ppSet == nullptr || CurrentSetSize >= MaxResidencySetSize)
+				{
+					Realloc();
+				}
+				if (ppSet == nullptr)
+				{
+					OutOfMemory = true;
+					return false;
+				}
+
+				ppSet[CurrentSetSize++] = pObject;
+
+				return true;
+			}
+			else
+			{
+				return false;
+			}
+		}
+
+		HRESULT Open()
+		{
+			Internal::ScopedLock Lock(&pSyncManager->MaskCriticalSection);
+
+			// It's invalid to open a set that is already open
+			if (IsOpen)
+			{
+				return E_INVALIDARG;
+			}
+
+			RESIDENCY_CHECK(CommandListIndex == InvalidIndex);
+
+			bool CommandlistAvailable = false;
+			// Find the first available command list by bitscanning
+			for (UINT32 i = 0; i < ARRAYSIZE(pSyncManager->AvailableCommandLists); i++)
+			{
+				if (pSyncManager->AvailableCommandLists[i] == false)
+				{
+					CommandListIndex = i;
+					pSyncManager->AvailableCommandLists[i] = true;
+					CommandlistAvailable = true;
+					break;
+				}
+			}
+
+			if (CommandlistAvailable == false)
+			{
+				// There are too many open residency sets, consider using less or increasing the value of MAX_NUM_CONCURRENT_CMD_LISTS
+				RESIDENCY_CHECK(false);
+				return E_OUTOFMEMORY;
+			}
+
+			CurrentSetSize = 0;
+
+			IsOpen = true;
+			OutOfMemory = false;
+			return S_OK;
+		}
+
+		HRESULT Close()
+		{
+			if (IsOpen == false)
+			{
+				return E_INVALIDARG;
+			}
+
+			if (OutOfMemory == true)
+			{
+				return E_OUTOFMEMORY;
+			}
+
+			for (INT32 i = 0; i < CurrentSetSize; i++)
+			{
+				Remove(ppSet[i]);
+			}
+
+			ReturnCommandListReservation();
+
+			IsOpen = false;
+
+			return S_OK;
+		}
+
+	private:
+
+		inline void Remove(ManagedObject* pObject)
+		{
+			pObject->CommandListsUsedOn[CommandListIndex] = false;
+		}
+
+		inline void ReturnCommandListReservation()
+		{
+			Internal::ScopedLock Lock(&pSyncManager->MaskCriticalSection);
+
+			pSyncManager->AvailableCommandLists[CommandListIndex] = false;
+
+			CommandListIndex = ResidencySet::InvalidIndex;
+
+			IsOpen = false;
+		}
+
+		void Initialize(Internal::SyncManager* pSyncManagerIn)
+		{
+			pSyncManager = pSyncManagerIn;
+		}
+
+		bool Initialize(Internal::SyncManager* pSyncManagerIn, UINT32 MaxSize)
+		{
+			pSyncManager = pSyncManagerIn;
+			MaxResidencySetSize = MaxSize;
+
+			ppSet = new ManagedObject*[MaxResidencySetSize];
+
+			return ppSet != nullptr;
+		}
+
+		inline void Realloc()
+		{
+			MaxResidencySetSize = (MaxResidencySetSize == 0) ? 4096 : INT32(MaxResidencySetSize + (MaxResidencySetSize / 2.0f));
+			ManagedObject** ppNewAlloc = new ManagedObject*[MaxResidencySetSize];
+
+			if (ppSet && ppNewAlloc)
+			{
+				memcpy(ppNewAlloc, ppSet, CurrentSetSize * sizeof(ManagedObject*));
+				delete[](ppSet);
+			}
+
+			ppSet = ppNewAlloc;
+		}
+
+		UINT32 CommandListIndex;
+
+		ManagedObject** ppSet;
+		INT32 MaxResidencySetSize;
+		INT32 CurrentSetSize;
+
+		bool IsOpen;
+		bool OutOfMemory;
+
+		Internal::SyncManager* pSyncManager;
+	};
+
+	namespace Internal
+	{
+		/* List Helpers */
+		inline void InitializeListHead(LIST_ENTRY* pHead)
+		{
+			pHead->Flink = pHead->Blink = pHead;
+		}
+
+		inline void InsertHeadList(LIST_ENTRY* pHead, LIST_ENTRY* pEntry)
+		{
+			pEntry->Blink = pHead;
+			pEntry->Flink = pHead->Flink;
+
+			pHead->Flink->Blink = pEntry;
+			pHead->Flink = pEntry;
+		}
+
+		inline void InsertTailList(LIST_ENTRY* pHead, LIST_ENTRY* pEntry)
+		{
+			pEntry->Flink = pHead;
+			pEntry->Blink = pHead->Blink;
+
+			pHead->Blink->Flink = pEntry;
+			pHead->Blink = pEntry;
+		}
+
+		inline void RemoveEntryList(LIST_ENTRY* pEntry)
+		{
+			pEntry->Blink->Flink = pEntry->Flink;
+			pEntry->Flink->Blink = pEntry->Blink;
+		}
+
+		inline LIST_ENTRY* RemoveHeadList(LIST_ENTRY* pHead)
+		{
+			LIST_ENTRY* pEntry = pHead->Flink;
+			Internal::RemoveEntryList(pEntry);
+			return pEntry;
+		}
+
+		inline LIST_ENTRY* RemoveTailList(LIST_ENTRY* pHead)
+		{
+			LIST_ENTRY* pEntry = pHead->Blink;
+			Internal::RemoveEntryList(pEntry);
+			return pEntry;
+		}
+
+		inline bool IsListEmpty(LIST_ENTRY* pEntry)
+		{
+			return pEntry->Flink == pEntry;
+		}
+
+		struct Fence
+		{
+			Fence(UINT64 StartingValue) : pFence(nullptr), FenceValue(StartingValue)
+			{
+				Internal::InitializeListHead(&ListEntry);
+			};
+
+			HRESULT Initialize(ID3D12Device* pDevice)
+			{
+				HRESULT hr = pDevice->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&pFence));
+				RESIDENCY_CHECK_RESULT(hr);
+
+				return hr;
+			}
+
+			void Destroy()
+			{
+				if (pFence)
+				{
+					pFence->Release();
+					pFence = nullptr;
+				}
+			}
+
+			HRESULT GPUWait(ID3D12CommandQueue* pQueue)
+			{
+				HRESULT hr = pQueue->Wait(pFence, FenceValue);
+				RESIDENCY_CHECK_RESULT(hr);
+				return hr;
+			}
+
+			HRESULT GPUSignal(ID3D12CommandQueue* pQueue)
+			{
+				HRESULT hr = pQueue->Signal(pFence, FenceValue);
+				RESIDENCY_CHECK_RESULT(hr);
+				return hr;
+			}
+
+			inline void Increment()
+			{
+				FenceValue++;
+			}
+
+			ID3D12Fence* pFence;
+			UINT64 FenceValue;
+			LIST_ENTRY ListEntry;
+		};
+
+		// Represents a time on a particular queue that a resource was used
+		struct QueueSyncPoint
+		{
+			QueueSyncPoint() : pFence(nullptr), LastUsedValue(0) {};
+
+			inline bool IsCompleted() { return LastUsedValue <= pFence->pFence->GetCompletedValue(); }
+
+			inline void WaitForCompletion(HANDLE Event)
+			{
+				RESIDENCY_CHECK_RESULT(pFence->pFence->SetEventOnCompletion(LastUsedValue, Event));
+				RESIDENCY_CHECK_RESULT(WaitForSingleObject(Event, INFINITE));
+			}
+
+			Fence* pFence;
+			UINT64 LastUsedValue;
+		};
+
+		struct DeviceWideSyncPoint
+		{
+			DeviceWideSyncPoint(UINT32 NumQueues, UINT64 Generation) :
+				GenerationID(Generation), NumQueueSyncPoints(NumQueues) {};
+
+			// Create the whole structure in one allocation for locality
+			static DeviceWideSyncPoint* CreateSyncPoint(UINT32 NumQueues, UINT64 Generation)
+			{
+				DeviceWideSyncPoint* pSyncPoint = nullptr;
+				const SIZE_T Size = sizeof(DeviceWideSyncPoint) + (sizeof(QueueSyncPoint) * (NumQueues - 1));
+
+				BYTE* pAlloc = new BYTE[Size];
+				if (pAlloc && Size >= sizeof(DeviceWideSyncPoint))
+				{
+					pSyncPoint = new (pAlloc) DeviceWideSyncPoint(NumQueues, Generation);
+				}
+
+				return pSyncPoint;
+			}
+
+			// A device wide fence is completed if all of the queues that were active at that point are completed
+			inline bool IsCompleted()
+			{
+				for (UINT32 i = 0; i < NumQueueSyncPoints; i++)
+				{
+					if (pQueueSyncPoints[i].IsCompleted() == false)
+					{
+						return false;
+					}
+				}
+				return true;
+			}
+
+			inline void WaitForCompletion(HANDLE Event)
+			{
+				for (UINT32 i = 0; i < NumQueueSyncPoints; i++)
+				{
+					if (pQueueSyncPoints[i].IsCompleted() == false)
+					{
+						pQueueSyncPoints[i].WaitForCompletion(Event);
+					}
+				}
+			}
+
+			const UINT64 GenerationID;
+			const UINT32 NumQueueSyncPoints;
+			LIST_ENTRY ListEntry;
+			// NumQueueSyncPoints QueueSyncPoints will be placed below here
+			QueueSyncPoint pQueueSyncPoints[1];
+		};
+
+		// A Least Recently Used Cache. Tracks all of the objects requested by the app so that objects
+		// that aren't used freqently can get evicted to help the app stay under buget.
+		class LRUCache
+		{
+		public:
+			LRUCache() :
+				NumResidentObjects(0),
+				NumEvictedObjects(0),
+				ResidentSize(0)
+			{
+				Internal::InitializeListHead(&ResidentObjectListHead);
+				Internal::InitializeListHead(&EvictedObjectListHead);
+			};
+
+			void Insert(ManagedObject* pObject)
+			{
+				if (pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT)
+				{
+					Internal::InsertHeadList(&ResidentObjectListHead, &pObject->ListEntry);
+					NumResidentObjects++;
+					ResidentSize += pObject->Size;
+				}
+				else
+				{
+					Internal::InsertHeadList(&EvictedObjectListHead, &pObject->ListEntry);
+					NumEvictedObjects++;
+				}
+			}
+
+			void Remove(ManagedObject* pObject)
+			{
+				Internal::RemoveEntryList(&pObject->ListEntry);
+				if (pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT)
+				{
+					NumResidentObjects--;
+					ResidentSize -= pObject->Size;
+				}
+				else
+				{
+					NumEvictedObjects--;
+				}
+			}
+
+			// When an object is used by the GPU we move it to the end of the list.
+			// This way things closer to the head of the list are the objects which
+			// are stale and better candidates for eviction
+			void ObjectReferenced(ManagedObject* pObject)
+			{
+				RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT);
+
+				Internal::RemoveEntryList(&pObject->ListEntry);
+				Internal::InsertTailList(&ResidentObjectListHead, &pObject->ListEntry);
+			}
+
+			void MakeResident(ManagedObject* pObject)
+			{
+				RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::EVICTED);
+
+				pObject->ResidencyStatus = ManagedObject::RESIDENCY_STATUS::RESIDENT;
+				Internal::RemoveEntryList(&pObject->ListEntry);
+				Internal::InsertTailList(&ResidentObjectListHead, &pObject->ListEntry);
+
+				NumEvictedObjects--;
+				NumResidentObjects++;
+				ResidentSize += pObject->Size;
+			}
+
+			void Evict(ManagedObject* pObject)
+			{
+				RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT);
+
+				pObject->ResidencyStatus = ManagedObject::RESIDENCY_STATUS::EVICTED;
+				Internal::RemoveEntryList(&pObject->ListEntry);
+				Internal::InsertTailList(&EvictedObjectListHead, &pObject->ListEntry);
+
+				NumResidentObjects--;
+				ResidentSize -= pObject->Size;
+				NumEvictedObjects++;
+			}
+
+			// Evict all of the resident objects used in sync points up to the specficied one (inclusive)
+			void TrimToSyncPointInclusive(INT64 CurrentUsage, INT64 CurrentBudget, ID3D12Pageable** EvictionList, UINT32& NumObjectsToEvict, UINT64 SyncPoint)
+			{
+				NumObjectsToEvict = 0;
+
+				LIST_ENTRY* pResourceEntry = ResidentObjectListHead.Flink;
+				while (pResourceEntry != &ResidentObjectListHead)
+				{
+					ManagedObject* pObject = CONTAINING_RECORD(pResourceEntry, ManagedObject, ListEntry);
+
+					if (pObject->LastGPUSyncPoint > SyncPoint || CurrentUsage < CurrentBudget)
+					{
+						break;
+					}
+
+					RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT);
+
+					EvictionList[NumObjectsToEvict++] = pObject->pUnderlying;
+					Evict(pObject);
+
+					CurrentUsage -= pObject->Size;
+
+					pResourceEntry = ResidentObjectListHead.Flink;
+				}
+			}
+
+			// Trim all objects which are older than the specified time
+			void TrimAgedAllocations(DeviceWideSyncPoint* MaxSyncPoint, ID3D12Pageable** EvictionList, UINT32& NumObjectsToEvict, UINT64 CurrentTimeStamp, UINT64 MinDelta)
+			{
+				LIST_ENTRY* pResourceEntry = ResidentObjectListHead.Flink;
+				while (pResourceEntry != &ResidentObjectListHead)
+				{
+					ManagedObject* pObject = CONTAINING_RECORD(pResourceEntry, ManagedObject, ListEntry);
+
+					if ((MaxSyncPoint && pObject->LastGPUSyncPoint >= MaxSyncPoint->GenerationID) || // Only trim allocations done on the GPU
+						CurrentTimeStamp - pObject->LastUsedTimestamp <= MinDelta) // Don't evict things which have been used recently
+					{
+						break;
+					}
+
+					RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT);
+					EvictionList[NumObjectsToEvict++] = pObject->pUnderlying;
+					Evict(pObject);
+
+					pResourceEntry = ResidentObjectListHead.Flink;
+				}
+			}
+
+			ManagedObject* GetResidentListHead()
+			{
+				if (IsListEmpty(&ResidentObjectListHead))
+				{
+					return nullptr;
+				}
+				return CONTAINING_RECORD(ResidentObjectListHead.Flink, ManagedObject, ListEntry);
+			}
+
+			LIST_ENTRY ResidentObjectListHead;
+			LIST_ENTRY EvictedObjectListHead;
+
+			UINT32 NumResidentObjects;
+			UINT32 NumEvictedObjects;
+
+			UINT64 ResidentSize;
+		};
+
+		class ResidencyManagerInternal
+		{
+		public:
+			ResidencyManagerInternal(SyncManager* pSyncManagerIn) :
+				Device(nullptr),
+				AsyncThreadFence(1),
+				CompletionEvent(INVALID_HANDLE_VALUE),
+				AsyncThreadWorkCompletionEvent(INVALID_HANDLE_VALUE),
+				Adapter(nullptr),
+				AsyncWorkEvent(INVALID_HANDLE_VALUE),
+				AsyncWorkThread(INVALID_HANDLE_VALUE),
+				FinishAsyncWork(false),
+				cStartEvicted(false),
+				CurrentSyncPointGeneration(0),
+				NumQueuesSeen(0),
+				NodeIndex(0),
+				CurrentAsyncWorkloadHead(0),
+				CurrentAsyncWorkloadTail(0),
+				cMinEvictionGracePeriod(1.0f),
+				cMaxEvictionGracePeriod(60.0f),
+				cTrimPercentageMemoryUsageThreshold(0.7f),
+				AsyncWorkQueue(nullptr),
+				MaxSoftwareQueueLatency(6),
+				AsyncWorkQueueSize(7),
+				pSyncManager(pSyncManagerIn)
+			{
+				Internal::InitializeListHead(&QueueFencesListHead);
+				Internal::InitializeListHead(&InFlightSyncPointsHead);
+
+				ResidencyManagerUniqueID = InterlockedIncrement64(&g_ResidencyManagerUniqueID);
+			};
+
+			// NOTE: DeviceNodeIndex is an index not a mask. The majority of D3D12 uses bit masks to identify a GPU node whereas DXGI uses 0 based indices.
+			HRESULT Initialize(ID3D12Device* ParentDevice, UINT DeviceNodeIndex, IDXGIAdapter3* ParentAdapter, UINT32 MaxLatency)
+			{
+				Device = ParentDevice;
+				NodeIndex = DeviceNodeIndex;
+				Adapter = ParentAdapter;
+				MaxSoftwareQueueLatency = MaxLatency;
+
+				AsyncWorkQueueSize = MaxLatency + 1;
+				AsyncWorkQueue = new AsyncWorkload[AsyncWorkQueueSize];
+
+				if (AsyncWorkQueue == nullptr)
+				{
+					return E_OUTOFMEMORY;
+				}
+
+				LARGE_INTEGER Frequency;
+				QueryPerformanceFrequency(&Frequency);
+
+				// Calculate how many QPC ticks are equivalent to the given time in seconds
+				MinEvictionGracePeriodTicks = UINT64(Frequency.QuadPart * cMinEvictionGracePeriod);
+				MaxEvictionGracePeriodTicks = UINT64(Frequency.QuadPart * cMaxEvictionGracePeriod);
+
+				HRESULT hr = S_OK;
+				hr = AsyncThreadFence.Initialize(Device);
+
+				if (SUCCEEDED(hr))
+				{
+					CompletionEvent = CreateEvent(nullptr, false, false, nullptr);
+					if (CompletionEvent == INVALID_HANDLE_VALUE)
+					{
+						hr = HRESULT_FROM_WIN32(GetLastError());
+					}
+				}
+
+				if (SUCCEEDED(hr))
+				{
+					AsyncThreadWorkCompletionEvent = CreateEvent(nullptr, false, false, nullptr);
+					if (AsyncThreadWorkCompletionEvent == INVALID_HANDLE_VALUE)
+					{
+						hr = HRESULT_FROM_WIN32(GetLastError());
+					}
+				}
+
+				if (SUCCEEDED(hr))
+				{
+					AsyncWorkEvent = CreateEvent(nullptr, true, false, nullptr);
+					if (AsyncWorkEvent == INVALID_HANDLE_VALUE)
+					{
+						hr = HRESULT_FROM_WIN32(GetLastError());
+					}
+				}
 
 #if !RESIDENCY_SINGLE_THREADED
-                if (SUCCEEDED(hr))
-                {
-                    AsyncWorkThread = CreateThread(nullptr, 0, AsyncThreadStart, (void*) this, 0, nullptr);
+				if (SUCCEEDED(hr))
+				{
+					AsyncWorkThread = CreateThread(nullptr, 0, AsyncThreadStart, (void*) this, 0, nullptr);
 
-                    if (AsyncWorkThread == INVALID_HANDLE_VALUE)
-                    {
-                        hr = HRESULT_FROM_WIN32(GetLastError());
-                    }
-                }
+					if (AsyncWorkThread == INVALID_HANDLE_VALUE)
+					{
+						hr = HRESULT_FROM_WIN32(GetLastError());
+					}
+				}
 #endif
 
-                return hr;
-            }
+				return hr;
+			}
 
-            void Destroy()
-            {
-                AsyncThreadFence.Destroy();
+			void Destroy()
+			{
+				AsyncThreadFence.Destroy();
 
-                if (CompletionEvent != INVALID_HANDLE_VALUE)
-                {
-                    CloseHandle(CompletionEvent);
-                    CompletionEvent = INVALID_HANDLE_VALUE;
-                }
+				if (CompletionEvent != INVALID_HANDLE_VALUE)
+				{
+					CloseHandle(CompletionEvent);
+					CompletionEvent = INVALID_HANDLE_VALUE;
+				}
 
 #if !RESIDENCY_SINGLE_THREADED
-                AsyncWorkload* pWork = DequeueAsyncWork();
+				AsyncWorkload* pWork = DequeueAsyncWork();
 
-                while (pWork)
-                {
-                    pWork = DequeueAsyncWork();
-                }
+				while (pWork)
+				{
+					pWork = DequeueAsyncWork();
+				}
 
-                FinishAsyncWork = true;
-                if (SetEvent(AsyncWorkEvent) == false)
-                {
-                    RESIDENCY_CHECK_RESULT(HRESULT_FROM_WIN32(GetLastError()));
-                }
+				FinishAsyncWork = true;
+				if (SetEvent(AsyncWorkEvent) == false)
+				{
+					RESIDENCY_CHECK_RESULT(HRESULT_FROM_WIN32(GetLastError()));
+				}
 
-                // Make sure the async worker thread is finished to prevent dereferencing
-                // dangling pointers to ResidencyManagerInternal
-                WaitForSingleObject(AsyncWorkThread, INFINITE);
-                if (AsyncWorkThread != INVALID_HANDLE_VALUE)
-                {
-                    CloseHandle(AsyncWorkThread);
-                    AsyncWorkThread = INVALID_HANDLE_VALUE;
-                }
+				// Make sure the async worker thread is finished to prevent dereferencing
+				// dangling pointers to ResidencyManagerInternal
+				WaitForSingleObject(AsyncWorkThread, INFINITE);
+				if (AsyncWorkThread != INVALID_HANDLE_VALUE)
+				{
+					CloseHandle(AsyncWorkThread);
+					AsyncWorkThread = INVALID_HANDLE_VALUE;
+				}
 
-                if (AsyncWorkEvent != INVALID_HANDLE_VALUE)
-                {
-                    CloseHandle(AsyncWorkEvent);
-                    AsyncWorkEvent = INVALID_HANDLE_VALUE;
-                }
+				if (AsyncWorkEvent != INVALID_HANDLE_VALUE)
+				{
+					CloseHandle(AsyncWorkEvent);
+					AsyncWorkEvent = INVALID_HANDLE_VALUE;
+				}
 #endif
 
-                if (AsyncThreadWorkCompletionEvent != INVALID_HANDLE_VALUE)
-                {
-                    CloseHandle(AsyncThreadWorkCompletionEvent);
-                    AsyncThreadWorkCompletionEvent = INVALID_HANDLE_VALUE;
-                }
+				if (AsyncThreadWorkCompletionEvent != INVALID_HANDLE_VALUE)
+				{
+					CloseHandle(AsyncThreadWorkCompletionEvent);
+					AsyncThreadWorkCompletionEvent = INVALID_HANDLE_VALUE;
+				}
 
-                while (Internal::IsListEmpty(&QueueFencesListHead) == false)
-                {
-                    Internal::Fence* pObject =
-                        CONTAINING_RECORD(QueueFencesListHead.Flink, Internal::Fence, ListEntry);
+				while (Internal::IsListEmpty(&QueueFencesListHead) == false)
+				{
+					Internal::Fence* pObject =
+						CONTAINING_RECORD(QueueFencesListHead.Flink, Internal::Fence, ListEntry);
 
-                    pObject->Destroy();
-                    Internal::RemoveHeadList(&QueueFencesListHead);
-                    delete(pObject);
-                }
-            }
+					pObject->Destroy();
+					Internal::RemoveHeadList(&QueueFencesListHead);
+					delete(pObject);
+				}
+			}
 
-            void BeginTrackingObject(ManagedObject* pObject)
-            {
-                Internal::ScopedLock Lock(&Mutex);
+			void BeginTrackingObject(ManagedObject* pObject)
+			{
+				Internal::ScopedLock Lock(&Mutex);
 
-                if (pObject)
-                {
-                    RESIDENCY_CHECK(pObject->pUnderlying != nullptr);
-                    if (cStartEvicted)
-                    {
-                        pObject->ResidencyStatus = ManagedObject::RESIDENCY_STATUS::EVICTED;
-                        RESIDENCY_CHECK_RESULT(Device->Evict(1, &pObject->pUnderlying));
-                    }
+				if (pObject)
+				{
+					RESIDENCY_CHECK(pObject->pUnderlying != nullptr);
+					if (cStartEvicted)
+					{
+						pObject->ResidencyStatus = ManagedObject::RESIDENCY_STATUS::EVICTED;
+						RESIDENCY_CHECK_RESULT(Device->Evict(1, &pObject->pUnderlying));
+					}
 
-                    LRU.Insert(pObject);
-                }
-            }
+					LRU.Insert(pObject);
+				}
+			}
 
-            void EndTrackingObject(ManagedObject* pObject)
-            {
-                Internal::ScopedLock Lock(&Mutex);
+			void EndTrackingObject(ManagedObject* pObject)
+			{
+				Internal::ScopedLock Lock(&Mutex);
 
-                LRU.Remove(pObject);
-            }
+				LRU.Remove(pObject);
+			}
 
-            // One residency set per command-list
-            HRESULT ExecuteCommandLists(ID3D12CommandQueue* Queue, ID3D12CommandList** CommandLists, ResidencySet** ResidencySets, UINT32 Count)
-            {
-                return ExecuteSubset(Queue, CommandLists, ResidencySets, Count);
-            }
+			// One residency set per command-list
+			HRESULT ExecuteCommandLists(ID3D12CommandQueue* Queue, ID3D12CommandList** CommandLists, ResidencySet** ResidencySets, UINT32 Count)
+			{
+				return ExecuteSubset(Queue, CommandLists, ResidencySets, Count);
+			}
 
-            HRESULT GetCurrentGPUSyncPoint(ID3D12CommandQueue* Queue, UINT64 *pGPUSyncPoint)
-            {
-                Internal::Fence* QueueFence = nullptr;
-                HRESULT hr = GetFence(Queue, QueueFence);
+			HRESULT GetCurrentGPUSyncPoint(ID3D12CommandQueue* Queue, UINT64 *pGPUSyncPoint)
+			{
+				Internal::Fence* QueueFence = nullptr;
+				HRESULT hr = GetFence(Queue, QueueFence);
 
-                // The signal and increment need to be atomic
-                if(SUCCEEDED(hr))
-                {
-                    Internal::ScopedLock Lock(&ExecutionCS);
-                    *pGPUSyncPoint = QueueFence->FenceValue;
-                    hr = SignalFence(Queue, QueueFence);
-                }
-                return hr;
-            }
+				// The signal and increment need to be atomic
+				if(SUCCEEDED(hr))
+				{
+					Internal::ScopedLock Lock(&ExecutionCS);
+					*pGPUSyncPoint = QueueFence->FenceValue;
+					hr = SignalFence(Queue, QueueFence);
+				}
+				return hr;
+			}
 
-        private:
-            HRESULT GetFence(ID3D12CommandQueue *Queue, Internal::Fence *&QueueFence)
-            {
-                // We have to track each object on each queue so we know when it is safe to evict them. Therefore, for every queue that we
-                // see, associate a fence with it
-                GUID FenceGuid = { 0xf0, 0, 0xd, { 0, 0, 0, 0, 0, 0, 0, 0 } };
+		private:
+			HRESULT GetFence(ID3D12CommandQueue *Queue, Internal::Fence *&QueueFence)
+			{
+				// We have to track each object on each queue so we know when it is safe to evict them. Therefore, for every queue that we
+				// see, associate a fence with it
+				GUID FenceGuid = { 0xf0, 0, 0xd, { 0, 0, 0, 0, 0, 0, 0, 0 } };
 
-                // Generate a GUID based on this queue
-                memcpy((void*)FenceGuid.Data4, Queue, sizeof(ID3D12CommandQueue*));
+				// Generate a GUID based on this queue
+				memcpy((void*)FenceGuid.Data4, Queue, sizeof(ID3D12CommandQueue*));
 
-                QueueFence = nullptr;
-                HRESULT hr = S_OK;
+				QueueFence = nullptr;
+				HRESULT hr = S_OK;
 
-                struct
-                {
-                    Internal::Fence* pFence;
-                    INT64 ResidencyManagerUniqueID;
-                } CommandQueuePrivateData;
+				struct
+				{
+					Internal::Fence* pFence;
+					INT64 ResidencyManagerUniqueID;
+				} CommandQueuePrivateData;
 
-                // Find or create the fence for this queue
-                {
-                    UINT32 Size = sizeof(CommandQueuePrivateData);
-                    hr = Queue->GetPrivateData(FenceGuid, &Size, &CommandQueuePrivateData);
-                    if (FAILED(hr) || ResidencyManagerUniqueID != CommandQueuePrivateData.ResidencyManagerUniqueID)
-                    {
-                        QueueFence = new Internal::Fence(1);
-                        hr = QueueFence->Initialize(Device);
-                        Internal::InsertTailList(&QueueFencesListHead, &QueueFence->ListEntry);
+				// Find or create the fence for this queue
+				{
+					UINT32 Size = sizeof(CommandQueuePrivateData);
+					hr = Queue->GetPrivateData(FenceGuid, &Size, &CommandQueuePrivateData);
+					if (FAILED(hr) || ResidencyManagerUniqueID != CommandQueuePrivateData.ResidencyManagerUniqueID)
+					{
+						QueueFence = new Internal::Fence(1);
+						hr = QueueFence->Initialize(Device);
+						Internal::InsertTailList(&QueueFencesListHead, &QueueFence->ListEntry);
 
-                        InterlockedIncrement(&NumQueuesSeen);
+						InterlockedIncrement(&NumQueuesSeen);
 
-                        if (SUCCEEDED(hr))
-                        {
-                            CommandQueuePrivateData = { QueueFence, ResidencyManagerUniqueID };
-                            hr = Queue->SetPrivateData(FenceGuid, UINT32(sizeof(CommandQueuePrivateData)), &CommandQueuePrivateData);
-                            RESIDENCY_CHECK_RESULT(hr);
-                        }
-                    }
-                    QueueFence = CommandQueuePrivateData.pFence;
-                    RESIDENCY_CHECK(QueueFence != nullptr);
-                }
+						if (SUCCEEDED(hr))
+						{
+							CommandQueuePrivateData = { QueueFence, ResidencyManagerUniqueID };
+							hr = Queue->SetPrivateData(FenceGuid, UINT32(sizeof(CommandQueuePrivateData)), &CommandQueuePrivateData);
+							RESIDENCY_CHECK_RESULT(hr);
+						}
+					}
+					QueueFence = CommandQueuePrivateData.pFence;
+					RESIDENCY_CHECK(QueueFence != nullptr);
+				}
 
-                return hr;
-            }
+				return hr;
+			}
 
-            HRESULT SignalFence(ID3D12CommandQueue *Queue, Internal::Fence *QueueFence)
-            {
-                // When this fence is passed it is safe to evict the resources used in the list just submitted
-                HRESULT hr = QueueFence->GPUSignal(Queue);
-                QueueFence->Increment();
+			HRESULT SignalFence(ID3D12CommandQueue *Queue, Internal::Fence *QueueFence)
+			{
+				// When this fence is passed it is safe to evict the resources used in the list just submitted
+				HRESULT hr = QueueFence->GPUSignal(Queue);
+				QueueFence->Increment();
 
-                if (SUCCEEDED(hr))
-                {
-                    hr = EnqueueSyncPoint();
-                    RESIDENCY_CHECK_RESULT(hr);
-                }
+				if (SUCCEEDED(hr))
+				{
+					hr = EnqueueSyncPoint();
+					RESIDENCY_CHECK_RESULT(hr);
+				}
 
-                CurrentSyncPointGeneration++;
-                return hr;
-            }
+				CurrentSyncPointGeneration++;
+				return hr;
+			}
 
-            HRESULT ExecuteSubset(ID3D12CommandQueue* Queue, ID3D12CommandList** CommandLists, ResidencySet** ResidencySets, UINT32 Count)
-            {
-                HRESULT hr = S_OK;
+			HRESULT ExecuteSubset(ID3D12CommandQueue* Queue, ID3D12CommandList** CommandLists, ResidencySet** ResidencySets, UINT32 Count)
+			{
+				HRESULT hr = S_OK;
 
-                DXGI_QUERY_VIDEO_MEMORY_INFO LocalMemory;
-                ZeroMemory(&LocalMemory, sizeof(LocalMemory));
-                GetCurrentBudget(&LocalMemory, DXGI_MEMORY_SEGMENT_GROUP_LOCAL);
+				DXGI_QUERY_VIDEO_MEMORY_INFO LocalMemory;
+				ZeroMemory(&LocalMemory, sizeof(LocalMemory));
+				GetCurrentBudget(&LocalMemory, DXGI_MEMORY_SEGMENT_GROUP_LOCAL);
 
-                DXGI_QUERY_VIDEO_MEMORY_INFO NonLocalMemory;
-                ZeroMemory(&NonLocalMemory, sizeof(NonLocalMemory));
-                GetCurrentBudget(&NonLocalMemory, DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL);
+				DXGI_QUERY_VIDEO_MEMORY_INFO NonLocalMemory;
+				ZeroMemory(&NonLocalMemory, sizeof(NonLocalMemory));
+				GetCurrentBudget(&NonLocalMemory, DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL);
 
-                UINT64 TotalSizeNeeded = 0;
+				UINT64 TotalSizeNeeded = 0;
 
-                UINT32 MaxObjectsReferenced = 0;
-                for (UINT32 i = 0; i < Count; i++)
-                {
-                    if (ResidencySets[i])
-                    {
-                        if (ResidencySets[i]->IsOpen)
-                        {
-                            // Residency Sets must be closed before execution just like Command Lists
-                            return E_INVALIDARG;
-                        }
-                        MaxObjectsReferenced += ResidencySets[i]->CurrentSetSize;
-                    }
-                }
+				UINT32 MaxObjectsReferenced = 0;
+				for (UINT32 i = 0; i < Count; i++)
+				{
+					if (ResidencySets[i])
+					{
+						if (ResidencySets[i]->IsOpen)
+						{
+							// Residency Sets must be closed before execution just like Command Lists
+							return E_INVALIDARG;
+						}
+						MaxObjectsReferenced += ResidencySets[i]->CurrentSetSize;
+					}
+				}
 
-                // Create a set to gather up all unique resources required by this call
-                ResidencySet* pMasterSet = new ResidencySet();
-                if (pMasterSet == nullptr || pMasterSet->Initialize(pSyncManager, MaxObjectsReferenced) == false)
-                {
-                    return E_OUTOFMEMORY;
-                }
+				// Create a set to gather up all unique resources required by this call
+				ResidencySet* pMasterSet = new ResidencySet();
+				if (pMasterSet == nullptr || pMasterSet->Initialize(pSyncManager, MaxObjectsReferenced) == false)
+				{
+					return E_OUTOFMEMORY;
+				}
 
-                hr = pMasterSet->Open();
-                if (FAILED(hr))
-                {
-                    return hr;
-                }
+				hr = pMasterSet->Open();
+				if (FAILED(hr))
+				{
+					return hr;
+				}
 
-                // For each residency set
-                for (UINT32 i = 0; i < Count; i++)
-                {
-                    if (ResidencySets[i])
-                    {
-                        // For each object in this set
-                        for (INT32 x = 0; x < ResidencySets[i]->CurrentSetSize; x++)
-                        {
-                            if (pMasterSet->Insert(ResidencySets[i]->ppSet[x]))
-                            {
-                                TotalSizeNeeded += ResidencySets[i]->ppSet[x]->Size;
-                            }
-                        }
-                    }
-                }
-                // Close this set to free it's slot up for the app
-                hr = pMasterSet->Close();
-                if (FAILED(hr))
-                {
-                    return hr;
-                }
+				// For each residency set
+				for (UINT32 i = 0; i < Count; i++)
+				{
+					if (ResidencySets[i])
+					{
+						// For each object in this set
+						for (INT32 x = 0; x < ResidencySets[i]->CurrentSetSize; x++)
+						{
+							if (pMasterSet->Insert(ResidencySets[i]->ppSet[x]))
+							{
+								TotalSizeNeeded += ResidencySets[i]->ppSet[x]->Size;
+							}
+						}
+					}
+				}
+				// Close this set to free it's slot up for the app
+				hr = pMasterSet->Close();
+				if (FAILED(hr))
+				{
+					return hr;
+				}
 
-                // This set of commandlists can't possibly fit within the budget, they need to be split up. If the number of command lists is 1 there is
-                // nothing we can do
-                if (Count > 1 && TotalSizeNeeded > LocalMemory.Budget + NonLocalMemory.Budget)
-                {
-                    delete(pMasterSet);
+				// This set of commandlists can't possibly fit within the budget, they need to be split up. If the number of command lists is 1 there is
+				// nothing we can do
+				if (Count > 1 && TotalSizeNeeded > LocalMemory.Budget + NonLocalMemory.Budget)
+				{
+					delete(pMasterSet);
 
-                    // Recursively try to find a small enough set to fit in memory
-                    const UINT32 Half = Count / 2;
-                    const HRESULT LowerHR = ExecuteSubset(Queue, CommandLists, ResidencySets, Half);
-                    const HRESULT UpperHR = ExecuteSubset(Queue, &CommandLists[Half], &ResidencySets[Half], Count - Half);
+					// Recursively try to find a small enough set to fit in memory
+					const UINT32 Half = Count / 2;
+					const HRESULT LowerHR = ExecuteSubset(Queue, CommandLists, ResidencySets, Half);
+					const HRESULT UpperHR = ExecuteSubset(Queue, &CommandLists[Half], &ResidencySets[Half], Count - Half);
 
-                    return (LowerHR == S_OK && UpperHR == S_OK) ? S_OK : E_FAIL;
-                }
+					return (LowerHR == S_OK && UpperHR == S_OK) ? S_OK : E_FAIL;
+				}
 
 
-                Internal::Fence* QueueFence = nullptr;
-                hr = GetFence(Queue, QueueFence);
+				Internal::Fence* QueueFence = nullptr;
+				hr = GetFence(Queue, QueueFence);
 
-                if (SUCCEEDED(hr))
-                {
-                    // The following code must be atomic so that things get ordered correctly
+				if (SUCCEEDED(hr))
+				{
+					// The following code must be atomic so that things get ordered correctly
 
-                    Internal::ScopedLock Lock(&ExecutionCS);
-                    // Evict or make resident all of the objects we identified above.
-                    // This will run on an async thread, allowing the current to continue while still blocking the GPU if required
-                    hr = EnqueueAsyncWork(pMasterSet, AsyncThreadFence.FenceValue, CurrentSyncPointGeneration);
+					Internal::ScopedLock Lock(&ExecutionCS);
+					// Evict or make resident all of the objects we identified above.
+					// This will run on an async thread, allowing the current to continue while still blocking the GPU if required
+					hr = EnqueueAsyncWork(pMasterSet, AsyncThreadFence.FenceValue, CurrentSyncPointGeneration);
 #if RESIDENCY_SINGLE_THREADED
-                    AsyncWorkload* pWorkload = DequeueAsyncWork();
-                    ProcessPagingWork(pWorkload);
+					AsyncWorkload* pWorkload = DequeueAsyncWork();
+					ProcessPagingWork(pWorkload);
 #endif
 
-                    // If there are some things that need to be made resident we need to make sure that the GPU
-                    // doesn't execute until the async thread signals that the MakeResident call has returned.
-                    if (SUCCEEDED(hr))
-                    {
-                        hr = AsyncThreadFence.GPUWait(Queue);
-                        AsyncThreadFence.Increment();
-                    }
-
-                    Queue->ExecuteCommandLists(Count, CommandLists);
-
-                    if (SUCCEEDED(hr))
-                    {
-                        hr = SignalFence(Queue, QueueFence);
-                    }
-                }
-                return hr;
-            }
-
-            struct AsyncWorkload
-            {
-                AsyncWorkload() :
-                    pMasterSet(nullptr),
-                    FenceValueToSignal(0),
-                    SyncPointGeneration(0)
-                {}
-
-                UINT64 SyncPointGeneration;
-
-                // List of objects to make resident
-                ResidencySet* pMasterSet;
-
-                // The GPU will wait on this value so that it doesn't execute until the objects are made resident
-                UINT64 FenceValueToSignal;
-            };
-
-            SIZE_T AsyncWorkQueueSize;
-            AsyncWorkload* AsyncWorkQueue;
-
-            HANDLE AsyncWorkEvent;
-            HANDLE AsyncWorkThread;
-            Internal::CriticalSection AsyncWorkMutex;
-            volatile bool FinishAsyncWork;
-            volatile SIZE_T CurrentAsyncWorkloadHead;
-            volatile SIZE_T CurrentAsyncWorkloadTail;
-
-            static unsigned long WINAPI AsyncThreadStart(void* pData)
-            {
-                ResidencyManagerInternal* pManager = (ResidencyManagerInternal*)pData;
-
-                while (1)
-                {
-                    AsyncWorkload* pWork = pManager->DequeueAsyncWork();
-
-                    while (pWork)
-                    {
-                        // Submit the work
-                        pManager->ProcessPagingWork(pWork);
-                        if (SetEvent(pManager->AsyncThreadWorkCompletionEvent) == false)
-                        {
-                            RESIDENCY_CHECK_RESULT(HRESULT_FROM_WIN32(GetLastError()));
-                        }
-
-                        // Get more work
-                        pWork = pManager->DequeueAsyncWork();
-                    }
-
-                    //Wait until there is more work do be done
-                    WaitForSingleObject(pManager->AsyncWorkEvent, INFINITE);
-                    if (ResetEvent(pManager->AsyncWorkEvent) == false)
-                    {
-                        RESIDENCY_CHECK_RESULT(HRESULT_FROM_WIN32(GetLastError()));
-                    }
-
-                    if (pManager->FinishAsyncWork)
-                    {
-                        return 0;
-                    }
-                }
-
-                return 0;
-            }
-
-            // This will be run from a worker thread and will emulate a software queue for making gpu resources resident or evicted.
-            // The GPU will be synchronized by this queue to ensure that it never executes using an evicted resource.
-            void ProcessPagingWork(AsyncWorkload* pWork)
-            {
-                Internal::DeviceWideSyncPoint* FirstUncompletedSyncPoint = DequeueCompletedSyncPoints();
-
-                // Use a union so that we only need 1 allocation
-                union ResidentScratchSpace
-                {
-                    ManagedObject* pManagedObject;
-                    ID3D12Pageable* pUnderlying;
-                };
-
-                ResidentScratchSpace* pMakeResidentList = nullptr;
-                UINT32 NumObjectsToMakeResident = 0;
-
-                ID3D12Pageable** pEvictionList = nullptr;
-                UINT32 NumObjectsToEvict = 0;
-
-                // the size of all the objects which will need to be made resident in order to execute this set.
-                UINT64 SizeToMakeResident = 0;
-
-                LARGE_INTEGER CurrentTime;
-                QueryPerformanceCounter(&CurrentTime);
-
-                {
-                    // A lock must be taken here as the state of the objects will be altered
-                    Internal::ScopedLock Lock(&Mutex);
-
-                    pMakeResidentList = new ResidentScratchSpace[pWork->pMasterSet->CurrentSetSize];
-                    pEvictionList = new ID3D12Pageable*[LRU.NumResidentObjects];
-
-                    // Mark the objects used by this command list to be made resident
-                    for (INT32 i = 0; i < pWork->pMasterSet->CurrentSetSize; i++)
-                    {
-                        ManagedObject*& pObject = pWork->pMasterSet->ppSet[i];
-                        // If it's evicted we need to make it resident again
-                        if (pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::EVICTED)
-                        {
-                            pMakeResidentList[NumObjectsToMakeResident++].pManagedObject = pObject;
-                            LRU.MakeResident(pObject);
-
-                            SizeToMakeResident += pObject->Size;
-                        }
-
-                        // Update the last sync point that this was used on
-                        pObject->LastGPUSyncPoint = pWork->SyncPointGeneration;
-
-                        pObject->LastUsedTimestamp = CurrentTime.QuadPart;
-                        LRU.ObjectReferenced(pObject);
-                    }
-
-                    DXGI_QUERY_VIDEO_MEMORY_INFO LocalMemory;
-                    ZeroMemory(&LocalMemory, sizeof(LocalMemory));
-                    GetCurrentBudget(&LocalMemory, DXGI_MEMORY_SEGMENT_GROUP_LOCAL);
-
-                    UINT64 EvictionGracePeriod = GetCurrentEvictionGracePeriod(&LocalMemory);
-                    LRU.TrimAgedAllocations(FirstUncompletedSyncPoint, pEvictionList, NumObjectsToEvict, CurrentTime.QuadPart, EvictionGracePeriod);
-
-                    if (NumObjectsToEvict)
-                    {
-                        RESIDENCY_CHECK_RESULT(Device->Evict(NumObjectsToEvict, pEvictionList));
-                        NumObjectsToEvict = 0;
-                    }
-
-                    if (NumObjectsToMakeResident)
-                    {
-                        UINT32 ObjectsMadeResident = 0;
-                        UINT32 MakeResidentIndex = 0;
-                        while (true)
-                        {
-                            ZeroMemory(&LocalMemory, sizeof(LocalMemory));
-
-                            GetCurrentBudget(&LocalMemory, DXGI_MEMORY_SEGMENT_GROUP_LOCAL);
-                            DXGI_QUERY_VIDEO_MEMORY_INFO NonLocalMemory;
-                            ZeroMemory(&NonLocalMemory, sizeof(NonLocalMemory));
-                            GetCurrentBudget(&NonLocalMemory, DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL);
-
-                            INT64 TotalUsage = LocalMemory.CurrentUsage + NonLocalMemory.CurrentUsage;
-                            INT64 TotalBudget = LocalMemory.Budget + NonLocalMemory.Budget;
-
-                            INT64 AvailableSpace = TotalBudget - TotalUsage;
-
-                            UINT64 BatchSize = 0;
-                            UINT32 NumObjectsInBatch = 0;
-                            UINT32 BatchStart = MakeResidentIndex;
-
-                            HRESULT hr = S_OK;
-                            if (AvailableSpace > 0)
-                            {
-                                for (UINT32 i = MakeResidentIndex; i < NumObjectsToMakeResident; i++)
-                                {
-                                    // If we try to make this object resident, will we go over budget?
-                                    if (BatchSize + pMakeResidentList[i].pManagedObject->Size > UINT64(AvailableSpace))
-                                    {
-                                        // Next time we will start here
-                                        MakeResidentIndex = i;
-                                        break;
-                                    }
-                                    else
-                                    {
-                                        BatchSize += pMakeResidentList[i].pManagedObject->Size;
-                                        NumObjectsInBatch++;
-                                        ObjectsMadeResident++;
-
-                                        pMakeResidentList[i].pUnderlying = pMakeResidentList[i].pManagedObject->pUnderlying;
-                                    }
-                                }
-
-                                hr = Device->MakeResident(NumObjectsInBatch, &pMakeResidentList[BatchStart].pUnderlying);
-                                if (SUCCEEDED(hr))
-                                {
-                                    SizeToMakeResident -= BatchSize;
-                                }
-                            }
-
-                            if (FAILED(hr) || ObjectsMadeResident != NumObjectsToMakeResident)
-                            {
-                                ManagedObject* pResidentHead = LRU.GetResidentListHead();
-
-                                // Get the next sync point to wait for
-                                FirstUncompletedSyncPoint = DequeueCompletedSyncPoints();
-
-                                // If there is nothing to trim OR the only objects 'Resident' are the ones about to be used by this execute.
-                                if (pResidentHead == nullptr ||
-                                    pResidentHead->LastGPUSyncPoint >= pWork->SyncPointGeneration ||
-                                    FirstUncompletedSyncPoint == nullptr)
-                                {
-                                    // Make resident the rest of the objects as there is nothing left to trim
-                                    UINT32 NumObjects = NumObjectsToMakeResident - ObjectsMadeResident;
-
-                                    // Gather up the remaining underlying objects
-                                    for (UINT32 i = MakeResidentIndex; i < NumObjectsToMakeResident; i++)
-                                    {
-                                        pMakeResidentList[i].pUnderlying = pMakeResidentList[i].pManagedObject->pUnderlying;
-                                    }
-
-                                    hr = Device->MakeResident(NumObjects, &pMakeResidentList[MakeResidentIndex].pUnderlying);
-                                    if (FAILED(hr))
-                                    {
-                                        // TODO: What should we do if this fails? This is a catastrophic failure in which the app is trying to use more memory
-                                        //       in 1 command list than can possibly be made resident by the system.
-                                        RESIDENCY_CHECK_RESULT(hr);
-                                    }
-                                    break;
-                                }
-
-                                UINT64 GenerationToWaitFor = FirstUncompletedSyncPoint->GenerationID;
-
-                                // We can't wait for the sync-point that this work is intended for
-                                if (GenerationToWaitFor == pWork->SyncPointGeneration)
-                                {
-                                    RESIDENCY_CHECK(GenerationToWaitFor >= 0);
-                                    GenerationToWaitFor -= 1;
-                                }
-                                // Wait until the GPU is done
-                                WaitForSyncPoint(GenerationToWaitFor);
-
-                                LRU.TrimToSyncPointInclusive(TotalUsage + INT64(SizeToMakeResident), TotalBudget, pEvictionList, NumObjectsToEvict, GenerationToWaitFor);
-
-                                RESIDENCY_CHECK_RESULT(Device->Evict(NumObjectsToEvict, pEvictionList));
-                            }
-                            else
-                            {
-                                // We made everything resident, mission accomplished
-                                break;
-                            }
-                        }
-                    }
-
-                    delete[](pMakeResidentList);
-                    delete[](pEvictionList);
-                }
-
-                // Tell the GPU that it's safe to execute since we made things resident
-                RESIDENCY_CHECK_RESULT(AsyncThreadFence.pFence->Signal(pWork->FenceValueToSignal));
-
-                delete(pWork->pMasterSet);
-                pWork->pMasterSet = nullptr;
-            }
-            // The Enqueue and Dequeue Async Work functions are threadsafe as there is only 1 producer and 1 consumer, if that changes
-            // Synchronisation will be required
-            HRESULT EnqueueAsyncWork(ResidencySet* pMasterSet, UINT64 FenceValueToSignal, UINT64 SyncPointGeneration)
-            {
-                // We can't get too far ahead of the worker thread otherwise huge hitches occur
-                while ((CurrentAsyncWorkloadTail - CurrentAsyncWorkloadHead) >= MaxSoftwareQueueLatency)
-                {
-                    WaitForSingleObject(AsyncThreadWorkCompletionEvent, INFINITE);
-                }
-
-                RESIDENCY_CHECK(CurrentAsyncWorkloadTail >= CurrentAsyncWorkloadHead);
-
-                const SIZE_T currentIndex = CurrentAsyncWorkloadTail % AsyncWorkQueueSize;
-                AsyncWorkQueue[currentIndex].pMasterSet = pMasterSet;
-                AsyncWorkQueue[currentIndex].FenceValueToSignal = FenceValueToSignal;
-                AsyncWorkQueue[currentIndex].SyncPointGeneration = SyncPointGeneration;
-
-                CurrentAsyncWorkloadTail++;
-                if (SetEvent(AsyncWorkEvent) == false)
-                {
-                    return HRESULT_FROM_WIN32(GetLastError());
-                }
-
-                return S_OK;
-            }
-
-            AsyncWorkload* DequeueAsyncWork()
-            {
-                if (CurrentAsyncWorkloadHead == CurrentAsyncWorkloadTail)
-                {
-                    return nullptr;
-                }
-
-                const SIZE_T currentHead = CurrentAsyncWorkloadHead % AsyncWorkQueueSize;
-                AsyncWorkload* pWork = &AsyncWorkQueue[currentHead];
-
-                CurrentAsyncWorkloadHead++;
-                return pWork;
-            }
-
-            void GetCurrentBudget(DXGI_QUERY_VIDEO_MEMORY_INFO* InfoOut, DXGI_MEMORY_SEGMENT_GROUP Segment)
-            {
-                RESIDENCY_CHECK_RESULT(Adapter->QueryVideoMemoryInfo(NodeIndex, Segment, InfoOut));
-            }
-
-            HRESULT EnqueueSyncPoint()
-            {
-                Internal::ScopedLock Lock(&AsyncWorkMutex);
-
-                Internal::DeviceWideSyncPoint* pPoint = Internal::DeviceWideSyncPoint::CreateSyncPoint(NumQueuesSeen, CurrentSyncPointGeneration);
-                if (pPoint == nullptr)
-                {
-                    return E_OUTOFMEMORY;
-                }
-
-                UINT32 i = 0;
-                LIST_ENTRY* pFenceEntry = QueueFencesListHead.Flink;
-                // Record the current state of each queue we track into this sync point
-                while (pFenceEntry != &QueueFencesListHead)
-                {
-                    Internal::Fence* pFence = CONTAINING_RECORD(pFenceEntry, Internal::Fence, ListEntry);
-                    pFenceEntry = pFenceEntry->Flink;
-
-                    pPoint->pQueueSyncPoints[i].pFence = pFence;
-                    pPoint->pQueueSyncPoints[i].LastUsedValue = pFence->FenceValue - 1;//Minus one as we want the last submitted
-
-                    i++;
-                }
-
-                Internal::InsertTailList(&InFlightSyncPointsHead, &pPoint->ListEntry);
-
-                return S_OK;
-            }
-
-            // Returns a pointer to the first synch point which is not completed
-            Internal::DeviceWideSyncPoint* DequeueCompletedSyncPoints()
-            {
-                Internal::ScopedLock Lock(&AsyncWorkMutex);
-
-                while (Internal::IsListEmpty(&InFlightSyncPointsHead) == false)
-                {
-                    Internal::DeviceWideSyncPoint* pPoint =
-                        CONTAINING_RECORD(InFlightSyncPointsHead.Flink, Internal::DeviceWideSyncPoint, ListEntry);
-
-                    if (pPoint->IsCompleted())
-                    {
-                        Internal::RemoveHeadList(&InFlightSyncPointsHead);
-                        delete pPoint;
-                    }
-                    else
-                    {
-                        return pPoint;
-                    }
-                }
-
-                return nullptr;
-            }
-
-            void WaitForSyncPoint(UINT64 SyncPointID)
-            {
-                Internal::ScopedLock Lock(&AsyncWorkMutex);
-
-                LIST_ENTRY* pPointEntry = InFlightSyncPointsHead.Flink;
-                while (pPointEntry != &InFlightSyncPointsHead)
-                {
-                    Internal::DeviceWideSyncPoint* pPoint =
-                        CONTAINING_RECORD(InFlightSyncPointsHead.Flink, Internal::DeviceWideSyncPoint, ListEntry);
-
-                    if (pPoint->GenerationID > SyncPointID)
-                    {
-                        // this point is already done
-                        return;
-                    }
-                    else if (pPoint->GenerationID < SyncPointID)
-                    {
-                        // Keep popping off until we find the one to wait on
-                        Internal::RemoveHeadList(&InFlightSyncPointsHead);
-                        delete(pPoint);
-                    }
-                    else
-                    {
-                        pPoint->WaitForCompletion(CompletionEvent);
-                        Internal::RemoveHeadList(&InFlightSyncPointsHead);
-                        delete(pPoint);
-                        return;
-                    }
-                }
-            }
-
-            // Generate a result between the minimum period and the maximum period based on the current
-            // local memory pressure. I.e. when memory pressure is low, objects will persist longer before
-            // being evicted.
-            UINT64 GetCurrentEvictionGracePeriod(DXGI_QUERY_VIDEO_MEMORY_INFO* LocalMemoryState)
-            {
-                // 1 == full pressure, 0 == no pressure
-                double Pressure = (double(LocalMemoryState->CurrentUsage) / double(LocalMemoryState->Budget));
-                Pressure = RESIDENCY_MIN(Pressure, 1.0);
-
-                if (Pressure > cTrimPercentageMemoryUsageThreshold)
-                {
-                    // Normalize the pressure for the range 0 to cTrimPercentageMemoryUsageThreshold
-                    Pressure = (Pressure - cTrimPercentageMemoryUsageThreshold) / (1.0 - cTrimPercentageMemoryUsageThreshold);
-
-                    // Linearly interpolate between the min period and the max period based on the pressure
-                    return UINT64((MaxEvictionGracePeriodTicks - MinEvictionGracePeriodTicks) * (1.0 - Pressure)) + MinEvictionGracePeriodTicks;
-                }
-                else
-                {
-                    // Essentially don't trim at all
-                    return MAXUINT64;
-                }
-            }
-
-            LIST_ENTRY QueueFencesListHead;
-            UINT32 NumQueuesSeen;
-            Internal::Fence AsyncThreadFence;
-
-            LIST_ENTRY InFlightSyncPointsHead;
-            UINT64 CurrentSyncPointGeneration;
-
-            HANDLE CompletionEvent;
-            HANDLE AsyncThreadWorkCompletionEvent;
-
-            ID3D12Device* Device;
-            // NOTE: This is an index not a mask. The majority of D3D12 uses bit masks to identify a GPU node whereas DXGI uses 0 based indices.
-            UINT NodeIndex;
-            IDXGIAdapter3* Adapter;
-            Internal::LRUCache LRU;
-
-            Internal::CriticalSection Mutex;
-
-            Internal::CriticalSection ExecutionCS;
-
-            const bool cStartEvicted;
-
-            const float cMinEvictionGracePeriod;
-            UINT64 MinEvictionGracePeriodTicks;
-            const float cMaxEvictionGracePeriod;
-            UINT64 MaxEvictionGracePeriodTicks;
-            // When the app is using more than this % of its budgeted local VidMem trimming will occur
-            // (valid between 0.0 - 1.0)
-            const float cTrimPercentageMemoryUsageThreshold;
-
-            UINT32 MaxSoftwareQueueLatency;
-            INT64 ResidencyManagerUniqueID;
-
-            SyncManager* pSyncManager;
-        };
-    }
-
-    class ResidencyManager
-    {
-    public:
-        ResidencyManager() :
-            Manager(&SyncManager)
-        {
-        }
-
-        // NOTE: DeviceNodeIndex is an index not a mask. The majority of D3D12 uses bit masks to identify a GPU node whereas DXGI uses 0 based indices.
-        FORCEINLINE HRESULT Initialize(ID3D12Device* ParentDevice, UINT DeviceNodeIndex, IDXGIAdapter3* ParentAdapter, UINT32 MaxLatency)
-        {
-            return Manager.Initialize(ParentDevice, DeviceNodeIndex, ParentAdapter, MaxLatency);
-        }
-
-        FORCEINLINE void Destroy()
-        {
-            Manager.Destroy();
-        }
-
-        FORCEINLINE void BeginTrackingObject(ManagedObject* pObject)
-        {
-            Manager.BeginTrackingObject(pObject);
-        }
-
-        FORCEINLINE void EndTrackingObject(ManagedObject* pObject)
-        {
-            Manager.EndTrackingObject(pObject);
-        }
-
-        HRESULT GetCurrentGPUSyncPoint(ID3D12CommandQueue* Queue, UINT64 *pCurrentGPUSyncPoint)
-        {
-            return Manager.GetCurrentGPUSyncPoint(Queue, pCurrentGPUSyncPoint);
-        }
-
-        // One residency set per command-list
-        FORCEINLINE HRESULT ExecuteCommandLists(ID3D12CommandQueue* Queue, ID3D12CommandList** CommandLists, ResidencySet** ResidencySets, UINT32 Count)
-        {
-            return Manager.ExecuteCommandLists(Queue, CommandLists, ResidencySets, Count);
-        }
-
-        FORCEINLINE ResidencySet* CreateResidencySet()
-        {
-            ResidencySet* pSet = new ResidencySet();
-
-            if (pSet)
-            {
-                pSet->Initialize(&SyncManager);
-            }
-            return pSet;
-        }
-
-        FORCEINLINE void DestroyResidencySet(ResidencySet* pSet)
-        {
-            delete(pSet);
-        }
-
-    private:
-        Internal::ResidencyManagerInternal Manager;
-        Internal::SyncManager SyncManager;
-    };
+					// If there are some things that need to be made resident we need to make sure that the GPU
+					// doesn't execute until the async thread signals that the MakeResident call has returned.
+					if (SUCCEEDED(hr))
+					{
+						hr = AsyncThreadFence.GPUWait(Queue);
+						AsyncThreadFence.Increment();
+					}
+
+					Queue->ExecuteCommandLists(Count, CommandLists);
+
+					if (SUCCEEDED(hr))
+					{
+						hr = SignalFence(Queue, QueueFence);
+					}
+				}
+				return hr;
+			}
+
+			struct AsyncWorkload
+			{
+				AsyncWorkload() :
+					pMasterSet(nullptr),
+					FenceValueToSignal(0),
+					SyncPointGeneration(0)
+				{}
+
+				UINT64 SyncPointGeneration;
+
+				// List of objects to make resident
+				ResidencySet* pMasterSet;
+
+				// The GPU will wait on this value so that it doesn't execute until the objects are made resident
+				UINT64 FenceValueToSignal;
+			};
+
+			SIZE_T AsyncWorkQueueSize;
+			AsyncWorkload* AsyncWorkQueue;
+
+			HANDLE AsyncWorkEvent;
+			HANDLE AsyncWorkThread;
+			Internal::CriticalSection AsyncWorkMutex;
+			volatile bool FinishAsyncWork;
+			volatile SIZE_T CurrentAsyncWorkloadHead;
+			volatile SIZE_T CurrentAsyncWorkloadTail;
+
+			static unsigned long WINAPI AsyncThreadStart(void* pData)
+			{
+				ResidencyManagerInternal* pManager = (ResidencyManagerInternal*)pData;
+
+				while (1)
+				{
+					AsyncWorkload* pWork = pManager->DequeueAsyncWork();
+
+					while (pWork)
+					{
+						// Submit the work
+						pManager->ProcessPagingWork(pWork);
+						if (SetEvent(pManager->AsyncThreadWorkCompletionEvent) == false)
+						{
+							RESIDENCY_CHECK_RESULT(HRESULT_FROM_WIN32(GetLastError()));
+						}
+
+						// Get more work
+						pWork = pManager->DequeueAsyncWork();
+					}
+
+					//Wait until there is more work do be done
+					WaitForSingleObject(pManager->AsyncWorkEvent, INFINITE);
+					if (ResetEvent(pManager->AsyncWorkEvent) == false)
+					{
+						RESIDENCY_CHECK_RESULT(HRESULT_FROM_WIN32(GetLastError()));
+					}
+
+					if (pManager->FinishAsyncWork)
+					{
+						return 0;
+					}
+				}
+
+				return 0;
+			}
+
+			// This will be run from a worker thread and will emulate a software queue for making gpu resources resident or evicted.
+			// The GPU will be synchronized by this queue to ensure that it never executes using an evicted resource.
+			void ProcessPagingWork(AsyncWorkload* pWork)
+			{
+				Internal::DeviceWideSyncPoint* FirstUncompletedSyncPoint = DequeueCompletedSyncPoints();
+
+				// Use a union so that we only need 1 allocation
+				union ResidentScratchSpace
+				{
+					ManagedObject* pManagedObject;
+					ID3D12Pageable* pUnderlying;
+				};
+
+				ResidentScratchSpace* pMakeResidentList = nullptr;
+				UINT32 NumObjectsToMakeResident = 0;
+
+				ID3D12Pageable** pEvictionList = nullptr;
+				UINT32 NumObjectsToEvict = 0;
+
+				// the size of all the objects which will need to be made resident in order to execute this set.
+				UINT64 SizeToMakeResident = 0;
+
+				LARGE_INTEGER CurrentTime;
+				QueryPerformanceCounter(&CurrentTime);
+
+				{
+					// A lock must be taken here as the state of the objects will be altered
+					Internal::ScopedLock Lock(&Mutex);
+
+					pMakeResidentList = new ResidentScratchSpace[pWork->pMasterSet->CurrentSetSize];
+					pEvictionList = new ID3D12Pageable*[LRU.NumResidentObjects];
+
+					// Mark the objects used by this command list to be made resident
+					for (INT32 i = 0; i < pWork->pMasterSet->CurrentSetSize; i++)
+					{
+						ManagedObject*& pObject = pWork->pMasterSet->ppSet[i];
+						// If it's evicted we need to make it resident again
+						if (pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::EVICTED)
+						{
+							pMakeResidentList[NumObjectsToMakeResident++].pManagedObject = pObject;
+							LRU.MakeResident(pObject);
+
+							SizeToMakeResident += pObject->Size;
+						}
+
+						// Update the last sync point that this was used on
+						pObject->LastGPUSyncPoint = pWork->SyncPointGeneration;
+
+						pObject->LastUsedTimestamp = CurrentTime.QuadPart;
+						LRU.ObjectReferenced(pObject);
+					}
+
+					DXGI_QUERY_VIDEO_MEMORY_INFO LocalMemory;
+					ZeroMemory(&LocalMemory, sizeof(LocalMemory));
+					GetCurrentBudget(&LocalMemory, DXGI_MEMORY_SEGMENT_GROUP_LOCAL);
+
+					UINT64 EvictionGracePeriod = GetCurrentEvictionGracePeriod(&LocalMemory);
+					LRU.TrimAgedAllocations(FirstUncompletedSyncPoint, pEvictionList, NumObjectsToEvict, CurrentTime.QuadPart, EvictionGracePeriod);
+
+					if (NumObjectsToEvict)
+					{
+						RESIDENCY_CHECK_RESULT(Device->Evict(NumObjectsToEvict, pEvictionList));
+						NumObjectsToEvict = 0;
+					}
+
+					if (NumObjectsToMakeResident)
+					{
+						UINT32 ObjectsMadeResident = 0;
+						UINT32 MakeResidentIndex = 0;
+						while (true)
+						{
+							ZeroMemory(&LocalMemory, sizeof(LocalMemory));
+
+							GetCurrentBudget(&LocalMemory, DXGI_MEMORY_SEGMENT_GROUP_LOCAL);
+							DXGI_QUERY_VIDEO_MEMORY_INFO NonLocalMemory;
+							ZeroMemory(&NonLocalMemory, sizeof(NonLocalMemory));
+							GetCurrentBudget(&NonLocalMemory, DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL);
+
+							INT64 TotalUsage = LocalMemory.CurrentUsage + NonLocalMemory.CurrentUsage;
+							INT64 TotalBudget = LocalMemory.Budget + NonLocalMemory.Budget;
+
+							INT64 AvailableSpace = TotalBudget - TotalUsage;
+
+							UINT64 BatchSize = 0;
+							UINT32 NumObjectsInBatch = 0;
+							UINT32 BatchStart = MakeResidentIndex;
+
+							HRESULT hr = S_OK;
+							if (AvailableSpace > 0)
+							{
+								for (UINT32 i = MakeResidentIndex; i < NumObjectsToMakeResident; i++)
+								{
+									// If we try to make this object resident, will we go over budget?
+									if (BatchSize + pMakeResidentList[i].pManagedObject->Size > UINT64(AvailableSpace))
+									{
+										// Next time we will start here
+										MakeResidentIndex = i;
+										break;
+									}
+									else
+									{
+										BatchSize += pMakeResidentList[i].pManagedObject->Size;
+										NumObjectsInBatch++;
+										ObjectsMadeResident++;
+
+										pMakeResidentList[i].pUnderlying = pMakeResidentList[i].pManagedObject->pUnderlying;
+									}
+								}
+
+								hr = Device->MakeResident(NumObjectsInBatch, &pMakeResidentList[BatchStart].pUnderlying);
+								if (SUCCEEDED(hr))
+								{
+									SizeToMakeResident -= BatchSize;
+								}
+							}
+
+							if (FAILED(hr) || ObjectsMadeResident != NumObjectsToMakeResident)
+							{
+								ManagedObject* pResidentHead = LRU.GetResidentListHead();
+
+								// Get the next sync point to wait for
+								FirstUncompletedSyncPoint = DequeueCompletedSyncPoints();
+
+								// If there is nothing to trim OR the only objects 'Resident' are the ones about to be used by this execute.
+								if (pResidentHead == nullptr ||
+									pResidentHead->LastGPUSyncPoint >= pWork->SyncPointGeneration ||
+									FirstUncompletedSyncPoint == nullptr)
+								{
+									// Make resident the rest of the objects as there is nothing left to trim
+									UINT32 NumObjects = NumObjectsToMakeResident - ObjectsMadeResident;
+
+									// Gather up the remaining underlying objects
+									for (UINT32 i = MakeResidentIndex; i < NumObjectsToMakeResident; i++)
+									{
+										pMakeResidentList[i].pUnderlying = pMakeResidentList[i].pManagedObject->pUnderlying;
+									}
+
+									hr = Device->MakeResident(NumObjects, &pMakeResidentList[MakeResidentIndex].pUnderlying);
+									if (FAILED(hr))
+									{
+										// TODO: What should we do if this fails? This is a catastrophic failure in which the app is trying to use more memory
+										//       in 1 command list than can possibly be made resident by the system.
+										RESIDENCY_CHECK_RESULT(hr);
+									}
+									break;
+								}
+
+								UINT64 GenerationToWaitFor = FirstUncompletedSyncPoint->GenerationID;
+
+								// We can't wait for the sync-point that this work is intended for
+								if (GenerationToWaitFor == pWork->SyncPointGeneration)
+								{
+									RESIDENCY_CHECK(GenerationToWaitFor >= 0);
+									GenerationToWaitFor -= 1;
+								}
+								// Wait until the GPU is done
+								WaitForSyncPoint(GenerationToWaitFor);
+
+								LRU.TrimToSyncPointInclusive(TotalUsage + INT64(SizeToMakeResident), TotalBudget, pEvictionList, NumObjectsToEvict, GenerationToWaitFor);
+
+								RESIDENCY_CHECK_RESULT(Device->Evict(NumObjectsToEvict, pEvictionList));
+							}
+							else
+							{
+								// We made everything resident, mission accomplished
+								break;
+							}
+						}
+					}
+
+					delete[](pMakeResidentList);
+					delete[](pEvictionList);
+				}
+
+				// Tell the GPU that it's safe to execute since we made things resident
+				RESIDENCY_CHECK_RESULT(AsyncThreadFence.pFence->Signal(pWork->FenceValueToSignal));
+
+				delete(pWork->pMasterSet);
+				pWork->pMasterSet = nullptr;
+			}
+			// The Enqueue and Dequeue Async Work functions are threadsafe as there is only 1 producer and 1 consumer, if that changes
+			// Synchronisation will be required
+			HRESULT EnqueueAsyncWork(ResidencySet* pMasterSet, UINT64 FenceValueToSignal, UINT64 SyncPointGeneration)
+			{
+				// We can't get too far ahead of the worker thread otherwise huge hitches occur
+				while ((CurrentAsyncWorkloadTail - CurrentAsyncWorkloadHead) >= MaxSoftwareQueueLatency)
+				{
+					WaitForSingleObject(AsyncThreadWorkCompletionEvent, INFINITE);
+				}
+
+				RESIDENCY_CHECK(CurrentAsyncWorkloadTail >= CurrentAsyncWorkloadHead);
+
+				const SIZE_T currentIndex = CurrentAsyncWorkloadTail % AsyncWorkQueueSize;
+				AsyncWorkQueue[currentIndex].pMasterSet = pMasterSet;
+				AsyncWorkQueue[currentIndex].FenceValueToSignal = FenceValueToSignal;
+				AsyncWorkQueue[currentIndex].SyncPointGeneration = SyncPointGeneration;
+
+				CurrentAsyncWorkloadTail++;
+				if (SetEvent(AsyncWorkEvent) == false)
+				{
+					return HRESULT_FROM_WIN32(GetLastError());
+				}
+
+				return S_OK;
+			}
+
+			AsyncWorkload* DequeueAsyncWork()
+			{
+				if (CurrentAsyncWorkloadHead == CurrentAsyncWorkloadTail)
+				{
+					return nullptr;
+				}
+
+				const SIZE_T currentHead = CurrentAsyncWorkloadHead % AsyncWorkQueueSize;
+				AsyncWorkload* pWork = &AsyncWorkQueue[currentHead];
+
+				CurrentAsyncWorkloadHead++;
+				return pWork;
+			}
+
+			void GetCurrentBudget(DXGI_QUERY_VIDEO_MEMORY_INFO* InfoOut, DXGI_MEMORY_SEGMENT_GROUP Segment)
+			{
+				RESIDENCY_CHECK_RESULT(Adapter->QueryVideoMemoryInfo(NodeIndex, Segment, InfoOut));
+			}
+
+			HRESULT EnqueueSyncPoint()
+			{
+				Internal::ScopedLock Lock(&AsyncWorkMutex);
+
+				Internal::DeviceWideSyncPoint* pPoint = Internal::DeviceWideSyncPoint::CreateSyncPoint(NumQueuesSeen, CurrentSyncPointGeneration);
+				if (pPoint == nullptr)
+				{
+					return E_OUTOFMEMORY;
+				}
+
+				UINT32 i = 0;
+				LIST_ENTRY* pFenceEntry = QueueFencesListHead.Flink;
+				// Record the current state of each queue we track into this sync point
+				while (pFenceEntry != &QueueFencesListHead)
+				{
+					Internal::Fence* pFence = CONTAINING_RECORD(pFenceEntry, Internal::Fence, ListEntry);
+					pFenceEntry = pFenceEntry->Flink;
+
+					pPoint->pQueueSyncPoints[i].pFence = pFence;
+					pPoint->pQueueSyncPoints[i].LastUsedValue = pFence->FenceValue - 1;//Minus one as we want the last submitted
+
+					i++;
+				}
+
+				Internal::InsertTailList(&InFlightSyncPointsHead, &pPoint->ListEntry);
+
+				return S_OK;
+			}
+
+			// Returns a pointer to the first synch point which is not completed
+			Internal::DeviceWideSyncPoint* DequeueCompletedSyncPoints()
+			{
+				Internal::ScopedLock Lock(&AsyncWorkMutex);
+
+				while (Internal::IsListEmpty(&InFlightSyncPointsHead) == false)
+				{
+					Internal::DeviceWideSyncPoint* pPoint =
+						CONTAINING_RECORD(InFlightSyncPointsHead.Flink, Internal::DeviceWideSyncPoint, ListEntry);
+
+					if (pPoint->IsCompleted())
+					{
+						Internal::RemoveHeadList(&InFlightSyncPointsHead);
+						delete pPoint;
+					}
+					else
+					{
+						return pPoint;
+					}
+				}
+
+				return nullptr;
+			}
+
+			void WaitForSyncPoint(UINT64 SyncPointID)
+			{
+				Internal::ScopedLock Lock(&AsyncWorkMutex);
+
+				LIST_ENTRY* pPointEntry = InFlightSyncPointsHead.Flink;
+				while (pPointEntry != &InFlightSyncPointsHead)
+				{
+					Internal::DeviceWideSyncPoint* pPoint =
+						CONTAINING_RECORD(InFlightSyncPointsHead.Flink, Internal::DeviceWideSyncPoint, ListEntry);
+
+					if (pPoint->GenerationID > SyncPointID)
+					{
+						// this point is already done
+						return;
+					}
+					else if (pPoint->GenerationID < SyncPointID)
+					{
+						// Keep popping off until we find the one to wait on
+						Internal::RemoveHeadList(&InFlightSyncPointsHead);
+						delete(pPoint);
+					}
+					else
+					{
+						pPoint->WaitForCompletion(CompletionEvent);
+						Internal::RemoveHeadList(&InFlightSyncPointsHead);
+						delete(pPoint);
+						return;
+					}
+				}
+			}
+
+			// Generate a result between the minimum period and the maximum period based on the current
+			// local memory pressure. I.e. when memory pressure is low, objects will persist longer before
+			// being evicted.
+			UINT64 GetCurrentEvictionGracePeriod(DXGI_QUERY_VIDEO_MEMORY_INFO* LocalMemoryState)
+			{
+				// 1 == full pressure, 0 == no pressure
+				double Pressure = (double(LocalMemoryState->CurrentUsage) / double(LocalMemoryState->Budget));
+				Pressure = RESIDENCY_MIN(Pressure, 1.0);
+
+				if (Pressure > cTrimPercentageMemoryUsageThreshold)
+				{
+					// Normalize the pressure for the range 0 to cTrimPercentageMemoryUsageThreshold
+					Pressure = (Pressure - cTrimPercentageMemoryUsageThreshold) / (1.0 - cTrimPercentageMemoryUsageThreshold);
+
+					// Linearly interpolate between the min period and the max period based on the pressure
+					return UINT64((MaxEvictionGracePeriodTicks - MinEvictionGracePeriodTicks) * (1.0 - Pressure)) + MinEvictionGracePeriodTicks;
+				}
+				else
+				{
+					// Essentially don't trim at all
+					return MAXUINT64;
+				}
+			}
+
+			LIST_ENTRY QueueFencesListHead;
+			UINT32 NumQueuesSeen;
+			Internal::Fence AsyncThreadFence;
+
+			LIST_ENTRY InFlightSyncPointsHead;
+			UINT64 CurrentSyncPointGeneration;
+
+			HANDLE CompletionEvent;
+			HANDLE AsyncThreadWorkCompletionEvent;
+
+			ID3D12Device* Device;
+			// NOTE: This is an index not a mask. The majority of D3D12 uses bit masks to identify a GPU node whereas DXGI uses 0 based indices.
+			UINT NodeIndex;
+			IDXGIAdapter3* Adapter;
+			Internal::LRUCache LRU;
+
+			Internal::CriticalSection Mutex;
+
+			Internal::CriticalSection ExecutionCS;
+
+			const bool cStartEvicted;
+
+			const float cMinEvictionGracePeriod;
+			UINT64 MinEvictionGracePeriodTicks;
+			const float cMaxEvictionGracePeriod;
+			UINT64 MaxEvictionGracePeriodTicks;
+			// When the app is using more than this % of its budgeted local VidMem trimming will occur
+			// (valid between 0.0 - 1.0)
+			const float cTrimPercentageMemoryUsageThreshold;
+
+			UINT32 MaxSoftwareQueueLatency;
+			INT64 ResidencyManagerUniqueID;
+
+			SyncManager* pSyncManager;
+		};
+	}
+
+	class ResidencyManager
+	{
+	public:
+		ResidencyManager() :
+			Manager(&SyncManager)
+		{
+		}
+
+		// NOTE: DeviceNodeIndex is an index not a mask. The majority of D3D12 uses bit masks to identify a GPU node whereas DXGI uses 0 based indices.
+		FORCEINLINE HRESULT Initialize(ID3D12Device* ParentDevice, UINT DeviceNodeIndex, IDXGIAdapter3* ParentAdapter, UINT32 MaxLatency)
+		{
+			return Manager.Initialize(ParentDevice, DeviceNodeIndex, ParentAdapter, MaxLatency);
+		}
+
+		FORCEINLINE void Destroy()
+		{
+			Manager.Destroy();
+		}
+
+		FORCEINLINE void BeginTrackingObject(ManagedObject* pObject)
+		{
+			Manager.BeginTrackingObject(pObject);
+		}
+
+		FORCEINLINE void EndTrackingObject(ManagedObject* pObject)
+		{
+			Manager.EndTrackingObject(pObject);
+		}
+
+		HRESULT GetCurrentGPUSyncPoint(ID3D12CommandQueue* Queue, UINT64 *pCurrentGPUSyncPoint)
+		{
+			return Manager.GetCurrentGPUSyncPoint(Queue, pCurrentGPUSyncPoint);
+		}
+
+		// One residency set per command-list
+		FORCEINLINE HRESULT ExecuteCommandLists(ID3D12CommandQueue* Queue, ID3D12CommandList** CommandLists, ResidencySet** ResidencySets, UINT32 Count)
+		{
+			return Manager.ExecuteCommandLists(Queue, CommandLists, ResidencySets, Count);
+		}
+
+		FORCEINLINE ResidencySet* CreateResidencySet()
+		{
+			ResidencySet* pSet = new ResidencySet();
+
+			if (pSet)
+			{
+				pSet->Initialize(&SyncManager);
+			}
+			return pSet;
+		}
+
+		FORCEINLINE void DestroyResidencySet(ResidencySet* pSet)
+		{
+			delete(pSet);
+		}
+
+	private:
+		Internal::ResidencyManagerInternal Manager;
+		Internal::SyncManager SyncManager;
+	};
 };

--- a/Samples/UWP/D3D12Residency/src/shaders.hlsl
+++ b/Samples/UWP/D3D12Residency/src/shaders.hlsl
@@ -11,8 +11,8 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 Texture2D g_texture : register(t0);
@@ -20,15 +20,15 @@ SamplerState g_sampler : register(s0);
 
 PSInput VSMain(float4 position : POSITION, float4 uv : TEXCOORD)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.uv = uv;
+	result.position = position;
+	result.uv = uv;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return g_texture.Sample(g_sampler, input.uv);
+	return g_texture.Sample(g_sampler, input.uv);
 }

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.cpp
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.cpp
@@ -41,9 +41,10 @@ D3D12SM6WaveIntrinsics::D3D12SM6WaveIntrinsics(UINT width, UINT height, std::wst
     m_cbSrvDescriptorSize(0),
     m_constantBufferData{},
     m_mousePosition{ width*0.5f, height*0.5f },
-    m_mouseLeftButtonDown(false),
+	m_mouseLeftButtonDown(false),
     m_rendermode{ 1 }
 {
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
 }
 
 void D3D12SM6WaveIntrinsics::OnInit()
@@ -69,7 +70,7 @@ void D3D12SM6WaveIntrinsics::CreateDevice(const ComPtr<IDXGIFactory4>& factory)
     else
     {
         ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+        GetHardwareAdapter(factory.Get(), &hardwareAdapter, true);
 
         ThrowIfFailed(D3D12CreateDevice(
             hardwareAdapter.Get(),
@@ -104,8 +105,8 @@ void D3D12SM6WaveIntrinsics::LoadPipeline()
     ComPtr<IDXGIFactory4> factory;
     ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    // Create device.
-    CreateDevice(factory);
+	// Create device.
+	CreateDevice(factory);
 
     // Query the level of support of Shader Model.
     D3D12_FEATURE_DATA_SHADER_MODEL shaderModelSupport = { D3D_SHADER_MODEL_6_0 };
@@ -132,8 +133,8 @@ void D3D12SM6WaveIntrinsics::LoadPipeline()
         {
             exit(-1);
         }
-    }    
-    
+    }	
+	
     // Describe and create the command queue.
     D3D12_COMMAND_QUEUE_DESC queueDesc = {};
     queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
@@ -155,7 +156,7 @@ void D3D12SM6WaveIntrinsics::LoadPipeline()
     ComPtr<IDXGISwapChain1> swapChain;
 
     ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
+        m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
         reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
         &swapChainDesc,
         nullptr,
@@ -349,13 +350,13 @@ void D3D12SM6WaveIntrinsics::LoadAssets()
         // Describe and create a constant buffer view.
         D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
         cbvDesc.BufferLocation = m_constantBuffer->GetGPUVirtualAddress();
-        cbvDesc.SizeInBytes = (sizeof(SceneConstantBuffer) + 255) & ~255;    // CB size is required to be 256-byte aligned.
+        cbvDesc.SizeInBytes = (sizeof(SceneConstantBuffer) + 255) & ~255;	// CB size is required to be 256-byte aligned.
         CD3DX12_CPU_DESCRIPTOR_HANDLE cbHandle(m_cbSrvHeap->GetCPUDescriptorHandleForHeapStart());
         m_d3d12Device->CreateConstantBufferView(&cbvDesc, cbHandle);
 
         // Map and initialize the constant buffer. We don't unmap this until the
         // app closes. Keeping things mapped for the lifetime of the resource is okay.
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
+        CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
         ThrowIfFailed(m_constantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&m_pCbSrvDataBegin)));
         memcpy(m_pCbSrvDataBegin, &m_constantBufferData, sizeof(m_constantBufferData));
     }
@@ -416,7 +417,7 @@ void D3D12SM6WaveIntrinsics::LoadSizeDependentResources()
 
         // Copy the triangle data to the vertex buffer.
         UINT8* pVertexDataBegin;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
+        CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
         ThrowIfFailed(m_renderPass1VertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
         memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
         m_renderPass1VertexBuffer->Unmap(0, nullptr);
@@ -457,7 +458,7 @@ void D3D12SM6WaveIntrinsics::LoadSizeDependentResources()
 
         // Copy the triangle data to the vertex buffer.
         UINT8* pVertexDataBegin;
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
+        CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
         ThrowIfFailed(m_renderPass2VertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)));
         memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
         m_renderPass2VertexBuffer->Unmap(0, nullptr);
@@ -598,14 +599,56 @@ void D3D12SM6WaveIntrinsics::OnUpdate()
 // Render the scene.
 void D3D12SM6WaveIntrinsics::OnRender()
 {
-    RenderUI();
-    // Record all the commands we need to render the scene into the command list.
-    RenderScene();
+    try
+    {
+        RenderUI();
+        // Record all the commands we need to render the scene into the command list.
+        RenderScene();
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+        // Present the frame.
+        ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    MoveToNextFrame();
+        MoveToNextFrame();
+    }
+    catch (HrException& e)
+    {
+        if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
+        {
+            RestoreD3DResources();
+        }
+        else
+        {
+            throw;
+        }
+    }
+}
+
+// Release sample's D3D objects.
+void D3D12SM6WaveIntrinsics::ReleaseD3DResources()
+{
+    m_fence.Reset();
+    m_renderPass1RenderTargets.Reset();
+    m_uiRenderTarget.Reset();
+    ResetComPtrArray(&m_renderPass2RenderTargets);
+    m_commandQueue.Reset();
+    m_swapChain.Reset();
+    m_d3d12Device.Reset();
+}
+
+// Tears down D3D resources and reinitializes them.
+void D3D12SM6WaveIntrinsics::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
+    {
+        WaitForGpu();
+    }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
 }
 
 void D3D12SM6WaveIntrinsics::OnDestroy()
@@ -791,17 +834,17 @@ void D3D12SM6WaveIntrinsics::OnSizeChanged(UINT width, UINT height, bool minimiz
 
 void D3D12SM6WaveIntrinsics::OnMouseMove(UINT x, UINT y)
 {
-    // Only update the zoom-in area while mouse left button is pressed.
-    if(m_mouseLeftButtonDown)
-    {
-        m_mousePosition[0] = static_cast<float>(x);
-        m_mousePosition[1] = static_cast<float>(y);        
-    }
+	// Only update the zoom-in area while mouse left button is pressed.
+	if(m_mouseLeftButtonDown)
+	{
+		m_mousePosition[0] = static_cast<float>(x);
+		m_mousePosition[1] = static_cast<float>(y);		
+	}
 }
 
 void D3D12SM6WaveIntrinsics::OnLeftButtonDown(UINT /*x*/, UINT /*y*/)
 {
-    m_mouseLeftButtonDown = true;
+	m_mouseLeftButtonDown = true;
 }
 
 void D3D12SM6WaveIntrinsics::OnLeftButtonUp(UINT /*x*/, UINT /*y*/)

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.h
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.h
@@ -37,8 +37,8 @@ public:
     virtual void OnDestroy();
     virtual void OnKeyDown(UINT8 key);
     virtual void OnSizeChanged(UINT width, UINT height, bool minimized);
-    virtual void OnMouseMove(UINT x, UINT y);
-    virtual void OnLeftButtonDown(UINT x, UINT y);
+	virtual void OnMouseMove(UINT x, UINT y);
+	virtual void OnLeftButtonDown(UINT x, UINT y);
     virtual void OnLeftButtonUp(UINT x, UINT y);
     virtual IDXGISwapChain* GetSwapchain() { return m_swapChain.Get(); }
 
@@ -105,7 +105,7 @@ private:
     SceneConstantBuffer m_constantBufferData;
     UINT8* m_pCbSrvDataBegin;
     float m_mousePosition[2];
-    bool m_mouseLeftButtonDown;
+	bool m_mouseLeftButtonDown;
 
     // Synchronization objects.
     UINT m_frameIndex;
@@ -120,9 +120,11 @@ private:
     // UILayer
     std::shared_ptr<UILayer> m_uiLayer;
 
-    void CreateDevice(const ComPtr<IDXGIFactory4>& factory);
+	void CreateDevice(const ComPtr<IDXGIFactory4>& factory);
     void LoadPipeline();
     void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
     void LoadSizeDependentResources();
     void MoveToNextFrame();
     void WaitForGpu();

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/DXSample.cpp
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/DXSample.cpp
@@ -52,33 +52,78 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
+
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+            }
+#if !defined(_XBOX_ONE)
+        }
+#endif
 
     *ppAdapter = adapter.Detach();
-}
+    }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/DXSample.h
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/DXSample.h
@@ -48,7 +48,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/Main.cpp
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12SM6WaveIntrinsics sample(1200, 900, L"");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12SM6WaveIntrinsics sample(1200, 900, L"");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/View.cpp
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/View.cpp
@@ -17,61 +17,61 @@ using namespace Windows::System;
 
 inline int ConvertToPixels(float dimension, float dpi)
 {
-    return static_cast<int>(dimension * dpi / 96.0f + 0.5f);
+	return static_cast<int>(dimension * dpi / 96.0f + 0.5f);
 }
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false),
-    m_windowResizing(false),
-    m_windowVisible(true),
-    m_logicalWidth(0),
-    m_logicalHeight(0)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false),
+	m_windowResizing(false),
+	m_windowVisible(true),
+	m_logicalWidth(0),
+	m_logicalHeight(0)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    m_logicalWidth = window->Bounds.Width;
-    m_logicalHeight = window->Bounds.Height;
+	m_logicalWidth = window->Bounds.Width;
+	m_logicalHeight = window->Bounds.Height;
 
     auto dispatcher = CoreWindow::GetForCurrentThread()->Dispatcher;
     dispatcher->AcceleratorKeyActivated +=
         ref new TypedEventHandler<CoreDispatcher^, AcceleratorKeyEventArgs^>(this, &View::OnAcceleratorKeyActivated);
 
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->SizeChanged += ref new TypedEventHandler<CoreWindow^, WindowSizeChangedEventArgs^>(this, &View::OnSizeChanged);
-    window->VisibilityChanged += ref new TypedEventHandler<CoreWindow^, VisibilityChangedEventArgs^>(this, &View::OnVisibilityChanged);
-    window->Closed += ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &View::OnClosed);
-    window->PointerMoved += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerMoved);
-    window->PointerPressed += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerPressed);
-    window->PointerReleased += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerReleased);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->SizeChanged += ref new TypedEventHandler<CoreWindow^, WindowSizeChangedEventArgs^>(this, &View::OnSizeChanged);
+	window->VisibilityChanged += ref new TypedEventHandler<CoreWindow^, VisibilityChangedEventArgs^>(this, &View::OnVisibilityChanged);
+	window->Closed += ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &View::OnClosed);
+	window->PointerMoved += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerMoved);
+	window->PointerPressed += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerPressed);
+	window->PointerReleased += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerReleased);
 
-    try
-    {
-        window->ResizeStarted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeStarted);
-        window->ResizeCompleted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeCompleted);
-    }
-    catch (Exception^ e)
-    {
-        // Requires Windows 10 Creators Update (10.0.15063) or later.
-    }
+	try
+	{
+		window->ResizeStarted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeStarted);
+		window->ResizeCompleted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeCompleted);
+	}
+	catch (Exception^ e)
+	{
+		// Requires Windows 10 Creators Update (10.0.15063) or later.
+	}
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 
-    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-    displayInformation->DpiChanged += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDpiChanged);
-    displayInformation->DisplayContentsInvalidated += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDisplayContentsInvalidated);
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	displayInformation->DpiChanged += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDpiChanged);
+	displayInformation->DisplayContentsInvalidated += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDisplayContentsInvalidated);
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -80,20 +80,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -102,15 +102,15 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
     if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnAcceleratorKeyActivated(CoreDispatcher^, AcceleratorKeyEventArgs^ args)
@@ -138,97 +138,97 @@ void View::OnAcceleratorKeyActivated(CoreDispatcher^, AcceleratorKeyEventArgs^ a
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnSizeChanged(CoreWindow^ /*window*/, WindowSizeChangedEventArgs^ args)
 {
-    m_logicalWidth = args->Size.Width;
-    m_logicalHeight = args->Size.Height;
+	m_logicalWidth = args->Size.Width;
+	m_logicalHeight = args->Size.Height;
 
-    if (!m_windowResizing)
-    {
-        UpdateWindowSize();
-    }
+	if (!m_windowResizing)
+	{
+		UpdateWindowSize();
+	}
 }
 
 void View::OnResizeStarted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
 {
-    m_windowResizing = true;
+	m_windowResizing = true;
 }
 
 void View::OnResizeCompleted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
 {
-    m_windowResizing = false;
-    UpdateWindowSize();
+	m_windowResizing = false;
+	UpdateWindowSize();
 }
 
 void View::OnDpiChanged(DisplayInformation^ /*sender*/, Object^ /*args*/)
 {
-    UpdateWindowSize();
+	UpdateWindowSize();
 }
 
 void View::OnVisibilityChanged(CoreWindow^ /*window*/, VisibilityChangedEventArgs^ args)
 {
-    m_windowVisible = args->Visible;
-    UpdateWindowSize();
+	m_windowVisible = args->Visible;
+	UpdateWindowSize();
 }
 
 void View::OnClosed(CoreWindow^ /*window*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }
 
 void View::OnPointerMoved(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
-    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-    float dpi = displayInformation->LogicalDpi;
-    m_pSample->OnMouseMove(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	float dpi = displayInformation->LogicalDpi;
+	m_pSample->OnMouseMove(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
 }
 
 void View::OnPointerPressed(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
-    // For simplicity, we only consider left button press here.
-    if(args->CurrentPoint->Properties->IsLeftButtonPressed)
-    {
-        DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-        float dpi = displayInformation->LogicalDpi;
-        m_pSample->OnLeftButtonDown(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
-    }
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonDown(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
 }
 
 void View::OnPointerReleased(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
-    // For simplicity, we only consider left button press here.
-    if(args->CurrentPoint->Properties->IsLeftButtonPressed)
-    {
-        DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-        float dpi = displayInformation->LogicalDpi;
-        m_pSample->OnLeftButtonUp(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
-    }
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonUp(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
 }
 
 void View::UpdateWindowSize()
 {
-    CoreWindow^ window = CoreWindow::GetForCurrentThread();
-    Windows::Foundation::Rect windowBounds = window->Bounds;
+	CoreWindow^ window = CoreWindow::GetForCurrentThread();
+	Windows::Foundation::Rect windowBounds = window->Bounds;
 
-    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-    float dpi = displayInformation->LogicalDpi;
-    
-    m_pSample->SetWindowBounds(
-        ConvertToPixels(windowBounds.Left, dpi),
-        ConvertToPixels(windowBounds.Top, dpi),
-        ConvertToPixels(windowBounds.Right, dpi),
-        ConvertToPixels(windowBounds.Bottom, dpi));
-        
-    m_pSample->OnSizeChanged(ConvertToPixels(m_logicalWidth, dpi), ConvertToPixels(m_logicalHeight, dpi), !m_windowVisible);
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	float dpi = displayInformation->LogicalDpi;
+	
+	m_pSample->SetWindowBounds(
+		ConvertToPixels(windowBounds.Left, dpi),
+		ConvertToPixels(windowBounds.Top, dpi),
+		ConvertToPixels(windowBounds.Right, dpi),
+		ConvertToPixels(windowBounds.Bottom, dpi));
+		
+	m_pSample->OnSizeChanged(ConvertToPixels(m_logicalWidth, dpi), ConvertToPixels(m_logicalHeight, dpi), !m_windowVisible);
 }
 
 void View::OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args)
 {
-    m_pSample->OnDisplayChanged();
+	m_pSample->OnDisplayChanged();
 }

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/View.h
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/View.h
@@ -24,36 +24,36 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
     void OnAcceleratorKeyActivated(CoreDispatcher^, AcceleratorKeyEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ args);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ args);
-    void OnSizeChanged(CoreWindow^ window, WindowSizeChangedEventArgs^ args);
-    void OnResizeStarted(CoreWindow^ window, Object^ args);
-    void OnResizeCompleted(CoreWindow^ window, Object^ args);
-    void OnDpiChanged(DisplayInformation^ sender, Object^ args);
-    void OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args);
-    void OnClosed(CoreWindow^ window, CoreWindowEventArgs^ args);
-    void OnPointerMoved(CoreWindow^ window, PointerEventArgs^ args);
-    void OnPointerPressed(CoreWindow^ window, PointerEventArgs^ args);
-    void OnPointerReleased(CoreWindow^ window, PointerEventArgs^ args);
-    void OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args);
-    
-    void UpdateWindowSize();
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ args);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ args);
+	void OnSizeChanged(CoreWindow^ window, WindowSizeChangedEventArgs^ args);
+	void OnResizeStarted(CoreWindow^ window, Object^ args);
+	void OnResizeCompleted(CoreWindow^ window, Object^ args);
+	void OnDpiChanged(DisplayInformation^ sender, Object^ args);
+	void OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args);
+	void OnClosed(CoreWindow^ window, CoreWindowEventArgs^ args);
+	void OnPointerMoved(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerPressed(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerReleased(CoreWindow^ window, PointerEventArgs^ args);
+	void OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args);
+	
+	void UpdateWindowSize();
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
-    bool m_windowResizing;
-    bool m_windowVisible;
-    float m_logicalWidth;
-    float m_logicalHeight;
+	DXSample* m_pSample;
+	bool m_windowClosed;
+	bool m_windowResizing;
+	bool m_windowVisible;
+	float m_logicalWidth;
+	float m_logicalHeight;
 };

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/ViewProvider.cpp
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/ViewProvider.h
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/d3dx12.h
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/wave.hlsl
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/wave.hlsl
@@ -19,18 +19,18 @@ cbuffer SceneConstantBuffer : register(b0)
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
+	float4 position : SV_POSITION;
+	float4 color : COLOR;
 };
 
 PSInput VSMain(float4 position : POSITION, float4 color : COLOR)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = mul(position, orthProjMatrix);
-    result.color = color;
+	result.position = mul(position, orthProjMatrix);
+	result.color = color;
 
-    return result;
+	return result;
 }
 
 

--- a/Samples/UWP/D3D12SmallResources/src/D3D12SmallResources.cpp
+++ b/Samples/UWP/D3D12SmallResources/src/D3D12SmallResources.cpp
@@ -13,495 +13,495 @@
 #include "D3D12SmallResources.h"
 
 D3D12SmallResources::D3D12SmallResources(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_fenceValues{},
-    m_rtvDescriptorSize(0),
-    m_srvDescriptorSize(0),
-    m_usePlacedResources(true)
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_fenceValues{},
+	m_rtvDescriptorSize(0),
+	m_srvDescriptorSize(0),
+	m_usePlacedResources(true)
 {
 }
 
 void D3D12SmallResources::OnInit()
 {
-    LoadPipeline();
-    LoadAssets();
+	LoadPipeline();
+	LoadAssets();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12SmallResources::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&m_adapter)));
+	if (m_useWarpDevice)
+	{
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&m_adapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            m_adapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			m_adapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter);
 
-        ThrowIfFailed(hardwareAdapter.As(&m_adapter));
+		ThrowIfFailed(hardwareAdapter.As(&m_adapter));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            m_adapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			m_adapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
-    NAME_D3D12_OBJECT(m_commandQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	NAME_D3D12_OBJECT(m_commandQueue);
 
-    // Describe and create the copy queue.
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_COPY;
+	// Describe and create the copy queue.
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_COPY;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_copyQueue)));
-    NAME_D3D12_OBJECT(m_copyQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_copyQueue)));
+	NAME_D3D12_OBJECT(m_copyQueue);
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a constant buffer view (CBV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
-        cbvHeapDesc.NumDescriptors = TextureCount;
-        cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
-        NAME_D3D12_OBJECT(m_srvHeap);
+		// Describe and create a constant buffer view (CBV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC cbvHeapDesc = {};
+		cbvHeapDesc.NumDescriptors = TextureCount;
+		cbvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		cbvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&cbvHeapDesc, IID_PPV_ARGS(&m_srvHeap)));
+		NAME_D3D12_OBJECT(m_srvHeap);
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-        m_srvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_srvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV and a command allocator for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
+		// Create a RTV and a command allocator for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-            NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
+			NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
 
-            ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
-        }
-    }
+			ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
+		}
+	}
 
-    // Create copy queue resources.
-    ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_COPY, IID_PPV_ARGS(&m_copyCommandAllocator)));
+	// Create copy queue resources.
+	ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_COPY, IID_PPV_ARGS(&m_copyCommandAllocator)));
 }
 
 // Load the sample assets.
 void D3D12SmallResources::LoadAssets()
 {
-    // Create a root signature consisting of a single CBV parameter.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create a root signature consisting of a single CBV parameter.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
-        CD3DX12_ROOT_PARAMETER1 rootParameters[1];
+		CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
+		CD3DX12_ROOT_PARAMETER1 rootParameters[1];
 
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
+		ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
 
-        // Allow input layout and deny uneccessary access to certain pipeline stages.
-        D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
-            D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_VERTEX_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS;
+		// Allow input layout and deny uneccessary access to certain pipeline stages.
+		D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags =
+			D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_VERTEX_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
+			D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS;
 
-        CD3DX12_STATIC_SAMPLER_DESC samplerDesc(0, D3D12_FILTER_MIN_MAG_MIP_LINEAR);
+		CD3DX12_STATIC_SAMPLER_DESC samplerDesc(0, D3D12_FILTER_MIN_MAG_MIP_LINEAR);
 
-        CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &samplerDesc, rootSignatureFlags);
+		CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+		rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 1, &samplerDesc, rootSignatureFlags);
 
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-        ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-        NAME_D3D12_OBJECT(m_rootSignature);
-    }
+		ComPtr<ID3DBlob> signature;
+		ComPtr<ID3DBlob> error;
+		ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+		ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+		NAME_D3D12_OBJECT(m_rootSignature);
+	}
 
-    // Create the pipeline state, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> pixelShader;
+	// Create the pipeline state, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> pixelShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"shaders.hlsl").c_str(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
-        // Define the vertex input layout.
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-        };
+		// Define the vertex input layout.
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+			{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+		};
 
-        // Describe and create the graphics pipeline state objects (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        psoDesc.DepthStencilState.DepthEnable = FALSE;
-        psoDesc.DepthStencilState.StencilEnable = FALSE;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state objects (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+		psoDesc.DepthStencilState.DepthEnable = FALSE;
+		psoDesc.DepthStencilState.StencilEnable = FALSE;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-        NAME_D3D12_OBJECT(m_pipelineState);
-    }
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+		NAME_D3D12_OBJECT(m_pipelineState);
+	}
 
-    // Create the command lists.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
-    NAME_D3D12_OBJECT(m_commandList);
+	// Create the command lists.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	NAME_D3D12_OBJECT(m_commandList);
 
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_COPY, m_copyCommandAllocator.Get(), nullptr, IID_PPV_ARGS(&m_copyCommandList)));
-    ThrowIfFailed(m_copyCommandList->Close());
-    NAME_D3D12_OBJECT(m_copyCommandList);
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_COPY, m_copyCommandAllocator.Get(), nullptr, IID_PPV_ARGS(&m_copyCommandList)));
+	ThrowIfFailed(m_copyCommandList->Close());
+	NAME_D3D12_OBJECT(m_copyCommandList);
 
-    // Note: ComPtr's are CPU objects but this resource needs to stay in scope until
-    // the command list that references it has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resource is not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> vertexBufferUpload;
+	// Note: ComPtr's are CPU objects but this resource needs to stay in scope until
+	// the command list that references it has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resource is not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> vertexBufferUpload;
 
-    // Create the vertex buffer.
-    {
-        // Create quads for all of the images that will be generated and drawn to the screen.
-        Vertex quadVertices[TextureCount * 4];
-        UINT index = 0;
-        float offsetX = 0.15f;
-        float marginX = offsetX / 10.0f;;
-        float startX = (GridWidth / 2.0f) * -(offsetX + marginX) + marginX / 2.0f;
-        float offsetY = offsetX * m_aspectRatio;
-        float marginY = offsetY / 10.0f;
-        float y = (GridHeight / 2.0f) * (offsetY + marginY) - marginY / 2.0f;
-        for (UINT row = 0; row < GridHeight; row++)
-        {
-            float x = startX;
-            for (UINT column = 0; column < GridWidth; column++)
-            {
-                quadVertices[index++] = { { x, y - offsetY, 0.0f }, { 0.0f, 0.0f } };
-                quadVertices[index++] = { { x, y, 0.0f }, { 0.0f, 1.0f } };
-                quadVertices[index++] = { { x + offsetX, y - offsetY, 0.0f }, { 1.0f, 0.0f } };
-                quadVertices[index++] = { { x + offsetX, y, 0.0f }, { 1.0f, 1.0f } };
-                x += offsetX + marginX;
-            }
-            y -= offsetY + marginY;
-        }
-        const UINT vertexBufferSize = sizeof(quadVertices);
+	// Create the vertex buffer.
+	{
+		// Create quads for all of the images that will be generated and drawn to the screen.
+		Vertex quadVertices[TextureCount * 4];
+		UINT index = 0;
+		float offsetX = 0.15f;
+		float marginX = offsetX / 10.0f;;
+		float startX = (GridWidth / 2.0f) * -(offsetX + marginX) + marginX / 2.0f;
+		float offsetY = offsetX * m_aspectRatio;
+		float marginY = offsetY / 10.0f;
+		float y = (GridHeight / 2.0f) * (offsetY + marginY) - marginY / 2.0f;
+		for (UINT row = 0; row < GridHeight; row++)
+		{
+			float x = startX;
+			for (UINT column = 0; column < GridWidth; column++)
+			{
+				quadVertices[index++] = { { x, y - offsetY, 0.0f }, { 0.0f, 0.0f } };
+				quadVertices[index++] = { { x, y, 0.0f }, { 0.0f, 1.0f } };
+				quadVertices[index++] = { { x + offsetX, y - offsetY, 0.0f }, { 1.0f, 0.0f } };
+				quadVertices[index++] = { { x + offsetX, y, 0.0f }, { 1.0f, 1.0f } };
+				x += offsetX + marginX;
+			}
+			y -= offsetY + marginY;
+		}
+		const UINT vertexBufferSize = sizeof(quadVertices);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_vertexBuffer)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_vertexBuffer)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&vertexBufferUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&vertexBufferUpload)));
 
-        NAME_D3D12_OBJECT(m_vertexBuffer);
+		NAME_D3D12_OBJECT(m_vertexBuffer);
 
-        // Copy data to the intermediate upload heap and then schedule a copy 
-        // from the upload heap to the vertex buffer.
-        D3D12_SUBRESOURCE_DATA vertexData = {};
-        vertexData.pData = reinterpret_cast<UINT8*>(quadVertices);
-        vertexData.RowPitch = vertexBufferSize;
-        vertexData.SlicePitch = vertexData.RowPitch;
+		// Copy data to the intermediate upload heap and then schedule a copy 
+		// from the upload heap to the vertex buffer.
+		D3D12_SUBRESOURCE_DATA vertexData = {};
+		vertexData.pData = reinterpret_cast<UINT8*>(quadVertices);
+		vertexData.RowPitch = vertexBufferSize;
+		vertexData.SlicePitch = vertexData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+		UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-        // Initialize the vertex buffer view.
-        m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-        m_vertexBufferView.StrideInBytes = sizeof(Vertex);
-        m_vertexBufferView.SizeInBytes = sizeof(quadVertices);
-    }
+		// Initialize the vertex buffer view.
+		m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+		m_vertexBufferView.StrideInBytes = sizeof(Vertex);
+		m_vertexBufferView.SizeInBytes = sizeof(quadVertices);
+	}
 
-    // Close the command list and execute it to begin the vertex buffer copy into
-    // the default heap.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the vertex buffer copy into
+	// the default heap.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
-        m_fenceValues[m_frameIndex]++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_fenceValues[m_frameIndex], D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)));
+		m_fenceValues[m_frameIndex]++;
 
-        // Create an event handle to use for frame synchronization.
-        m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_fenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		// Create an event handle to use for frame synchronization.
+		m_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_fenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        // Wait for the command list to execute; we are reusing the same command 
-        // list in our main loop but for now, we just want to wait for setup to 
-        // complete before continuing.
-        WaitForGpu();
-    }
+		// Wait for the command list to execute; we are reusing the same command 
+		// list in our main loop but for now, we just want to wait for setup to 
+		// complete before continuing.
+		WaitForGpu();
+	}
 
-    CreateTextures();
+	CreateTextures();
 }
 
 void D3D12SmallResources::CreateTextures()
 {
-    m_textures.clear();
-    m_textures.resize(TextureCount);
-    m_textureHeap.Reset();
+	m_textures.clear();
+	m_textures.resize(TextureCount);
+	m_textureHeap.Reset();
 
-    ThrowIfFailed(m_copyCommandAllocator->Reset());
-    ThrowIfFailed(m_copyCommandList->Reset(m_copyCommandAllocator.Get(), nullptr));
+	ThrowIfFailed(m_copyCommandAllocator->Reset());
+	ThrowIfFailed(m_copyCommandList->Reset(m_copyCommandAllocator.Get(), nullptr));
 
-    CD3DX12_RESOURCE_DESC textureDesc = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R8G8B8A8_UNORM, TextureWidth, TextureHeight, 1, 1);
+	CD3DX12_RESOURCE_DESC textureDesc = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R8G8B8A8_UNORM, TextureWidth, TextureHeight, 1, 1);
 
-    if (m_usePlacedResources)
-    {
-        // Since we are using small resources we can take advantage of 4KB
-        // resource alignments. As long as the most detailed mip can fit in an
-        // allocation less than 64KB, 4KB alignments can be used.
-        //
-        // When dealing with MSAA textures the rules are similar, but the minimum
-        // alignment is 64KB for a texture whose most detailed mip can fit in an
-        // allocation less than 4MB.
-        textureDesc.Alignment = D3D12_SMALL_RESOURCE_PLACEMENT_ALIGNMENT;
-        D3D12_RESOURCE_ALLOCATION_INFO info = m_device->GetResourceAllocationInfo(0, 1, &textureDesc);
+	if (m_usePlacedResources)
+	{
+		// Since we are using small resources we can take advantage of 4KB
+		// resource alignments. As long as the most detailed mip can fit in an
+		// allocation less than 64KB, 4KB alignments can be used.
+		//
+		// When dealing with MSAA textures the rules are similar, but the minimum
+		// alignment is 64KB for a texture whose most detailed mip can fit in an
+		// allocation less than 4MB.
+		textureDesc.Alignment = D3D12_SMALL_RESOURCE_PLACEMENT_ALIGNMENT;
+		D3D12_RESOURCE_ALLOCATION_INFO info = m_device->GetResourceAllocationInfo(0, 1, &textureDesc);
 
-        if (info.Alignment != D3D12_SMALL_RESOURCE_PLACEMENT_ALIGNMENT)
-        {
-            // If the alignment requested is not granted, then let D3D tell us
-            // the alignment that needs to be used for these resources.
-            textureDesc.Alignment = 0;
-            info = m_device->GetResourceAllocationInfo(0, 1, &textureDesc);
-        }
+		if (info.Alignment != D3D12_SMALL_RESOURCE_PLACEMENT_ALIGNMENT)
+		{
+			// If the alignment requested is not granted, then let D3D tell us
+			// the alignment that needs to be used for these resources.
+			textureDesc.Alignment = 0;
+			info = m_device->GetResourceAllocationInfo(0, 1, &textureDesc);
+		}
 
-        const UINT64 heapSize = TextureCount * info.SizeInBytes;
-        CD3DX12_HEAP_DESC heapDesc(heapSize, D3D12_HEAP_TYPE_DEFAULT, 0, D3D12_HEAP_FLAG_DENY_BUFFERS | D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES);
-        ThrowIfFailed(m_device->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_textureHeap)));
+		const UINT64 heapSize = TextureCount * info.SizeInBytes;
+		CD3DX12_HEAP_DESC heapDesc(heapSize, D3D12_HEAP_TYPE_DEFAULT, 0, D3D12_HEAP_FLAG_DENY_BUFFERS | D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES);
+		ThrowIfFailed(m_device->CreateHeap(&heapDesc, IID_PPV_ARGS(&m_textureHeap)));
 
-        std::vector<D3D12_RESOURCE_BARRIER> barriers;
-        barriers.resize(TextureCount);
-        for (UINT n = 0; n < TextureCount; n++)
-        {
-            ThrowIfFailed(m_device->CreatePlacedResource(
-                m_textureHeap.Get(),
-                n * info.SizeInBytes,
-                &textureDesc,
-                D3D12_RESOURCE_STATE_COMMON,
-                nullptr,
-                IID_PPV_ARGS(&m_textures[n])));
+		std::vector<D3D12_RESOURCE_BARRIER> barriers;
+		barriers.resize(TextureCount);
+		for (UINT n = 0; n < TextureCount; n++)
+		{
+			ThrowIfFailed(m_device->CreatePlacedResource(
+				m_textureHeap.Get(),
+				n * info.SizeInBytes,
+				&textureDesc,
+				D3D12_RESOURCE_STATE_COMMON,
+				nullptr,
+				IID_PPV_ARGS(&m_textures[n])));
 
-            barriers[n] = CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, m_textures[n].Get());
-        }
+			barriers[n] = CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, m_textures[n].Get());
+		}
 
-        m_copyCommandList->ResourceBarrier(static_cast<UINT>(barriers.size()), barriers.data());
-    }
-    else
-    {
-        for (UINT n = 0; n < TextureCount; n++)
-        {
-            ThrowIfFailed(m_device->CreateCommittedResource(
-                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-                D3D12_HEAP_FLAG_NONE,
-                &textureDesc,
-                D3D12_RESOURCE_STATE_COMMON,
-                nullptr,
-                IID_PPV_ARGS(&m_textures[n])));
-        }
-    }
+		m_copyCommandList->ResourceBarrier(static_cast<UINT>(barriers.size()), barriers.data());
+	}
+	else
+	{
+		for (UINT n = 0; n < TextureCount; n++)
+		{
+			ThrowIfFailed(m_device->CreateCommittedResource(
+				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+				D3D12_HEAP_FLAG_NONE,
+				&textureDesc,
+				D3D12_RESOURCE_STATE_COMMON,
+				nullptr,
+				IID_PPV_ARGS(&m_textures[n])));
+		}
+	}
 
-    // Note: ComPtr's are CPU objects but these resources need to stay in scope until
-    // the command list that references them has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resources are not
-    // prematurely destroyed.
-    std::vector<ComPtr<ID3D12Resource>> uploadResources;
-    uploadResources.resize(TextureCount);
+	// Note: ComPtr's are CPU objects but these resources need to stay in scope until
+	// the command list that references them has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resources are not
+	// prematurely destroyed.
+	std::vector<ComPtr<ID3D12Resource>> uploadResources;
+	uploadResources.resize(TextureCount);
 
-    // Colors for textures are randomly generated. Reset the seed so that the colors
-    // don't change when the resource type changes.
-    srand(100);
+	// Colors for textures are randomly generated. Reset the seed so that the colors
+	// don't change when the resource type changes.
+	srand(100);
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_srvHeap->GetCPUDescriptorHandleForHeapStart());
-    for (UINT n = 0; n < TextureCount; n++)
-    {
-        const UINT64 uploadBufferSize = GetRequiredIntermediateSize(m_textures[n].Get(), 0, 1) + D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
+	CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_srvHeap->GetCPUDescriptorHandleForHeapStart());
+	for (UINT n = 0; n < TextureCount; n++)
+	{
+		const UINT64 uploadBufferSize = GetRequiredIntermediateSize(m_textures[n].Get(), 0, 1) + D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&uploadResources[n])));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(uploadBufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&uploadResources[n])));
 
-        auto texture = GenerateTexture();
+		auto texture = GenerateTexture();
 
-        // Copy data to the intermediate upload heap and then schedule a copy
-        // from the upload heap to the texture.
-        D3D12_SUBRESOURCE_DATA textureData = {};
-        textureData.pData = reinterpret_cast<UINT8*>(texture.data());
-        textureData.RowPitch = TextureWidth * TexturePixelSizeInBytes;
-        textureData.SlicePitch = textureData.RowPitch * TextureHeight;
+		// Copy data to the intermediate upload heap and then schedule a copy
+		// from the upload heap to the texture.
+		D3D12_SUBRESOURCE_DATA textureData = {};
+		textureData.pData = reinterpret_cast<UINT8*>(texture.data());
+		textureData.RowPitch = TextureWidth * TexturePixelSizeInBytes;
+		textureData.SlicePitch = textureData.RowPitch * TextureHeight;
 
-        UpdateSubresources<1>(m_copyCommandList.Get(), m_textures[n].Get(), uploadResources[n].Get(), 0, 0, 1, &textureData);
+		UpdateSubresources<1>(m_copyCommandList.Get(), m_textures[n].Get(), uploadResources[n].Get(), 0, 0, 1, &textureData);
 
-        NAME_D3D12_OBJECT_INDEXED(m_textures, n);
+		NAME_D3D12_OBJECT_INDEXED(m_textures, n);
 
-        // Describe and create a SRV for the texture.
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Format = textureDesc.Format;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = textureDesc.MipLevels;
+		// Describe and create a SRV for the texture.
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Format = textureDesc.Format;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = textureDesc.MipLevels;
 
-        m_device->CreateShaderResourceView(m_textures[n].Get(), &srvDesc, cpuHandle);
-        cpuHandle.Offset(m_srvDescriptorSize);
-    }
+		m_device->CreateShaderResourceView(m_textures[n].Get(), &srvDesc, cpuHandle);
+		cpuHandle.Offset(m_srvDescriptorSize);
+	}
 
-    ThrowIfFailed(m_copyCommandList->Close());
+	ThrowIfFailed(m_copyCommandList->Close());
 
-    ID3D12CommandList* ppCommandLists[] = { m_copyCommandList.Get() };
-    m_copyQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	ID3D12CommandList* ppCommandLists[] = { m_copyCommandList.Get() };
+	m_copyQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Wait for the copy queue to complete execution of the command list.
-    m_copyQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]);
-    ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-    WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-    m_fenceValues[m_frameIndex]++;
+	// Wait for the copy queue to complete execution of the command list.
+	m_copyQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]);
+	ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+	WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	m_fenceValues[m_frameIndex]++;
 }
 
 // Generate a simple checkerboard texture.
 std::vector<UINT8> D3D12SmallResources::GenerateTexture()
 {
-    const UINT rowPitch = TextureWidth * TexturePixelSizeInBytes;
-    const UINT cellPitch = rowPitch >> 3;        // The width of a cell in the checkboard texture.
-    const UINT cellHeight = TextureWidth >> 3;    // The height of a cell in the checkerboard texture.
-    const UINT textureSize = rowPitch * TextureHeight;
+	const UINT rowPitch = TextureWidth * TexturePixelSizeInBytes;
+	const UINT cellPitch = rowPitch >> 3;		// The width of a cell in the checkboard texture.
+	const UINT cellHeight = TextureWidth >> 3;	// The height of a cell in the checkerboard texture.
+	const UINT textureSize = rowPitch * TextureHeight;
 
-    std::vector<UINT8> data(textureSize);
-    UINT8* pData = &data[0];
-    UINT8 r = rand() & 0xff;
-    UINT8 g = rand() & 0xff;
-    UINT8 b = rand() & 0xff;
+	std::vector<UINT8> data(textureSize);
+	UINT8* pData = &data[0];
+	UINT8 r = rand() & 0xff;
+	UINT8 g = rand() & 0xff;
+	UINT8 b = rand() & 0xff;
 
-    for (UINT n = 0; n < textureSize; n += TexturePixelSizeInBytes)
-    {
-        UINT x = n % rowPitch;
-        UINT y = n / rowPitch;
-        UINT i = x / cellPitch;
-        UINT j = y / cellHeight;
+	for (UINT n = 0; n < textureSize; n += TexturePixelSizeInBytes)
+	{
+		UINT x = n % rowPitch;
+		UINT y = n / rowPitch;
+		UINT i = x / cellPitch;
+		UINT j = y / cellHeight;
 
-        if (i % 2 == j % 2)
-        {
-            pData[n] = 0x00;        // R
-            pData[n + 1] = 0x00;    // G
-            pData[n + 2] = 0x00;    // B
-            pData[n + 3] = 0xff;    // A
-        }
-        else
-        {
-            pData[n] = r;            // R
-            pData[n + 1] = g;        // G
-            pData[n + 2] = b;        // B
-            pData[n + 3] = 0xff;    // A
-        }
-    }
+		if (i % 2 == j % 2)
+		{
+			pData[n] = 0x00;		// R
+			pData[n + 1] = 0x00;	// G
+			pData[n + 2] = 0x00;	// B
+			pData[n + 3] = 0xff;	// A
+		}
+		else
+		{
+			pData[n] = r;			// R
+			pData[n + 1] = g;		// G
+			pData[n + 2] = b;		// B
+			pData[n + 3] = 0xff;	// A
+		}
+	}
 
-    return data;
+	return data;
 }
 
 // Update frame-based values.
@@ -512,164 +512,164 @@ void D3D12SmallResources::OnUpdate()
 template <UINT _Size>
 LPWSTR FormatMemoryUsage(UINT64 usage, WCHAR (&result)[_Size])
 {
-    const UINT64 mb = 1 << 20;
-    const UINT64 kb = 1 << 10;
-    if (usage > mb)
-    {
-        swprintf_s(result, L"%.1f MB", static_cast<float>(usage) / mb);
-    }
-    else if (usage > kb)
-    {
-        swprintf_s(result, L"%.1f KB", static_cast<float>(usage) / kb);
-    }
-    else
-    {
-        swprintf_s(result, L"%I64d B", usage);
-    }
-    return result;
+	const UINT64 mb = 1 << 20;
+	const UINT64 kb = 1 << 10;
+	if (usage > mb)
+	{
+		swprintf_s(result, L"%.1f MB", static_cast<float>(usage) / mb);
+	}
+	else if (usage > kb)
+	{
+		swprintf_s(result, L"%.1f KB", static_cast<float>(usage) / kb);
+	}
+	else
+	{
+		swprintf_s(result, L"%I64d B", usage);
+	}
+	return result;
 }
 
 // Render the scene.
 void D3D12SmallResources::OnRender()
 {
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+	PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
 
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+	// Record all the commands we need to render the scene into the command list.
+	PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Execute the command list.
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    PIXEndEvent(m_commandQueue.Get());
+	PIXEndEvent(m_commandQueue.Get());
 
-    DXGI_QUERY_VIDEO_MEMORY_INFO memoryInfo;
-    m_adapter->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &memoryInfo);
+	DXGI_QUERY_VIDEO_MEMORY_INFO memoryInfo;
+	m_adapter->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &memoryInfo);
 
-    WCHAR text[100];
-    WCHAR usageString[20];
-    swprintf_s(text, L"[ResourceType: %s] - Memory Used: %s", m_usePlacedResources ? L"Placed" : L"Committed", FormatMemoryUsage(memoryInfo.CurrentUsage, usageString));
-    SetCustomWindowText(text);
+	WCHAR text[100];
+	WCHAR usageString[20];
+	swprintf_s(text, L"[ResourceType: %s] - Memory Used: %s", m_usePlacedResources ? L"Placed" : L"Committed", FormatMemoryUsage(memoryInfo.CurrentUsage, usageString));
+	SetCustomWindowText(text);
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+	// Present the frame.
+	ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    MoveToNextFrame();
+	MoveToNextFrame();
 }
 
 void D3D12SmallResources::OnDestroy()
 {
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForGpu();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForGpu();
 
-    CloseHandle(m_fenceEvent);
+	CloseHandle(m_fenceEvent);
 }
 
 void D3D12SmallResources::OnKeyDown(UINT8 key)
 {
-    switch (key)
-    {
-    case VK_SPACE:
-        m_usePlacedResources = !m_usePlacedResources;
+	switch (key)
+	{
+	case VK_SPACE:
+		m_usePlacedResources = !m_usePlacedResources;
 
-        // Flush the GPU to ensure that the resources we are about to destroy are
-        // no longer in use.
-        WaitForGpu();
+		// Flush the GPU to ensure that the resources we are about to destroy are
+		// no longer in use.
+		WaitForGpu();
 
-        CreateTextures();
-        break;
-    }
+		CreateTextures();
+		break;
+	}
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12SmallResources::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated 
-    // command lists have finished execution on the GPU; apps should use 
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
+	// Command list allocators can only be reset when the associated 
+	// command lists have finished execution on the GPU; apps should use 
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command 
-    // list, that command list can then be reset at any time and must be before 
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command 
+	// list, that command list can then be reset at any time and must be before 
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
-    m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_srvHeap.Get() };
+	m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_commandList->RSSetViewports(1, &m_viewport);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Record drawing commands.
-    const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	// Record drawing commands.
+	const float clearColor[] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
 
-    // Draw the grid.
-    {
-        m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-        m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+	// Draw the grid.
+	{
+		m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+		m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
 
-        // Draw the far quad conditionally based on the result of the occlusion query
-        // from the previous frame.
-        PIXBeginEvent(m_commandList.Get(), 0, L"Draw grid");
+		// Draw the far quad conditionally based on the result of the occlusion query
+		// from the previous frame.
+		PIXBeginEvent(m_commandList.Get(), 0, L"Draw grid");
 
-        CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_srvHeap->GetGPUDescriptorHandleForHeapStart());
-        for (UINT n = 0; n < TextureCount; n++)
-        {
-            m_commandList->SetGraphicsRootDescriptorTable(0, srvHandle);
-            m_commandList->DrawInstanced(4, 1, n * 4, 0);
-            srvHandle.Offset(m_srvDescriptorSize);
-        }
-        PIXEndEvent(m_commandList.Get());
-    }
+		CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_srvHeap->GetGPUDescriptorHandleForHeapStart());
+		for (UINT n = 0; n < TextureCount; n++)
+		{
+			m_commandList->SetGraphicsRootDescriptorTable(0, srvHandle);
+			m_commandList->DrawInstanced(4, 1, n * 4, 0);
+			srvHandle.Offset(m_srvDescriptorSize);
+		}
+		PIXEndEvent(m_commandList.Get());
+	}
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 // Wait for pending GPU work to complete.
 void D3D12SmallResources::WaitForGpu()
 {
-    // Schedule a Signal command in the queue.
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
+	// Schedule a Signal command in the queue.
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
 
-    // Wait until the fence has been processed.
-    ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-    WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	// Wait until the fence has been processed.
+	ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+	WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
 
-    // Increment the fence value for the current frame.
-    m_fenceValues[m_frameIndex]++;
+	// Increment the fence value for the current frame.
+	m_fenceValues[m_frameIndex]++;
 }
 
 // Prepare to render the next frame.
 void D3D12SmallResources::MoveToNextFrame()
 {
-    // Schedule a Signal command in the queue.
-    const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
+	// Schedule a Signal command in the queue.
+	const UINT64 currentFenceValue = m_fenceValues[m_frameIndex];
+	ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), currentFenceValue));
 
-    // Update the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Update the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
-        WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	if (m_fence->GetCompletedValue() < m_fenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));
+		WaitForSingleObjectEx(m_fenceEvent, INFINITE, FALSE);
+	}
 
-    // Set the fence value for the next frame.
-    m_fenceValues[m_frameIndex] = currentFenceValue + 1;
+	// Set the fence value for the next frame.
+	m_fenceValues[m_frameIndex] = currentFenceValue + 1;
 }

--- a/Samples/UWP/D3D12SmallResources/src/D3D12SmallResources.h
+++ b/Samples/UWP/D3D12SmallResources/src/D3D12SmallResources.h
@@ -27,68 +27,68 @@ using Microsoft::WRL::ComPtr;
 class D3D12SmallResources : public DXSample
 {
 public:
-    D3D12SmallResources(UINT width, UINT height, std::wstring name);
+	D3D12SmallResources(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
-    virtual void OnKeyDown(UINT8 key);
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
+	virtual void OnKeyDown(UINT8 key);
 
 private:
-    static const UINT FrameCount = 2;
-    static const UINT GridWidth = 11;
-    static const UINT GridHeight = 7;
-    static const UINT TextureCount = GridWidth * GridHeight;
-    static const UINT TextureWidth = 32;
-    static const UINT TextureHeight = 32;
-    static const UINT TexturePixelSizeInBytes = 4;
+	static const UINT FrameCount = 2;
+	static const UINT GridWidth = 11;
+	static const UINT GridHeight = 7;
+	static const UINT TextureCount = GridWidth * GridHeight;
+	static const UINT TextureWidth = 32;
+	static const UINT TextureHeight = 32;
+	static const UINT TexturePixelSizeInBytes = 4;
 
-    // Vertex definition.
-    struct Vertex
-    {
-        XMFLOAT3 position;
-        XMFLOAT2 uv;
-    };
+	// Vertex definition.
+	struct Vertex
+	{
+		XMFLOAT3 position;
+		XMFLOAT2 uv;
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<IDXGIAdapter3> m_adapter;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
-    ComPtr<ID3D12CommandAllocator> m_copyCommandAllocator;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12CommandQueue> m_copyQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_srvHeap;
-    UINT m_rtvDescriptorSize;
-    UINT m_srvDescriptorSize;
-    UINT m_frameIndex;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<IDXGIAdapter3> m_adapter;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
+	ComPtr<ID3D12CommandAllocator> m_copyCommandAllocator;
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12CommandQueue> m_copyQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_srvHeap;
+	UINT m_rtvDescriptorSize;
+	UINT m_srvDescriptorSize;
+	UINT m_frameIndex;
 
-    // Synchronization objects.
-    ComPtr<ID3D12Fence> m_fence;
-    UINT64 m_fenceValues[FrameCount];
-    HANDLE m_fenceEvent;
+	// Synchronization objects.
+	ComPtr<ID3D12Fence> m_fence;
+	UINT64 m_fenceValues[FrameCount];
+	HANDLE m_fenceEvent;
 
-    // Asset objects.
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    ComPtr<ID3D12GraphicsCommandList> m_copyCommandList;
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    std::vector<ComPtr<ID3D12Resource>> m_textures;
-    ComPtr<ID3D12Heap> m_textureHeap;        // Only used when the resources being drawn are placed resources.
-    bool m_usePlacedResources;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	// Asset objects.
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	ComPtr<ID3D12GraphicsCommandList> m_copyCommandList;
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	std::vector<ComPtr<ID3D12Resource>> m_textures;
+	ComPtr<ID3D12Heap> m_textureHeap;		// Only used when the resources being drawn are placed resources.
+	bool m_usePlacedResources;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
 
-    void LoadPipeline();
-    void LoadAssets();
-    std::vector<UINT8> GenerateTexture();
-    void CreateTextures();
-    void PopulateCommandList();
-    void WaitForGpu();
-    void MoveToNextFrame();
+	void LoadPipeline();
+	void LoadAssets();
+	std::vector<UINT8> GenerateTexture();
+	void CreateTextures();
+	void PopulateCommandList();
+	void WaitForGpu();
+	void MoveToNextFrame();
 };

--- a/Samples/UWP/D3D12SmallResources/src/DXSample.cpp
+++ b/Samples/UWP/D3D12SmallResources/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,59 +34,104 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
-    auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(windowText.c_str());
+	std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
+	auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/UWP/D3D12SmallResources/src/DXSample.h
+++ b/Samples/UWP/D3D12SmallResources/src/DXSample.h
@@ -16,42 +16,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/UWP/D3D12SmallResources/src/Main.cpp
+++ b/Samples/UWP/D3D12SmallResources/src/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12SmallResources sample(1200, 900, L"");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12SmallResources sample(1200, 900, L"");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12SmallResources/src/View.cpp
+++ b/Samples/UWP/D3D12SmallResources/src/View.cpp
@@ -15,27 +15,27 @@
 using namespace Windows::Foundation;
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -44,20 +44,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -66,26 +66,26 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnClosed(CoreWindow^ /*sender*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }

--- a/Samples/UWP/D3D12SmallResources/src/View.h
+++ b/Samples/UWP/D3D12SmallResources/src/View.h
@@ -23,20 +23,20 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
+	DXSample* m_pSample;
+	bool m_windowClosed;
 };

--- a/Samples/UWP/D3D12SmallResources/src/ViewProvider.cpp
+++ b/Samples/UWP/D3D12SmallResources/src/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12SmallResources/src/ViewProvider.h
+++ b/Samples/UWP/D3D12SmallResources/src/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12SmallResources/src/d3dx12.h
+++ b/Samples/UWP/D3D12SmallResources/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12SmallResources/src/shaders.hlsl
+++ b/Samples/UWP/D3D12SmallResources/src/shaders.hlsl
@@ -11,8 +11,8 @@
 
 struct PSInput
 {
-    float4 position : SV_POSITION;
-    float2 uv : TEXCOORD;
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD;
 };
 
 Texture2D g_texture : register(t0);
@@ -20,15 +20,15 @@ SamplerState g_sampler : register(s0);
 
 PSInput VSMain(float4 position : POSITION, float2 uv : TEXCOORD)
 {
-    PSInput result;
+	PSInput result;
 
-    result.position = position;
-    result.uv = uv;
+	result.position = position;
+	result.uv = uv;
 
-    return result;
+	return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return g_texture.Sample(g_sampler, input.uv);
+	return g_texture.Sample(g_sampler, input.uv);
 }

--- a/Samples/UWP/D3D12nBodyGravity/src/D3D12nBodyGravity.cpp
+++ b/Samples/UWP/D3D12nBodyGravity/src/D3D12nBodyGravity.cpp
@@ -20,828 +20,884 @@
 const float D3D12nBodyGravity::ParticleSpread = 400.0f;
 
 D3D12nBodyGravity::D3D12nBodyGravity(UINT width, UINT height, std::wstring name) :
-    DXSample(width, height, name),
-    m_frameIndex(0),
-    m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
-    m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
-    m_rtvDescriptorSize(0),
-    m_srvUavDescriptorSize(0),
-    m_pConstantBufferGSData(nullptr),
-    m_renderContextFenceValue(0),
-    m_terminating(0),
-    m_srvIndex{},
-    m_frameFenceValues{}
+	DXSample(width, height, name),
+	m_frameIndex(0),
+	m_viewport(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height)),
+	m_scissorRect(0, 0, static_cast<LONG>(width), static_cast<LONG>(height)),
+	m_rtvDescriptorSize(0),
+	m_srvUavDescriptorSize(0),
+	m_pConstantBufferGSData(nullptr),
+	m_renderContextFenceValue(0),
+	m_terminating(0),
+	m_srvIndex{},
+	m_frameFenceValues{}
 {
-    for (int n = 0; n < ThreadCount; n++)
-    {
-        m_renderContextFenceValues[n] = 0;
-        m_threadFenceValues[n] = 0;
-    }
+	for (int n = 0; n < ThreadCount; n++)
+	{
+		m_renderContextFenceValues[n] = 0;
+		m_threadFenceValues[n] = 0;
+	}
 
-    float sqRootNumAsyncContexts = sqrt(static_cast<float>(ThreadCount));
-    m_heightInstances = static_cast<UINT>(ceil(sqRootNumAsyncContexts));
-    m_widthInstances = static_cast<UINT>(ceil(sqRootNumAsyncContexts));
+	float sqRootNumAsyncContexts = sqrt(static_cast<float>(ThreadCount));
+	m_heightInstances = static_cast<UINT>(ceil(sqRootNumAsyncContexts));
+	m_widthInstances = static_cast<UINT>(ceil(sqRootNumAsyncContexts));
 
-    if (m_widthInstances * (m_heightInstances - 1) >= ThreadCount)
-    {
-        m_heightInstances--;
-    }
+	if (m_widthInstances * (m_heightInstances - 1) >= ThreadCount)
+	{
+		m_heightInstances--;
+	}
+
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
 }
 
 void D3D12nBodyGravity::OnInit()
 {
-    m_camera.Init({ 0.0f, 0.0f, 1500.0f });
-    m_camera.SetMoveSpeed(250.0f);
+	m_camera.Init({ 0.0f, 0.0f, 1500.0f });
+	m_camera.SetMoveSpeed(250.0f);
 
-    LoadPipeline();
-    LoadAssets();
-    CreateAsyncContexts();
+	LoadPipeline();
+	LoadAssets();
+	CreateAsyncContexts();
 }
 
 // Load the rendering pipeline dependencies.
 void D3D12nBodyGravity::LoadPipeline()
 {
-    UINT dxgiFactoryFlags = 0;
+	UINT dxgiFactoryFlags = 0;
 
 #if defined(_DEBUG)
-    // Enable the debug layer (requires the Graphics Tools "optional feature").
-    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
-    {
-        ComPtr<ID3D12Debug> debugController;
-        if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-        {
-            debugController->EnableDebugLayer();
+	// Enable the debug layer (requires the Graphics Tools "optional feature").
+	// NOTE: Enabling the debug layer after device creation will invalidate the active device.
+	{
+		ComPtr<ID3D12Debug> debugController;
+		if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+		{
+			debugController->EnableDebugLayer();
 
-            // Enable additional debug layers.
-            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
-        }
-    }
+			// Enable additional debug layers.
+			dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+		}
+	}
 #endif
 
-    ComPtr<IDXGIFactory4> factory;
-    ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+	ComPtr<IDXGIFactory4> factory;
+	ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
 
-    if (m_useWarpDevice)
-    {
-        ComPtr<IDXGIAdapter> warpAdapter;
-        ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+	if (m_useWarpDevice)
+	{
+		ComPtr<IDXGIAdapter> warpAdapter;
+		ThrowIfFailed(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
 
-        ThrowIfFailed(D3D12CreateDevice(
-            warpAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
-    else
-    {
-        ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+		ThrowIfFailed(D3D12CreateDevice(
+			warpAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
+	else
+	{
+		ComPtr<IDXGIAdapter1> hardwareAdapter;
+		GetHardwareAdapter(factory.Get(), &hardwareAdapter, true);
 
-        ThrowIfFailed(D3D12CreateDevice(
-            hardwareAdapter.Get(),
-            D3D_FEATURE_LEVEL_11_0,
-            IID_PPV_ARGS(&m_device)
-            ));
-    }
+		ThrowIfFailed(D3D12CreateDevice(
+			hardwareAdapter.Get(),
+			D3D_FEATURE_LEVEL_11_0,
+			IID_PPV_ARGS(&m_device)
+			));
+	}
 
-    // Describe and create the command queue.
-    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
-    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	// Describe and create the command queue.
+	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+	queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
-    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
-    NAME_D3D12_OBJECT(m_commandQueue);
+	ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_commandQueue)));
+	NAME_D3D12_OBJECT(m_commandQueue);
 
-    // Describe and create the swap chain.
-    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
-    swapChainDesc.BufferCount = FrameCount;
-    swapChainDesc.Width = m_width;
-    swapChainDesc.Height = m_height;
-    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.SampleDesc.Count = 1;
-    swapChainDesc.Flags = DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
+	// Describe and create the swap chain.
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+	swapChainDesc.BufferCount = FrameCount;
+	swapChainDesc.Width = m_width;
+	swapChainDesc.Height = m_height;
+	swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	swapChainDesc.SampleDesc.Count = 1;
+	swapChainDesc.Flags = DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
 
-    ComPtr<IDXGISwapChain1> swapChain;
-    ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
-        reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
-        &swapChainDesc,
-        nullptr,
-        &swapChain
-        ));
+	ComPtr<IDXGISwapChain1> swapChain;
+	ThrowIfFailed(factory->CreateSwapChainForCoreWindow(
+		m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
+		reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
+		&swapChainDesc,
+		nullptr,
+		&swapChain
+		));
 
-    ThrowIfFailed(swapChain.As(&m_swapChain));
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
-    m_swapChainEvent = m_swapChain->GetFrameLatencyWaitableObject();
+	ThrowIfFailed(swapChain.As(&m_swapChain));
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	m_swapChainEvent = m_swapChain->GetFrameLatencyWaitableObject();
 
-    // Create descriptor heaps.
-    {
-        // Describe and create a render target view (RTV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
-        rtvHeapDesc.NumDescriptors = FrameCount;
-        rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
+	// Create descriptor heaps.
+	{
+		// Describe and create a render target view (RTV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
+		rtvHeapDesc.NumDescriptors = FrameCount;
+		rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+		rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&m_rtvHeap)));
 
-        // Describe and create a shader resource view (SRV) and unordered
-        // access view (UAV) descriptor heap.
-        D3D12_DESCRIPTOR_HEAP_DESC srvUavHeapDesc = {};
-        srvUavHeapDesc.NumDescriptors = DescriptorCount;
-        srvUavHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        srvUavHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-        ThrowIfFailed(m_device->CreateDescriptorHeap(&srvUavHeapDesc, IID_PPV_ARGS(&m_srvUavHeap)));
-        NAME_D3D12_OBJECT(m_srvUavHeap);
+		// Describe and create a shader resource view (SRV) and unordered
+		// access view (UAV) descriptor heap.
+		D3D12_DESCRIPTOR_HEAP_DESC srvUavHeapDesc = {};
+		srvUavHeapDesc.NumDescriptors = DescriptorCount;
+		srvUavHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		srvUavHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+		ThrowIfFailed(m_device->CreateDescriptorHeap(&srvUavHeapDesc, IID_PPV_ARGS(&m_srvUavHeap)));
+		NAME_D3D12_OBJECT(m_srvUavHeap);
 
-        m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-        m_srvUavDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    }
+		m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		m_srvUavDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	}
 
-    // Create frame resources.
-    {
-        CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
+	// Create frame resources.
+	{
+		CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart());
 
-        // Create a RTV and a command allocator for each frame.
-        for (UINT n = 0; n < FrameCount; n++)
-        {
-            ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
-            m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
-            rtvHandle.Offset(1, m_rtvDescriptorSize);
+		// Create a RTV and a command allocator for each frame.
+		for (UINT n = 0; n < FrameCount; n++)
+		{
+			ThrowIfFailed(m_swapChain->GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])));
+			m_device->CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
+			rtvHandle.Offset(1, m_rtvDescriptorSize);
 
-            NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
+			NAME_D3D12_OBJECT_INDEXED(m_renderTargets, n);
 
-            ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
-        }
-    }
+			ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[n])));
+		}
+	}
 }
 
 // Load the sample assets.
 void D3D12nBodyGravity::LoadAssets()
 {
-    // Create the root signatures.
-    {
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+	// Create the root signatures.
+	{
+		D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
 
-        // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
-        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+		// This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned will not be greater than this.
+		featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
 
-        if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
-        {
-            featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        }
+		if (FAILED(m_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData))))
+		{
+			featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+		}
 
-        // Graphics root signature.
-        {
-            CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
-            ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+		// Graphics root signature.
+		{
+			CD3DX12_DESCRIPTOR_RANGE1 ranges[1];
+			ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
 
-            CD3DX12_ROOT_PARAMETER1 rootParameters[GraphicsRootParametersCount];
-            rootParameters[GraphicsRootCBV].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_ALL);
-            rootParameters[GraphicsRootSRVTable].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_VERTEX);
+			CD3DX12_ROOT_PARAMETER1 rootParameters[GraphicsRootParametersCount];
+			rootParameters[GraphicsRootCBV].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_ALL);
+			rootParameters[GraphicsRootSRVTable].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_VERTEX);
 
-            CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-            rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+			CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+			rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-            ComPtr<ID3DBlob> signature;
-            ComPtr<ID3DBlob> error;
-            ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
-            ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
-            NAME_D3D12_OBJECT(m_rootSignature);
-        }
+			ComPtr<ID3DBlob> signature;
+			ComPtr<ID3DBlob> error;
+			ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, featureData.HighestVersion, &signature, &error));
+			ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_rootSignature)));
+			NAME_D3D12_OBJECT(m_rootSignature);
+		}
 
-        // Compute root signature.
-        {
-            CD3DX12_DESCRIPTOR_RANGE1 ranges[2];
-            ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DESCRIPTORS_VOLATILE);
-            ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_VOLATILE);
+		// Compute root signature.
+		{
+			CD3DX12_DESCRIPTOR_RANGE1 ranges[2];
+			ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DESCRIPTORS_VOLATILE);
+			ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_VOLATILE);
 
-            CD3DX12_ROOT_PARAMETER1 rootParameters[ComputeRootParametersCount];
-            rootParameters[ComputeRootCBV].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_ALL);
-            rootParameters[ComputeRootSRVTable].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_ALL);
-            rootParameters[ComputeRootUAVTable].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_ALL);
+			CD3DX12_ROOT_PARAMETER1 rootParameters[ComputeRootParametersCount];
+			rootParameters[ComputeRootCBV].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC, D3D12_SHADER_VISIBILITY_ALL);
+			rootParameters[ComputeRootSRVTable].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_ALL);
+			rootParameters[ComputeRootUAVTable].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_ALL);
 
-            CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC computeRootSignatureDesc;
-            computeRootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr);
+			CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC computeRootSignatureDesc;
+			computeRootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 0, nullptr);
 
-            ComPtr<ID3DBlob> signature;
-            ComPtr<ID3DBlob> error;
-            ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&computeRootSignatureDesc, featureData.HighestVersion, &signature, &error));
-            ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_computeRootSignature)));
-            NAME_D3D12_OBJECT(m_computeRootSignature);
-        }
-    }
+			ComPtr<ID3DBlob> signature;
+			ComPtr<ID3DBlob> error;
+			ThrowIfFailed(D3DX12SerializeVersionedRootSignature(&computeRootSignatureDesc, featureData.HighestVersion, &signature, &error));
+			ThrowIfFailed(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_computeRootSignature)));
+			NAME_D3D12_OBJECT(m_computeRootSignature);
+		}
+	}
 
-    // Create the pipeline states, which includes compiling and loading shaders.
-    {
-        ComPtr<ID3DBlob> vertexShader;
-        ComPtr<ID3DBlob> geometryShader;
-        ComPtr<ID3DBlob> pixelShader;
-        ComPtr<ID3DBlob> computeShader;
+	// Create the pipeline states, which includes compiling and loading shaders.
+	{
+		ComPtr<ID3DBlob> vertexShader;
+		ComPtr<ID3DBlob> geometryShader;
+		ComPtr<ID3DBlob> pixelShader;
+		ComPtr<ID3DBlob> computeShader;
 
 #if defined(_DEBUG)
-        // Enable better shader debugging with the graphics debugging tools.
-        UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+		// Enable better shader debugging with the graphics debugging tools.
+		UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-        UINT compileFlags = 0;
+		UINT compileFlags = 0;
 #endif
 
-        // Load and compile shaders.
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"ParticleDraw.hlsl").c_str(), nullptr, nullptr, "VSParticleDraw", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"ParticleDraw.hlsl").c_str(), nullptr, nullptr, "GSParticleDraw", "gs_5_0", compileFlags, 0, &geometryShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"ParticleDraw.hlsl").c_str(), nullptr, nullptr, "PSParticleDraw", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
-        ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"NBodyGravityCS.hlsl").c_str(), nullptr, nullptr, "CSMain", "cs_5_0", compileFlags, 0, &computeShader, nullptr));
+		// Load and compile shaders.
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"ParticleDraw.hlsl").c_str(), nullptr, nullptr, "VSParticleDraw", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"ParticleDraw.hlsl").c_str(), nullptr, nullptr, "GSParticleDraw", "gs_5_0", compileFlags, 0, &geometryShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"ParticleDraw.hlsl").c_str(), nullptr, nullptr, "PSParticleDraw", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+		ThrowIfFailed(D3DCompileFromFile(GetAssetFullPath(L"NBodyGravityCS.hlsl").c_str(), nullptr, nullptr, "CSMain", "cs_5_0", compileFlags, 0, &computeShader, nullptr));
 
-        D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-        {
-            { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        };
+		D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
+		{
+			{ "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		};
 
-        // Describe the blend and depth states.
-        CD3DX12_BLEND_DESC blendDesc(D3D12_DEFAULT);
-        blendDesc.RenderTarget[0].BlendEnable = TRUE;
-        blendDesc.RenderTarget[0].SrcBlend = D3D12_BLEND_SRC_ALPHA;
-        blendDesc.RenderTarget[0].DestBlend = D3D12_BLEND_ONE;
-        blendDesc.RenderTarget[0].SrcBlendAlpha = D3D12_BLEND_ZERO;
-        blendDesc.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_ZERO;
+		// Describe the blend and depth states.
+		CD3DX12_BLEND_DESC blendDesc(D3D12_DEFAULT);
+		blendDesc.RenderTarget[0].BlendEnable = TRUE;
+		blendDesc.RenderTarget[0].SrcBlend = D3D12_BLEND_SRC_ALPHA;
+		blendDesc.RenderTarget[0].DestBlend = D3D12_BLEND_ONE;
+		blendDesc.RenderTarget[0].SrcBlendAlpha = D3D12_BLEND_ZERO;
+		blendDesc.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_ZERO;
 
-        CD3DX12_DEPTH_STENCIL_DESC depthStencilDesc(D3D12_DEFAULT);
-        depthStencilDesc.DepthEnable = FALSE;
-        depthStencilDesc.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ZERO;
+		CD3DX12_DEPTH_STENCIL_DESC depthStencilDesc(D3D12_DEFAULT);
+		depthStencilDesc.DepthEnable = FALSE;
+		depthStencilDesc.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ZERO;
 
-        // Describe and create the graphics pipeline state object (PSO).
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-        psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
-        psoDesc.pRootSignature = m_rootSignature.Get();
-        psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
-        psoDesc.GS = CD3DX12_SHADER_BYTECODE(geometryShader.Get());
-        psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
-        psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        psoDesc.BlendState = blendDesc;
-        psoDesc.DepthStencilState = depthStencilDesc;
-        psoDesc.SampleMask = UINT_MAX;
-        psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_POINT;
-        psoDesc.NumRenderTargets = 1;
-        psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-        psoDesc.DSVFormat = DXGI_FORMAT_D24_UNORM_S8_UINT;
-        psoDesc.SampleDesc.Count = 1;
+		// Describe and create the graphics pipeline state object (PSO).
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+		psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+		psoDesc.pRootSignature = m_rootSignature.Get();
+		psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShader.Get());
+		psoDesc.GS = CD3DX12_SHADER_BYTECODE(geometryShader.Get());
+		psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShader.Get());
+		psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+		psoDesc.BlendState = blendDesc;
+		psoDesc.DepthStencilState = depthStencilDesc;
+		psoDesc.SampleMask = UINT_MAX;
+		psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_POINT;
+		psoDesc.NumRenderTargets = 1;
+		psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+		psoDesc.DSVFormat = DXGI_FORMAT_D24_UNORM_S8_UINT;
+		psoDesc.SampleDesc.Count = 1;
 
-        ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
-        NAME_D3D12_OBJECT(m_pipelineState);
+		ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)));
+		NAME_D3D12_OBJECT(m_pipelineState);
 
-        // Describe and create the compute pipeline state object (PSO).
-        D3D12_COMPUTE_PIPELINE_STATE_DESC computePsoDesc = {};
-        computePsoDesc.pRootSignature = m_computeRootSignature.Get();
-        computePsoDesc.CS = CD3DX12_SHADER_BYTECODE(computeShader.Get());
+		// Describe and create the compute pipeline state object (PSO).
+		D3D12_COMPUTE_PIPELINE_STATE_DESC computePsoDesc = {};
+		computePsoDesc.pRootSignature = m_computeRootSignature.Get();
+		computePsoDesc.CS = CD3DX12_SHADER_BYTECODE(computeShader.Get());
 
-        ThrowIfFailed(m_device->CreateComputePipelineState(&computePsoDesc, IID_PPV_ARGS(&m_computeState)));
-        NAME_D3D12_OBJECT(m_computeState);
-    }
+		ThrowIfFailed(m_device->CreateComputePipelineState(&computePsoDesc, IID_PPV_ARGS(&m_computeState)));
+		NAME_D3D12_OBJECT(m_computeState);
+	}
 
-    // Create the command list.
-    ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
-    NAME_D3D12_OBJECT(m_commandList);
+	// Create the command list.
+	ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get(), IID_PPV_ARGS(&m_commandList)));
+	NAME_D3D12_OBJECT(m_commandList);
 
-    CreateVertexBuffer();
-    CreateParticleBuffers();
+	CreateVertexBuffer();
+	CreateParticleBuffers();
 
-    // Note: ComPtr's are CPU objects but this resource needs to stay in scope until
-    // the command list that references it has finished executing on the GPU.
-    // We will flush the GPU at the end of this method to ensure the resource is not
-    // prematurely destroyed.
-    ComPtr<ID3D12Resource> constantBufferCSUpload;
+	// Note: ComPtr's are CPU objects but this resource needs to stay in scope until
+	// the command list that references it has finished executing on the GPU.
+	// We will flush the GPU at the end of this method to ensure the resource is not
+	// prematurely destroyed.
+	ComPtr<ID3D12Resource> constantBufferCSUpload;
 
-    // Create the compute shader's constant buffer.
-    {
-        const UINT bufferSize = sizeof(ConstantBufferCS);
+	// Create the compute shader's constant buffer.
+	{
+		const UINT bufferSize = sizeof(ConstantBufferCS);
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(bufferSize),
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_constantBufferCS)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(bufferSize),
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_constantBufferCS)));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(bufferSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&constantBufferCSUpload)));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(bufferSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&constantBufferCSUpload)));
 
-        NAME_D3D12_OBJECT(m_constantBufferCS);
+		NAME_D3D12_OBJECT(m_constantBufferCS);
 
-        ConstantBufferCS constantBufferCS = {};
-        constantBufferCS.param[0] = ParticleCount;
-        constantBufferCS.param[1] = int(ceil(ParticleCount / 128.0f));
-        constantBufferCS.paramf[0] = 0.1f;
-        constantBufferCS.paramf[1] = 1.0f;
+		ConstantBufferCS constantBufferCS = {};
+		constantBufferCS.param[0] = ParticleCount;
+		constantBufferCS.param[1] = int(ceil(ParticleCount / 128.0f));
+		constantBufferCS.paramf[0] = 0.1f;
+		constantBufferCS.paramf[1] = 1.0f;
 
-        D3D12_SUBRESOURCE_DATA computeCBData = {};
-        computeCBData.pData = reinterpret_cast<UINT8*>(&constantBufferCS);
-        computeCBData.RowPitch = bufferSize;
-        computeCBData.SlicePitch = computeCBData.RowPitch;
+		D3D12_SUBRESOURCE_DATA computeCBData = {};
+		computeCBData.pData = reinterpret_cast<UINT8*>(&constantBufferCS);
+		computeCBData.RowPitch = bufferSize;
+		computeCBData.SlicePitch = computeCBData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_constantBufferCS.Get(), constantBufferCSUpload.Get(), 0, 0, 1, &computeCBData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_constantBufferCS.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
-    }
+		UpdateSubresources<1>(m_commandList.Get(), m_constantBufferCS.Get(), constantBufferCSUpload.Get(), 0, 0, 1, &computeCBData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_constantBufferCS.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+	}
 
-    // Create the geometry shader's constant buffer.
-    {
-        const UINT constantBufferGSSize = sizeof(ConstantBufferGS) * FrameCount;
+	// Create the geometry shader's constant buffer.
+	{
+		const UINT constantBufferGSSize = sizeof(ConstantBufferGS) * FrameCount;
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-            D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(constantBufferGSSize),
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_constantBufferGS)
-            ));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			D3D12_HEAP_FLAG_NONE,
+			&CD3DX12_RESOURCE_DESC::Buffer(constantBufferGSSize),
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_constantBufferGS)
+			));
 
-        NAME_D3D12_OBJECT(m_constantBufferGS);
+		NAME_D3D12_OBJECT(m_constantBufferGS);
 
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_constantBufferGS->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBufferGSData)));
-        ZeroMemory(m_pConstantBufferGSData, constantBufferGSSize);
-    }
+		CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
+		ThrowIfFailed(m_constantBufferGS->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBufferGSData)));
+		ZeroMemory(m_pConstantBufferGSData, constantBufferGSSize);
+	}
 
-    // Close the command list and execute it to begin the initial GPU setup.
-    ThrowIfFailed(m_commandList->Close());
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+	// Close the command list and execute it to begin the initial GPU setup.
+	ThrowIfFailed(m_commandList->Close());
+	ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+	m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    // Create synchronization objects and wait until assets have been uploaded to the GPU.
-    {
-        ThrowIfFailed(m_device->CreateFence(m_renderContextFenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_renderContextFence)));
-        m_renderContextFenceValue++;
+	// Create synchronization objects and wait until assets have been uploaded to the GPU.
+	{
+		ThrowIfFailed(m_device->CreateFence(m_renderContextFenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_renderContextFence)));
+		m_renderContextFenceValue++;
 
-        m_renderContextFenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_renderContextFenceEvent == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		m_renderContextFenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_renderContextFenceEvent == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        WaitForRenderContext();
-    }
+		WaitForRenderContext();
+	}
 }
 
 // Create the particle vertex buffer.
 void D3D12nBodyGravity::CreateVertexBuffer()
 {
-    std::vector<ParticleVertex> vertices;
-    vertices.resize(ParticleCount);
-    for (UINT i = 0; i < ParticleCount; i++)
-    {
-        vertices[i].color = XMFLOAT4(1.0f, 1.0f, 0.2f, 1.0f);
-    }
-    const UINT bufferSize = ParticleCount * sizeof(ParticleVertex);
+	std::vector<ParticleVertex> vertices;
+	vertices.resize(ParticleCount);
+	for (UINT i = 0; i < ParticleCount; i++)
+	{
+		vertices[i].color = XMFLOAT4(1.0f, 1.0f, 0.2f, 1.0f);
+	}
+	const UINT bufferSize = ParticleCount * sizeof(ParticleVertex);
 
-    ThrowIfFailed(m_device->CreateCommittedResource(
-        &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-        D3D12_HEAP_FLAG_NONE,
-        &CD3DX12_RESOURCE_DESC::Buffer(bufferSize),
-        D3D12_RESOURCE_STATE_COPY_DEST,
-        nullptr,
-        IID_PPV_ARGS(&m_vertexBuffer)));
+	ThrowIfFailed(m_device->CreateCommittedResource(
+		&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+		D3D12_HEAP_FLAG_NONE,
+		&CD3DX12_RESOURCE_DESC::Buffer(bufferSize),
+		D3D12_RESOURCE_STATE_COPY_DEST,
+		nullptr,
+		IID_PPV_ARGS(&m_vertexBuffer)));
 
-    ThrowIfFailed(m_device->CreateCommittedResource(
-        &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
-        D3D12_HEAP_FLAG_NONE,
-        &CD3DX12_RESOURCE_DESC::Buffer(bufferSize),
-        D3D12_RESOURCE_STATE_GENERIC_READ,
-        nullptr,
-        IID_PPV_ARGS(&m_vertexBufferUpload)));
+	ThrowIfFailed(m_device->CreateCommittedResource(
+		&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+		D3D12_HEAP_FLAG_NONE,
+		&CD3DX12_RESOURCE_DESC::Buffer(bufferSize),
+		D3D12_RESOURCE_STATE_GENERIC_READ,
+		nullptr,
+		IID_PPV_ARGS(&m_vertexBufferUpload)));
 
-    NAME_D3D12_OBJECT(m_vertexBuffer);
+	NAME_D3D12_OBJECT(m_vertexBuffer);
 
-    D3D12_SUBRESOURCE_DATA vertexData = {};
-    vertexData.pData = reinterpret_cast<UINT8*>(&vertices[0]);
-    vertexData.RowPitch = bufferSize;
-    vertexData.SlicePitch = vertexData.RowPitch;
+	D3D12_SUBRESOURCE_DATA vertexData = {};
+	vertexData.pData = reinterpret_cast<UINT8*>(&vertices[0]);
+	vertexData.RowPitch = bufferSize;
+	vertexData.SlicePitch = vertexData.RowPitch;
 
-    UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), m_vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
+	UpdateSubresources<1>(m_commandList.Get(), m_vertexBuffer.Get(), m_vertexBufferUpload.Get(), 0, 0, 1, &vertexData);
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_vertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER));
 
-    m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
-    m_vertexBufferView.SizeInBytes = static_cast<UINT>(bufferSize);
-    m_vertexBufferView.StrideInBytes = sizeof(ParticleVertex);
+	m_vertexBufferView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+	m_vertexBufferView.SizeInBytes = static_cast<UINT>(bufferSize);
+	m_vertexBufferView.StrideInBytes = sizeof(ParticleVertex);
 }
 
 // Random percent value, from -1 to 1.
 float D3D12nBodyGravity::RandomPercent()
 {
-    float ret = static_cast<float>((rand() % 10000) - 5000);
-    return ret / 5000.0f;
+	float ret = static_cast<float>((rand() % 10000) - 5000);
+	return ret / 5000.0f;
 }
 
 void D3D12nBodyGravity::LoadParticles(_Out_writes_(numParticles) Particle* pParticles, const XMFLOAT3& center, const XMFLOAT4& velocity, float spread, UINT numParticles)
 {
-    srand(0);
-    for (UINT i = 0; i < numParticles; i++)
-    {
-        XMFLOAT3 delta(spread, spread, spread);
+	srand(0);
+	for (UINT i = 0; i < numParticles; i++)
+	{
+		XMFLOAT3 delta(spread, spread, spread);
 
-        while (XMVectorGetX(XMVector3LengthSq(XMLoadFloat3(&delta))) > spread * spread)
-        {
-            delta.x = RandomPercent() * spread;
-            delta.y = RandomPercent() * spread;
-            delta.z = RandomPercent() * spread;
-        }
+		while (XMVectorGetX(XMVector3LengthSq(XMLoadFloat3(&delta))) > spread * spread)
+		{
+			delta.x = RandomPercent() * spread;
+			delta.y = RandomPercent() * spread;
+			delta.z = RandomPercent() * spread;
+		}
 
-        pParticles[i].position.x = center.x + delta.x;
-        pParticles[i].position.y = center.y + delta.y;
-        pParticles[i].position.z = center.z + delta.z;
-        pParticles[i].position.w = 10000.0f * 10000.0f;
+		pParticles[i].position.x = center.x + delta.x;
+		pParticles[i].position.y = center.y + delta.y;
+		pParticles[i].position.z = center.z + delta.z;
+		pParticles[i].position.w = 10000.0f * 10000.0f;
 
-        pParticles[i].velocity = velocity;
-    }
+		pParticles[i].velocity = velocity;
+	}
 }
 
 // Create the position and velocity buffer shader resources.
 void D3D12nBodyGravity::CreateParticleBuffers()
 {
-    // Initialize the data in the buffers.
-    std::vector<Particle> data;
-    data.resize(ParticleCount);
-    const UINT dataSize = ParticleCount * sizeof(Particle);
+	// Initialize the data in the buffers.
+	std::vector<Particle> data;
+	data.resize(ParticleCount);
+	const UINT dataSize = ParticleCount * sizeof(Particle);
 
-    // Split the particles into two groups.
-    float centerSpread = ParticleSpread * 0.50f;
-    LoadParticles(&data[0], XMFLOAT3(centerSpread, 0, 0), XMFLOAT4(0, 0, -20, 1 / 100000000.0f), ParticleSpread, ParticleCount / 2);
-    LoadParticles(&data[ParticleCount / 2], XMFLOAT3(-centerSpread, 0, 0), XMFLOAT4(0, 0, 20, 1 / 100000000.0f), ParticleSpread, ParticleCount / 2);
+	// Split the particles into two groups.
+	float centerSpread = ParticleSpread * 0.50f;
+	LoadParticles(&data[0], XMFLOAT3(centerSpread, 0, 0), XMFLOAT4(0, 0, -20, 1 / 100000000.0f), ParticleSpread, ParticleCount / 2);
+	LoadParticles(&data[ParticleCount / 2], XMFLOAT3(-centerSpread, 0, 0), XMFLOAT4(0, 0, 20, 1 / 100000000.0f), ParticleSpread, ParticleCount / 2);
 
-    D3D12_HEAP_PROPERTIES defaultHeapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
-    D3D12_HEAP_PROPERTIES uploadHeapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
-    D3D12_RESOURCE_DESC bufferDesc = CD3DX12_RESOURCE_DESC::Buffer(dataSize, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
-    D3D12_RESOURCE_DESC uploadBufferDesc = CD3DX12_RESOURCE_DESC::Buffer(dataSize);
+	D3D12_HEAP_PROPERTIES defaultHeapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+	D3D12_HEAP_PROPERTIES uploadHeapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+	D3D12_RESOURCE_DESC bufferDesc = CD3DX12_RESOURCE_DESC::Buffer(dataSize, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+	D3D12_RESOURCE_DESC uploadBufferDesc = CD3DX12_RESOURCE_DESC::Buffer(dataSize);
 
-    for (UINT index = 0; index < ThreadCount; index++)
-    {
-        // Create two buffers in the GPU, each with a copy of the particles data.
-        // The compute shader will update one of them while the rendering thread 
-        // renders the other. When rendering completes, the threads will swap 
-        // which buffer they work on.
+	for (UINT index = 0; index < ThreadCount; index++)
+	{
+		// Create two buffers in the GPU, each with a copy of the particles data.
+		// The compute shader will update one of them while the rendering thread 
+		// renders the other. When rendering completes, the threads will swap 
+		// which buffer they work on.
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &defaultHeapProperties,
-            D3D12_HEAP_FLAG_NONE,
-            &bufferDesc,
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_particleBuffer0[index])));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&defaultHeapProperties,
+			D3D12_HEAP_FLAG_NONE,
+			&bufferDesc,
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_particleBuffer0[index])));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &defaultHeapProperties,
-            D3D12_HEAP_FLAG_NONE,
-            &bufferDesc,
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&m_particleBuffer1[index])));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&defaultHeapProperties,
+			D3D12_HEAP_FLAG_NONE,
+			&bufferDesc,
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&m_particleBuffer1[index])));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &uploadHeapProperties,
-            D3D12_HEAP_FLAG_NONE,
-            &uploadBufferDesc,
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_particleBuffer0Upload[index])));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&uploadHeapProperties,
+			D3D12_HEAP_FLAG_NONE,
+			&uploadBufferDesc,
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_particleBuffer0Upload[index])));
 
-        ThrowIfFailed(m_device->CreateCommittedResource(
-            &uploadHeapProperties,
-            D3D12_HEAP_FLAG_NONE,
-            &uploadBufferDesc,
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_particleBuffer1Upload[index])));
+		ThrowIfFailed(m_device->CreateCommittedResource(
+			&uploadHeapProperties,
+			D3D12_HEAP_FLAG_NONE,
+			&uploadBufferDesc,
+			D3D12_RESOURCE_STATE_GENERIC_READ,
+			nullptr,
+			IID_PPV_ARGS(&m_particleBuffer1Upload[index])));
 
-        NAME_D3D12_OBJECT_INDEXED(m_particleBuffer0, index);
-        NAME_D3D12_OBJECT_INDEXED(m_particleBuffer1, index);
+		NAME_D3D12_OBJECT_INDEXED(m_particleBuffer0, index);
+		NAME_D3D12_OBJECT_INDEXED(m_particleBuffer1, index);
 
-        D3D12_SUBRESOURCE_DATA particleData = {};
-        particleData.pData = reinterpret_cast<UINT8*>(&data[0]);
-        particleData.RowPitch = dataSize;
-        particleData.SlicePitch = particleData.RowPitch;
+		D3D12_SUBRESOURCE_DATA particleData = {};
+		particleData.pData = reinterpret_cast<UINT8*>(&data[0]);
+		particleData.RowPitch = dataSize;
+		particleData.SlicePitch = particleData.RowPitch;
 
-        UpdateSubresources<1>(m_commandList.Get(), m_particleBuffer0[index].Get(), m_particleBuffer0Upload[index].Get(), 0, 0, 1, &particleData);
-        UpdateSubresources<1>(m_commandList.Get(), m_particleBuffer1[index].Get(), m_particleBuffer1Upload[index].Get(), 0, 0, 1, &particleData);
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_particleBuffer0[index].Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE));
-        m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_particleBuffer1[index].Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE));
+		UpdateSubresources<1>(m_commandList.Get(), m_particleBuffer0[index].Get(), m_particleBuffer0Upload[index].Get(), 0, 0, 1, &particleData);
+		UpdateSubresources<1>(m_commandList.Get(), m_particleBuffer1[index].Get(), m_particleBuffer1Upload[index].Get(), 0, 0, 1, &particleData);
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_particleBuffer0[index].Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE));
+		m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_particleBuffer1[index].Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE));
 
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        srvDesc.Format = DXGI_FORMAT_UNKNOWN;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
-        srvDesc.Buffer.FirstElement = 0;
-        srvDesc.Buffer.NumElements = ParticleCount;
-        srvDesc.Buffer.StructureByteStride = sizeof(Particle);
-        srvDesc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_NONE;
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.Format = DXGI_FORMAT_UNKNOWN;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
+		srvDesc.Buffer.FirstElement = 0;
+		srvDesc.Buffer.NumElements = ParticleCount;
+		srvDesc.Buffer.StructureByteStride = sizeof(Particle);
+		srvDesc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_NONE;
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle0(m_srvUavHeap->GetCPUDescriptorHandleForHeapStart(), SrvParticlePosVelo0 + index, m_srvUavDescriptorSize);
-        CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle1(m_srvUavHeap->GetCPUDescriptorHandleForHeapStart(), SrvParticlePosVelo1 + index, m_srvUavDescriptorSize);
-        m_device->CreateShaderResourceView(m_particleBuffer0[index].Get(), &srvDesc, srvHandle0);
-        m_device->CreateShaderResourceView(m_particleBuffer1[index].Get(), &srvDesc, srvHandle1);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle0(m_srvUavHeap->GetCPUDescriptorHandleForHeapStart(), SrvParticlePosVelo0 + index, m_srvUavDescriptorSize);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle1(m_srvUavHeap->GetCPUDescriptorHandleForHeapStart(), SrvParticlePosVelo1 + index, m_srvUavDescriptorSize);
+		m_device->CreateShaderResourceView(m_particleBuffer0[index].Get(), &srvDesc, srvHandle0);
+		m_device->CreateShaderResourceView(m_particleBuffer1[index].Get(), &srvDesc, srvHandle1);
 
-        D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
-        uavDesc.Format = DXGI_FORMAT_UNKNOWN;
-        uavDesc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
-        uavDesc.Buffer.FirstElement = 0;
-        uavDesc.Buffer.NumElements = ParticleCount;
-        uavDesc.Buffer.StructureByteStride = sizeof(Particle);
-        uavDesc.Buffer.CounterOffsetInBytes = 0;
-        uavDesc.Buffer.Flags = D3D12_BUFFER_UAV_FLAG_NONE;
+		D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
+		uavDesc.Format = DXGI_FORMAT_UNKNOWN;
+		uavDesc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
+		uavDesc.Buffer.FirstElement = 0;
+		uavDesc.Buffer.NumElements = ParticleCount;
+		uavDesc.Buffer.StructureByteStride = sizeof(Particle);
+		uavDesc.Buffer.CounterOffsetInBytes = 0;
+		uavDesc.Buffer.Flags = D3D12_BUFFER_UAV_FLAG_NONE;
 
-        CD3DX12_CPU_DESCRIPTOR_HANDLE uavHandle0(m_srvUavHeap->GetCPUDescriptorHandleForHeapStart(), UavParticlePosVelo0 + index, m_srvUavDescriptorSize);
-        CD3DX12_CPU_DESCRIPTOR_HANDLE uavHandle1(m_srvUavHeap->GetCPUDescriptorHandleForHeapStart(), UavParticlePosVelo1 + index, m_srvUavDescriptorSize);
-        m_device->CreateUnorderedAccessView(m_particleBuffer0[index].Get(), nullptr, &uavDesc, uavHandle0);
-        m_device->CreateUnorderedAccessView(m_particleBuffer1[index].Get(), nullptr, &uavDesc, uavHandle1);
-    }
+		CD3DX12_CPU_DESCRIPTOR_HANDLE uavHandle0(m_srvUavHeap->GetCPUDescriptorHandleForHeapStart(), UavParticlePosVelo0 + index, m_srvUavDescriptorSize);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE uavHandle1(m_srvUavHeap->GetCPUDescriptorHandleForHeapStart(), UavParticlePosVelo1 + index, m_srvUavDescriptorSize);
+		m_device->CreateUnorderedAccessView(m_particleBuffer0[index].Get(), nullptr, &uavDesc, uavHandle0);
+		m_device->CreateUnorderedAccessView(m_particleBuffer1[index].Get(), nullptr, &uavDesc, uavHandle1);
+	}
 }
 
 void D3D12nBodyGravity::CreateAsyncContexts()
 {
-    for (UINT threadIndex = 0; threadIndex < ThreadCount; ++threadIndex)
-    {
-        // Create compute resources.
-        D3D12_COMMAND_QUEUE_DESC queueDesc = { D3D12_COMMAND_LIST_TYPE_COMPUTE, 0, D3D12_COMMAND_QUEUE_FLAG_NONE };
-        ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_computeCommandQueue[threadIndex])));
-        ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_COMPUTE, IID_PPV_ARGS(&m_computeAllocator[threadIndex])));
-        ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_COMPUTE, m_computeAllocator[threadIndex].Get(), nullptr, IID_PPV_ARGS(&m_computeCommandList[threadIndex])));
-        ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_SHARED, IID_PPV_ARGS(&m_threadFences[threadIndex])));
+	for (UINT threadIndex = 0; threadIndex < ThreadCount; ++threadIndex)
+	{
+		// Create compute resources.
+		D3D12_COMMAND_QUEUE_DESC queueDesc = { D3D12_COMMAND_LIST_TYPE_COMPUTE, 0, D3D12_COMMAND_QUEUE_FLAG_NONE };
+		ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_computeCommandQueue[threadIndex])));
+		ThrowIfFailed(m_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_COMPUTE, IID_PPV_ARGS(&m_computeAllocator[threadIndex])));
+		ThrowIfFailed(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_COMPUTE, m_computeAllocator[threadIndex].Get(), nullptr, IID_PPV_ARGS(&m_computeCommandList[threadIndex])));
+		ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_SHARED, IID_PPV_ARGS(&m_threadFences[threadIndex])));
 
-        m_threadFenceEvents[threadIndex] = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (m_threadFenceEvents[threadIndex] == nullptr)
-        {
-            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
-        }
+		m_threadFenceEvents[threadIndex] = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (m_threadFenceEvents[threadIndex] == nullptr)
+		{
+			ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+		}
 
-        m_threadData[threadIndex].pContext = this;
-        m_threadData[threadIndex].threadIndex = threadIndex;
+		m_threadData[threadIndex].pContext = this;
+		m_threadData[threadIndex].threadIndex = threadIndex;
 
-        m_threadHandles[threadIndex] = CreateThread(
-            nullptr,
-            0,
-            reinterpret_cast<LPTHREAD_START_ROUTINE>(ThreadProc),
-            reinterpret_cast<void*>(&m_threadData[threadIndex]),
-            CREATE_SUSPENDED,
-            nullptr);
+		m_threadHandles[threadIndex] = CreateThread(
+			nullptr,
+			0,
+			reinterpret_cast<LPTHREAD_START_ROUTINE>(ThreadProc),
+			reinterpret_cast<void*>(&m_threadData[threadIndex]),
+			CREATE_SUSPENDED,
+			nullptr);
 
-        ResumeThread(m_threadHandles[threadIndex]);
-    }
+		ResumeThread(m_threadHandles[threadIndex]);
+	}
 }
 
 // Update frame-based values.
 void D3D12nBodyGravity::OnUpdate()
 {
-    // Wait for the previous Present to complete.
-    WaitForSingleObjectEx(m_swapChainEvent, 100, FALSE);
+	// Wait for the previous Present to complete.
+	WaitForSingleObjectEx(m_swapChainEvent, 100, FALSE);
 
-    m_timer.Tick(NULL);
-    m_camera.Update(static_cast<float>(m_timer.GetElapsedSeconds()));
+	m_timer.Tick(NULL);
+	m_camera.Update(static_cast<float>(m_timer.GetElapsedSeconds()));
 
-    ConstantBufferGS constantBufferGS = {};
-    XMStoreFloat4x4(&constantBufferGS.worldViewProjection, XMMatrixMultiply(m_camera.GetViewMatrix(), m_camera.GetProjectionMatrix(0.8f, m_aspectRatio, 1.0f, 5000.0f)));
-    XMStoreFloat4x4(&constantBufferGS.inverseView, XMMatrixInverse(nullptr, m_camera.GetViewMatrix()));
+	ConstantBufferGS constantBufferGS = {};
+	XMStoreFloat4x4(&constantBufferGS.worldViewProjection, XMMatrixMultiply(m_camera.GetViewMatrix(), m_camera.GetProjectionMatrix(0.8f, m_aspectRatio, 1.0f, 5000.0f)));
+	XMStoreFloat4x4(&constantBufferGS.inverseView, XMMatrixInverse(nullptr, m_camera.GetViewMatrix()));
 
-    UINT8* destination = m_pConstantBufferGSData + sizeof(ConstantBufferGS) * m_frameIndex;
-    memcpy(destination, &constantBufferGS, sizeof(ConstantBufferGS));
+	UINT8* destination = m_pConstantBufferGSData + sizeof(ConstantBufferGS) * m_frameIndex;
+	memcpy(destination, &constantBufferGS, sizeof(ConstantBufferGS));
 }
 
 // Render the scene.
 void D3D12nBodyGravity::OnRender()
 {
-    // Let the compute thread know that a new frame is being rendered.
-    for (int n = 0; n < ThreadCount; n++)
+    try
     {
-        InterlockedExchange(&m_renderContextFenceValues[n], m_renderContextFenceValue);
-    }
-
-    // Compute work must be completed before the frame can render or else the SRV 
-    // will be in the wrong state.
-    for (UINT n = 0; n < ThreadCount; n++)
-    {
-        UINT64 threadFenceValue = InterlockedGetValue(&m_threadFenceValues[n]);
-        if (m_threadFences[n]->GetCompletedValue() < threadFenceValue)
+        // Let the compute thread know that a new frame is being rendered.
+        for (int n = 0; n < ThreadCount; n++)
         {
-            // Instruct the rendering command queue to wait for the current 
-            // compute work to complete.
-            ThrowIfFailed(m_commandQueue->Wait(m_threadFences[n].Get(), threadFenceValue));
+            InterlockedExchange(&m_renderContextFenceValues[n], m_renderContextFenceValue);
+        }
+
+        // Compute work must be completed before the frame can render or else the SRV 
+        // will be in the wrong state.
+        for (UINT n = 0; n < ThreadCount; n++)
+        {
+            UINT64 threadFenceValue = InterlockedGetValue(&m_threadFenceValues[n]);
+            if (m_threadFences[n]->GetCompletedValue() < threadFenceValue)
+            {
+                // Instruct the rendering command queue to wait for the current 
+                // compute work to complete.
+                ThrowIfFailed(m_commandQueue->Wait(m_threadFences[n].Get(), threadFenceValue));
+            }
+        }
+
+        PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+
+        // Record all the commands we need to render the scene into the command list.
+        PopulateCommandList();
+
+        // Execute the command list.
+        ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+        m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+
+        PIXEndEvent(m_commandQueue.Get());
+
+        // Present the frame.
+        ThrowIfFailed(m_swapChain->Present(1, 0));
+
+        MoveToNextFrame();
+    }
+    catch (HrException& e)
+    {
+        if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
+        {
+            RestoreD3DResources();
+        }
+        else
+        {
+            throw;
         }
     }
+}
 
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+// Release sample's D3D objects.
+void D3D12nBodyGravity::ReleaseD3DResources()
+{
+    m_renderContextFence.Reset();
+    ResetComPtrArray(&m_renderTargets);
+    m_commandQueue.Reset();
+    m_swapChain.Reset();
+    m_device.Reset();
+}
 
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+// Tears down D3D resources and reinitializes them.
+void D3D12nBodyGravity::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
+    {
+        WaitForGpu();
+    }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
+}
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+// Wait for pending GPU work to complete.
+void D3D12nBodyGravity::WaitForGpu()
+{
+    // Schedule a Signal command in the queue.
+    ThrowIfFailed(m_commandQueue->Signal(m_renderContextFence.Get(), m_renderContextFenceValues[m_frameIndex]));
 
-    PIXEndEvent(m_commandQueue.Get());
+    // Wait until the fence has been processed.
+    ThrowIfFailed(m_renderContextFence->SetEventOnCompletion(m_renderContextFenceValues[m_frameIndex], m_renderContextFenceEvent));
+    WaitForSingleObjectEx(m_renderContextFenceEvent, INFINITE, FALSE);
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
-
-    MoveToNextFrame();
+    // Increment the fence value for the current frame.
+    m_renderContextFenceValues[m_frameIndex]++;
 }
 
 // Fill the command list with all the render commands and dependent state.
 void D3D12nBodyGravity::PopulateCommandList()
 {
-    // Command list allocators can only be reset when the associated
-    // command lists have finished execution on the GPU; apps should use
-    // fences to determine GPU execution progress.
-    ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
+	// Command list allocators can only be reset when the associated
+	// command lists have finished execution on the GPU; apps should use
+	// fences to determine GPU execution progress.
+	ThrowIfFailed(m_commandAllocators[m_frameIndex]->Reset());
 
-    // However, when ExecuteCommandList() is called on a particular command
-    // list, that command list can then be reset at any time and must be before
-    // re-recording.
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
+	// However, when ExecuteCommandList() is called on a particular command
+	// list, that command list can then be reset at any time and must be before
+	// re-recording.
+	ThrowIfFailed(m_commandList->Reset(m_commandAllocators[m_frameIndex].Get(), m_pipelineState.Get()));
 
-    // Set necessary state.
-    m_commandList->SetPipelineState(m_pipelineState.Get());
-    m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
+	// Set necessary state.
+	m_commandList->SetPipelineState(m_pipelineState.Get());
+	m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
 
-    m_commandList->SetGraphicsRootConstantBufferView(GraphicsRootCBV, m_constantBufferGS->GetGPUVirtualAddress() + m_frameIndex * sizeof(ConstantBufferGS));
+	m_commandList->SetGraphicsRootConstantBufferView(GraphicsRootCBV, m_constantBufferGS->GetGPUVirtualAddress() + m_frameIndex * sizeof(ConstantBufferGS));
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_srvUavHeap.Get() };
-    m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_srvUavHeap.Get() };
+	m_commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
-    m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_POINTLIST);
-    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+	m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
+	m_commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_POINTLIST);
+	m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
-    // Indicate that the back buffer will be used as a render target.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+	// Indicate that the back buffer will be used as a render target.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
-    m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+	m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
-    // Record commands.
-    const float clearColor[] = { 0.0f, 0.0f, 0.1f, 0.0f };
-    m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
+	// Record commands.
+	const float clearColor[] = { 0.0f, 0.0f, 0.1f, 0.0f };
+	m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
 
-    // Render the particles.
-    float viewportHeight = static_cast<float>(static_cast<UINT>(m_viewport.Height) / m_heightInstances);
-    float viewportWidth = static_cast<float>(static_cast<UINT>(m_viewport.Width) / m_widthInstances);
-    for (UINT n = 0; n < ThreadCount; n++)
-    {
-        const UINT srvIndex = n + (m_srvIndex[n] == 0 ? SrvParticlePosVelo0 : SrvParticlePosVelo1);
+	// Render the particles.
+	float viewportHeight = static_cast<float>(static_cast<UINT>(m_viewport.Height) / m_heightInstances);
+	float viewportWidth = static_cast<float>(static_cast<UINT>(m_viewport.Width) / m_widthInstances);
+	for (UINT n = 0; n < ThreadCount; n++)
+	{
+		const UINT srvIndex = n + (m_srvIndex[n] == 0 ? SrvParticlePosVelo0 : SrvParticlePosVelo1);
 
-        CD3DX12_VIEWPORT viewport(
-            (n % m_widthInstances) * viewportWidth,
-            (n / m_widthInstances) * viewportHeight,
-            viewportWidth,
-            viewportHeight);
+		CD3DX12_VIEWPORT viewport(
+			(n % m_widthInstances) * viewportWidth,
+			(n / m_widthInstances) * viewportHeight,
+			viewportWidth,
+			viewportHeight);
 
-        m_commandList->RSSetViewports(1, &viewport);
+		m_commandList->RSSetViewports(1, &viewport);
 
-        CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_srvUavHeap->GetGPUDescriptorHandleForHeapStart(), srvIndex, m_srvUavDescriptorSize);
-        m_commandList->SetGraphicsRootDescriptorTable(GraphicsRootSRVTable, srvHandle);
+		CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_srvUavHeap->GetGPUDescriptorHandleForHeapStart(), srvIndex, m_srvUavDescriptorSize);
+		m_commandList->SetGraphicsRootDescriptorTable(GraphicsRootSRVTable, srvHandle);
 
-        PIXBeginEvent(m_commandList.Get(), 0, L"Draw particles for thread %u", n);
-        m_commandList->DrawInstanced(ParticleCount, 1, 0, 0);
-        PIXEndEvent(m_commandList.Get());
-    }
+		PIXBeginEvent(m_commandList.Get(), 0, L"Draw particles for thread %u", n);
+		m_commandList->DrawInstanced(ParticleCount, 1, 0, 0);
+		PIXEndEvent(m_commandList.Get());
+	}
 
-    m_commandList->RSSetViewports(1, &m_viewport);
+	m_commandList->RSSetViewports(1, &m_viewport);
 
-    // Indicate that the back buffer will now be used to present.
-    m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	// Indicate that the back buffer will now be used to present.
+	m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
 
-    ThrowIfFailed(m_commandList->Close());
+	ThrowIfFailed(m_commandList->Close());
 }
 
 DWORD D3D12nBodyGravity::AsyncComputeThreadProc(int threadIndex)
 {
-    ID3D12CommandQueue* pCommandQueue = m_computeCommandQueue[threadIndex].Get();
-    ID3D12CommandAllocator* pCommandAllocator = m_computeAllocator[threadIndex].Get();
-    ID3D12GraphicsCommandList* pCommandList = m_computeCommandList[threadIndex].Get();
-    ID3D12Fence* pFence = m_threadFences[threadIndex].Get();
+	ID3D12CommandQueue* pCommandQueue = m_computeCommandQueue[threadIndex].Get();
+	ID3D12CommandAllocator* pCommandAllocator = m_computeAllocator[threadIndex].Get();
+	ID3D12GraphicsCommandList* pCommandList = m_computeCommandList[threadIndex].Get();
+	ID3D12Fence* pFence = m_threadFences[threadIndex].Get();
 
-    while (0 == InterlockedGetValue(&m_terminating))
-    {
-        // Run the particle simulation.
-        Simulate(threadIndex);
+	while (0 == InterlockedGetValue(&m_terminating))
+	{
+		// Run the particle simulation.
+		Simulate(threadIndex);
 
-        // Close and execute the command list.
-        ThrowIfFailed(pCommandList->Close());
-        ID3D12CommandList* ppCommandLists[] = { pCommandList };
+		// Close and execute the command list.
+		ThrowIfFailed(pCommandList->Close());
+		ID3D12CommandList* ppCommandLists[] = { pCommandList };
 
-        PIXBeginEvent(pCommandQueue, 0, L"Thread %d: Iterate on the particle simulation", threadIndex);
-        pCommandQueue->ExecuteCommandLists(1, ppCommandLists);
-        PIXEndEvent(pCommandQueue);
+		PIXBeginEvent(pCommandQueue, 0, L"Thread %d: Iterate on the particle simulation", threadIndex);
+		pCommandQueue->ExecuteCommandLists(1, ppCommandLists);
+		PIXEndEvent(pCommandQueue);
 
-        // Wait for the compute shader to complete the simulation.
-        UINT64 threadFenceValue = InterlockedIncrement(&m_threadFenceValues[threadIndex]);
-        ThrowIfFailed(pCommandQueue->Signal(pFence, threadFenceValue));
-        ThrowIfFailed(pFence->SetEventOnCompletion(threadFenceValue, m_threadFenceEvents[threadIndex]));
-        WaitForSingleObject(m_threadFenceEvents[threadIndex], INFINITE);
+		// Wait for the compute shader to complete the simulation.
+		UINT64 threadFenceValue = InterlockedIncrement(&m_threadFenceValues[threadIndex]);
+		ThrowIfFailed(pCommandQueue->Signal(pFence, threadFenceValue));
+		ThrowIfFailed(pFence->SetEventOnCompletion(threadFenceValue, m_threadFenceEvents[threadIndex]));
+		WaitForSingleObject(m_threadFenceEvents[threadIndex], INFINITE);
 
-        // Wait for the render thread to be done with the SRV so that
-        // the next frame in the simulation can run.
-        UINT64 renderContextFenceValue = InterlockedGetValue(&m_renderContextFenceValues[threadIndex]);
-        if (m_renderContextFence->GetCompletedValue() < renderContextFenceValue)
-        {
-            ThrowIfFailed(pCommandQueue->Wait(m_renderContextFence.Get(), renderContextFenceValue));
-            InterlockedExchange(&m_renderContextFenceValues[threadIndex], 0);
-        }
+		// Wait for the render thread to be done with the SRV so that
+		// the next frame in the simulation can run.
+		UINT64 renderContextFenceValue = InterlockedGetValue(&m_renderContextFenceValues[threadIndex]);
+		if (m_renderContextFence->GetCompletedValue() < renderContextFenceValue)
+		{
+			ThrowIfFailed(pCommandQueue->Wait(m_renderContextFence.Get(), renderContextFenceValue));
+			InterlockedExchange(&m_renderContextFenceValues[threadIndex], 0);
+		}
 
-        // Swap the indices to the SRV and UAV.
-        m_srvIndex[threadIndex] = 1 - m_srvIndex[threadIndex];
+		// Swap the indices to the SRV and UAV.
+		m_srvIndex[threadIndex] = 1 - m_srvIndex[threadIndex];
 
-        // Prepare for the next frame.
-        ThrowIfFailed(pCommandAllocator->Reset());
-        ThrowIfFailed(pCommandList->Reset(pCommandAllocator, m_computeState.Get()));
-    }
+		// Prepare for the next frame.
+		ThrowIfFailed(pCommandAllocator->Reset());
+		ThrowIfFailed(pCommandList->Reset(pCommandAllocator, m_computeState.Get()));
+	}
 
-    return 0;
+	return 0;
 }
 
 // Run the particle simulation using the compute shader.
 void D3D12nBodyGravity::Simulate(UINT threadIndex)
 {
-    ID3D12GraphicsCommandList* pCommandList = m_computeCommandList[threadIndex].Get();
+	ID3D12GraphicsCommandList* pCommandList = m_computeCommandList[threadIndex].Get();
 
-    UINT srvIndex;
-    UINT uavIndex;
-    ID3D12Resource *pUavResource;
-    if (m_srvIndex[threadIndex] == 0)
-    {
-        srvIndex = SrvParticlePosVelo0;
-        uavIndex = UavParticlePosVelo1;
-        pUavResource = m_particleBuffer1[threadIndex].Get();
-    }
-    else
-    {
-        srvIndex = SrvParticlePosVelo1;
-        uavIndex = UavParticlePosVelo0;
-        pUavResource = m_particleBuffer0[threadIndex].Get();
-    }
+	UINT srvIndex;
+	UINT uavIndex;
+	ID3D12Resource *pUavResource;
+	if (m_srvIndex[threadIndex] == 0)
+	{
+		srvIndex = SrvParticlePosVelo0;
+		uavIndex = UavParticlePosVelo1;
+		pUavResource = m_particleBuffer1[threadIndex].Get();
+	}
+	else
+	{
+		srvIndex = SrvParticlePosVelo1;
+		uavIndex = UavParticlePosVelo0;
+		pUavResource = m_particleBuffer0[threadIndex].Get();
+	}
 
-    pCommandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(pUavResource, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS));
+	pCommandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(pUavResource, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS));
 
-    pCommandList->SetPipelineState(m_computeState.Get());
-    pCommandList->SetComputeRootSignature(m_computeRootSignature.Get());
+	pCommandList->SetPipelineState(m_computeState.Get());
+	pCommandList->SetComputeRootSignature(m_computeRootSignature.Get());
 
-    ID3D12DescriptorHeap* ppHeaps[] = { m_srvUavHeap.Get() };
-    pCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	ID3D12DescriptorHeap* ppHeaps[] = { m_srvUavHeap.Get() };
+	pCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
-    CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_srvUavHeap->GetGPUDescriptorHandleForHeapStart(), srvIndex + threadIndex, m_srvUavDescriptorSize);
-    CD3DX12_GPU_DESCRIPTOR_HANDLE uavHandle(m_srvUavHeap->GetGPUDescriptorHandleForHeapStart(), uavIndex + threadIndex, m_srvUavDescriptorSize);
+	CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_srvUavHeap->GetGPUDescriptorHandleForHeapStart(), srvIndex + threadIndex, m_srvUavDescriptorSize);
+	CD3DX12_GPU_DESCRIPTOR_HANDLE uavHandle(m_srvUavHeap->GetGPUDescriptorHandleForHeapStart(), uavIndex + threadIndex, m_srvUavDescriptorSize);
 
-    pCommandList->SetComputeRootConstantBufferView(ComputeRootCBV, m_constantBufferCS->GetGPUVirtualAddress());
-    pCommandList->SetComputeRootDescriptorTable(ComputeRootSRVTable, srvHandle);
-    pCommandList->SetComputeRootDescriptorTable(ComputeRootUAVTable, uavHandle);
+	pCommandList->SetComputeRootConstantBufferView(ComputeRootCBV, m_constantBufferCS->GetGPUVirtualAddress());
+	pCommandList->SetComputeRootDescriptorTable(ComputeRootSRVTable, srvHandle);
+	pCommandList->SetComputeRootDescriptorTable(ComputeRootUAVTable, uavHandle);
 
-    pCommandList->Dispatch(static_cast<int>(ceil(ParticleCount / 128.0f)), 1, 1);
+	pCommandList->Dispatch(static_cast<int>(ceil(ParticleCount / 128.0f)), 1, 1);
 
-    pCommandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(pUavResource, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE));
+	pCommandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(pUavResource, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE));
 }
 
 void D3D12nBodyGravity::OnDestroy()
 {
-    // Notify the compute threads that the app is shutting down.
-    InterlockedExchange(&m_terminating, 1);
-    WaitForMultipleObjects(ThreadCount, m_threadHandles, TRUE, INFINITE);
+	// Notify the compute threads that the app is shutting down.
+	InterlockedExchange(&m_terminating, 1);
+	WaitForMultipleObjects(ThreadCount, m_threadHandles, TRUE, INFINITE);
 
-    // Ensure that the GPU is no longer referencing resources that are about to be
-    // cleaned up by the destructor.
-    WaitForRenderContext();
+	// Ensure that the GPU is no longer referencing resources that are about to be
+	// cleaned up by the destructor.
+	WaitForRenderContext();
 
-    // Close handles to fence events and threads.
-    CloseHandle(m_renderContextFenceEvent);
-    for (int n = 0; n < ThreadCount; n++)
-    {
-        CloseHandle(m_threadHandles[n]);
-        CloseHandle(m_threadFenceEvents[n]);
-    }
+	// Close handles to fence events and threads.
+	CloseHandle(m_renderContextFenceEvent);
+	for (int n = 0; n < ThreadCount; n++)
+	{
+		CloseHandle(m_threadHandles[n]);
+		CloseHandle(m_threadFenceEvents[n]);
+	}
 }
 
 void D3D12nBodyGravity::OnKeyDown(UINT8 key)
 {
-    m_camera.OnKeyDown(key);
+	m_camera.OnKeyDown(key);
 }
 
 void D3D12nBodyGravity::OnKeyUp(UINT8 key)
 {
-    m_camera.OnKeyUp(key);
+	m_camera.OnKeyUp(key);
 }
 
 void D3D12nBodyGravity::WaitForRenderContext()
 {
-    // Add a signal command to the queue.
-    ThrowIfFailed(m_commandQueue->Signal(m_renderContextFence.Get(), m_renderContextFenceValue));
+	// Add a signal command to the queue.
+	ThrowIfFailed(m_commandQueue->Signal(m_renderContextFence.Get(), m_renderContextFenceValue));
 
-    // Instruct the fence to set the event object when the signal command completes.
-    ThrowIfFailed(m_renderContextFence->SetEventOnCompletion(m_renderContextFenceValue, m_renderContextFenceEvent));
-    m_renderContextFenceValue++;
+	// Instruct the fence to set the event object when the signal command completes.
+	ThrowIfFailed(m_renderContextFence->SetEventOnCompletion(m_renderContextFenceValue, m_renderContextFenceEvent));
+	m_renderContextFenceValue++;
 
-    // Wait until the signal command has been processed.
-    WaitForSingleObject(m_renderContextFenceEvent, INFINITE);
+	// Wait until the signal command has been processed.
+	WaitForSingleObject(m_renderContextFenceEvent, INFINITE);
 }
 
 // Cycle through the frame resources. This method blocks execution if the 
@@ -849,20 +905,20 @@ void D3D12nBodyGravity::WaitForRenderContext()
 // processed by the GPU.
 void D3D12nBodyGravity::MoveToNextFrame()
 {
-    // Assign the current fence value to the current frame.
-    m_frameFenceValues[m_frameIndex] = m_renderContextFenceValue;
+	// Assign the current fence value to the current frame.
+	m_frameFenceValues[m_frameIndex] = m_renderContextFenceValue;
 
-    // Signal and increment the fence value.
-    ThrowIfFailed(m_commandQueue->Signal(m_renderContextFence.Get(), m_renderContextFenceValue));
-    m_renderContextFenceValue++;
+	// Signal and increment the fence value.
+	ThrowIfFailed(m_commandQueue->Signal(m_renderContextFence.Get(), m_renderContextFenceValue));
+	m_renderContextFenceValue++;
 
-    // Update the frame index.
-    m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
+	// Update the frame index.
+	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
-    // If the next frame is not ready to be rendered yet, wait until it is ready.
-    if (m_renderContextFence->GetCompletedValue() < m_frameFenceValues[m_frameIndex])
-    {
-        ThrowIfFailed(m_renderContextFence->SetEventOnCompletion(m_frameFenceValues[m_frameIndex], m_renderContextFenceEvent));
-        WaitForSingleObject(m_renderContextFenceEvent, INFINITE);
-    }
+	// If the next frame is not ready to be rendered yet, wait until it is ready.
+	if (m_renderContextFence->GetCompletedValue() < m_frameFenceValues[m_frameIndex])
+	{
+		ThrowIfFailed(m_renderContextFence->SetEventOnCompletion(m_frameFenceValues[m_frameIndex], m_renderContextFenceEvent));
+		WaitForSingleObject(m_renderContextFenceEvent, INFINITE);
+	}
 }

--- a/Samples/UWP/D3D12nBodyGravity/src/D3D12nBodyGravity.h
+++ b/Samples/UWP/D3D12nBodyGravity/src/D3D12nBodyGravity.h
@@ -27,163 +27,166 @@ using Microsoft::WRL::ComPtr;
 class D3D12nBodyGravity : public DXSample
 {
 public:
-    D3D12nBodyGravity(UINT width, UINT height, std::wstring name);
+	D3D12nBodyGravity(UINT width, UINT height, std::wstring name);
 
-    virtual void OnInit();
-    virtual void OnUpdate();
-    virtual void OnRender();
-    virtual void OnDestroy();
-    virtual void OnKeyDown(UINT8 key);
-    virtual void OnKeyUp(UINT8 key);
+	virtual void OnInit();
+	virtual void OnUpdate();
+	virtual void OnRender();
+	virtual void OnDestroy();
+	virtual void OnKeyDown(UINT8 key);
+	virtual void OnKeyUp(UINT8 key);
 
 private:
-    static const UINT FrameCount = 2;
-    static const UINT ThreadCount = 1;
-    static const float ParticleSpread;
-    static const UINT ParticleCount = 10000;        // The number of particles in the n-body simulation.
+	static const UINT FrameCount = 2;
+	static const UINT ThreadCount = 1;
+	static const float ParticleSpread;
+	static const UINT ParticleCount = 10000;		// The number of particles in the n-body simulation.
 
-    // "Vertex" definition for particles. Triangle vertices are generated 
-    // by the geometry shader. Color data will be assigned to those 
-    // vertices via this struct.
-    struct ParticleVertex
-    {
-        XMFLOAT4 color;
-    };
+	// "Vertex" definition for particles. Triangle vertices are generated 
+	// by the geometry shader. Color data will be assigned to those 
+	// vertices via this struct.
+	struct ParticleVertex
+	{
+		XMFLOAT4 color;
+	};
 
-    // Position and velocity data for the particles in the system.
-    // Two buffers full of Particle data are utilized in this sample.
-    // The compute thread alternates writing to each of them.
-    // The render thread renders using the buffer that is not currently
-    // in use by the compute shader.
-    struct Particle
-    {
-        XMFLOAT4 position;
-        XMFLOAT4 velocity;
-    };
+	// Position and velocity data for the particles in the system.
+	// Two buffers full of Particle data are utilized in this sample.
+	// The compute thread alternates writing to each of them.
+	// The render thread renders using the buffer that is not currently
+	// in use by the compute shader.
+	struct Particle
+	{
+		XMFLOAT4 position;
+		XMFLOAT4 velocity;
+	};
 
-    struct ConstantBufferGS
-    {
-        XMFLOAT4X4 worldViewProjection;
-        XMFLOAT4X4 inverseView;
+	struct ConstantBufferGS
+	{
+		XMFLOAT4X4 worldViewProjection;
+		XMFLOAT4X4 inverseView;
 
-        // Constant buffers are 256-byte aligned in GPU memory. Padding is added
-        // for convenience when computing the struct's size.
-        float padding[32];
-    };
+		// Constant buffers are 256-byte aligned in GPU memory. Padding is added
+		// for convenience when computing the struct's size.
+		float padding[32];
+	};
 
-    struct ConstantBufferCS
-    {
-        UINT param[4];
-        float paramf[4];
-    };
+	struct ConstantBufferCS
+	{
+		UINT param[4];
+		float paramf[4];
+	};
 
-    // Pipeline objects.
-    CD3DX12_VIEWPORT m_viewport;
-    CD3DX12_RECT m_scissorRect;
-    ComPtr<IDXGISwapChain3> m_swapChain;
-    ComPtr<ID3D12Device> m_device;
-    ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
-    UINT m_frameIndex;
-    ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    ComPtr<ID3D12RootSignature> m_rootSignature;
-    ComPtr<ID3D12RootSignature> m_computeRootSignature;
-    ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
-    ComPtr<ID3D12DescriptorHeap> m_srvUavHeap;
-    UINT m_rtvDescriptorSize;
-    UINT m_srvUavDescriptorSize;
+	// Pipeline objects.
+	CD3DX12_VIEWPORT m_viewport;
+	CD3DX12_RECT m_scissorRect;
+	ComPtr<IDXGISwapChain3> m_swapChain;
+	ComPtr<ID3D12Device> m_device;
+	ComPtr<ID3D12Resource> m_renderTargets[FrameCount];
+	UINT m_frameIndex;
+	ComPtr<ID3D12CommandAllocator> m_commandAllocators[FrameCount];
+	ComPtr<ID3D12CommandQueue> m_commandQueue;
+	ComPtr<ID3D12RootSignature> m_rootSignature;
+	ComPtr<ID3D12RootSignature> m_computeRootSignature;
+	ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+	ComPtr<ID3D12DescriptorHeap> m_srvUavHeap;
+	UINT m_rtvDescriptorSize;
+	UINT m_srvUavDescriptorSize;
 
-    // Asset objects.
-    ComPtr<ID3D12PipelineState> m_pipelineState;
-    ComPtr<ID3D12PipelineState> m_computeState;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    ComPtr<ID3D12Resource> m_vertexBuffer;
-    ComPtr<ID3D12Resource> m_vertexBufferUpload;
-    D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
-    ComPtr<ID3D12Resource> m_particleBuffer0[ThreadCount];
-    ComPtr<ID3D12Resource> m_particleBuffer1[ThreadCount];
-    ComPtr<ID3D12Resource> m_particleBuffer0Upload[ThreadCount];
-    ComPtr<ID3D12Resource> m_particleBuffer1Upload[ThreadCount];
-    ComPtr<ID3D12Resource> m_constantBufferGS;
-    UINT8* m_pConstantBufferGSData;
-    ComPtr<ID3D12Resource> m_constantBufferCS;
+	// Asset objects.
+	ComPtr<ID3D12PipelineState> m_pipelineState;
+	ComPtr<ID3D12PipelineState> m_computeState;
+	ComPtr<ID3D12GraphicsCommandList> m_commandList;
+	ComPtr<ID3D12Resource> m_vertexBuffer;
+	ComPtr<ID3D12Resource> m_vertexBufferUpload;
+	D3D12_VERTEX_BUFFER_VIEW m_vertexBufferView;
+	ComPtr<ID3D12Resource> m_particleBuffer0[ThreadCount];
+	ComPtr<ID3D12Resource> m_particleBuffer1[ThreadCount];
+	ComPtr<ID3D12Resource> m_particleBuffer0Upload[ThreadCount];
+	ComPtr<ID3D12Resource> m_particleBuffer1Upload[ThreadCount];
+	ComPtr<ID3D12Resource> m_constantBufferGS;
+	UINT8* m_pConstantBufferGSData;
+	ComPtr<ID3D12Resource> m_constantBufferCS;
 
-    UINT m_srvIndex[ThreadCount];        // Denotes which of the particle buffer resource views is the SRV (0 or 1). The UAV is 1 - srvIndex.
-    UINT m_heightInstances;
-    UINT m_widthInstances;
-    SimpleCamera m_camera;
-    StepTimer m_timer;
+	UINT m_srvIndex[ThreadCount];		// Denotes which of the particle buffer resource views is the SRV (0 or 1). The UAV is 1 - srvIndex.
+	UINT m_heightInstances;
+	UINT m_widthInstances;
+	SimpleCamera m_camera;
+	StepTimer m_timer;
 
-    // Compute objects.
-    ComPtr<ID3D12CommandAllocator> m_computeAllocator[ThreadCount];
-    ComPtr<ID3D12CommandQueue> m_computeCommandQueue[ThreadCount];
-    ComPtr<ID3D12GraphicsCommandList> m_computeCommandList[ThreadCount];
+	// Compute objects.
+	ComPtr<ID3D12CommandAllocator> m_computeAllocator[ThreadCount];
+	ComPtr<ID3D12CommandQueue> m_computeCommandQueue[ThreadCount];
+	ComPtr<ID3D12GraphicsCommandList> m_computeCommandList[ThreadCount];
 
-    // Synchronization objects.
-    HANDLE m_swapChainEvent;
-    ComPtr<ID3D12Fence> m_renderContextFence;
-    UINT64 m_renderContextFenceValue;
-    HANDLE m_renderContextFenceEvent;
-    UINT64 m_frameFenceValues[FrameCount];
+	// Synchronization objects.
+	HANDLE m_swapChainEvent;
+	ComPtr<ID3D12Fence> m_renderContextFence;
+	UINT64 m_renderContextFenceValue;
+	HANDLE m_renderContextFenceEvent;
+	UINT64 m_frameFenceValues[FrameCount];
 
-    ComPtr<ID3D12Fence> m_threadFences[ThreadCount];
-    volatile HANDLE m_threadFenceEvents[ThreadCount];
+	ComPtr<ID3D12Fence> m_threadFences[ThreadCount];
+	volatile HANDLE m_threadFenceEvents[ThreadCount];
 
-    // Thread state.
-    LONG volatile m_terminating;
-    UINT64 volatile m_renderContextFenceValues[ThreadCount];
-    UINT64 volatile m_threadFenceValues[ThreadCount];
+	// Thread state.
+	LONG volatile m_terminating;
+	UINT64 volatile m_renderContextFenceValues[ThreadCount];
+	UINT64 volatile m_threadFenceValues[ThreadCount];
 
-    struct ThreadData
-    {
-        D3D12nBodyGravity* pContext;
-        UINT threadIndex;
-    };
-    ThreadData m_threadData[ThreadCount];
-    HANDLE m_threadHandles[ThreadCount];
+	struct ThreadData
+	{
+		D3D12nBodyGravity* pContext;
+		UINT threadIndex;
+	};
+	ThreadData m_threadData[ThreadCount];
+	HANDLE m_threadHandles[ThreadCount];
 
-    // Indices of the root signature parameters.
-    enum GraphicsRootParameters : UINT32
-    {
-        GraphicsRootCBV = 0,
-        GraphicsRootSRVTable,
-        GraphicsRootParametersCount
-    };
+	// Indices of the root signature parameters.
+	enum GraphicsRootParameters : UINT32
+	{
+		GraphicsRootCBV = 0,
+		GraphicsRootSRVTable,
+		GraphicsRootParametersCount
+	};
 
-    enum ComputeRootParameters : UINT32
-    {
-        ComputeRootCBV = 0,
-        ComputeRootSRVTable,
-        ComputeRootUAVTable,
-        ComputeRootParametersCount
-    };
+	enum ComputeRootParameters : UINT32
+	{
+		ComputeRootCBV = 0,
+		ComputeRootSRVTable,
+		ComputeRootUAVTable,
+		ComputeRootParametersCount
+	};
 
-    // Indices of shader resources in the descriptor heap.
-    enum DescriptorHeapIndex : UINT32
-    {
-        UavParticlePosVelo0 = 0,
-        UavParticlePosVelo1 = UavParticlePosVelo0 + ThreadCount,
-        SrvParticlePosVelo0 = UavParticlePosVelo1 + ThreadCount,
-        SrvParticlePosVelo1 = SrvParticlePosVelo0 + ThreadCount,
-        DescriptorCount = SrvParticlePosVelo1 + ThreadCount
-    };
+	// Indices of shader resources in the descriptor heap.
+	enum DescriptorHeapIndex : UINT32
+	{
+		UavParticlePosVelo0 = 0,
+		UavParticlePosVelo1 = UavParticlePosVelo0 + ThreadCount,
+		SrvParticlePosVelo0 = UavParticlePosVelo1 + ThreadCount,
+		SrvParticlePosVelo1 = SrvParticlePosVelo0 + ThreadCount,
+		DescriptorCount = SrvParticlePosVelo1 + ThreadCount
+	};
 
-    void LoadPipeline();
-    void LoadAssets();
-    void CreateAsyncContexts();
-    void CreateVertexBuffer();
-    float RandomPercent();
-    void LoadParticles(_Out_writes_(numParticles) Particle* pParticles, const XMFLOAT3 &center, const XMFLOAT4 &velocity, float spread, UINT numParticles);
-    void CreateParticleBuffers();
-    void PopulateCommandList();
+	void LoadPipeline();
+	void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
+    void WaitForGpu();
+	void CreateAsyncContexts();
+	void CreateVertexBuffer();
+	float RandomPercent();
+	void LoadParticles(_Out_writes_(numParticles) Particle* pParticles, const XMFLOAT3 &center, const XMFLOAT4 &velocity, float spread, UINT numParticles);
+	void CreateParticleBuffers();
+	void PopulateCommandList();
 
-    static DWORD WINAPI ThreadProc(ThreadData* pData)
-    {
-        return pData->pContext->AsyncComputeThreadProc(pData->threadIndex);
-    }
-    DWORD AsyncComputeThreadProc(int threadIndex);
-    void Simulate(UINT threadIndex);
+	static DWORD WINAPI ThreadProc(ThreadData* pData)
+	{
+		return pData->pContext->AsyncComputeThreadProc(pData->threadIndex);
+	}
+	DWORD AsyncComputeThreadProc(int threadIndex);
+	void Simulate(UINT threadIndex);
 
-    void WaitForRenderContext();
-    void MoveToNextFrame();
+	void WaitForRenderContext();
+	void MoveToNextFrame();
 };

--- a/Samples/UWP/D3D12nBodyGravity/src/DXSample.cpp
+++ b/Samples/UWP/D3D12nBodyGravity/src/DXSample.cpp
@@ -15,16 +15,16 @@
 using namespace Microsoft::WRL;
 
 DXSample::DXSample(UINT width, UINT height, std::wstring name) :
-    m_width(width),
-    m_height(height),
-    m_title(name),
-    m_useWarpDevice(false)
+	m_width(width),
+	m_height(height),
+	m_title(name),
+	m_useWarpDevice(false)
 {
-    WCHAR assetsPath[512];
-    GetAssetsPath(assetsPath, _countof(assetsPath));
-    m_assetsPath = assetsPath;
+	WCHAR assetsPath[512];
+	GetAssetsPath(assetsPath, _countof(assetsPath));
+	m_assetsPath = assetsPath;
 
-    m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+	m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 }
 
 DXSample::~DXSample()
@@ -34,59 +34,104 @@ DXSample::~DXSample()
 // Helper function for resolving the full path of assets.
 std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 {
-    return m_assetsPath + assetName;
+	return m_assetsPath + assetName;
 }
 
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-    *ppAdapter = adapter.Detach();
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+#if !defined(_XBOX_ONE)
+    }
+#endif
+
+	*ppAdapter = adapter.Detach();
 }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)
 {
-    std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
-    auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(windowText.c_str());
+	std::wstring windowText = m_title.empty() ? text : m_title + L": " + text;
+	auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(windowText.c_str());
 }
 
 // Helper function for parsing any supplied command line args.
 _Use_decl_annotations_
 void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 {
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
-            _wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
-        {
-            m_useWarpDevice = true;
-            m_title = m_title + L" (WARP)";
-        }
-    }
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsnicmp(argv[i], L"-warp", wcslen(argv[i])) == 0 || 
+			_wcsnicmp(argv[i], L"/warp", wcslen(argv[i])) == 0)
+		{
+			m_useWarpDevice = true;
+			m_title = m_title + L" (WARP)";
+		}
+	}
 }

--- a/Samples/UWP/D3D12nBodyGravity/src/DXSample.h
+++ b/Samples/UWP/D3D12nBodyGravity/src/DXSample.h
@@ -16,42 +16,47 @@
 class DXSample
 {
 public:
-    DXSample(UINT width, UINT height, std::wstring name);
-    virtual ~DXSample();
+	DXSample(UINT width, UINT height, std::wstring name);
+	virtual ~DXSample();
 
-    virtual void OnInit() = 0;
-    virtual void OnUpdate() = 0;
-    virtual void OnRender() = 0;
-    virtual void OnDestroy() = 0;
+	virtual void OnInit() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
+	virtual void OnDestroy() = 0;
 
-    // Samples override the event handlers to handle specific messages.
-    virtual void OnKeyDown(UINT8 /*key*/)   {}
-    virtual void OnKeyUp(UINT8 /*key*/)     {}
+	// Samples override the event handlers to handle specific messages.
+	virtual void OnKeyDown(UINT8 /*key*/)   {}
+	virtual void OnKeyUp(UINT8 /*key*/)     {}
 
-    // Accessors.
-    UINT GetWidth() const           { return m_width; }
-    UINT GetHeight() const          { return m_height; }
-    const WCHAR* GetTitle() const   { return m_title.c_str(); }
+	// Accessors.
+	UINT GetWidth() const           { return m_width; }
+	UINT GetHeight() const          { return m_height; }
+	const WCHAR* GetTitle() const   { return m_title.c_str(); }
 
-    void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
+	void ParseCommandLineArgs(_In_reads_(argc) WCHAR* argv[], int argc);
 
 protected:
-    std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
-    void SetCustomWindowText(LPCWSTR text);
+	std::wstring GetAssetFullPath(LPCWSTR assetName);
 
-    // Viewport dimensions.
-    UINT m_width;
-    UINT m_height;
-    float m_aspectRatio;
+	void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
 
-    // Adapter info.
-    bool m_useWarpDevice;
+	void SetCustomWindowText(LPCWSTR text);
+
+	// Viewport dimensions.
+	UINT m_width;
+	UINT m_height;
+	float m_aspectRatio;
+
+	// Adapter info.
+	bool m_useWarpDevice;
 
 private:
-    // Root assets path.
-    std::wstring m_assetsPath;
+	// Root assets path.
+	std::wstring m_assetsPath;
 
-    // Window title.
-    std::wstring m_title;
+	// Window title.
+	std::wstring m_title;
 };

--- a/Samples/UWP/D3D12nBodyGravity/src/Main.cpp
+++ b/Samples/UWP/D3D12nBodyGravity/src/Main.cpp
@@ -16,9 +16,9 @@
 [Platform::MTAThread]
 int WINAPIV main(Platform::Array<Platform::String^>^ /*params*/)
 {
-    D3D12nBodyGravity sample(1200, 900, L"");
-    auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
+	D3D12nBodyGravity sample(1200, 900, L"");
+	auto viewProvider = ref new ViewProvider(reinterpret_cast<UINT_PTR>(&sample));
 
-    Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
-    return 0;
+	Windows::ApplicationModel::Core::CoreApplication::Run(viewProvider);
+	return 0;
 }

--- a/Samples/UWP/D3D12nBodyGravity/src/ParticleDraw.hlsl
+++ b/Samples/UWP/D3D12nBodyGravity/src/ParticleDraw.hlsl
@@ -11,65 +11,65 @@
 
 struct VSParticleIn
 {
-    float4 color    : COLOR;
-    uint id            : SV_VERTEXID;
+	float4 color	: COLOR;
+	uint id			: SV_VERTEXID;
 };
 
 struct VSParticleDrawOut
 {
-    float3 pos            : POSITION;
-    float4 color        : COLOR;
+	float3 pos			: POSITION;
+	float4 color		: COLOR;
 };
 
 struct GSParticleDrawOut
 {
-    float2 tex            : TEXCOORD0;
-    float4 color        : COLOR;
-    float4 pos            : SV_POSITION;
+	float2 tex			: TEXCOORD0;
+	float4 color		: COLOR;
+	float4 pos			: SV_POSITION;
 };
 
 struct PSParticleDrawIn
 {
-    float2 tex            : TEXCOORD0;
-    float4 color        : COLOR;
+	float2 tex			: TEXCOORD0;
+	float4 color		: COLOR;
 };
 
 struct PosVelo
 {
-    float4 pos;
-    float4 velo;
+	float4 pos;
+	float4 velo;
 };
 
 StructuredBuffer<PosVelo> g_bufPosVelo;
 
 cbuffer cb0
 {
-    row_major float4x4 g_mWorldViewProj;
-    row_major float4x4 g_mInvView;
+	row_major float4x4 g_mWorldViewProj;
+	row_major float4x4 g_mInvView;
 };
 
 cbuffer cb1
 {
-    static float g_fParticleRad = 10.0f;
+	static float g_fParticleRad = 10.0f;
 };
 
 cbuffer cbImmutable
 {
-    static float3 g_positions[4] =
-    {
-        float3(-1, 1, 0),
-        float3(1, 1, 0),
-        float3(-1, -1, 0),
-        float3(1, -1, 0),
-    };
-    
-    static float2 g_texcoords[4] =
-    { 
-        float2(0, 0), 
-        float2(1, 0),
-        float2(0, 1),
-        float2(1, 1),
-    };
+	static float3 g_positions[4] =
+	{
+		float3(-1, 1, 0),
+		float3(1, 1, 0),
+		float3(-1, -1, 0),
+		float3(1, -1, 0),
+	};
+	
+	static float2 g_texcoords[4] =
+	{ 
+		float2(0, 0), 
+		float2(1, 0),
+		float2(0, 1),
+		float2(1, 1),
+	};
 };
 
 //
@@ -77,14 +77,14 @@ cbuffer cbImmutable
 //
 VSParticleDrawOut VSParticleDraw(VSParticleIn input)
 {
-    VSParticleDrawOut output;
-    
-    output.pos = g_bufPosVelo[input.id].pos.xyz;
-    
-    float mag = g_bufPosVelo[input.id].velo.w / 9;
-    output.color = lerp(float4(1.0f, 0.1f, 0.1f, 1.0f), input.color, mag);
-    
-    return output;
+	VSParticleDrawOut output;
+	
+	output.pos = g_bufPosVelo[input.id].pos.xyz;
+	
+	float mag = g_bufPosVelo[input.id].velo.w / 9;
+	output.color = lerp(float4(1.0f, 0.1f, 0.1f, 1.0f), input.color, mag);
+	
+	return output;
 }
 
 //
@@ -94,20 +94,20 @@ VSParticleDrawOut VSParticleDraw(VSParticleIn input)
 [maxvertexcount(4)]
 void GSParticleDraw(point VSParticleDrawOut input[1], inout TriangleStream<GSParticleDrawOut> SpriteStream)
 {
-    GSParticleDrawOut output;
-    
-    // Emit two new triangles.
-    for (int i = 0; i < 4; i++)
-    {
-        float3 position = g_positions[i] * g_fParticleRad;
-        position = mul(position, (float3x3)g_mInvView) + input[0].pos;
-        output.pos = mul(float4(position,1.0), g_mWorldViewProj);
+	GSParticleDrawOut output;
+	
+	// Emit two new triangles.
+	for (int i = 0; i < 4; i++)
+	{
+		float3 position = g_positions[i] * g_fParticleRad;
+		position = mul(position, (float3x3)g_mInvView) + input[0].pos;
+		output.pos = mul(float4(position,1.0), g_mWorldViewProj);
 
-        output.color = input[0].color;
-        output.tex = g_texcoords[i];
-        SpriteStream.Append(output);
-    }
-    SpriteStream.RestartStrip();
+		output.color = input[0].color;
+		output.tex = g_texcoords[i];
+		SpriteStream.Append(output);
+	}
+	SpriteStream.RestartStrip();
 }
 
 //
@@ -116,7 +116,7 @@ void GSParticleDraw(point VSParticleDrawOut input[1], inout TriangleStream<GSPar
 //
 float4 PSParticleDraw(PSParticleDrawIn input) : SV_Target
 {
-    float intensity = 0.5f - length(float2(0.5f, 0.5f) - input.tex);
-    intensity = clamp(intensity, 0.0f, 0.5f) * 2.0f;
-    return float4(input.color.xyz, intensity);
+	float intensity = 0.5f - length(float2(0.5f, 0.5f) - input.tex);
+	intensity = clamp(intensity, 0.0f, 0.5f) * 2.0f;
+	return float4(input.color.xyz, intensity);
 }

--- a/Samples/UWP/D3D12nBodyGravity/src/SimpleCamera.cpp
+++ b/Samples/UWP/D3D12nBodyGravity/src/SimpleCamera.cpp
@@ -13,163 +13,163 @@
 #include "SimpleCamera.h"
 
 SimpleCamera::SimpleCamera():
-    m_initialPosition(0, 0, 0),
-    m_position(m_initialPosition),
-    m_yaw(XM_PI),
-    m_pitch(0.0f),
-    m_lookDirection(0, 0, -1),
-    m_upDirection(0, 1, 0),
-    m_moveSpeed(20.0f),
-    m_turnSpeed(XM_PIDIV2),
-    m_keysPressed{}
+	m_initialPosition(0, 0, 0),
+	m_position(m_initialPosition),
+	m_yaw(XM_PI),
+	m_pitch(0.0f),
+	m_lookDirection(0, 0, -1),
+	m_upDirection(0, 1, 0),
+	m_moveSpeed(20.0f),
+	m_turnSpeed(XM_PIDIV2),
+	m_keysPressed{}
 {
 }
 
 void SimpleCamera::Init(XMFLOAT3 position)
 {
-    m_initialPosition = position;
-    Reset();
+	m_initialPosition = position;
+	Reset();
 }
 
 void SimpleCamera::SetMoveSpeed(float unitsPerSecond)
 {
-    m_moveSpeed = unitsPerSecond;
+	m_moveSpeed = unitsPerSecond;
 }
 
 void SimpleCamera::SetTurnSpeed(float radiansPerSecond)
 {
-    m_turnSpeed = radiansPerSecond;
+	m_turnSpeed = radiansPerSecond;
 }
 
 void SimpleCamera::Reset()
 {
-    m_position = m_initialPosition;
-    m_yaw = XM_PI;
-    m_pitch = 0.0f;
-    m_lookDirection = { 0, 0, -1 };
+	m_position = m_initialPosition;
+	m_yaw = XM_PI;
+	m_pitch = 0.0f;
+	m_lookDirection = { 0, 0, -1 };
 }
 
 void SimpleCamera::Update(float elapsedSeconds)
 {
-    // Calculate the move vector in camera space.
-    XMFLOAT3 move(0, 0, 0);
+	// Calculate the move vector in camera space.
+	XMFLOAT3 move(0, 0, 0);
 
-    if (m_keysPressed.a)
-        move.x -= 1.0f;
-    if (m_keysPressed.d)
-        move.x += 1.0f;
-    if (m_keysPressed.w)
-        move.z -= 1.0f;
-    if (m_keysPressed.s)
-        move.z += 1.0f;
+	if (m_keysPressed.a)
+		move.x -= 1.0f;
+	if (m_keysPressed.d)
+		move.x += 1.0f;
+	if (m_keysPressed.w)
+		move.z -= 1.0f;
+	if (m_keysPressed.s)
+		move.z += 1.0f;
 
-    if (fabs(move.x) > 0.1f && fabs(move.z) > 0.1f)
-    {
-        XMVECTOR vector = XMVector3Normalize(XMLoadFloat3(&move));
-        move.x = XMVectorGetX(vector);
-        move.z = XMVectorGetZ(vector);
-    }
+	if (fabs(move.x) > 0.1f && fabs(move.z) > 0.1f)
+	{
+		XMVECTOR vector = XMVector3Normalize(XMLoadFloat3(&move));
+		move.x = XMVectorGetX(vector);
+		move.z = XMVectorGetZ(vector);
+	}
 
-    float moveInterval = m_moveSpeed * elapsedSeconds;
-    float rotateInterval = m_turnSpeed * elapsedSeconds;
+	float moveInterval = m_moveSpeed * elapsedSeconds;
+	float rotateInterval = m_turnSpeed * elapsedSeconds;
 
-    if (m_keysPressed.left)
-        m_yaw += rotateInterval;
-    if (m_keysPressed.right)
-        m_yaw -= rotateInterval;
-    if (m_keysPressed.up)
-        m_pitch += rotateInterval;
-    if (m_keysPressed.down)
-        m_pitch -= rotateInterval;
+	if (m_keysPressed.left)
+		m_yaw += rotateInterval;
+	if (m_keysPressed.right)
+		m_yaw -= rotateInterval;
+	if (m_keysPressed.up)
+		m_pitch += rotateInterval;
+	if (m_keysPressed.down)
+		m_pitch -= rotateInterval;
 
-    // Prevent looking too far up or down.
-    m_pitch = min(m_pitch, XM_PIDIV4);
-    m_pitch = max(-XM_PIDIV4, m_pitch);
+	// Prevent looking too far up or down.
+	m_pitch = min(m_pitch, XM_PIDIV4);
+	m_pitch = max(-XM_PIDIV4, m_pitch);
 
-    // Move the camera in model space.
-    float x = move.x * -cosf(m_yaw) - move.z * sinf(m_yaw);
-    float z = move.x * sinf(m_yaw) - move.z * cosf(m_yaw);
-    m_position.x += x * moveInterval;
-    m_position.z += z * moveInterval;
+	// Move the camera in model space.
+	float x = move.x * -cosf(m_yaw) - move.z * sinf(m_yaw);
+	float z = move.x * sinf(m_yaw) - move.z * cosf(m_yaw);
+	m_position.x += x * moveInterval;
+	m_position.z += z * moveInterval;
 
-    // Determine the look direction.
-    float r = cosf(m_pitch);
-    m_lookDirection.x = r * sinf(m_yaw);
-    m_lookDirection.y = sinf(m_pitch);
-    m_lookDirection.z = r * cosf(m_yaw);
+	// Determine the look direction.
+	float r = cosf(m_pitch);
+	m_lookDirection.x = r * sinf(m_yaw);
+	m_lookDirection.y = sinf(m_pitch);
+	m_lookDirection.z = r * cosf(m_yaw);
 }
 
 XMMATRIX SimpleCamera::GetViewMatrix()
 {
-    return XMMatrixLookToRH(XMLoadFloat3(&m_position), XMLoadFloat3(&m_lookDirection), XMLoadFloat3(&m_upDirection));
+	return XMMatrixLookToRH(XMLoadFloat3(&m_position), XMLoadFloat3(&m_lookDirection), XMLoadFloat3(&m_upDirection));
 }
 
 XMMATRIX SimpleCamera::GetProjectionMatrix(float fov, float aspectRatio, float nearPlane, float farPlane)
 {
-    return XMMatrixPerspectiveFovRH(fov, aspectRatio, nearPlane, farPlane);
+	return XMMatrixPerspectiveFovRH(fov, aspectRatio, nearPlane, farPlane);
 }
 
 void SimpleCamera::OnKeyDown(WPARAM key)
 {
-    switch (key)
-    {
-    case 'W':
-        m_keysPressed.w = true;
-        break;
-    case 'A':
-        m_keysPressed.a = true;
-        break;
-    case 'S':
-        m_keysPressed.s = true;
-        break;
-    case 'D':
-        m_keysPressed.d = true;
-        break;
-    case VK_LEFT:
-        m_keysPressed.left = true;
-        break;
-    case VK_RIGHT:
-        m_keysPressed.right = true;
-        break;
-    case VK_UP:
-        m_keysPressed.up = true;
-        break;
-    case VK_DOWN:
-        m_keysPressed.down = true;
-        break;
-    case VK_ESCAPE:
-        Reset();
-        break;
-    }
+	switch (key)
+	{
+	case 'W':
+		m_keysPressed.w = true;
+		break;
+	case 'A':
+		m_keysPressed.a = true;
+		break;
+	case 'S':
+		m_keysPressed.s = true;
+		break;
+	case 'D':
+		m_keysPressed.d = true;
+		break;
+	case VK_LEFT:
+		m_keysPressed.left = true;
+		break;
+	case VK_RIGHT:
+		m_keysPressed.right = true;
+		break;
+	case VK_UP:
+		m_keysPressed.up = true;
+		break;
+	case VK_DOWN:
+		m_keysPressed.down = true;
+		break;
+	case VK_ESCAPE:
+		Reset();
+		break;
+	}
 }
 
 void SimpleCamera::OnKeyUp(WPARAM key)
 {
-    switch (key)
-    {
-    case 'W':
-        m_keysPressed.w = false;
-        break;
-    case 'A':
-        m_keysPressed.a = false;
-        break;
-    case 'S':
-        m_keysPressed.s = false;
-        break;
-    case 'D':
-        m_keysPressed.d = false;
-        break;
-    case VK_LEFT:
-        m_keysPressed.left = false;
-        break;
-    case VK_RIGHT:
-        m_keysPressed.right = false;
-        break;
-    case VK_UP:
-        m_keysPressed.up = false;
-        break;
-    case VK_DOWN:
-        m_keysPressed.down = false;
-        break;
-    }
+	switch (key)
+	{
+	case 'W':
+		m_keysPressed.w = false;
+		break;
+	case 'A':
+		m_keysPressed.a = false;
+		break;
+	case 'S':
+		m_keysPressed.s = false;
+		break;
+	case 'D':
+		m_keysPressed.d = false;
+		break;
+	case VK_LEFT:
+		m_keysPressed.left = false;
+		break;
+	case VK_RIGHT:
+		m_keysPressed.right = false;
+		break;
+	case VK_UP:
+		m_keysPressed.up = false;
+		break;
+	case VK_DOWN:
+		m_keysPressed.down = false;
+		break;
+	}
 }

--- a/Samples/UWP/D3D12nBodyGravity/src/SimpleCamera.h
+++ b/Samples/UWP/D3D12nBodyGravity/src/SimpleCamera.h
@@ -16,42 +16,42 @@ using namespace DirectX;
 class SimpleCamera
 {
 public:
-    SimpleCamera();
+	SimpleCamera();
 
-    void Init(XMFLOAT3 position);
-    void Update(float elapsedSeconds);
-    XMMATRIX GetViewMatrix();
-    XMMATRIX GetProjectionMatrix(float fov, float aspectRatio, float nearPlane = 1.0f, float farPlane = 1000.0f);
-    void SetMoveSpeed(float unitsPerSecond);
-    void SetTurnSpeed(float radiansPerSecond);
+	void Init(XMFLOAT3 position);
+	void Update(float elapsedSeconds);
+	XMMATRIX GetViewMatrix();
+	XMMATRIX GetProjectionMatrix(float fov, float aspectRatio, float nearPlane = 1.0f, float farPlane = 1000.0f);
+	void SetMoveSpeed(float unitsPerSecond);
+	void SetTurnSpeed(float radiansPerSecond);
 
-    void OnKeyDown(WPARAM key);
-    void OnKeyUp(WPARAM key);
+	void OnKeyDown(WPARAM key);
+	void OnKeyUp(WPARAM key);
 
 private:
-    void Reset();
+	void Reset();
 
-    struct KeysPressed
-    {
-        bool w;
-        bool a;
-        bool s;
-        bool d;
+	struct KeysPressed
+	{
+		bool w;
+		bool a;
+		bool s;
+		bool d;
 
-        bool left;
-        bool right;
-        bool up;
-        bool down;
-    };
+		bool left;
+		bool right;
+		bool up;
+		bool down;
+	};
 
-    XMFLOAT3 m_initialPosition;
-    XMFLOAT3 m_position;
-    float m_yaw;                // Relative to the +z axis.
-    float m_pitch;                // Relative to the xz plane.
-    XMFLOAT3 m_lookDirection;
-    XMFLOAT3 m_upDirection;
-    float m_moveSpeed;            // Speed at which the camera moves, in units per second.
-    float m_turnSpeed;            // Speed at which the camera turns, in radians per second.
+	XMFLOAT3 m_initialPosition;
+	XMFLOAT3 m_position;
+	float m_yaw;				// Relative to the +z axis.
+	float m_pitch;				// Relative to the xz plane.
+	XMFLOAT3 m_lookDirection;
+	XMFLOAT3 m_upDirection;
+	float m_moveSpeed;			// Speed at which the camera moves, in units per second.
+	float m_turnSpeed;			// Speed at which the camera turns, in radians per second.
 
-    KeysPressed m_keysPressed;
+	KeysPressed m_keysPressed;
 };

--- a/Samples/UWP/D3D12nBodyGravity/src/View.cpp
+++ b/Samples/UWP/D3D12nBodyGravity/src/View.cpp
@@ -15,27 +15,27 @@
 using namespace Windows::Foundation;
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->Closed += ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &View::OnClosed);
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -44,20 +44,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new Platform::String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -66,26 +66,26 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnClosed(CoreWindow^ /*sender*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }

--- a/Samples/UWP/D3D12nBodyGravity/src/View.h
+++ b/Samples/UWP/D3D12nBodyGravity/src/View.h
@@ -23,20 +23,20 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
-    void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ keyEventArgs);
+	void OnClosed(CoreWindow ^sender, CoreWindowEventArgs ^args);
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
+	DXSample* m_pSample;
+	bool m_windowClosed;
 };

--- a/Samples/UWP/D3D12nBodyGravity/src/ViewProvider.cpp
+++ b/Samples/UWP/D3D12nBodyGravity/src/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12nBodyGravity/src/ViewProvider.h
+++ b/Samples/UWP/D3D12nBodyGravity/src/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12nBodyGravity/src/d3dx12.h
+++ b/Samples/UWP/D3D12nBodyGravity/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12nBodyGravity/src/nBodyGravityCS.hlsl
+++ b/Samples/UWP/D3D12nBodyGravity/src/nBodyGravityCS.hlsl
@@ -9,9 +9,9 @@
 //
 //*********************************************************
 
-static float softeningSquared    = 0.0012500000f * 0.0012500000f;
-static float g_fG                = 6.67300e-11f * 10000.0f;
-static float g_fParticleMass    = g_fG * 10000.0f * 10000.0f;
+static float softeningSquared	= 0.0012500000f * 0.0012500000f;
+static float g_fG				= 6.67300e-11f * 10000.0f;
+static float g_fParticleMass	= g_fG * 10000.0f * 10000.0f;
 
 #define blocksize 128
 groupshared float4 sharedPos[blocksize];
@@ -22,87 +22,87 @@ groupshared float4 sharedPos[blocksize];
 //
 void bodyBodyInteraction(inout float3 ai, float4 bj, float4 bi, float mass, int particles) 
 {
-    float3 r = bj.xyz - bi.xyz;
+	float3 r = bj.xyz - bi.xyz;
 
-    float distSqr = dot(r, r);
-    distSqr += softeningSquared;
+	float distSqr = dot(r, r);
+	distSqr += softeningSquared;
 
-    float invDist = 1.0f / sqrt(distSqr);
-    float invDistCube =  invDist * invDist * invDist;
-    
-    float s = mass * invDistCube * particles;
+	float invDist = 1.0f / sqrt(distSqr);
+	float invDistCube =  invDist * invDist * invDist;
+	
+	float s = mass * invDistCube * particles;
 
-    ai += r * s;
+	ai += r * s;
 }
 
 cbuffer cbCS : register(b0)
 {
-    uint4   g_param;    // param[0] = MAX_PARTICLES;
-                        // param[1] = dimx;
-    float4  g_paramf;    // paramf[0] = 0.1f;
-                        // paramf[1] = 1; 
+	uint4   g_param;	// param[0] = MAX_PARTICLES;
+						// param[1] = dimx;
+	float4  g_paramf;	// paramf[0] = 0.1f;
+						// paramf[1] = 1; 
 };
 
 struct PosVelo
 {
-    float4 pos;
-    float4 velo;
+	float4 pos;
+	float4 velo;
 };
 
-StructuredBuffer<PosVelo> oldPosVelo    : register(t0);    // SRV
-RWStructuredBuffer<PosVelo> newPosVelo    : register(u0);    // UAV
+StructuredBuffer<PosVelo> oldPosVelo	: register(t0);	// SRV
+RWStructuredBuffer<PosVelo> newPosVelo	: register(u0);	// UAV
 
 [numthreads(blocksize, 1, 1)]
 void CSMain(uint3 Gid : SV_GroupID, uint3 DTid : SV_DispatchThreadID, uint3 GTid : SV_GroupThreadID, uint GI : SV_GroupIndex)
 {
-    // Each thread of the CS updates one of the particles.
-    float4 pos = oldPosVelo[DTid.x].pos;
-    float4 vel = oldPosVelo[DTid.x].velo;
-    float3 accel = 0;
-    float mass = g_fParticleMass;
+	// Each thread of the CS updates one of the particles.
+	float4 pos = oldPosVelo[DTid.x].pos;
+	float4 vel = oldPosVelo[DTid.x].velo;
+	float3 accel = 0;
+	float mass = g_fParticleMass;
 
-    // Update current particle using all other particles.
-    [loop]
-    for (uint tile = 0; tile < g_param.y; tile++)
-    {
-        // Cache a tile of particles unto shared memory to increase IO efficiency.
-        sharedPos[GI] = oldPosVelo[tile * blocksize + GI].pos;
-       
-        GroupMemoryBarrierWithGroupSync();
+	// Update current particle using all other particles.
+	[loop]
+	for (uint tile = 0; tile < g_param.y; tile++)
+	{
+		// Cache a tile of particles unto shared memory to increase IO efficiency.
+		sharedPos[GI] = oldPosVelo[tile * blocksize + GI].pos;
+	   
+		GroupMemoryBarrierWithGroupSync();
 
-        [unroll]
-        for (uint counter = 0; counter < blocksize; counter += 8 ) 
-        {
-            bodyBodyInteraction(accel, sharedPos[counter], pos, mass, 1);
-            bodyBodyInteraction(accel, sharedPos[counter+1], pos, mass, 1);
-            bodyBodyInteraction(accel, sharedPos[counter+2], pos, mass, 1);
-            bodyBodyInteraction(accel, sharedPos[counter+3], pos, mass, 1);
-            bodyBodyInteraction(accel, sharedPos[counter+4], pos, mass, 1);
-            bodyBodyInteraction(accel, sharedPos[counter+5], pos, mass, 1);
-            bodyBodyInteraction(accel, sharedPos[counter+6], pos, mass, 1);
-            bodyBodyInteraction(accel, sharedPos[counter+7], pos, mass, 1);
-        }
-        
-        GroupMemoryBarrierWithGroupSync();
-    }  
+		[unroll]
+		for (uint counter = 0; counter < blocksize; counter += 8 ) 
+		{
+			bodyBodyInteraction(accel, sharedPos[counter], pos, mass, 1);
+			bodyBodyInteraction(accel, sharedPos[counter+1], pos, mass, 1);
+			bodyBodyInteraction(accel, sharedPos[counter+2], pos, mass, 1);
+			bodyBodyInteraction(accel, sharedPos[counter+3], pos, mass, 1);
+			bodyBodyInteraction(accel, sharedPos[counter+4], pos, mass, 1);
+			bodyBodyInteraction(accel, sharedPos[counter+5], pos, mass, 1);
+			bodyBodyInteraction(accel, sharedPos[counter+6], pos, mass, 1);
+			bodyBodyInteraction(accel, sharedPos[counter+7], pos, mass, 1);
+		}
+		
+		GroupMemoryBarrierWithGroupSync();
+	}  
 
-    // g_param.x is the number of our particles, however this number might not 
-    // be an exact multiple of the tile size. In such cases, out of bound reads 
-    // occur in the process above, which means there will be tooManyParticles 
-    // "phantom" particles generating false gravity at position (0, 0, 0), so 
-    // we have to subtract them here. NOTE, out of bound reads always return 0 in CS.
-    const int tooManyParticles = g_param.y * blocksize - g_param.x;
-    bodyBodyInteraction(accel, float4(0, 0, 0, 0), pos, mass, -tooManyParticles);
+	// g_param.x is the number of our particles, however this number might not 
+	// be an exact multiple of the tile size. In such cases, out of bound reads 
+	// occur in the process above, which means there will be tooManyParticles 
+	// "phantom" particles generating false gravity at position (0, 0, 0), so 
+	// we have to subtract them here. NOTE, out of bound reads always return 0 in CS.
+	const int tooManyParticles = g_param.y * blocksize - g_param.x;
+	bodyBodyInteraction(accel, float4(0, 0, 0, 0), pos, mass, -tooManyParticles);
 
-    // Update the velocity and position of current particle using the 
-    // acceleration computed above.
-    vel.xyz += accel.xyz * g_paramf.x;        //deltaTime;
-    vel.xyz *= g_paramf.y;                    //damping;
-    pos.xyz += vel.xyz * g_paramf.x;        //deltaTime;
+	// Update the velocity and position of current particle using the 
+	// acceleration computed above.
+	vel.xyz += accel.xyz * g_paramf.x;		//deltaTime;
+	vel.xyz *= g_paramf.y;					//damping;
+	pos.xyz += vel.xyz * g_paramf.x;		//deltaTime;
 
-    if (DTid.x < g_param.x)
-    {
-        newPosVelo[DTid.x].pos = pos;
-        newPosVelo[DTid.x].velo = float4(vel.xyz, length(accel));
-    }
+	if (DTid.x < g_param.x)
+	{
+		newPosVelo[DTid.x].pos = pos;
+		newPosVelo[DTid.x].velo = float4(vel.xyz, length(accel));
+	}
 }

--- a/Samples/UWP/D3D12nBodyGravity/src/stdafx.h
+++ b/Samples/UWP/D3D12nBodyGravity/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>

--- a/Samples/UWP/D3D12xGPU/readme.md
+++ b/Samples/UWP/D3D12xGPU/readme.md
@@ -14,5 +14,5 @@ As the sample is able to survive an adapter removal event, it declares that it s
 * [1-9] - adapter selection, when manual override is enabled.
 
 ## Requirements
-* Windows 10 October 2018 Update or higher
-* [Visual Studio 2017](https://www.visualstudio.com/) with the [Windows 10 October 2018 Update SDK (17763)](https://developer.microsoft.com/en-US/windows/downloads/windows-10-sdk)
+* Windows 10 17655 or higher (available via [Windows Insider Program](https://insider.windows.com/en-us/))
+* [Visual Studio 2017](https://www.visualstudio.com/) with the Windows 10 17655 SDK

--- a/Samples/UWP/D3D12xGPU/src/Camera.cpp
+++ b/Samples/UWP/D3D12xGPU/src/Camera.cpp
@@ -16,18 +16,18 @@ Camera* Camera::mCamera = nullptr;
 
 Camera::Camera()
 {
-    Reset();
-    mCamera = this;
+	Reset();
+	mCamera = this;
 }
 
 Camera::~Camera()
 {
-    mCamera = nullptr;
+	mCamera = nullptr;
 }
 
 Camera* Camera::get()
 {
-    return mCamera;
+	return mCamera;
 }
 
 void Camera::Get3DViewProjMatricesLH(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float fovInDegrees, float screenWidth, float screenHeight)
@@ -47,23 +47,23 @@ void Camera::Get3DViewProjMatricesLH(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float f
 
 void Camera::Get3DViewProjMatrices(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float fovInDegrees, float screenWidth, float screenHeight)
 {
-    
-    float aspectRatio = (float)screenWidth / (float)screenHeight;
-    float fovAngleY = fovInDegrees * XM_PI / 180.0f;
+	
+	float aspectRatio = (float)screenWidth / (float)screenHeight;
+	float fovAngleY = fovInDegrees * XM_PI / 180.0f;
 
-    if (aspectRatio < 1.0f)
-    {
-        fovAngleY /= aspectRatio;
-    }
+	if (aspectRatio < 1.0f)
+	{
+		fovAngleY /= aspectRatio;
+	}
 
-    XMStoreFloat4x4(view, XMMatrixTranspose(XMMatrixLookAtRH(mEye, mAt, mUp)));
-    XMStoreFloat4x4(proj, XMMatrixTranspose(XMMatrixPerspectiveFovRH(fovAngleY, aspectRatio, 0.01f, 125.0f)));
+	XMStoreFloat4x4(view, XMMatrixTranspose(XMMatrixLookAtRH(mEye, mAt, mUp)));
+	XMStoreFloat4x4(proj, XMMatrixTranspose(XMMatrixPerspectiveFovRH(fovAngleY, aspectRatio, 0.01f, 125.0f)));
 }
 
 void Camera::GetOrthoProjMatrices(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float width, float height)
 {
-    XMStoreFloat4x4(view, XMMatrixTranspose(XMMatrixLookAtRH(mEye, mAt, mUp)));
-    XMStoreFloat4x4(proj, XMMatrixTranspose(XMMatrixOrthographicRH(width, height, 0.01f, 125.0f)));
+	XMStoreFloat4x4(view, XMMatrixTranspose(XMMatrixLookAtRH(mEye, mAt, mUp)));
+	XMStoreFloat4x4(proj, XMMatrixTranspose(XMMatrixOrthographicRH(width, height, 0.01f, 125.0f)));
 }
 
 void Camera::RotateAroundYAxis(float angleRad)
@@ -76,30 +76,30 @@ void Camera::RotateAroundYAxis(float angleRad)
 
 void Camera::RotateYaw(float angleRad)
 {
-    XMMATRIX rotation = XMMatrixRotationAxis(mUp, angleRad);
+	XMMATRIX rotation = XMMatrixRotationAxis(mUp, angleRad);
 
-    mEye = mAt + XMVector3TransformCoord(mEye - mAt, rotation);
+	mEye = mAt + XMVector3TransformCoord(mEye - mAt, rotation);
 }
 
 void Camera::RotatePitch(float angleRad)
 {
-    XMVECTOR right = XMVector3Normalize(XMVector3Cross(mAt - mEye, mUp));
-    XMMATRIX rotation = XMMatrixRotationAxis(right, angleRad);
+	XMVECTOR right = XMVector3Normalize(XMVector3Cross(mAt - mEye, mUp));
+	XMMATRIX rotation = XMMatrixRotationAxis(right, angleRad);
 
-    mEye = mAt + XMVector3TransformCoord(mEye - mAt, rotation);
+	mEye = mAt + XMVector3TransformCoord(mEye - mAt, rotation);
     mUp = XMVector3TransformCoord(mUp, rotation);
 }
 
 void Camera::Reset()
 {
     mEye = XMVectorSet(0.0f, 8.0f, -30.0f, 0.0f);
-    mAt = XMVectorSet(0.0f, 8.0f, 0.0f, 0.0f);
-    mUp = XMVectorSet(0.0f, 1.0f, 0.0f, 0.0f);
+	mAt = XMVectorSet(0.0f, 8.0f, 0.0f, 0.0f);
+	mUp = XMVectorSet(0.0f, 1.0f, 0.0f, 0.0f);
 }
 
 void Camera::Set(XMVECTOR eye, XMVECTOR at, XMVECTOR up)
 {
-    mEye = eye;
-    mAt = at;
-    mUp = up;
+	mEye = eye;
+	mAt = at;
+	mUp = up;
 }

--- a/Samples/UWP/D3D12xGPU/src/Camera.h
+++ b/Samples/UWP/D3D12xGPU/src/Camera.h
@@ -17,22 +17,22 @@ using namespace DirectX;
 class Camera
 {
 public:
-    Camera();
-    ~Camera();
+	Camera();
+	~Camera();
 
 
     void Get3DViewProjMatricesLH(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float fovInDegrees, float screenWidth, float screenHeight);
-    void Get3DViewProjMatrices(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float fovInDegrees, float screenWidth, float screenHeight);
-    void Reset();
-    void Set(XMVECTOR eye, XMVECTOR at, XMVECTOR up);
-    static Camera *get();
+	void Get3DViewProjMatrices(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float fovInDegrees, float screenWidth, float screenHeight);
+	void Reset();
+	void Set(XMVECTOR eye, XMVECTOR at, XMVECTOR up);
+	static Camera *get();
     void RotateAroundYAxis(float angleRad);
-    void RotateYaw(float angleRad);
-    void RotatePitch(float angleRad);
-    void GetOrthoProjMatrices(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float width, float height);
-    XMVECTOR mEye; // Where the camera is in world space. Z increases into of the screen when using LH coord system (which we are and DX uses)
-    XMVECTOR mAt; // What the camera is looking at (world origin)
-    XMVECTOR mUp; // Which way is up
+	void RotateYaw(float angleRad);
+	void RotatePitch(float angleRad);
+	void GetOrthoProjMatrices(XMFLOAT4X4 *view, XMFLOAT4X4 *proj, float width, float height);
+	XMVECTOR mEye; // Where the camera is in world space. Z increases into of the screen when using LH coord system (which we are and DX uses)
+	XMVECTOR mAt; // What the camera is looking at (world origin)
+	XMVECTOR mUp; // Which way is up
 private:
-    static Camera* mCamera;
+	static Camera* mCamera;
 };

--- a/Samples/UWP/D3D12xGPU/src/D3D12xGPU.cpp
+++ b/Samples/UWP/D3D12xGPU/src/D3D12xGPU.cpp
@@ -140,7 +140,7 @@ void D3D12xGPU::LoadPipeline()
 
     ComPtr<IDXGISwapChain1> swapChain;
     ThrowIfFailed(m_dxgiFactory->CreateSwapChainForCoreWindow(
-        m_commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
+        m_commandQueue.Get(),		// Swap chain needs the queue so that it can force a flush on it.
         reinterpret_cast<IUnknown*>(Windows::UI::Core::CoreWindow::GetForCurrentThread()),
         &swapChainDesc,
         nullptr,

--- a/Samples/UWP/D3D12xGPU/src/DXSample.cpp
+++ b/Samples/UWP/D3D12xGPU/src/DXSample.cpp
@@ -52,33 +52,78 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+#if defined(_XBOX_ONE)
+    UNREFERENCED_PARAMETER(requestHighPerformanceAdapter);
+#else
+    ComPtr<IDXGIFactory6> factory6;
+#endif
+
+    ComPtr<IDXGIAdapter1> adapter;
+
+#if !defined(_XBOX_ONE)
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+#endif
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
+
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+            }
+#if !defined(_XBOX_ONE)
+        }
+#endif
 
     *ppAdapter = adapter.Detach();
-}
+    }
 
 // Helper function for setting the window's title text.
 void DXSample::SetCustomWindowText(LPCWSTR text)

--- a/Samples/UWP/D3D12xGPU/src/DXSample.h
+++ b/Samples/UWP/D3D12xGPU/src/DXSample.h
@@ -48,7 +48,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/UWP/D3D12xGPU/src/FrameResource.cpp
+++ b/Samples/UWP/D3D12xGPU/src/FrameResource.cpp
@@ -17,47 +17,47 @@
 using namespace SceneEnums;
 
 FrameResource::FrameResource(ID3D12Device* pDevice, ComPtr<ID3D12PipelineState> pPipelineStates[RenderPass::Count], ID3D12DescriptorHeap* pDsvHeap, ID3D12DescriptorHeap* pCbvSrvHeap, UINT frameIndex) :
-    m_frameResourceIndex(frameIndex)
+	m_frameResourceIndex(frameIndex)
 {
     for (UINT i = 0; i < RenderPass::Count; i++)
     {
         m_pipelineStates[i] = pPipelineStates[i];
     }
 
-    for (UINT i = 0; i < CommandListCount; i++)
-    {
-        ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[i])));
-        ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[i].Get(), m_pipelineStates[i].Get(), IID_PPV_ARGS(&m_commandLists[i])));
-        NAME_D3D12_OBJECT_INDEXED(m_commandLists, i);
+	for (UINT i = 0; i < CommandListCount; i++)
+	{
+		ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[i])));
+		ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[i].Get(), m_pipelineStates[i].Get(), IID_PPV_ARGS(&m_commandLists[i])));
+		NAME_D3D12_OBJECT_INDEXED(m_commandLists, i);
 
-        // Close these command lists; don't record into them for now.
-        ThrowIfFailed(m_commandLists[i]->Close());
-    }
+		// Close these command lists; don't record into them for now.
+		ThrowIfFailed(m_commandLists[i]->Close());
+	}
 
-    for (UINT i = 0; i < NumContexts; i++)
-    {
-        // Create command list allocators for worker threads. One alloc is 
-        // for the shadow pass command list, and one is for the scene pass.
-        ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_shadowCommandAllocators[i])));
-        ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[i])));
+	for (UINT i = 0; i < NumContexts; i++)
+	{
+		// Create command list allocators for worker threads. One alloc is 
+		// for the shadow pass command list, and one is for the scene pass.
+		ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_shadowCommandAllocators[i])));
+		ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[i])));
 
-        ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_shadowCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Shadow].Get(), IID_PPV_ARGS(&m_shadowCommandLists[i])));
-        ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_sceneCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Scene].Get(), IID_PPV_ARGS(&m_sceneCommandLists[i])));
+		ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_shadowCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Shadow].Get(), IID_PPV_ARGS(&m_shadowCommandLists[i])));
+		ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_sceneCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Scene].Get(), IID_PPV_ARGS(&m_sceneCommandLists[i])));
 
-        NAME_D3D12_OBJECT_INDEXED(m_shadowCommandLists, i);
-        NAME_D3D12_OBJECT_INDEXED(m_sceneCommandLists, i);
+		NAME_D3D12_OBJECT_INDEXED(m_shadowCommandLists, i);
+		NAME_D3D12_OBJECT_INDEXED(m_sceneCommandLists, i);
 
-        // Close these command lists; don't record into them for now. We will 
-        // reset them to a recording state when we start the render loop.
-        ThrowIfFailed(m_shadowCommandLists[i]->Close());
-        ThrowIfFailed(m_sceneCommandLists[i]->Close());
-    }
+		// Close these command lists; don't record into them for now. We will 
+		// reset them to a recording state when we start the render loop.
+		ThrowIfFailed(m_shadowCommandLists[i]->Close());
+		ThrowIfFailed(m_sceneCommandLists[i]->Close());
+	}
     ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_postprocessCommandAllocator)));
     ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_postprocessCommandAllocator.Get(), m_pipelineStates[RenderPass::Postprocess].Get(), IID_PPV_ARGS(&m_postprocessCommandList)));
     NAME_D3D12_OBJECT(m_postprocessCommandList);
     ThrowIfFailed(m_postprocessCommandList->Close());
 
-    const UINT textureCount = _countof(SampleAssets::Textures);    // Diffuse + normal textures near the start of the heap.  Ideally, track descriptor heap contents/offsets at a higher level.
+    const UINT textureCount = _countof(SampleAssets::Textures);	// Diffuse + normal textures near the start of the heap.  Ideally, track descriptor heap contents/offsets at a higher level.
     const UINT cbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
     const UINT dsvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_DSV);
     CD3DX12_CPU_DESCRIPTOR_HANDLE cbvSrvCpuHandle(pCbvSrvHeap->GetCPUDescriptorHandleForHeapStart());
@@ -84,8 +84,8 @@ FrameResource::FrameResource(ID3D12Device* pDevice, ComPtr<ID3D12PipelineState> 
         m_depthSRVs[DepthGenPass::Scene] = cbvSrvCpuHandle;
         m_depthSrvHandles[DepthGenPass::Scene] = cbvSrvGpuHandle;
     }
-        
-    // Create constant buffers.
+    	
+	// Create constant buffers.
     {
         // Shadow generation constant buffer.
         cbvSrvCpuHandle.Offset(cbvSrvDescriptorSize);
@@ -110,41 +110,41 @@ FrameResource::FrameResource(ID3D12Device* pDevice, ComPtr<ID3D12PipelineState> 
 
         // Map the constant buffers and cache their heap pointers.
         // We don't unmap this until the app closes. Keeping buffer mapped for the lifetime of the resource is okay.
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
+        CD3DX12_RANGE readRange(0, 0);		// We do not intend to read from this resource on the CPU.
         ThrowIfFailed(m_constantBuffers[RenderPass::Shadow]->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBuffersWO[RenderPass::Shadow])));
         ThrowIfFailed(m_constantBuffers[RenderPass::Scene]->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBuffersWO[RenderPass::Scene])));
         ThrowIfFailed(m_constantBuffers[RenderPass::Postprocess]->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBuffersWO[RenderPass::Postprocess])));
         
     }
 
-    // Batch up command lists for execution later.
-    const UINT batchSize = _countof(m_sceneCommandLists) + _countof(m_shadowCommandLists) + CommandListCount;
-    m_batchSubmit[0] = m_commandLists[CommandListPre].Get();
-    memcpy(m_batchSubmit + 1, m_shadowCommandLists, _countof(m_shadowCommandLists) * sizeof(ID3D12CommandList*));
-    m_batchSubmit[_countof(m_shadowCommandLists) + 1] = m_commandLists[CommandListMid].Get();
-    memcpy(m_batchSubmit + _countof(m_shadowCommandLists) + 2, m_sceneCommandLists, _countof(m_sceneCommandLists) * sizeof(ID3D12CommandList*));
-    m_batchSubmit[batchSize - 1] = m_commandLists[CommandListPost].Get();
+	// Batch up command lists for execution later.
+	const UINT batchSize = _countof(m_sceneCommandLists) + _countof(m_shadowCommandLists) + CommandListCount;
+	m_batchSubmit[0] = m_commandLists[CommandListPre].Get();
+	memcpy(m_batchSubmit + 1, m_shadowCommandLists, _countof(m_shadowCommandLists) * sizeof(ID3D12CommandList*));
+	m_batchSubmit[_countof(m_shadowCommandLists) + 1] = m_commandLists[CommandListMid].Get();
+	memcpy(m_batchSubmit + _countof(m_shadowCommandLists) + 2, m_sceneCommandLists, _countof(m_sceneCommandLists) * sizeof(ID3D12CommandList*));
+	m_batchSubmit[batchSize - 1] = m_commandLists[CommandListPost].Get();
 }
 
 FrameResource::~FrameResource()
 {
-    for (int i = 0; i < CommandListCount; i++)
-    {
-        m_commandAllocators[i] = nullptr;
-        m_commandLists[i] = nullptr;
-    }
+	for (int i = 0; i < CommandListCount; i++)
+	{
+		m_commandAllocators[i] = nullptr;
+		m_commandLists[i] = nullptr;
+	}
 
-    m_constantBuffers[RenderPass::Shadow] = nullptr;
-    m_constantBuffers[RenderPass::Scene] = nullptr;
+	m_constantBuffers[RenderPass::Shadow] = nullptr;
+	m_constantBuffers[RenderPass::Scene] = nullptr;
 
-    for (int i = 0; i < NumContexts; i++)
-    {
-        m_shadowCommandLists[i] = nullptr;
-        m_shadowCommandAllocators[i] = nullptr;
+	for (int i = 0; i < NumContexts; i++)
+	{
+		m_shadowCommandLists[i] = nullptr;
+		m_shadowCommandAllocators[i] = nullptr;
 
-        m_sceneCommandLists[i] = nullptr;
-        m_sceneCommandAllocators[i] = nullptr;
-    }
+		m_sceneCommandLists[i] = nullptr;
+		m_sceneCommandAllocators[i] = nullptr;
+	}
     m_postprocessCommandAllocator = nullptr;
     m_postprocessCommandList = nullptr;
 
@@ -180,33 +180,33 @@ void FrameResource::ClearDepthStencilViews(ID3D12GraphicsCommandList* pCommandLi
 // this frame resource.
 void FrameResource::WriteConstantBuffers(D3D12_VIEWPORT* pViewport, Camera* pSceneCamera, Camera lightCams[NumLights], LightState lights[NumLights])
 {
-    SceneConstantBuffer sceneConsts = {}; 
-    SceneConstantBuffer shadowConsts = {};
+	SceneConstantBuffer sceneConsts = {}; 
+	SceneConstantBuffer shadowConsts = {};
     PostprocessConstantBuffer postprocessConsts = {};
-    
-    // Scale down the world a bit.
-    ::XMStoreFloat4x4(&sceneConsts.model, XMMatrixScaling(0.1f, 0.1f, 0.1f));
-    ::XMStoreFloat4x4(&shadowConsts.model, XMMatrixScaling(0.1f, 0.1f, 0.1f));
+	
+	// Scale down the world a bit.
+	::XMStoreFloat4x4(&sceneConsts.model, XMMatrixScaling(0.1f, 0.1f, 0.1f));
+	::XMStoreFloat4x4(&shadowConsts.model, XMMatrixScaling(0.1f, 0.1f, 0.1f));
 
-    // The scene pass is drawn from the camera.
-    pSceneCamera->Get3DViewProjMatrices(&sceneConsts.view, &sceneConsts.projection, 90.0f, pViewport->Width, pViewport->Height);
+	// The scene pass is drawn from the camera.
+	pSceneCamera->Get3DViewProjMatrices(&sceneConsts.view, &sceneConsts.projection, 90.0f, pViewport->Width, pViewport->Height);
 
-    // The light pass is drawn from the first light.
-    lightCams[0].Get3DViewProjMatrices(&shadowConsts.view, &shadowConsts.projection, 90.0f, pViewport->Width, pViewport->Height);
+	// The light pass is drawn from the first light.
+	lightCams[0].Get3DViewProjMatrices(&shadowConsts.view, &shadowConsts.projection, 90.0f, pViewport->Width, pViewport->Height);
 
-    for (int i = 0; i < NumLights; i++)
-    {
-        memcpy(&sceneConsts.lights[i], &lights[i], sizeof(LightState));
-        memcpy(&shadowConsts.lights[i], &lights[i], sizeof(LightState));
-    }
+	for (int i = 0; i < NumLights; i++)
+	{
+		memcpy(&sceneConsts.lights[i], &lights[i], sizeof(LightState));
+		memcpy(&shadowConsts.lights[i], &lights[i], sizeof(LightState));
+	}
 
-    // The shadow pass won't sample the shadow map, but rather write to it.
-    shadowConsts.sampleShadowMap = FALSE;
+	// The shadow pass won't sample the shadow map, but rather write to it.
+	shadowConsts.sampleShadowMap = FALSE;
 
-    // The scene pass samples the shadow map.
-    sceneConsts.sampleShadowMap = TRUE;
+	// The scene pass samples the shadow map.
+	sceneConsts.sampleShadowMap = TRUE;
 
-    shadowConsts.ambientColor = sceneConsts.ambientColor = { 0.1f, 0.2f, 0.3f, 1.0f };
+	shadowConsts.ambientColor = sceneConsts.ambientColor = { 0.1f, 0.2f, 0.3f, 1.0f };
 
     postprocessConsts.lightPosition = lights[0].position;
     XMStoreFloat4(&postprocessConsts.cameraPosition, pSceneCamera->mEye);
@@ -231,29 +231,29 @@ void FrameResource::WriteConstantBuffers(D3D12_VIEWPORT* pViewport, Camera* pSce
     XMStoreFloat4x4(&postprocessConsts.projInverse, XMMatrixTranspose(projInverse));
     XMStoreFloat4x4(&postprocessConsts.viewProjInverseAtNearZ1, XMMatrixTranspose(viewProjInverseAtNearZ1));
 
-    memcpy(m_pConstantBuffersWO[RenderPass::Scene], &sceneConsts, sizeof(sceneConsts));
-    memcpy(m_pConstantBuffersWO[RenderPass::Shadow], &shadowConsts, sizeof(shadowConsts));
+	memcpy(m_pConstantBuffersWO[RenderPass::Scene], &sceneConsts, sizeof(sceneConsts));
+	memcpy(m_pConstantBuffersWO[RenderPass::Shadow], &shadowConsts, sizeof(shadowConsts));
     memcpy(m_pConstantBuffersWO[RenderPass::Postprocess], &postprocessConsts, sizeof(postprocessConsts));
 }
 
 void FrameResource::Init()
 {
-    // Reset the command allocators and lists for the main thread.
-    for (int i = 0; i < CommandListCount; i++)
-    {
-        ThrowIfFailed(m_commandAllocators[i]->Reset());
-        ThrowIfFailed(m_commandLists[i]->Reset(m_commandAllocators[i].Get(), m_pipelineStates[RenderPass::Scene].Get()));
-    }
+	// Reset the command allocators and lists for the main thread.
+	for (int i = 0; i < CommandListCount; i++)
+	{
+		ThrowIfFailed(m_commandAllocators[i]->Reset());
+		ThrowIfFailed(m_commandLists[i]->Reset(m_commandAllocators[i].Get(), m_pipelineStates[RenderPass::Scene].Get()));
+	}
     
-    // Reset the worker command allocators and lists.
-    for (int i = 0; i < NumContexts; i++)
-    {
-        ThrowIfFailed(m_shadowCommandAllocators[i]->Reset());
-        ThrowIfFailed(m_shadowCommandLists[i]->Reset(m_shadowCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Shadow].Get()));
+	// Reset the worker command allocators and lists.
+	for (int i = 0; i < NumContexts; i++)
+	{
+		ThrowIfFailed(m_shadowCommandAllocators[i]->Reset());
+		ThrowIfFailed(m_shadowCommandLists[i]->Reset(m_shadowCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Shadow].Get()));
 
-        ThrowIfFailed(m_sceneCommandAllocators[i]->Reset());
-        ThrowIfFailed(m_sceneCommandLists[i]->Reset(m_sceneCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Scene].Get()));
-    }
+		ThrowIfFailed(m_sceneCommandAllocators[i]->Reset());
+		ThrowIfFailed(m_sceneCommandLists[i]->Reset(m_sceneCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Scene].Get()));
+	}
 
     ThrowIfFailed(m_postprocessCommandAllocator->Reset());
     ThrowIfFailed(m_postprocessCommandList->Reset(m_postprocessCommandAllocator.Get(), m_pipelineStates[RenderPass::Postprocess].Get()));
@@ -261,14 +261,14 @@ void FrameResource::Init()
 
 void FrameResource::SwapBarriers()
 {
-    // Transition the shadow map from writeable to readable.
-    m_commandLists[CommandListMid]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_depthTextures[DepthGenPass::Shadow].Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
+	// Transition the shadow map from writeable to readable.
+	m_commandLists[CommandListMid]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_depthTextures[DepthGenPass::Shadow].Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
 }
 
 
 void FrameResource::Finish()
 {
-    m_commandLists[CommandListPost]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_depthTextures[DepthGenPass::Shadow].Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE));
+	m_commandLists[CommandListPost]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_depthTextures[DepthGenPass::Shadow].Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE));
 }
 
 // Sets up the descriptor tables for the worker command list to use 
@@ -280,15 +280,15 @@ void FrameResource::Bind(ID3D12GraphicsCommandList* pCommandList, RenderPass::Va
     case RenderPass::Shadow:
     {
         pCommandList->SetGraphicsRootDescriptorTable(1, m_cbvHandles[RenderPass::Shadow]);
-        pCommandList->SetGraphicsRootDescriptorTable(2, m_nullSrvHandle);                                // Set a null SRV for the shadow texture.
+        pCommandList->SetGraphicsRootDescriptorTable(2, m_nullSrvHandle);			                    // Set a null SRV for the shadow texture.
 
-        pCommandList->OMSetRenderTargets(0, nullptr, FALSE, &m_depthDSVs[DepthGenPass::Shadow]);        // No render target needed for the shadow pass.
+        pCommandList->OMSetRenderTargets(0, nullptr, FALSE, &m_depthDSVs[DepthGenPass::Shadow]);	    // No render target needed for the shadow pass.
         break;
     }
     case RenderPass::Scene:
     {
         pCommandList->SetGraphicsRootDescriptorTable(1, m_cbvHandles[RenderPass::Scene]);
-        pCommandList->SetGraphicsRootDescriptorTable(2, m_depthSrvHandles[DepthGenPass::Shadow]);        // Set the shadow texture as an SRV.
+        pCommandList->SetGraphicsRootDescriptorTable(2, m_depthSrvHandles[DepthGenPass::Shadow]);		// Set the shadow texture as an SRV.
 
         pCommandList->OMSetRenderTargets(1, pRtvHandle, FALSE, &m_depthDSVs[DepthGenPass::Scene]);
         break;
@@ -298,7 +298,7 @@ void FrameResource::Bind(ID3D12GraphicsCommandList* pCommandList, RenderPass::Va
         pCommandList->SetGraphicsRootDescriptorTable(0, m_depthSrvHandles[DepthGenPass::Scene]);
         pCommandList->SetGraphicsRootDescriptorTable(1, m_cbvHandles[RenderPass::Postprocess]);
 
-        pCommandList->OMSetRenderTargets(1, pRtvHandle, FALSE, nullptr);                                // No depth stencil needed for the postprocess pass.
+        pCommandList->OMSetRenderTargets(1, pRtvHandle, FALSE, nullptr);	                            // No depth stencil needed for the postprocess pass.
         break;
     }
     }

--- a/Samples/UWP/D3D12xGPU/src/FrameResource.h
+++ b/Samples/UWP/D3D12xGPU/src/FrameResource.h
@@ -36,12 +36,12 @@ public:
     ComPtr<ID3D12Resource> m_renderTarget;
     D3D12_CPU_DESCRIPTOR_HANDLE m_renderTargetView;
     ComPtr<ID3D12PipelineState> m_pipelineStates[SceneEnums::RenderPass::Count];
-    D3D12_GPU_DESCRIPTOR_HANDLE m_nullSrvHandle;                        // Null SRV for out of bounds behavior.
+    D3D12_GPU_DESCRIPTOR_HANDLE m_nullSrvHandle;                	    // Null SRV for out of bounds behavior.
 
     ComPtr<ID3D12Resource> m_constantBuffers[SceneEnums::RenderPass::Count];
-    SceneConstantBuffer* m_pConstantBuffersWO[SceneEnums::RenderPass::Count];        // WRITE-ONLY pointers to the constant buffers
+	SceneConstantBuffer* m_pConstantBuffersWO[SceneEnums::RenderPass::Count];		// WRITE-ONLY pointers to the constant buffers
     D3D12_GPU_DESCRIPTOR_HANDLE m_cbvHandles[SceneEnums::RenderPass::Count];
-    
+	
     ComPtr<ID3D12Resource> m_depthTextures[SceneEnums::DepthGenPass::Count];
     D3D12_CPU_DESCRIPTOR_HANDLE m_depthDSVs[SceneEnums::DepthGenPass::Count];
     D3D12_CPU_DESCRIPTOR_HANDLE m_depthSRVs[SceneEnums::DepthGenPass::Count];
@@ -50,18 +50,18 @@ public:
     UINT m_frameResourceIndex;
 
 public:
-    FrameResource(ID3D12Device* pDevice, ComPtr<ID3D12PipelineState> pPipelineStates[SceneEnums::RenderPass::Count], ID3D12DescriptorHeap* pDsvHeap, ID3D12DescriptorHeap* pCbvSrvHeap, UINT frameResourceIndex);
-    ~FrameResource();
+	FrameResource(ID3D12Device* pDevice, ComPtr<ID3D12PipelineState> pPipelineStates[SceneEnums::RenderPass::Count], ID3D12DescriptorHeap* pDsvHeap, ID3D12DescriptorHeap* pCbvSrvHeap, UINT frameResourceIndex);
+	~FrameResource();
 
     void LoadSizeDependentResources(ID3D12Device* pDevice, UINT width, UINT height);
     void ReleaseSizeDependentResources();
    
     void ClearDepthStencilViews(ID3D12GraphicsCommandList* pCommandList);
     void Bind(ID3D12GraphicsCommandList* pCommandList, SceneEnums::RenderPass::Value renderPass, D3D12_CPU_DESCRIPTOR_HANDLE* pRtvHandle);
-    void Init();
-    void SwapBarriers();
-    void Finish();
-    void WriteConstantBuffers(D3D12_VIEWPORT* pViewport, Camera* pSceneCamera, Camera lightCams[NumLights], LightState lights[NumLights]);
+	void Init();
+	void SwapBarriers();
+	void Finish();
+	void WriteConstantBuffers(D3D12_VIEWPORT* pViewport, Camera* pSceneCamera, Camera lightCams[NumLights], LightState lights[NumLights]);
 };
 
 
@@ -96,7 +96,7 @@ inline HRESULT CreateDepthStencilTexture2D(
             D3D12_TEXTURE_LAYOUT_UNKNOWN,
             D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
 
-        D3D12_CLEAR_VALUE clearValue;        // Performance tip: Tell the runtime at resource creation the desired clear value.
+        D3D12_CLEAR_VALUE clearValue;		// Performance tip: Tell the runtime at resource creation the desired clear value.
         clearValue.Format = dsvFormat;
         clearValue.DepthStencil.Depth = initDepthValue;
         clearValue.DepthStencil.Stencil = initStencilValue;

--- a/Samples/UWP/D3D12xGPU/src/ShadowsFogScatteringSquidScene.cpp
+++ b/Samples/UWP/D3D12xGPU/src/ShadowsFogScatteringSquidScene.cpp
@@ -46,9 +46,9 @@ ShadowsFogScatteringSquidScene::~ShadowsFogScatteringSquidScene()
 
 void ShadowsFogScatteringSquidScene::InitializeCameraAndLights()
 {
-    XMVECTOR eye = { 0.0f, 17.1954231f, -28.555980f, 1.0f };
-    XMVECTOR at = { 0.0f, 8.0f, 0.0f, 0.0f };  
-    XMVECTOR up = { 0.0f, 0.951865792f, 0.306514263f, 1.0f };
+    XMVECTOR eye = XMVectorSet(0.0f, 17.1954231f, -28.555980f, 1.0f);
+    XMVECTOR at = XMVectorSet(0.0f, 8.0f, 0.0f, 0.0f);
+    XMVECTOR up = XMVectorSet(0.0f, 0.951865792f, 0.306514263f, 1.0f);
     m_camera.Set(eye, at, up);
 
     // Create lights.
@@ -72,11 +72,11 @@ void ShadowsFogScatteringSquidScene::InitializeCameraAndLights()
 
             XMVECTOR eye = XMLoadFloat4(&m_lights[i].position);
             XMVECTOR at = XMVectorAdd(eye, XMLoadFloat4(&m_lights[i].direction));
-            XMVECTOR up = { 0, 1, 0 };
+            XMVECTOR up = XMVectorSet(0.0f, 1.0f, 0.0f, 0.0f);
             switch (i)
             {
-            case 4: up = { 0, 0, -1 }; break;
-            case 5: up = { 0, 0, 1 }; break;
+            case 4: up = XMVectorSet(0.0f, 0.0f, -1.0f, 0.0f); break;
+            case 5: up = XMVectorSet(0.0f, 0.0f, 1.0f, 0.0f); break;
             }
 
             m_lightCameras[i].Set(eye, at, up);
@@ -133,7 +133,7 @@ void ShadowsFogScatteringSquidScene::CreateDescriptorHeaps(ID3D12Device* pDevice
     // 1) null views, 
     // 2) object diffuse + normal textures views, 
     // 3) per frame views: 2x depth buffers (shadow, scene pass), 3x constant buffers (shadow, scene, postprocess pass)
-    const UINT NumNullSrvs = 2;        // Null descriptors are needed for out of bounds behavior reads.
+    const UINT NumNullSrvs = 2;		// Null descriptors are needed for out of bounds behavior reads.
     const UINT cbvCount = m_frameCount * NumConstantBuffers;
     const UINT srvCount = _countof(SampleAssets::Textures) + m_frameCount * NumDepthBuffers;
     D3D12_DESCRIPTOR_HEAP_DESC cbvSrvHeapDesc = {};
@@ -145,7 +145,7 @@ void ShadowsFogScatteringSquidScene::CreateDescriptorHeaps(ID3D12Device* pDevice
 
     // Describe and create a sampler descriptor heap.
     D3D12_DESCRIPTOR_HEAP_DESC samplerHeapDesc = {};
-    samplerHeapDesc.NumDescriptors = 2;        // One clamp and one wrap sampler.
+    samplerHeapDesc.NumDescriptors = 2;		// One clamp and one wrap sampler.
     samplerHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
     samplerHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
     ThrowIfFailed(pDevice->CreateDescriptorHeap(&samplerHeapDesc, IID_PPV_ARGS(&m_samplerHeap)));
@@ -171,10 +171,10 @@ void ShadowsFogScatteringSquidScene::CreateRootSignatures(ID3D12Device* pDevice)
     // Create a root signature for shadow and scene render pass.
     {
         CD3DX12_DESCRIPTOR_RANGE1 ranges[4]; // Perfomance TIP: Order from most frequent to least frequent.
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 1, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);    // 2 frequently changed diffuse + normal textures - using registers t1 and t2.
-        ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);    // 1 frequently changed constant buffer.
-        ranges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);                                                // 1 infrequently changed shadow texture - starting in register t0.
-        ranges[3].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 2, 0);                                            // 2 static samplers.
+        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 1, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);	// 2 frequently changed diffuse + normal textures - using registers t1 and t2.
+        ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);	// 1 frequently changed constant buffer.
+        ranges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);												// 1 infrequently changed shadow texture - starting in register t0.
+        ranges[3].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 2, 0);											// 2 static samplers.
 
         CD3DX12_ROOT_PARAMETER1 rootParameters[4];
         rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
@@ -197,7 +197,7 @@ void ShadowsFogScatteringSquidScene::CreateRootSignatures(ID3D12Device* pDevice)
         CD3DX12_DESCRIPTOR_RANGE1 ranges[3];
         CD3DX12_ROOT_PARAMETER1 rootParameters[3];
 
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);    // depth texture - using register t0.
+        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);	// depth texture - using register t0.
         ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0);
         ranges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
         rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
@@ -758,12 +758,12 @@ void ShadowsFogScatteringSquidScene::Update(double elapsedTime)
         {
             XMStoreFloat4(&m_lights[i].position, XMVector4Transform(XMLoadFloat4(&m_lights[i].position), XMMatrixRotationY(angleChange)));
             XMVECTOR eye = XMLoadFloat4(&m_lights[i].position);
-            XMVECTOR at = XMVectorSet(0.0f, 15.0f, 0.0f,0.0f);
-            XMVECTOR up = { 0, 1, 0 };
+            XMVECTOR at = XMVectorSet(0.0f, 15.0f, 0.0f, 0.0f);
+            XMVECTOR up = XMVectorSet(0.0f, 1.0f, 0.0f, 0.0f);
             switch (i)
             {
-            case 4: up = { 0, 0, -1 }; break;
-            case 5: up = { 0, 0, 1 }; break;
+            case 4: up = XMVectorSet(0.0f, 0.0f, -1.0f, 0.0f); break;
+            case 5: up = XMVectorSet(0.0f, 0.0f, 1.0f, 0.0f); break;
             }
             m_lightCameras[i].Set(eye, at, up);
 

--- a/Samples/UWP/D3D12xGPU/src/ShadowsFogScatteringSquidScene.h
+++ b/Samples/UWP/D3D12xGPU/src/ShadowsFogScatteringSquidScene.h
@@ -29,11 +29,11 @@ class DXSample;
 
 #define SINGLETHREADED FALSE
 
-static const UINT NumNullSrvs = 2;        // Null descriptors at the start of the heap.
+static const UINT NumNullSrvs = 2;		// Null descriptors at the start of the heap.
 static const UINT NumContexts = 3;
 
 // Currently the rendering code can only handle a single point light.
-static const UINT NumLights = 1;        // Keep this in sync with "ShadowsAndScenePass.hlsl".
+static const UINT NumLights = 1;		// Keep this in sync with "ShadowsAndScenePass.hlsl".
             
 
 static const UINT NumDepthBuffers = 2;      // Shadow + Scene pass
@@ -82,7 +82,7 @@ struct SceneConstantBuffer
     XMFLOAT4X4 projection;
     XMFLOAT4 ambientColor;
     BOOL sampleShadowMap;
-    BOOL padding[3];        // Must be aligned to be made up of N float4s.
+    BOOL padding[3];		// Must be aligned to be made up of N float4s.
     LightState lights[NumLights];
 };
 

--- a/Samples/UWP/D3D12xGPU/src/SquidRoom.h
+++ b/Samples/UWP/D3D12xGPU/src/SquidRoom.h
@@ -15,1153 +15,1153 @@
 
 namespace SampleAssets
 {
-    const wchar_t DataFileName[] = L"SquidRoom.bin";
+	const wchar_t DataFileName[] = L"SquidRoom.bin";
 
-    const D3D12_INPUT_ELEMENT_DESC StandardVertexDescription[] =
-    {
-        { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,  D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "NORMAL",   0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,    0, 24, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "TANGENT",  0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 32, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-    };
+	const D3D12_INPUT_ELEMENT_DESC StandardVertexDescription[] =
+	{
+		{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,  D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		{ "NORMAL",   0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,    0, 24, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+		{ "TANGENT",  0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 32, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+	};
 
-    const UINT StandardVertexStride = 44;
+	const UINT StandardVertexStride = 44;
 
-    const DXGI_FORMAT StandardIndexFormat = DXGI_FORMAT_R32_UINT;
+	const DXGI_FORMAT StandardIndexFormat = DXGI_FORMAT_R32_UINT;
 
-    struct TextureResource
-    {
-        UINT Width;
-        UINT Height;
-        UINT MipLevels;
-        DXGI_FORMAT Format;
-        struct DataProperties
-        {
-            UINT Offset;
-            UINT Size;
-            UINT Pitch;
-        } Data[D3D12_REQ_MIP_LEVELS];
-    };
+	struct TextureResource
+	{
+		UINT Width;
+		UINT Height;
+		UINT MipLevels;
+		DXGI_FORMAT Format;
+		struct DataProperties
+		{
+			UINT Offset;
+			UINT Size;
+			UINT Pitch;
+		} Data[D3D12_REQ_MIP_LEVELS];
+	};
 
-    struct DrawParameters
-    {
-        INT DiffuseTextureIndex;
-        INT NormalTextureIndex;
-        INT SpecularTextureIndex;
-        UINT IndexStart;
-        UINT IndexCount;
-        UINT VertexBase;
-    };
+	struct DrawParameters
+	{
+		INT DiffuseTextureIndex;
+		INT NormalTextureIndex;
+		INT SpecularTextureIndex;
+		UINT IndexStart;
+		UINT IndexCount;
+		UINT VertexBase;
+	};
 
-    const UINT VertexDataOffset = 30277640;
-    const UINT VertexDataSize = 9685808;
-    const UINT IndexDataOffset = 39963448;
-    const UINT IndexDataSize = 3056844;
+	const UINT VertexDataOffset = 30277640;
+	const UINT VertexDataSize = 9685808;
+	const UINT IndexDataOffset = 39963448;
+	const UINT IndexDataSize = 3056844;
 
-    const TextureResource Textures[] =
-    {
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 0, 131072, 1024 }, } }, // squard room platform_3_diff_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 131072, 131072, 1024 }, } }, // squard room platform_3_norm_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 262144, 524288, 2048 }, } }, // squard room platform_2_diff_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 786432, 524288, 2048 }, } }, // squard room platform_2_norm_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 1310720, 524288, 2048 }, } }, // squard room platform_1_diff_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 1835008, 524288, 2048 }, } }, // squard room platform_1_norm_1024.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 2359296, 131072, 1024 }, } }, // shelves2_diff1_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 2490368, 131072, 1024 }, } }, // shelves2_nm1_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 2621440, 524288, 2048 }, } }, // Misc_Boss_2 1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 3145728, 524288, 2048 }, } }, // Misc_Boss_2_normal1024.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 3670016, 131072, 1024 }, } }, // Hanging_bundle_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 3801088, 131072, 1024 }, } }, // Catwalk_03_Normal_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 3932160, 524288, 2048 }, } }, // Stack_ Boxes_Diff02_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 4456448, 524288, 2048 }, } }, // Stack_ Boxes_Nm02_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 4980736, 524288, 2048 }, } }, // Stack_ Boxes_Diff03_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 5505024, 524288, 2048 }, } }, // Stack_ Boxes_Nm03_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 6029312, 524288, 2048 }, } }, // Stack_ Boxes_Diff01_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 6553600, 524288, 2048 }, } }, // Stack_ Boxes_Nm01_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 7077888, 524288, 2048 }, } }, // Back_Alley_box_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 7602176, 524288, 2048 }, } }, // Back_Alley_box _norm_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 8126464, 524288, 2048 }, } }, // gameCrates_01_Diff_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 8650752, 524288, 2048 }, } }, // gameCrates_01_Nor_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 9175040, 524288, 2048 }, } }, // RaceCar_Strorage_Diff512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 9699328, 524288, 2048 }, } }, // RaceCar_Strorage_Norm512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10223616, 131072, 1024 }, } }, // hats_02_diff_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10354688, 131072, 1024 }, } }, // hats_02_norm_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10485760, 131072, 1024 }, } }, // hats_01_diff_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10616832, 131072, 1024 }, } }, // hats_01_norm_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 10747904, 524288, 2048 }, } }, // Misc_Boss_1_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 11272192, 524288, 2048 }, } }, // Misc_Boss_1_normal_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 11796480, 524288, 2048 }, } }, // gameCrates_03_Diff_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 12320768, 524288, 2048 }, } }, // gameCrates_03_Nor_1024.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 12845056, 131072, 1024 }, } }, // gameCrates_02_Diff_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 12976128, 524288, 2048 }, } }, // Back_Alley_Drum.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13500416, 131072, 1024 }, } }, // Back_Alley_Drum _norm_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13631488, 131072, 1024 }, } }, // shelves2_diff_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13762560, 131072, 1024 }, } }, // shelves2_nor_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13893632, 131072, 1024 }, } }, // shelves2_diff2_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 14024704, 131072, 1024 }, } }, // shelves2_nm2_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 14155776, 524288, 2048 }, } }, // marbel drum texture_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 14680064, 524288, 2048 }, } }, // marbel drum texture _Nrml_1024.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15204352, 131072, 1024 }, } }, // Catwalk_02_Diffuse512.dds
-        {     1,     1,   1,  DXGI_FORMAT_R8G8B8A8_UNORM, { { 15335424, 4, 4 }, } }, // default-normalmap.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15335428, 131072, 1024 }, } }, // Catwalk_03_Diffuse_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15466500, 131072, 1024 }, } }, // shelves3_diff_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15597572, 131072, 1024 }, } }, // shelves3_nor_512.dds
-        {  2048,  2048,   1,       DXGI_FORMAT_BC1_UNORM, { { 15728644, 2097152, 4096 }, } }, // Misc_Boss_3_2048.dds
-        {  2048,  2048,   1,       DXGI_FORMAT_BC1_UNORM, { { 17825796, 2097152, 4096 }, } }, // Misc_Boss_3_normal2048R.dds
-        {     1,     1,   1,  DXGI_FORMAT_R8G8B8A8_UNORM, { { 19922948, 4, 4 }, } }, // default.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 19922952, 131072, 1024 }, } }, // Hanghing Light_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20054024, 131072, 1024 }, } }, // Hanghing Light_normal_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20185096, 131072, 1024 }, } }, // Hanging_bundle_normal_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20316168, 131072, 1024 }, } }, // Hanging_bundle_marble_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20447240, 131072, 1024 }, } }, // Hanging_bundle_marble_normal_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20578312, 131072, 1024 }, } }, // window_Diff512.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 20709384, 262144, 1024 }, } }, // Sliding Steel Door_Diff_512.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 20971528, 262144, 1024 }, } }, // Sliding Steel Door_Norm_512.dds
-        {   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 21233672, 131072, 1024 }, } }, // window_Norm512.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 21364744, 262144, 1024 }, } }, // Door_Diff_512.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 21626888, 262144, 1024 }, } }, // Door_Norm_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 21889032, 524288, 2048 }, } }, // floor_Diff_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 22413320, 524288, 2048 }, } }, // floor_Normal_1024.dds
-        {  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 22937608, 1048576, 4096 }, } }, // wall03_Diff_2048.dds
-        {  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 23986184, 1048576, 4096 }, } }, // wall03_Normal_2048.dds
-        {  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 25034760, 1048576, 4096 }, } }, // wall01_Diff_2048.dds
-        {  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 26083336, 1048576, 4096 }, } }, // wall01_Normal_2048.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 27131912, 524288, 2048 }, } }, // Roof_Diff1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 27656200, 524288, 2048 }, } }, // Roof_Normal1024.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28180488, 262144, 1024 }, } }, // pillar_Diff_512.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28442632, 262144, 1024 }, } }, // pillar_Norm_512.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28704776, 262144, 1024 }, } }, // Broken_Pillar_Diff_512.dds
-        {   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28966920, 262144, 1024 }, } }, // Broken_Pillar_Norm_512.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 29229064, 524288, 2048 }, } }, // Golfclub_dm_1024.dds
-        {  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 29753352, 524288, 2048 }, } }, // Golfclub_nm_1024.dds
-    };
+	const TextureResource Textures[] =
+	{
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 0, 131072, 1024 }, } }, // squard room platform_3_diff_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 131072, 131072, 1024 }, } }, // squard room platform_3_norm_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 262144, 524288, 2048 }, } }, // squard room platform_2_diff_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 786432, 524288, 2048 }, } }, // squard room platform_2_norm_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 1310720, 524288, 2048 }, } }, // squard room platform_1_diff_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 1835008, 524288, 2048 }, } }, // squard room platform_1_norm_1024.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 2359296, 131072, 1024 }, } }, // shelves2_diff1_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 2490368, 131072, 1024 }, } }, // shelves2_nm1_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 2621440, 524288, 2048 }, } }, // Misc_Boss_2 1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 3145728, 524288, 2048 }, } }, // Misc_Boss_2_normal1024.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 3670016, 131072, 1024 }, } }, // Hanging_bundle_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 3801088, 131072, 1024 }, } }, // Catwalk_03_Normal_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 3932160, 524288, 2048 }, } }, // Stack_ Boxes_Diff02_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 4456448, 524288, 2048 }, } }, // Stack_ Boxes_Nm02_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 4980736, 524288, 2048 }, } }, // Stack_ Boxes_Diff03_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 5505024, 524288, 2048 }, } }, // Stack_ Boxes_Nm03_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 6029312, 524288, 2048 }, } }, // Stack_ Boxes_Diff01_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 6553600, 524288, 2048 }, } }, // Stack_ Boxes_Nm01_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 7077888, 524288, 2048 }, } }, // Back_Alley_box_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 7602176, 524288, 2048 }, } }, // Back_Alley_box _norm_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 8126464, 524288, 2048 }, } }, // gameCrates_01_Diff_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 8650752, 524288, 2048 }, } }, // gameCrates_01_Nor_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 9175040, 524288, 2048 }, } }, // RaceCar_Strorage_Diff512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 9699328, 524288, 2048 }, } }, // RaceCar_Strorage_Norm512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10223616, 131072, 1024 }, } }, // hats_02_diff_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10354688, 131072, 1024 }, } }, // hats_02_norm_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10485760, 131072, 1024 }, } }, // hats_01_diff_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 10616832, 131072, 1024 }, } }, // hats_01_norm_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 10747904, 524288, 2048 }, } }, // Misc_Boss_1_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 11272192, 524288, 2048 }, } }, // Misc_Boss_1_normal_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 11796480, 524288, 2048 }, } }, // gameCrates_03_Diff_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 12320768, 524288, 2048 }, } }, // gameCrates_03_Nor_1024.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 12845056, 131072, 1024 }, } }, // gameCrates_02_Diff_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 12976128, 524288, 2048 }, } }, // Back_Alley_Drum.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13500416, 131072, 1024 }, } }, // Back_Alley_Drum _norm_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13631488, 131072, 1024 }, } }, // shelves2_diff_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13762560, 131072, 1024 }, } }, // shelves2_nor_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 13893632, 131072, 1024 }, } }, // shelves2_diff2_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 14024704, 131072, 1024 }, } }, // shelves2_nm2_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 14155776, 524288, 2048 }, } }, // marbel drum texture_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 14680064, 524288, 2048 }, } }, // marbel drum texture _Nrml_1024.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15204352, 131072, 1024 }, } }, // Catwalk_02_Diffuse512.dds
+		{     1,     1,   1,  DXGI_FORMAT_R8G8B8A8_UNORM, { { 15335424, 4, 4 }, } }, // default-normalmap.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15335428, 131072, 1024 }, } }, // Catwalk_03_Diffuse_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15466500, 131072, 1024 }, } }, // shelves3_diff_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 15597572, 131072, 1024 }, } }, // shelves3_nor_512.dds
+		{  2048,  2048,   1,       DXGI_FORMAT_BC1_UNORM, { { 15728644, 2097152, 4096 }, } }, // Misc_Boss_3_2048.dds
+		{  2048,  2048,   1,       DXGI_FORMAT_BC1_UNORM, { { 17825796, 2097152, 4096 }, } }, // Misc_Boss_3_normal2048R.dds
+		{     1,     1,   1,  DXGI_FORMAT_R8G8B8A8_UNORM, { { 19922948, 4, 4 }, } }, // default.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 19922952, 131072, 1024 }, } }, // Hanghing Light_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20054024, 131072, 1024 }, } }, // Hanghing Light_normal_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20185096, 131072, 1024 }, } }, // Hanging_bundle_normal_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20316168, 131072, 1024 }, } }, // Hanging_bundle_marble_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20447240, 131072, 1024 }, } }, // Hanging_bundle_marble_normal_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 20578312, 131072, 1024 }, } }, // window_Diff512.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 20709384, 262144, 1024 }, } }, // Sliding Steel Door_Diff_512.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 20971528, 262144, 1024 }, } }, // Sliding Steel Door_Norm_512.dds
+		{   512,   512,   1,       DXGI_FORMAT_BC1_UNORM, { { 21233672, 131072, 1024 }, } }, // window_Norm512.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 21364744, 262144, 1024 }, } }, // Door_Diff_512.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 21626888, 262144, 1024 }, } }, // Door_Norm_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 21889032, 524288, 2048 }, } }, // floor_Diff_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 22413320, 524288, 2048 }, } }, // floor_Normal_1024.dds
+		{  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 22937608, 1048576, 4096 }, } }, // wall03_Diff_2048.dds
+		{  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 23986184, 1048576, 4096 }, } }, // wall03_Normal_2048.dds
+		{  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 25034760, 1048576, 4096 }, } }, // wall01_Diff_2048.dds
+		{  2048,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 26083336, 1048576, 4096 }, } }, // wall01_Normal_2048.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 27131912, 524288, 2048 }, } }, // Roof_Diff1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 27656200, 524288, 2048 }, } }, // Roof_Normal1024.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28180488, 262144, 1024 }, } }, // pillar_Diff_512.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28442632, 262144, 1024 }, } }, // pillar_Norm_512.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28704776, 262144, 1024 }, } }, // Broken_Pillar_Diff_512.dds
+		{   512,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 28966920, 262144, 1024 }, } }, // Broken_Pillar_Norm_512.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 29229064, 524288, 2048 }, } }, // Golfclub_dm_1024.dds
+		{  1024,  1024,   1,       DXGI_FORMAT_BC1_UNORM, { { 29753352, 524288, 2048 }, } }, // Golfclub_nm_1024.dds
+	};
 
-    const DrawParameters Draws[] =
-    {
-        {   0,   1,  -1,        0,    15198,        0 }, // subset0_squard_room_platform_3_dif1
-        {   2,   3,  -1,    15198,      438,     6051 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    15636,      300,     6164 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    15936,      300,     6225 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    16236,      438,     6286 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    16674,      300,     6399 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    16974,      438,     6460 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    17412,      300,     6573 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    17712,      450,     6634 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    18162,      300,     6756 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    18462,      438,     6817 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    18900,      300,     6930 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    19200,      300,     6991 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    19500,      438,     7052 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    19938,      300,     7165 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    20238,      438,     7226 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    20676,      300,     7339 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    20976,      300,     7400 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    21276,      438,     7461 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    21714,      300,     7574 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    22014,      438,     7635 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    22452,      300,     7748 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    22752,      450,     7809 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    23202,      300,     7931 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    23502,      438,     7992 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    23940,      300,     8105 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    24240,      300,     8166 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    24540,      438,     8227 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    24978,      300,     8340 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    25278,      438,     8401 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    25716,      300,     8514 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    26016,      300,     8575 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    26316,      438,     8636 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    26754,      300,     8749 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    27054,      438,     8810 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    27492,      300,     8923 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    27792,      300,     8984 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    28092,      438,     9045 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    28530,      300,     9158 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    28830,      438,     9219 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    29268,      300,     9332 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    29568,      450,     9393 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    30018,      300,     9515 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    30318,      438,     9576 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    30756,      300,     9689 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    31056,      300,     9750 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    31356,      438,     9811 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    31794,      300,     9924 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    32094,      438,     9985 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    32532,      300,    10098 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    32832,      450,    10159 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    33282,      300,    10281 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    33582,      438,    10342 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    34020,      300,    10455 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    34320,      300,    10516 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    34620,      438,    10577 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    35058,      300,    10690 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    35358,      900,    10751 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    36258,      282,    11016 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    36540,      282,    11142 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    36822,      222,    11228 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    37044,      282,    11304 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    37326,      282,    11396 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    37608,      282,    11485 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    37890,      243,    11577 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    38133,      222,    11665 }, // subset0_squard_room_platform_2_dif
-        {   2,   3,  -1,    38355,      282,    11743 }, // subset0_squard_room_platform_2_dif
-        {   4,   5,  -1,    38637,     2700,    11834 }, // subset0_squard_room_platform_1_diff
-        {   6,   7,  -1,    41337,     1788,    12560 }, // subset0_shelves1_diff
-        {   8,   9,  -1,    43125,      180,    13101 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43305,      180,    13138 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43485,       96,    13175 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43581,       96,    13202 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43677,       96,    13229 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43773,       96,    13256 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43869,       96,    13283 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43965,       30,    13310 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    43995,       24,    13322 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44019,       24,    13332 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44043,       24,    13342 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44067,       24,    13351 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44091,       54,    13360 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44145,       12,    13380 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44157,       72,    13386 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44229,       84,    13424 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44313,       30,    13448 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44343,        6,    13460 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44349,       36,    13464 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44385,       60,    13478 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44445,       72,    13496 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44517,       48,    13534 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44565,       24,    13549 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44589,       24,    13559 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44613,       24,    13569 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44637,       42,    13579 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44679,       12,    13595 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44691,       48,    13603 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44739,        6,    13625 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44745,       48,    13629 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44793,        6,    13644 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44799,       60,    13648 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44859,        6,    13666 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44865,       60,    13670 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44925,       72,    13688 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    44997,       48,    13709 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45045,       36,    13727 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45081,       72,    13741 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45153,       12,    13779 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45165,       12,    13785 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45177,       30,    13791 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45207,       36,    13803 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45243,        6,    13817 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45249,        6,    13821 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45255,       24,    13825 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45279,       24,    13835 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45303,       24,    13845 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45327,       96,    13855 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45423,       30,    13882 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45453,       96,    13894 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45549,       96,    13921 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45645,       72,    13948 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45717,       72,    13969 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45789,       42,    13990 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45831,       42,    14006 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45873,       54,    14022 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45927,       54,    14042 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    45981,       60,    14062 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46041,       60,    14080 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46101,       36,    14098 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46137,       12,    14112 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46149,       12,    14118 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46161,       12,    14124 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46173,       24,    14130 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46197,       24,    14140 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46221,       24,    14150 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46245,       24,    14160 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46269,       24,    14170 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46293,       48,    14180 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46341,       48,    14195 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46389,       48,    14210 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46437,       48,    14225 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46485,       48,    14240 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46533,       36,    14255 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46569,       36,    14269 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46605,       36,    14283 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46641,       36,    14297 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46677,       36,    14311 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46713,       72,    14325 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46785,       72,    14363 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46857,        6,    14401 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46863,        6,    14405 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46869,        6,    14409 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46875,       24,    14413 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46899,       24,    14422 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46923,       48,    14431 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    46971,       48,    14449 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47019,       12,    14464 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47031,       12,    14470 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47043,       12,    14476 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47055,       12,    14482 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47067,       12,    14488 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47079,       12,    14494 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47091,       12,    14500 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47103,       12,    14506 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47115,       24,    14512 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47139,       24,    14521 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47163,       60,    14530 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47223,       60,    14548 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47283,       60,    14566 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47343,       60,    14584 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47403,       60,    14602 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47463,       48,    14620 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47511,       48,    14642 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47559,       36,    14664 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47595,       36,    14678 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47631,       24,    14692 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47655,       12,    14701 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47667,       12,    14707 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47679,       12,    14713 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47691,       12,    14719 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47703,       12,    14725 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47715,       12,    14731 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47727,       12,    14737 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47739,        6,    14743 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47745,        6,    14747 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47751,        6,    14751 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47757,        6,    14755 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47763,       12,    14759 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47775,       12,    14765 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47787,       12,    14771 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47799,       12,    14777 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    47811,       60,    14783 }, // subset0_blinnMisc_Boss_2
-        {  10,  11,  -1,    47871,      762,    14801 }, // subset0_lambert1
-        {   8,   9,  -1,    48633,       66,    14801 }, // subset1_blinnMisc_Boss_2_0
-        {   8,   9,  -1,    48699,      144,    15136 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    48843,      144,    15171 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    48987,      144,    15206 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    49131,      144,    15241 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    49275,      180,    15276 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    49455,      144,    15318 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    49599,      144,    15353 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    49743,      144,    15388 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    49887,      180,    15423 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    50067,      180,    15465 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    50247,      144,    15507 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    50391,      180,    15542 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    50571,      144,    15584 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    50715,      108,    15619 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    50823,     4416,    15647 }, // subset0_blinnMisc_Boss_2
-        {   8,   9,  -1,    55239,      273,    16657 }, // subset0_blinnMisc_Boss_2
-        {  12,  13,  -1,    55512,     4143,    16754 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    59655,      360,    19212 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    60015,      300,    19293 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    60315,      360,    19359 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    60675,      240,    19436 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    60915,     1566,    19491 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62481,       48,    19889 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62529,       48,    19907 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62577,       48,    19925 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62625,       48,    19943 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62673,       48,    19961 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62721,       48,    19979 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62769,       96,    19997 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62865,       36,    20024 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62901,       36,    20038 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62937,       36,    20052 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    62973,       36,    20066 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63009,       36,    20080 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63045,       36,    20094 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63081,       36,    20108 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63117,       36,    20122 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63153,       36,    20136 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63189,       36,    20150 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63225,       36,    20164 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63261,      108,    20178 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63369,       36,    20206 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63405,       36,    20220 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63441,       36,    20234 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63477,       36,    20248 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63513,       36,    20262 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63549,       36,    20276 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63585,       36,    20290 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63621,       72,    20304 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63693,       72,    20325 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63765,      144,    20346 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63909,       72,    20381 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    63981,       36,    20402 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64017,       36,    20416 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64053,      144,    20430 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64197,      144,    20465 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64341,       36,    20500 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64377,       36,    20514 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64413,       36,    20528 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64449,       36,    20542 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64485,       36,    20556 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64521,       36,    20570 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64557,       36,    20584 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64593,       36,    20598 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64629,       36,    20612 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64665,       36,    20626 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64701,      252,    20640 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    64953,      276,    20816 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    65229,      276,    21014 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    65505,      276,    21200 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    65781,      294,    21394 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    66075,      279,    21582 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    66354,      264,    21732 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    66618,      288,    21898 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    66906,      468,    22065 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    67374,     1296,    22222 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    68670,       18,    22988 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    68688,       36,    22996 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    68724,       42,    23022 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    68766,       36,    23054 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    68802,       42,    23076 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    68844,      336,    23104 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    69180,      144,    23104 }, // subset1_lambert1_0
-        {  12,  13,  -1,    69324,      240,    23250 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    69564,      240,    23334 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    69804,      246,    23427 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    70050,      120,    23543 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    70170,      630,    23600 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    70800,     1080,    23743 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    71880,      720,    23991 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    72600,      204,    24154 }, // subset0_Stack__Boxes_Diff02
-        {  12,  13,  -1,    72804,      336,    24198 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    73140,      144,    24198 }, // subset1_lambert1_0
-        {  12,  13,  -1,    73284,      225,    24344 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    73509,       15,    24344 }, // subset1_lambert1_0
-        {  12,  13,  -1,    73524,      225,    24458 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    73749,       15,    24458 }, // subset1_lambert1_0
-        {  12,  13,  -1,    73764,      225,    24572 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    73989,       15,    24572 }, // subset1_lambert1_0
-        {  12,  13,  -1,    74004,      225,    24686 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    74229,       15,    24686 }, // subset1_lambert1_0
-        {  12,  13,  -1,    74244,      225,    24800 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    74469,       15,    24800 }, // subset1_lambert1_0
-        {  12,  13,  -1,    74484,      225,    24914 }, // subset0_Stack__Boxes_Diff02
-        {  10,  11,  -1,    74709,       15,    24914 }, // subset1_lambert1_0
-        {  14,  15,  -1,    74724,     2208,    25028 }, // subset0_Stack__Boxes_Diff03
-        {  16,  17,  -1,    76932,     9381,    25553 }, // subset0_Stack__Boxes_Diff01
-        {  18,  19,  -1,    86313,      948,    29643 }, // subset0_Back_Alley_box
-        {  20,  21,  -1,    87261,     1488,    29946 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,    88749,     1998,    30265 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,    90747,     1872,    30649 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,    92619,     1692,    31034 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,    94311,     1638,    31387 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,    95949,     1872,    31702 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,    97821,     1662,    32056 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,    99483,     1902,    32409 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   101385,      720,    32807 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   102105,     1296,    32957 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   103401,      432,    33232 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   103833,     1152,    33332 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   104985,     1152,    33557 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   106137,     1380,    33782 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   107517,     1470,    34080 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   108987,     1308,    34364 }, // subset0_gameCrates_01_Diff
-        {  20,  21,  -1,   110295,     1662,    34622 }, // subset0_gameCrates_01_Diff
-        {  22,  23,  -1,   111957,      636,    34941 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   112593,     1728,    35137 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   114321,      336,    35500 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   114657,     2304,    35577 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   116961,      246,    36138 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   117207,     1260,    36270 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   118467,     1866,    36512 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   120333,     2070,    36976 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   122403,     1050,    37421 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   123453,      450,    37624 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   123903,      450,    37760 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   124353,      390,    37896 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   124743,      390,    38021 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   125133,      390,    38148 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   125523,      330,    38273 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   125853,      390,    38387 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   126243,      330,    38512 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   126573,      420,    38626 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   126993,      390,    38763 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   127383,      300,    38888 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   127683,      300,    38961 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   127983,      300,    39045 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   128283,      300,    39131 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   128583,      300,    39215 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   128883,      300,    39286 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   129183,      300,    39410 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   129483,      300,    39483 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   129783,      300,    39567 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   130083,      300,    39653 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   130383,      300,    39737 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   130683,      300,    39808 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   130983,      300,    39968 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   131283,      300,    40041 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   131583,      300,    40125 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   131883,      300,    40211 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   132183,      300,    40295 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   132483,      300,    40366 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   132783,      300,    40490 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   133083,      300,    40561 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   133383,      300,    40721 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   133683,      300,    40794 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   133983,      300,    40878 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   134283,      300,    40964 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   134583,      300,    41048 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   134883,      300,    41119 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   135183,      300,    41243 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   135483,      300,    41314 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   135783,      300,    41474 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   136083,      300,    41547 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   136383,      300,    41631 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   136683,      300,    41717 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   136983,      300,    41801 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   137283,      300,    41872 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   137583,      300,    41996 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   137883,      300,    42069 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   138183,      300,    42153 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   138483,      300,    42239 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   138783,      300,    42323 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   139083,      300,    42394 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   139383,      300,    42554 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   139683,      300,    42627 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   139983,      300,    42711 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   140283,      300,    42797 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   140583,      300,    42881 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   140883,      300,    42952 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   141183,      300,    43076 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   141483,      300,    43149 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   141783,      300,    43349 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   142083,      300,    43551 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   142383,      300,    43751 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   142683,      300,    43951 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   142983,      300,    44151 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   143283,      300,    44351 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   143583,      300,    44551 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   143883,      300,    44751 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   144183,      300,    44951 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   144483,      300,    45153 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   144783,      300,    45353 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   145083,      300,    45553 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   145383,      300,    45753 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   145683,      300,    45953 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   145983,      300,    46153 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   146283,      300,    46353 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   146583,      300,    46553 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   146883,      300,    46755 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   147183,      300,    46955 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   147483,      300,    47155 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   147783,      300,    47355 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   148083,      300,    47555 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   148383,      300,    47755 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   148683,      300,    47955 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   148983,      300,    48155 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   149283,      300,    48355 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   149583,      300,    48557 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   149883,      300,    48757 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   150183,      300,    48957 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   150483,      300,    49157 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   150783,      216,    49357 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   150999,      216,    49455 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   151215,      216,    49553 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   151431,     1014,    49651 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   152445,      216,    49929 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   152661,     1014,    50029 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   153675,     1014,    50324 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   154689,     1014,    50614 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   155703,      588,    50894 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   156291,     5574,    51104 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   161865,      588,    52700 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   162453,      588,    52910 }, // subset0_RaceCar_Strorage_Diff
-        {  22,  23,  -1,   163041,      588,    53120 }, // subset0_RaceCar_Strorage_Diff
-        {  24,  25,  -1,   163629,       48,    53330 }, // subset0_hats_2
-        {  24,  25,  -1,   163677,      501,    53362 }, // subset0_hats_2
-        {  24,  25,  -1,   164178,      252,    53471 }, // subset0_hats_2
-        {  24,  25,  -1,   164430,       48,    53520 }, // subset0_hats_2
-        {  24,  25,  -1,   164478,     1620,    53552 }, // subset0_hats_2
-        {  24,  25,  -1,   166098,     3978,    53850 }, // subset0_hats_2
-        {  24,  25,  -1,   170076,      765,    54754 }, // subset0_hats_2
-        {  24,  25,  -1,   170841,      900,    54906 }, // subset0_hats_2
-        {  24,  25,  -1,   171741,     1260,    55154 }, // subset0_hats_2
-        {  24,  25,  -1,   173001,      408,    55431 }, // subset0_hats_2
-        {  24,  25,  -1,   173409,      765,    55546 }, // subset0_hats_2
-        {  24,  25,  -1,   174174,      720,    55694 }, // subset0_hats_2
-        {  24,  25,  -1,   174894,      252,    55894 }, // subset0_hats_2
-        {  24,  25,  -1,   175146,      252,    55943 }, // subset0_hats_2
-        {  24,  25,  -1,   175398,      252,    55992 }, // subset0_hats_2
-        {  24,  25,  -1,   175650,      252,    56041 }, // subset0_hats_2
-        {  24,  25,  -1,   175902,      252,    56090 }, // subset0_hats_2
-        {  24,  25,  -1,   176154,      252,    56139 }, // subset0_hats_2
-        {  24,  25,  -1,   176406,      252,    56188 }, // subset0_hats_2
-        {  24,  25,  -1,   176658,      252,    56237 }, // subset0_hats_2
-        {  26,  27,  -1,   176910,       48,    56286 }, // subset0_Hats_1
-        {  24,  25,  -1,   176958,     6792,    56318 }, // subset0_hats_2
-        {  24,  25,  -1,   183750,     2124,    57790 }, // subset0_hats_2
-        {  24,  25,  -1,   185874,     2268,    58361 }, // subset0_hats_2
-        {  24,  25,  -1,   188142,       66,    58938 }, // subset0_hats_2
-        {  24,  25,  -1,   188208,      270,    58973 }, // subset0_hats_2
-        {  24,  25,  -1,   188478,       48,    59080 }, // subset0_hats_2
-        {  24,  25,  -1,   188526,       66,    59111 }, // subset0_hats_2
-        {  24,  25,  -1,   188592,       60,    59148 }, // subset0_hats_2
-        {  24,  25,  -1,   188652,       66,    59178 }, // subset0_hats_2
-        {  24,  25,  -1,   188718,      168,    59215 }, // subset0_hats_2
-        {  24,  25,  -1,   188886,      168,    59275 }, // subset0_hats_2
-        {  24,  25,  -1,   189054,      174,    59333 }, // subset0_hats_2
-        {  24,  25,  -1,   189228,     1650,    59418 }, // subset0_hats_2
-        {  24,  25,  -1,   190878,      918,    59867 }, // subset0_hats_2
-        {  24,  25,  -1,   191796,      426,    60089 }, // subset0_hats_2
-        {  26,  27,  -1,   192222,     1209,    60211 }, // subset0_Hats_1
-        {  24,  25,  -1,   193431,      180,    60506 }, // subset0_hats_2
-        {  26,  27,  -1,   193611,      714,    60571 }, // subset0_Hats_1
-        {  26,  27,  -1,   194325,      426,    60759 }, // subset0_Hats_1
-        {  26,  27,  -1,   194751,      426,    60888 }, // subset0_Hats_1
-        {  26,  27,  -1,   195177,      432,    61010 }, // subset0_Hats_1
-        {  26,  27,  -1,   195609,      432,    61147 }, // subset0_Hats_1
-        {  26,  27,  -1,   196041,     1608,    61268 }, // subset0_Hats_1
-        {  28,  29,  -1,   197649,    18219,    61783 }, // subset0_Misc_Boss_1
-        {  16,  17,  -1,   215868,     2484,    69708 }, // subset0_Stack__Boxes_Diff01
-        {  16,  17,  -1,   218352,     2409,    71274 }, // subset0_Stack__Boxes_Diff01
-        {  16,  17,  -1,   220761,     2409,    72652 }, // subset0_Stack__Boxes_Diff01
-        {  16,  17,  -1,   223170,     2409,    74026 }, // subset0_Stack__Boxes_Diff01
-        {  16,  17,  -1,   225579,     1833,    75404 }, // subset0_Stack__Boxes_Diff01
-        {  30,  31,  -1,   227412,     3867,    76541 }, // subset0_gameCrates_03_Diff
-        {  30,  31,  -1,   231279,     3750,    78113 }, // subset0_gameCrates_03_Diff
-        {  16,  17,  -1,   235029,     2409,    79856 }, // subset0_Stack__Boxes_Diff01
-        {  16,  17,  -1,   237438,     2409,    81222 }, // subset0_Stack__Boxes_Diff01
-        {  30,  31,  -1,   239847,    12468,    82594 }, // subset0_gameCrates_03_Diff
-        {  30,  31,  -1,   252315,     3441,    88547 }, // subset0_gameCrates_03_Diff
-        {  32,  32,  -1,   255756,     1932,    89479 }, // subset0_gameCrates_02_Diff
-        {  14,  15,  -1,   257688,      984,    89905 }, // subset0_Stack__Boxes_Diff03
-        {  14,  15,  -1,   258672,      741,    90403 }, // subset0_Stack__Boxes_Diff03
-        {  14,  15,  -1,   259413,      426,    90727 }, // subset0_Stack__Boxes_Diff03
-        {  32,  32,  -1,   259839,     1419,    90932 }, // subset0_gameCrates_02_Diff
-        {  18,  19,  -1,   261258,     3090,    91251 }, // subset0_Back_Alley_box
-        {  14,  15,  -1,   264348,      573,    92286 }, // subset0_Stack__Boxes_Diff03
-        {  32,  32,  -1,   264921,     1176,    92524 }, // subset0_gameCrates_02_Diff
-        {  32,  32,  -1,   266097,      792,    92809 }, // subset0_gameCrates_02_Diff
-        {  14,  15,  -1,   266889,      573,    93047 }, // subset0_Stack__Boxes_Diff03
-        {  14,  15,  -1,   267462,      741,    93285 }, // subset0_Stack__Boxes_Diff03
-        {  18,  19,  -1,   268203,     1620,    93609 }, // subset0_Back_Alley_box
-        {  14,  15,  -1,   269823,      396,    94126 }, // subset0_Stack__Boxes_Diff03
-        {  14,  15,  -1,   270219,      396,    94281 }, // subset0_Stack__Boxes_Diff03
-        {  14,  15,  -1,   270615,      396,    94436 }, // subset0_Stack__Boxes_Diff03
-        {  32,  32,  -1,   271011,     1008,    94591 }, // subset0_gameCrates_02_Diff
-        {  32,  32,  -1,   272019,     2040,    94830 }, // subset0_gameCrates_02_Diff
-        {  14,  15,  -1,   274059,      468,    95269 }, // subset0_Stack__Boxes_Diff03
-        {  32,  32,  -1,   274527,     1236,    95437 }, // subset0_gameCrates_02_Diff
-        {  32,  32,  -1,   275763,      903,    95726 }, // subset0_gameCrates_02_Diff
-        {  32,  32,  -1,   276666,     1884,    95942 }, // subset0_gameCrates_02_Diff
-        {  32,  32,  -1,   278550,     2088,    96353 }, // subset0_gameCrates_02_Diff
-        {  32,  32,  -1,   280638,     1008,    96827 }, // subset0_gameCrates_02_Diff
-        {  33,  34,  -1,   281646,     1920,    97063 }, // subset0_Back_Alley_Drum
-        {  35,  36,  -1,   283566,     7809,    97728 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   291375,     8172,    99390 }, // subset0_shelves2_diff
-        {  37,  38,  -1,   299547,       12,   101144 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   299559,      132,   101150 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   299691,      132,   101218 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   299823,      228,   101286 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   300051,      228,   101382 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   300279,      228,   101485 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   300507,      228,   101581 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   300735,      228,   101689 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   300963,      228,   101785 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   301191,      852,   101881 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   302043,      702,   102217 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   302745,      372,   102461 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   303117,      564,   102637 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   303681,      324,   102857 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   304005,      324,   102977 }, // subset0_shelves2_diff1
-        {  37,  38,  -1,   304329,      588,   103097 }, // subset0_shelves2_diff1
-        {   6,   7,  -1,   304917,     1122,   103337 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   306039,      888,   103622 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   306927,       96,   103854 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   307023,       96,   103902 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   307119,      102,   103947 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   307221,       96,   103987 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   307317,       96,   104032 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   307413,      576,   104078 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   307989,       78,   104208 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   308067,      102,   104240 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   308169,       72,   104284 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   308241,      336,   104315 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   308577,      144,   104450 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   308721,      120,   104490 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   308841,      144,   104518 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   308985,      120,   104558 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   309105,      126,   104586 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   309231,      120,   104624 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   309351,      144,   104652 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   309495,      117,   104692 }, // subset0_shelves1_diff2
-        {   6,   7,  -1,   309612,     1572,   104720 }, // subset0_shelves1_diff2
-        {  39,  40,  -1,   311184,      540,   105150 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   311724,     2136,   105282 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   313860,       24,   105899 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   313884,       24,   105911 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   313908,       27,   105923 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   313935,     2964,   105936 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   316899,     2964,   106458 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   319863,      702,   106980 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   320565,      702,   107117 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   321267,      702,   107249 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   321969,      702,   107379 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   322671,     2964,   107511 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   325635,        6,   108033 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   325641,      432,   108037 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   326073,      429,   108130 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   326502,     2964,   108216 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   329466,     2106,   108738 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   331572,     2106,   109129 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   333678,      429,   109515 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   334107,     1794,   109614 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   335901,     2262,   109948 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   338163,     2964,   110365 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   341127,     2964,   110880 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   344091,     2964,   111402 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   347055,     2730,   111919 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   349785,     2964,   112407 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   352749,     2964,   112929 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   355713,     2964,   113444 }, // subset0_marbel_drum_phong
-        {  39,  40,  -1,   358677,     3276,   113961 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   361953,      780,   114605 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   362733,      936,   114773 }, // subset0_marbel_drum_blinn
-        {  39,  40,  -1,   363669,      936,   114969 }, // subset0_marbel_drum_blinn
-        {  41,  42,  -1,   364605,      108,   115165 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   364713,       81,   115185 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   364794,       81,   115225 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   364875,       81,   115255 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   364956,       81,   115287 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365037,      108,   115328 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365145,       81,   115348 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365226,       81,   115388 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365307,       81,   115418 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365388,      108,   115450 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365496,       81,   115470 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365577,      108,   115510 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365685,       81,   115530 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365766,       81,   115570 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365847,       81,   115602 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   365928,      108,   115641 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366036,       81,   115669 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366117,       81,   115709 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366198,       81,   115741 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366279,      108,   115780 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366387,       81,   115808 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366468,       81,   115847 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366549,       81,   115879 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366630,       81,   115909 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366711,      108,   115948 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366819,       81,   115976 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366900,       81,   116006 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   366981,      108,   116038 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367089,       81,   116066 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367170,       81,   116105 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367251,      108,   116137 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367359,       81,   116165 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367440,       81,   116204 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367521,      237,   116234 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367758,      216,   116293 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   367974,      216,   116348 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   368190,      240,   116398 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   368430,      216,   116453 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   368646,      216,   116503 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   368862,      324,   116558 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   369186,      108,   116650 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   369294,      324,   116688 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   369618,      108,   116780 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   369726,      324,   116818 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   370050,      108,   116910 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   370158,      324,   116948 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   370482,      108,   117040 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   370590,      324,   117078 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   370914,      108,   117170 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371022,      324,   117208 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371346,      108,   117300 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371454,       54,   117338 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371508,       54,   117357 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371562,       54,   117376 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371616,       54,   117395 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371670,       54,   117414 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   371724,       54,   117433 }, // subset0_blinnCatwalk
-        {  43,  11,  -1,   371778,      120,   117452 }, // subset0_Catwalk_03_Diffuse
-        {  43,  11,  -1,   371898,     3078,   117532 }, // subset0_Catwalk_03_Diffuse
-        {  43,  11,  -1,   374976,     4356,   118172 }, // subset0_Catwalk_03_Diffuse
-        {  43,  11,  -1,   379332,     4356,   119043 }, // subset0_Catwalk_03_Diffuse
-        {  43,  11,  -1,   383688,     4356,   119896 }, // subset0_Catwalk_03_Diffuse
-        {  43,  11,  -1,   388044,     3636,   120749 }, // subset0_Catwalk_03_Diffuse
-        {  41,  42,  -1,   391680,       72,   121481 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   391752,      162,   121513 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   391914,      324,   121553 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   392238,      144,   121630 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   392382,      144,   121665 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   392526,      162,   121705 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   392688,      324,   121745 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   393012,      144,   121822 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   393156,      144,   121857 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   393300,      162,   121897 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   393462,      360,   121937 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   393822,      144,   122014 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   393966,      144,   122049 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   394110,      162,   122084 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   394272,      324,   122124 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   394596,      153,   122194 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   394749,      144,   122234 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   394893,      162,   122269 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   395055,      324,   122309 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   395379,      144,   122379 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   395523,      144,   122419 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   395667,      162,   122459 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   395829,      324,   122503 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   396153,      150,   122573 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   396303,      144,   122621 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   396447,      162,   122661 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   396609,      324,   122701 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   396933,      144,   122778 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   397077,      144,   122818 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   397221,      162,   122853 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   397383,      324,   122897 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   397707,      141,   122967 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   397848,      144,   123006 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   397992,      162,   123041 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   398154,    19506,   123085 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   417660,    19506,   129867 }, // subset0_blinnCatwalk
-        {  43,  11,  -1,   437166,      120,   136640 }, // subset0_Catwalk_03_Diffuse
-        {  41,  42,  -1,   437286,       72,   136720 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437358,       24,   136752 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437382,       24,   136768 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437406,       24,   136784 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437430,       24,   136800 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437454,       24,   136816 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437478,       24,   136832 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437502,       24,   136848 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437526,       24,   136864 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437550,       24,   136880 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437574,       24,   136896 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437598,       24,   136912 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437622,       24,   136928 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437646,       24,   136944 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437670,       24,   136960 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437694,       24,   136976 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437718,       24,   136992 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437742,       24,   137008 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437766,       24,   137024 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437790,       24,   137040 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437814,       24,   137056 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437838,       24,   137072 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437862,       24,   137088 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437886,       24,   137104 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437910,       24,   137120 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437934,       24,   137136 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437958,       24,   137152 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   437982,       24,   137168 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438006,       24,   137184 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438030,       24,   137200 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438054,       24,   137216 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438078,       24,   137232 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438102,       24,   137248 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438126,       24,   137264 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438150,       24,   137280 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438174,       24,   137296 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438198,       24,   137312 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438222,       24,   137328 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438246,       24,   137344 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438270,       24,   137360 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438294,       24,   137376 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438318,       24,   137392 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438342,       24,   137408 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438366,       24,   137424 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438390,       24,   137440 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438414,       24,   137456 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438438,       24,   137472 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438462,       24,   137488 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438486,       24,   137504 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438510,       24,   137520 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438534,       24,   137536 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438558,       24,   137552 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438582,       24,   137568 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438606,       24,   137584 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438630,       24,   137600 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438654,       24,   137616 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438678,       24,   137632 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438702,       24,   137648 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438726,       24,   137664 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438750,       24,   137680 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438774,       24,   137696 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438798,       24,   137712 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438822,       24,   137728 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438846,       24,   137744 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438870,       24,   137760 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438894,       24,   137776 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438918,       24,   137792 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438942,       24,   137808 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438966,       24,   137824 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   438990,       24,   137840 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439014,       24,   137856 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439038,       24,   137872 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439062,       24,   137888 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439086,       24,   137904 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439110,       24,   137920 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439134,       24,   137936 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439158,       24,   137952 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439182,       24,   137968 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439206,       24,   137984 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439230,       24,   138000 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439254,       24,   138016 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439278,       24,   138032 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439302,       24,   138048 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439326,       24,   138064 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439350,       24,   138080 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439374,       24,   138096 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439398,       24,   138112 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439422,       24,   138128 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439446,       24,   138144 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439470,       24,   138160 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439494,       24,   138176 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439518,       24,   138192 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439542,       24,   138208 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439566,       24,   138224 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439590,       24,   138240 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439614,       24,   138256 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439638,       24,   138272 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439662,       24,   138288 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439686,       24,   138304 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439710,       24,   138320 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439734,       24,   138336 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439758,       24,   138352 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439782,       24,   138368 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439806,       24,   138384 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439830,       24,   138400 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439854,       24,   138416 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439878,       24,   138432 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439902,       24,   138448 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439926,       24,   138464 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439950,       24,   138480 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439974,       24,   138496 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   439998,       24,   138512 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440022,       24,   138528 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440046,       24,   138544 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440070,       24,   138560 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440094,       24,   138576 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440118,       24,   138592 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440142,       24,   138608 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440166,       24,   138624 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440190,       24,   138640 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440214,       24,   138656 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440238,       24,   138672 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440262,       24,   138688 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440286,       24,   138704 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440310,       24,   138720 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440334,       24,   138736 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440358,       24,   138752 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440382,       24,   138768 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440406,       24,   138784 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440430,       24,   138800 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440454,       24,   138816 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440478,       24,   138832 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440502,       24,   138848 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440526,       24,   138864 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440550,       24,   138880 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440574,       24,   138896 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440598,       24,   138912 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440622,       24,   138928 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440646,       24,   138944 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440670,       24,   138960 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440694,       24,   138976 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440718,       24,   138992 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440742,       24,   139008 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440766,       24,   139024 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440790,       24,   139040 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440814,       24,   139056 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440838,       24,   139072 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440862,       24,   139088 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440886,       24,   139104 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440910,       24,   139120 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440934,       24,   139136 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440958,       24,   139152 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   440982,       24,   139168 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441006,       24,   139184 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441030,       24,   139200 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441054,       24,   139216 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441078,       24,   139232 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441102,       24,   139248 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441126,       24,   139264 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441150,       24,   139280 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441174,       24,   139296 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441198,       24,   139312 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441222,       24,   139328 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441246,       24,   139344 }, // subset0_blinnCatwalk
-        {  41,  42,  -1,   441270,       24,   139360 }, // subset0_blinnCatwalk
-        {  44,  45,  -1,   441294,     2826,   139376 }, // subset0_shelves3_diff
-        {  35,  36,  -1,   444120,     2637,   139376 }, // subset1_shelves2_diff_0
-        {  14,  15,  -1,   446757,      636,   139376 }, // subset2_Stack__Boxes_Diff03_0
-        {  46,  47,  -1,   447393,       24,   141190 }, // subset0_blinn46
-        {  46,  47,  -1,   447417,      306,   141206 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   447723,      306,   141325 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   448029,      306,   141443 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   448335,      306,   141561 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   448641,      216,   141677 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   448857,     1812,   141759 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   450669,      306,   142479 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   450975,      222,   142604 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   451197,      132,   142704 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   451329,      222,   142754 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   451551,      306,   142854 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   451857,      132,   142975 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   451989,      222,   143025 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   452211,      306,   143125 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   452517,      306,   143247 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   452823,      132,   143370 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   452955,      222,   143420 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   453177,      132,   143520 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   453309,     1368,   143570 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   454677,     2484,   143914 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   457161,     5790,   144731 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   462951,     1836,   147045 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   464787,     3816,   147679 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   468603,    54240,   149038 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   522843,      792,   158991 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   523635,      792,   159136 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   524427,      216,   159281 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   524643,      216,   159363 }, // subset0_phongMisc_Boss_3_2048
-        {  46,  47,  -1,   524859,      216,   159445 }, // subset0_phongMisc_Boss_3_2048
-        {  48,  42,  -1,   525075,     1050,   159527 }, // subset0_LightBulbsColor
-        {  49,  50,  -1,   526125,     1128,   159773 }, // subset0_Hanghing_Light
-        {  10,  11,  -1,   527253,      540,   160003 }, // subset0_lambert1
-        {  10,  11,  -1,   527793,      225,   160123 }, // subset0_lambert1
-        {  49,  50,  -1,   528018,     2160,   160202 }, // subset0_Hanghing_Light
-        {  48,  42,  -1,   530178,     1050,   160707 }, // subset0_LightBulbsColor
-        {  49,  50,  -1,   531228,     1128,   160966 }, // subset0_Hanghing_Light
-        {  10,  11,  -1,   532356,      540,   161197 }, // subset0_lambert1
-        {  10,  11,  -1,   532896,      225,   161317 }, // subset0_lambert1
-        {  49,  50,  -1,   533121,     2160,   161391 }, // subset0_Hanghing_Light
-        {  48,  42,  -1,   535281,     1134,   161896 }, // subset0_LightBulbsColor
-        {  49,  50,  -1,   536415,     1128,   162168 }, // subset0_Hanghing_Light
-        {  49,  50,  -1,   537543,      600,   162399 }, // subset0_Hanghing_Light
-        {  49,  50,  -1,   538143,      225,   162531 }, // subset0_Hanghing_Light
-        {  49,  50,  -1,   538368,     2160,   162610 }, // subset0_Hanghing_Light
-        {  10,  51,  -1,   540528,      498,   163115 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   541026,      300,   163321 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   541326,      300,   163400 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   541626,      600,   163479 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   542226,      681,   163604 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   542907,      300,   163755 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   543207,      300,   163834 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   543507,      144,   163913 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   543651,      780,   163949 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   544431,      168,   164135 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   544599,      156,   164197 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   544755,      390,   164255 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   545145,     3702,   164393 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   548847,      468,   165239 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   549315,     1128,   165324 }, // subset0_Hanging_bundle
-        {  10,  51,  -1,   550443,      810,   165562 }, // subset0_Hanging_bundle
-        {  52,  53,  -1,   551253,      714,   165819 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   551967,      540,   165949 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   552507,     1080,   166048 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   553587,     1080,   166242 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   554667,      540,   166436 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   555207,      540,   166535 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   555747,     1080,   166642 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   556827,      540,   166836 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   557367,     1080,   166935 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   558447,     1080,   167129 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   559527,      540,   167323 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   560067,     1080,   167422 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   561147,     1080,   167616 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   562227,     1080,   167810 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   563307,     1080,   168001 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   564387,      714,   168195 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   565101,     1080,   168325 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   566181,      540,   168519 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   566721,      540,   168618 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   567261,      540,   168719 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   567801,     1080,   168818 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   568881,      540,   169012 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   569421,     1080,   169111 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   570501,      540,   169305 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   571041,      714,   169404 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   571755,     1080,   169534 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   572835,     1080,   169728 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   573915,      540,   169922 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   574455,      540,   170021 }, // subset0_Hanging_bundle_marble
-        {  52,  53,  -1,   574995,     1080,   170120 }, // subset0_Hanging_bundle_marble
-        {  10,  51,  -1,   576075,    17184,   170314 }, // subset0_Rope
-        {  10,  51,  -1,   593259,      576,   176140 }, // subset0_Rope
-        {  10,  51,  -1,   593835,     2556,   176293 }, // subset0_Rope
-        {  10,  51,  -1,   596391,     4032,   176950 }, // subset0_Rope
-        {  10,  51,  -1,   600423,     4284,   177857 }, // subset0_Rope
-        {  10,  51,  -1,   604707,     4536,   178939 }, // subset0_Rope
-        {  10,  51,  -1,   609243,     4536,   179837 }, // subset0_Rope
-        {  10,  51,  -1,   613779,      612,   180733 }, // subset0_Rope
-        {  44,  45,  -1,   614391,      396,   180879 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   614787,      600,   181009 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   615387,      600,   181216 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   615987,      744,   181423 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   616731,      729,   181680 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   617460,     1920,   181932 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   619380,      324,   182343 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   619704,     2274,   182475 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   621978,     1860,   182902 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   623838,     2376,   183256 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   626214,     2190,   183705 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   628404,     2280,   184118 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   630684,      840,   184550 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   631524,      840,   184754 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   632364,      840,   184958 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   633204,      840,   185162 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   634044,     1008,   185366 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   635052,     1332,   185608 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   636384,     1617,   185890 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   638001,     1410,   186290 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   639411,      948,   186589 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   640359,       90,   187035 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   640449,      504,   187055 }, // subset0_shelves3_diff
-        {  35,  36,  -1,   640953,      378,   187197 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   641331,      432,   187284 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   641763,      378,   187378 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   642141,     3120,   187462 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   645261,      402,   188387 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   645663,     2580,   188525 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   648243,     3180,   189008 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   651423,     2100,   189678 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   653523,     3180,   190158 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   656703,      180,   190828 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   656883,      276,   190872 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   657159,      180,   190970 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   657339,      180,   191014 }, // subset0_shelves2_diff
-        {  44,  45,  -1,   657519,      228,   191068 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   657747,      108,   191162 }, // subset0_shelves3_diff
-        {  35,  36,  -1,   657855,      192,   191197 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   658047,      192,   191271 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   658239,      192,   191345 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   658431,      168,   191419 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   658599,      168,   191485 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   658767,      168,   191551 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   658935,      192,   191617 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   659127,      192,   191691 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   659319,      168,   191765 }, // subset0_shelves2_diff
-        {  44,  45,  -1,   659487,     1617,   191831 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   661104,     1617,   192226 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   662721,     1617,   192605 }, // subset0_shelves3_diff
-        {  44,  45,  -1,   664338,       90,   192995 }, // subset0_shelves3_diff
-        {  54,  42,  -1,   664428,     1248,   193015 }, // subset0_Window
-        {  55,  56,  -1,   665676,     3312,   193319 }, // subset0_Sliding_Steel_Door
-        {  54,  57,  -1,   668988,      930,   194197 }, // subset0_window_Diff
-        {  58,  59,  -1,   669918,    12912,   194433 }, // subset0_Door2
-        {  60,  61,  -1,   682830,      969,   197161 }, // subset0_Floor
-        {  62,  63,  -1,   683799,     2037,   197482 }, // subset0_wall_4
-        {  62,  63,  -1,   685836,     3000,   198168 }, // subset0_wall_3
-        {  64,  65,  -1,   688836,     2205,   199986 }, // subset0_wall_1
-        {  64,  65,  -1,   691041,     1656,   200663 }, // subset0_wall_2
-        {  66,  67,  -1,   692697,     5424,   201041 }, // subset0_roof
-        {  68,  69,  -1,   698121,      939,   203677 }, // subset0_Pillar
-        {  66,  67,  -1,   699060,     1536,   203892 }, // subset0_roof
-        {  70,  71,  -1,   700596,      609,   204339 }, // subset0_Broken_Pillar_Diff
-        {  33,  34,  -1,   701205,     1920,   204469 }, // subset0_Back_Alley_Drum
-        {  33,  34,  -1,   703125,     1920,   205134 }, // subset0_Back_Alley_Drum
-        {  33,  34,  -1,   705045,     1920,   205799 }, // subset0_Back_Alley_Drum
-        {  35,  36,  -1,   706965,     7809,   206464 }, // subset0_shelves2_diff
-        {  14,  15,  -1,   714774,     1920,   208128 }, // subset0_Stack__Boxes_Diff03
-        {  33,  34,  -1,   716694,     1920,   208629 }, // subset0_Back_Alley_Drum
-        {  33,  34,  -1,   718614,     1920,   209294 }, // subset0_Back_Alley_Drum
-        {  33,  34,  -1,   720534,     1920,   209959 }, // subset0_Back_Alley_Drum
-        {  35,  36,  -1,   722454,     7809,   210624 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   730263,     7809,   212294 }, // subset0_shelves2_diff
-        {  35,  36,  -1,   738072,     7809,   213953 }, // subset0_shelves2_diff
-        {  32,  32,  -1,   745881,      783,   215619 }, // subset0_gameCrates_02_Diff
-        {  72,  73,  -1,   746664,    14451,   215808 }, // subset0_GolfBag:Golfclub
-        {  18,  19,  -1,   761115,     3096,   219093 }, // subset0_Back_Alley_box
-    };
+	const DrawParameters Draws[] =
+	{
+		{   0,   1,  -1,        0,    15198,        0 }, // subset0_squard_room_platform_3_dif1
+		{   2,   3,  -1,    15198,      438,     6051 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    15636,      300,     6164 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    15936,      300,     6225 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    16236,      438,     6286 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    16674,      300,     6399 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    16974,      438,     6460 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    17412,      300,     6573 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    17712,      450,     6634 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    18162,      300,     6756 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    18462,      438,     6817 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    18900,      300,     6930 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    19200,      300,     6991 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    19500,      438,     7052 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    19938,      300,     7165 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    20238,      438,     7226 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    20676,      300,     7339 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    20976,      300,     7400 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    21276,      438,     7461 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    21714,      300,     7574 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    22014,      438,     7635 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    22452,      300,     7748 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    22752,      450,     7809 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    23202,      300,     7931 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    23502,      438,     7992 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    23940,      300,     8105 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    24240,      300,     8166 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    24540,      438,     8227 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    24978,      300,     8340 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    25278,      438,     8401 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    25716,      300,     8514 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    26016,      300,     8575 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    26316,      438,     8636 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    26754,      300,     8749 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    27054,      438,     8810 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    27492,      300,     8923 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    27792,      300,     8984 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    28092,      438,     9045 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    28530,      300,     9158 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    28830,      438,     9219 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    29268,      300,     9332 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    29568,      450,     9393 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    30018,      300,     9515 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    30318,      438,     9576 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    30756,      300,     9689 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    31056,      300,     9750 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    31356,      438,     9811 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    31794,      300,     9924 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    32094,      438,     9985 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    32532,      300,    10098 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    32832,      450,    10159 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    33282,      300,    10281 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    33582,      438,    10342 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    34020,      300,    10455 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    34320,      300,    10516 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    34620,      438,    10577 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    35058,      300,    10690 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    35358,      900,    10751 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    36258,      282,    11016 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    36540,      282,    11142 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    36822,      222,    11228 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    37044,      282,    11304 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    37326,      282,    11396 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    37608,      282,    11485 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    37890,      243,    11577 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    38133,      222,    11665 }, // subset0_squard_room_platform_2_dif
+		{   2,   3,  -1,    38355,      282,    11743 }, // subset0_squard_room_platform_2_dif
+		{   4,   5,  -1,    38637,     2700,    11834 }, // subset0_squard_room_platform_1_diff
+		{   6,   7,  -1,    41337,     1788,    12560 }, // subset0_shelves1_diff
+		{   8,   9,  -1,    43125,      180,    13101 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43305,      180,    13138 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43485,       96,    13175 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43581,       96,    13202 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43677,       96,    13229 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43773,       96,    13256 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43869,       96,    13283 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43965,       30,    13310 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    43995,       24,    13322 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44019,       24,    13332 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44043,       24,    13342 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44067,       24,    13351 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44091,       54,    13360 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44145,       12,    13380 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44157,       72,    13386 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44229,       84,    13424 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44313,       30,    13448 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44343,        6,    13460 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44349,       36,    13464 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44385,       60,    13478 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44445,       72,    13496 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44517,       48,    13534 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44565,       24,    13549 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44589,       24,    13559 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44613,       24,    13569 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44637,       42,    13579 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44679,       12,    13595 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44691,       48,    13603 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44739,        6,    13625 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44745,       48,    13629 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44793,        6,    13644 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44799,       60,    13648 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44859,        6,    13666 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44865,       60,    13670 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44925,       72,    13688 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    44997,       48,    13709 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45045,       36,    13727 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45081,       72,    13741 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45153,       12,    13779 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45165,       12,    13785 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45177,       30,    13791 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45207,       36,    13803 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45243,        6,    13817 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45249,        6,    13821 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45255,       24,    13825 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45279,       24,    13835 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45303,       24,    13845 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45327,       96,    13855 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45423,       30,    13882 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45453,       96,    13894 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45549,       96,    13921 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45645,       72,    13948 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45717,       72,    13969 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45789,       42,    13990 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45831,       42,    14006 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45873,       54,    14022 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45927,       54,    14042 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    45981,       60,    14062 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46041,       60,    14080 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46101,       36,    14098 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46137,       12,    14112 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46149,       12,    14118 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46161,       12,    14124 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46173,       24,    14130 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46197,       24,    14140 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46221,       24,    14150 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46245,       24,    14160 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46269,       24,    14170 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46293,       48,    14180 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46341,       48,    14195 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46389,       48,    14210 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46437,       48,    14225 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46485,       48,    14240 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46533,       36,    14255 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46569,       36,    14269 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46605,       36,    14283 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46641,       36,    14297 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46677,       36,    14311 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46713,       72,    14325 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46785,       72,    14363 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46857,        6,    14401 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46863,        6,    14405 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46869,        6,    14409 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46875,       24,    14413 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46899,       24,    14422 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46923,       48,    14431 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    46971,       48,    14449 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47019,       12,    14464 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47031,       12,    14470 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47043,       12,    14476 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47055,       12,    14482 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47067,       12,    14488 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47079,       12,    14494 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47091,       12,    14500 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47103,       12,    14506 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47115,       24,    14512 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47139,       24,    14521 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47163,       60,    14530 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47223,       60,    14548 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47283,       60,    14566 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47343,       60,    14584 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47403,       60,    14602 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47463,       48,    14620 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47511,       48,    14642 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47559,       36,    14664 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47595,       36,    14678 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47631,       24,    14692 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47655,       12,    14701 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47667,       12,    14707 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47679,       12,    14713 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47691,       12,    14719 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47703,       12,    14725 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47715,       12,    14731 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47727,       12,    14737 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47739,        6,    14743 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47745,        6,    14747 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47751,        6,    14751 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47757,        6,    14755 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47763,       12,    14759 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47775,       12,    14765 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47787,       12,    14771 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47799,       12,    14777 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    47811,       60,    14783 }, // subset0_blinnMisc_Boss_2
+		{  10,  11,  -1,    47871,      762,    14801 }, // subset0_lambert1
+		{   8,   9,  -1,    48633,       66,    14801 }, // subset1_blinnMisc_Boss_2_0
+		{   8,   9,  -1,    48699,      144,    15136 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    48843,      144,    15171 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    48987,      144,    15206 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    49131,      144,    15241 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    49275,      180,    15276 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    49455,      144,    15318 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    49599,      144,    15353 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    49743,      144,    15388 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    49887,      180,    15423 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    50067,      180,    15465 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    50247,      144,    15507 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    50391,      180,    15542 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    50571,      144,    15584 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    50715,      108,    15619 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    50823,     4416,    15647 }, // subset0_blinnMisc_Boss_2
+		{   8,   9,  -1,    55239,      273,    16657 }, // subset0_blinnMisc_Boss_2
+		{  12,  13,  -1,    55512,     4143,    16754 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    59655,      360,    19212 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    60015,      300,    19293 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    60315,      360,    19359 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    60675,      240,    19436 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    60915,     1566,    19491 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62481,       48,    19889 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62529,       48,    19907 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62577,       48,    19925 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62625,       48,    19943 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62673,       48,    19961 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62721,       48,    19979 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62769,       96,    19997 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62865,       36,    20024 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62901,       36,    20038 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62937,       36,    20052 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    62973,       36,    20066 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63009,       36,    20080 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63045,       36,    20094 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63081,       36,    20108 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63117,       36,    20122 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63153,       36,    20136 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63189,       36,    20150 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63225,       36,    20164 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63261,      108,    20178 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63369,       36,    20206 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63405,       36,    20220 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63441,       36,    20234 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63477,       36,    20248 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63513,       36,    20262 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63549,       36,    20276 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63585,       36,    20290 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63621,       72,    20304 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63693,       72,    20325 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63765,      144,    20346 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63909,       72,    20381 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    63981,       36,    20402 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64017,       36,    20416 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64053,      144,    20430 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64197,      144,    20465 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64341,       36,    20500 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64377,       36,    20514 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64413,       36,    20528 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64449,       36,    20542 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64485,       36,    20556 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64521,       36,    20570 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64557,       36,    20584 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64593,       36,    20598 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64629,       36,    20612 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64665,       36,    20626 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64701,      252,    20640 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    64953,      276,    20816 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    65229,      276,    21014 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    65505,      276,    21200 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    65781,      294,    21394 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    66075,      279,    21582 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    66354,      264,    21732 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    66618,      288,    21898 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    66906,      468,    22065 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    67374,     1296,    22222 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    68670,       18,    22988 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    68688,       36,    22996 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    68724,       42,    23022 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    68766,       36,    23054 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    68802,       42,    23076 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    68844,      336,    23104 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    69180,      144,    23104 }, // subset1_lambert1_0
+		{  12,  13,  -1,    69324,      240,    23250 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    69564,      240,    23334 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    69804,      246,    23427 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    70050,      120,    23543 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    70170,      630,    23600 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    70800,     1080,    23743 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    71880,      720,    23991 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    72600,      204,    24154 }, // subset0_Stack__Boxes_Diff02
+		{  12,  13,  -1,    72804,      336,    24198 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    73140,      144,    24198 }, // subset1_lambert1_0
+		{  12,  13,  -1,    73284,      225,    24344 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    73509,       15,    24344 }, // subset1_lambert1_0
+		{  12,  13,  -1,    73524,      225,    24458 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    73749,       15,    24458 }, // subset1_lambert1_0
+		{  12,  13,  -1,    73764,      225,    24572 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    73989,       15,    24572 }, // subset1_lambert1_0
+		{  12,  13,  -1,    74004,      225,    24686 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    74229,       15,    24686 }, // subset1_lambert1_0
+		{  12,  13,  -1,    74244,      225,    24800 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    74469,       15,    24800 }, // subset1_lambert1_0
+		{  12,  13,  -1,    74484,      225,    24914 }, // subset0_Stack__Boxes_Diff02
+		{  10,  11,  -1,    74709,       15,    24914 }, // subset1_lambert1_0
+		{  14,  15,  -1,    74724,     2208,    25028 }, // subset0_Stack__Boxes_Diff03
+		{  16,  17,  -1,    76932,     9381,    25553 }, // subset0_Stack__Boxes_Diff01
+		{  18,  19,  -1,    86313,      948,    29643 }, // subset0_Back_Alley_box
+		{  20,  21,  -1,    87261,     1488,    29946 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,    88749,     1998,    30265 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,    90747,     1872,    30649 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,    92619,     1692,    31034 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,    94311,     1638,    31387 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,    95949,     1872,    31702 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,    97821,     1662,    32056 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,    99483,     1902,    32409 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   101385,      720,    32807 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   102105,     1296,    32957 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   103401,      432,    33232 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   103833,     1152,    33332 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   104985,     1152,    33557 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   106137,     1380,    33782 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   107517,     1470,    34080 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   108987,     1308,    34364 }, // subset0_gameCrates_01_Diff
+		{  20,  21,  -1,   110295,     1662,    34622 }, // subset0_gameCrates_01_Diff
+		{  22,  23,  -1,   111957,      636,    34941 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   112593,     1728,    35137 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   114321,      336,    35500 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   114657,     2304,    35577 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   116961,      246,    36138 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   117207,     1260,    36270 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   118467,     1866,    36512 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   120333,     2070,    36976 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   122403,     1050,    37421 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   123453,      450,    37624 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   123903,      450,    37760 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   124353,      390,    37896 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   124743,      390,    38021 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   125133,      390,    38148 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   125523,      330,    38273 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   125853,      390,    38387 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   126243,      330,    38512 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   126573,      420,    38626 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   126993,      390,    38763 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   127383,      300,    38888 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   127683,      300,    38961 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   127983,      300,    39045 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   128283,      300,    39131 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   128583,      300,    39215 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   128883,      300,    39286 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   129183,      300,    39410 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   129483,      300,    39483 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   129783,      300,    39567 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   130083,      300,    39653 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   130383,      300,    39737 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   130683,      300,    39808 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   130983,      300,    39968 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   131283,      300,    40041 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   131583,      300,    40125 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   131883,      300,    40211 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   132183,      300,    40295 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   132483,      300,    40366 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   132783,      300,    40490 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   133083,      300,    40561 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   133383,      300,    40721 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   133683,      300,    40794 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   133983,      300,    40878 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   134283,      300,    40964 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   134583,      300,    41048 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   134883,      300,    41119 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   135183,      300,    41243 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   135483,      300,    41314 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   135783,      300,    41474 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   136083,      300,    41547 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   136383,      300,    41631 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   136683,      300,    41717 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   136983,      300,    41801 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   137283,      300,    41872 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   137583,      300,    41996 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   137883,      300,    42069 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   138183,      300,    42153 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   138483,      300,    42239 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   138783,      300,    42323 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   139083,      300,    42394 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   139383,      300,    42554 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   139683,      300,    42627 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   139983,      300,    42711 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   140283,      300,    42797 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   140583,      300,    42881 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   140883,      300,    42952 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   141183,      300,    43076 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   141483,      300,    43149 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   141783,      300,    43349 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   142083,      300,    43551 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   142383,      300,    43751 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   142683,      300,    43951 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   142983,      300,    44151 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   143283,      300,    44351 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   143583,      300,    44551 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   143883,      300,    44751 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   144183,      300,    44951 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   144483,      300,    45153 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   144783,      300,    45353 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   145083,      300,    45553 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   145383,      300,    45753 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   145683,      300,    45953 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   145983,      300,    46153 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   146283,      300,    46353 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   146583,      300,    46553 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   146883,      300,    46755 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   147183,      300,    46955 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   147483,      300,    47155 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   147783,      300,    47355 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   148083,      300,    47555 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   148383,      300,    47755 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   148683,      300,    47955 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   148983,      300,    48155 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   149283,      300,    48355 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   149583,      300,    48557 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   149883,      300,    48757 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   150183,      300,    48957 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   150483,      300,    49157 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   150783,      216,    49357 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   150999,      216,    49455 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   151215,      216,    49553 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   151431,     1014,    49651 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   152445,      216,    49929 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   152661,     1014,    50029 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   153675,     1014,    50324 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   154689,     1014,    50614 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   155703,      588,    50894 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   156291,     5574,    51104 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   161865,      588,    52700 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   162453,      588,    52910 }, // subset0_RaceCar_Strorage_Diff
+		{  22,  23,  -1,   163041,      588,    53120 }, // subset0_RaceCar_Strorage_Diff
+		{  24,  25,  -1,   163629,       48,    53330 }, // subset0_hats_2
+		{  24,  25,  -1,   163677,      501,    53362 }, // subset0_hats_2
+		{  24,  25,  -1,   164178,      252,    53471 }, // subset0_hats_2
+		{  24,  25,  -1,   164430,       48,    53520 }, // subset0_hats_2
+		{  24,  25,  -1,   164478,     1620,    53552 }, // subset0_hats_2
+		{  24,  25,  -1,   166098,     3978,    53850 }, // subset0_hats_2
+		{  24,  25,  -1,   170076,      765,    54754 }, // subset0_hats_2
+		{  24,  25,  -1,   170841,      900,    54906 }, // subset0_hats_2
+		{  24,  25,  -1,   171741,     1260,    55154 }, // subset0_hats_2
+		{  24,  25,  -1,   173001,      408,    55431 }, // subset0_hats_2
+		{  24,  25,  -1,   173409,      765,    55546 }, // subset0_hats_2
+		{  24,  25,  -1,   174174,      720,    55694 }, // subset0_hats_2
+		{  24,  25,  -1,   174894,      252,    55894 }, // subset0_hats_2
+		{  24,  25,  -1,   175146,      252,    55943 }, // subset0_hats_2
+		{  24,  25,  -1,   175398,      252,    55992 }, // subset0_hats_2
+		{  24,  25,  -1,   175650,      252,    56041 }, // subset0_hats_2
+		{  24,  25,  -1,   175902,      252,    56090 }, // subset0_hats_2
+		{  24,  25,  -1,   176154,      252,    56139 }, // subset0_hats_2
+		{  24,  25,  -1,   176406,      252,    56188 }, // subset0_hats_2
+		{  24,  25,  -1,   176658,      252,    56237 }, // subset0_hats_2
+		{  26,  27,  -1,   176910,       48,    56286 }, // subset0_Hats_1
+		{  24,  25,  -1,   176958,     6792,    56318 }, // subset0_hats_2
+		{  24,  25,  -1,   183750,     2124,    57790 }, // subset0_hats_2
+		{  24,  25,  -1,   185874,     2268,    58361 }, // subset0_hats_2
+		{  24,  25,  -1,   188142,       66,    58938 }, // subset0_hats_2
+		{  24,  25,  -1,   188208,      270,    58973 }, // subset0_hats_2
+		{  24,  25,  -1,   188478,       48,    59080 }, // subset0_hats_2
+		{  24,  25,  -1,   188526,       66,    59111 }, // subset0_hats_2
+		{  24,  25,  -1,   188592,       60,    59148 }, // subset0_hats_2
+		{  24,  25,  -1,   188652,       66,    59178 }, // subset0_hats_2
+		{  24,  25,  -1,   188718,      168,    59215 }, // subset0_hats_2
+		{  24,  25,  -1,   188886,      168,    59275 }, // subset0_hats_2
+		{  24,  25,  -1,   189054,      174,    59333 }, // subset0_hats_2
+		{  24,  25,  -1,   189228,     1650,    59418 }, // subset0_hats_2
+		{  24,  25,  -1,   190878,      918,    59867 }, // subset0_hats_2
+		{  24,  25,  -1,   191796,      426,    60089 }, // subset0_hats_2
+		{  26,  27,  -1,   192222,     1209,    60211 }, // subset0_Hats_1
+		{  24,  25,  -1,   193431,      180,    60506 }, // subset0_hats_2
+		{  26,  27,  -1,   193611,      714,    60571 }, // subset0_Hats_1
+		{  26,  27,  -1,   194325,      426,    60759 }, // subset0_Hats_1
+		{  26,  27,  -1,   194751,      426,    60888 }, // subset0_Hats_1
+		{  26,  27,  -1,   195177,      432,    61010 }, // subset0_Hats_1
+		{  26,  27,  -1,   195609,      432,    61147 }, // subset0_Hats_1
+		{  26,  27,  -1,   196041,     1608,    61268 }, // subset0_Hats_1
+		{  28,  29,  -1,   197649,    18219,    61783 }, // subset0_Misc_Boss_1
+		{  16,  17,  -1,   215868,     2484,    69708 }, // subset0_Stack__Boxes_Diff01
+		{  16,  17,  -1,   218352,     2409,    71274 }, // subset0_Stack__Boxes_Diff01
+		{  16,  17,  -1,   220761,     2409,    72652 }, // subset0_Stack__Boxes_Diff01
+		{  16,  17,  -1,   223170,     2409,    74026 }, // subset0_Stack__Boxes_Diff01
+		{  16,  17,  -1,   225579,     1833,    75404 }, // subset0_Stack__Boxes_Diff01
+		{  30,  31,  -1,   227412,     3867,    76541 }, // subset0_gameCrates_03_Diff
+		{  30,  31,  -1,   231279,     3750,    78113 }, // subset0_gameCrates_03_Diff
+		{  16,  17,  -1,   235029,     2409,    79856 }, // subset0_Stack__Boxes_Diff01
+		{  16,  17,  -1,   237438,     2409,    81222 }, // subset0_Stack__Boxes_Diff01
+		{  30,  31,  -1,   239847,    12468,    82594 }, // subset0_gameCrates_03_Diff
+		{  30,  31,  -1,   252315,     3441,    88547 }, // subset0_gameCrates_03_Diff
+		{  32,  32,  -1,   255756,     1932,    89479 }, // subset0_gameCrates_02_Diff
+		{  14,  15,  -1,   257688,      984,    89905 }, // subset0_Stack__Boxes_Diff03
+		{  14,  15,  -1,   258672,      741,    90403 }, // subset0_Stack__Boxes_Diff03
+		{  14,  15,  -1,   259413,      426,    90727 }, // subset0_Stack__Boxes_Diff03
+		{  32,  32,  -1,   259839,     1419,    90932 }, // subset0_gameCrates_02_Diff
+		{  18,  19,  -1,   261258,     3090,    91251 }, // subset0_Back_Alley_box
+		{  14,  15,  -1,   264348,      573,    92286 }, // subset0_Stack__Boxes_Diff03
+		{  32,  32,  -1,   264921,     1176,    92524 }, // subset0_gameCrates_02_Diff
+		{  32,  32,  -1,   266097,      792,    92809 }, // subset0_gameCrates_02_Diff
+		{  14,  15,  -1,   266889,      573,    93047 }, // subset0_Stack__Boxes_Diff03
+		{  14,  15,  -1,   267462,      741,    93285 }, // subset0_Stack__Boxes_Diff03
+		{  18,  19,  -1,   268203,     1620,    93609 }, // subset0_Back_Alley_box
+		{  14,  15,  -1,   269823,      396,    94126 }, // subset0_Stack__Boxes_Diff03
+		{  14,  15,  -1,   270219,      396,    94281 }, // subset0_Stack__Boxes_Diff03
+		{  14,  15,  -1,   270615,      396,    94436 }, // subset0_Stack__Boxes_Diff03
+		{  32,  32,  -1,   271011,     1008,    94591 }, // subset0_gameCrates_02_Diff
+		{  32,  32,  -1,   272019,     2040,    94830 }, // subset0_gameCrates_02_Diff
+		{  14,  15,  -1,   274059,      468,    95269 }, // subset0_Stack__Boxes_Diff03
+		{  32,  32,  -1,   274527,     1236,    95437 }, // subset0_gameCrates_02_Diff
+		{  32,  32,  -1,   275763,      903,    95726 }, // subset0_gameCrates_02_Diff
+		{  32,  32,  -1,   276666,     1884,    95942 }, // subset0_gameCrates_02_Diff
+		{  32,  32,  -1,   278550,     2088,    96353 }, // subset0_gameCrates_02_Diff
+		{  32,  32,  -1,   280638,     1008,    96827 }, // subset0_gameCrates_02_Diff
+		{  33,  34,  -1,   281646,     1920,    97063 }, // subset0_Back_Alley_Drum
+		{  35,  36,  -1,   283566,     7809,    97728 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   291375,     8172,    99390 }, // subset0_shelves2_diff
+		{  37,  38,  -1,   299547,       12,   101144 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   299559,      132,   101150 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   299691,      132,   101218 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   299823,      228,   101286 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   300051,      228,   101382 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   300279,      228,   101485 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   300507,      228,   101581 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   300735,      228,   101689 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   300963,      228,   101785 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   301191,      852,   101881 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   302043,      702,   102217 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   302745,      372,   102461 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   303117,      564,   102637 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   303681,      324,   102857 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   304005,      324,   102977 }, // subset0_shelves2_diff1
+		{  37,  38,  -1,   304329,      588,   103097 }, // subset0_shelves2_diff1
+		{   6,   7,  -1,   304917,     1122,   103337 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   306039,      888,   103622 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   306927,       96,   103854 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   307023,       96,   103902 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   307119,      102,   103947 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   307221,       96,   103987 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   307317,       96,   104032 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   307413,      576,   104078 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   307989,       78,   104208 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   308067,      102,   104240 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   308169,       72,   104284 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   308241,      336,   104315 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   308577,      144,   104450 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   308721,      120,   104490 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   308841,      144,   104518 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   308985,      120,   104558 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   309105,      126,   104586 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   309231,      120,   104624 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   309351,      144,   104652 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   309495,      117,   104692 }, // subset0_shelves1_diff2
+		{   6,   7,  -1,   309612,     1572,   104720 }, // subset0_shelves1_diff2
+		{  39,  40,  -1,   311184,      540,   105150 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   311724,     2136,   105282 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   313860,       24,   105899 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   313884,       24,   105911 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   313908,       27,   105923 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   313935,     2964,   105936 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   316899,     2964,   106458 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   319863,      702,   106980 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   320565,      702,   107117 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   321267,      702,   107249 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   321969,      702,   107379 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   322671,     2964,   107511 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   325635,        6,   108033 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   325641,      432,   108037 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   326073,      429,   108130 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   326502,     2964,   108216 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   329466,     2106,   108738 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   331572,     2106,   109129 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   333678,      429,   109515 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   334107,     1794,   109614 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   335901,     2262,   109948 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   338163,     2964,   110365 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   341127,     2964,   110880 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   344091,     2964,   111402 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   347055,     2730,   111919 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   349785,     2964,   112407 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   352749,     2964,   112929 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   355713,     2964,   113444 }, // subset0_marbel_drum_phong
+		{  39,  40,  -1,   358677,     3276,   113961 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   361953,      780,   114605 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   362733,      936,   114773 }, // subset0_marbel_drum_blinn
+		{  39,  40,  -1,   363669,      936,   114969 }, // subset0_marbel_drum_blinn
+		{  41,  42,  -1,   364605,      108,   115165 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   364713,       81,   115185 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   364794,       81,   115225 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   364875,       81,   115255 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   364956,       81,   115287 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365037,      108,   115328 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365145,       81,   115348 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365226,       81,   115388 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365307,       81,   115418 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365388,      108,   115450 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365496,       81,   115470 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365577,      108,   115510 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365685,       81,   115530 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365766,       81,   115570 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365847,       81,   115602 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   365928,      108,   115641 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366036,       81,   115669 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366117,       81,   115709 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366198,       81,   115741 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366279,      108,   115780 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366387,       81,   115808 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366468,       81,   115847 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366549,       81,   115879 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366630,       81,   115909 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366711,      108,   115948 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366819,       81,   115976 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366900,       81,   116006 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   366981,      108,   116038 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367089,       81,   116066 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367170,       81,   116105 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367251,      108,   116137 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367359,       81,   116165 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367440,       81,   116204 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367521,      237,   116234 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367758,      216,   116293 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   367974,      216,   116348 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   368190,      240,   116398 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   368430,      216,   116453 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   368646,      216,   116503 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   368862,      324,   116558 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   369186,      108,   116650 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   369294,      324,   116688 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   369618,      108,   116780 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   369726,      324,   116818 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   370050,      108,   116910 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   370158,      324,   116948 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   370482,      108,   117040 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   370590,      324,   117078 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   370914,      108,   117170 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371022,      324,   117208 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371346,      108,   117300 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371454,       54,   117338 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371508,       54,   117357 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371562,       54,   117376 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371616,       54,   117395 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371670,       54,   117414 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   371724,       54,   117433 }, // subset0_blinnCatwalk
+		{  43,  11,  -1,   371778,      120,   117452 }, // subset0_Catwalk_03_Diffuse
+		{  43,  11,  -1,   371898,     3078,   117532 }, // subset0_Catwalk_03_Diffuse
+		{  43,  11,  -1,   374976,     4356,   118172 }, // subset0_Catwalk_03_Diffuse
+		{  43,  11,  -1,   379332,     4356,   119043 }, // subset0_Catwalk_03_Diffuse
+		{  43,  11,  -1,   383688,     4356,   119896 }, // subset0_Catwalk_03_Diffuse
+		{  43,  11,  -1,   388044,     3636,   120749 }, // subset0_Catwalk_03_Diffuse
+		{  41,  42,  -1,   391680,       72,   121481 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   391752,      162,   121513 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   391914,      324,   121553 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   392238,      144,   121630 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   392382,      144,   121665 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   392526,      162,   121705 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   392688,      324,   121745 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   393012,      144,   121822 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   393156,      144,   121857 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   393300,      162,   121897 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   393462,      360,   121937 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   393822,      144,   122014 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   393966,      144,   122049 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   394110,      162,   122084 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   394272,      324,   122124 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   394596,      153,   122194 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   394749,      144,   122234 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   394893,      162,   122269 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   395055,      324,   122309 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   395379,      144,   122379 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   395523,      144,   122419 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   395667,      162,   122459 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   395829,      324,   122503 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   396153,      150,   122573 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   396303,      144,   122621 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   396447,      162,   122661 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   396609,      324,   122701 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   396933,      144,   122778 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   397077,      144,   122818 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   397221,      162,   122853 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   397383,      324,   122897 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   397707,      141,   122967 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   397848,      144,   123006 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   397992,      162,   123041 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   398154,    19506,   123085 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   417660,    19506,   129867 }, // subset0_blinnCatwalk
+		{  43,  11,  -1,   437166,      120,   136640 }, // subset0_Catwalk_03_Diffuse
+		{  41,  42,  -1,   437286,       72,   136720 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437358,       24,   136752 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437382,       24,   136768 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437406,       24,   136784 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437430,       24,   136800 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437454,       24,   136816 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437478,       24,   136832 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437502,       24,   136848 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437526,       24,   136864 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437550,       24,   136880 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437574,       24,   136896 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437598,       24,   136912 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437622,       24,   136928 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437646,       24,   136944 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437670,       24,   136960 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437694,       24,   136976 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437718,       24,   136992 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437742,       24,   137008 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437766,       24,   137024 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437790,       24,   137040 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437814,       24,   137056 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437838,       24,   137072 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437862,       24,   137088 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437886,       24,   137104 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437910,       24,   137120 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437934,       24,   137136 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437958,       24,   137152 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   437982,       24,   137168 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438006,       24,   137184 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438030,       24,   137200 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438054,       24,   137216 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438078,       24,   137232 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438102,       24,   137248 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438126,       24,   137264 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438150,       24,   137280 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438174,       24,   137296 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438198,       24,   137312 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438222,       24,   137328 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438246,       24,   137344 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438270,       24,   137360 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438294,       24,   137376 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438318,       24,   137392 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438342,       24,   137408 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438366,       24,   137424 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438390,       24,   137440 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438414,       24,   137456 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438438,       24,   137472 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438462,       24,   137488 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438486,       24,   137504 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438510,       24,   137520 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438534,       24,   137536 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438558,       24,   137552 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438582,       24,   137568 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438606,       24,   137584 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438630,       24,   137600 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438654,       24,   137616 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438678,       24,   137632 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438702,       24,   137648 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438726,       24,   137664 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438750,       24,   137680 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438774,       24,   137696 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438798,       24,   137712 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438822,       24,   137728 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438846,       24,   137744 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438870,       24,   137760 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438894,       24,   137776 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438918,       24,   137792 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438942,       24,   137808 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438966,       24,   137824 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   438990,       24,   137840 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439014,       24,   137856 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439038,       24,   137872 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439062,       24,   137888 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439086,       24,   137904 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439110,       24,   137920 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439134,       24,   137936 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439158,       24,   137952 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439182,       24,   137968 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439206,       24,   137984 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439230,       24,   138000 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439254,       24,   138016 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439278,       24,   138032 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439302,       24,   138048 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439326,       24,   138064 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439350,       24,   138080 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439374,       24,   138096 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439398,       24,   138112 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439422,       24,   138128 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439446,       24,   138144 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439470,       24,   138160 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439494,       24,   138176 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439518,       24,   138192 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439542,       24,   138208 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439566,       24,   138224 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439590,       24,   138240 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439614,       24,   138256 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439638,       24,   138272 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439662,       24,   138288 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439686,       24,   138304 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439710,       24,   138320 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439734,       24,   138336 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439758,       24,   138352 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439782,       24,   138368 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439806,       24,   138384 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439830,       24,   138400 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439854,       24,   138416 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439878,       24,   138432 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439902,       24,   138448 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439926,       24,   138464 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439950,       24,   138480 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439974,       24,   138496 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   439998,       24,   138512 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440022,       24,   138528 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440046,       24,   138544 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440070,       24,   138560 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440094,       24,   138576 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440118,       24,   138592 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440142,       24,   138608 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440166,       24,   138624 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440190,       24,   138640 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440214,       24,   138656 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440238,       24,   138672 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440262,       24,   138688 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440286,       24,   138704 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440310,       24,   138720 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440334,       24,   138736 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440358,       24,   138752 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440382,       24,   138768 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440406,       24,   138784 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440430,       24,   138800 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440454,       24,   138816 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440478,       24,   138832 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440502,       24,   138848 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440526,       24,   138864 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440550,       24,   138880 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440574,       24,   138896 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440598,       24,   138912 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440622,       24,   138928 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440646,       24,   138944 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440670,       24,   138960 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440694,       24,   138976 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440718,       24,   138992 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440742,       24,   139008 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440766,       24,   139024 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440790,       24,   139040 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440814,       24,   139056 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440838,       24,   139072 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440862,       24,   139088 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440886,       24,   139104 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440910,       24,   139120 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440934,       24,   139136 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440958,       24,   139152 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   440982,       24,   139168 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441006,       24,   139184 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441030,       24,   139200 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441054,       24,   139216 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441078,       24,   139232 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441102,       24,   139248 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441126,       24,   139264 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441150,       24,   139280 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441174,       24,   139296 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441198,       24,   139312 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441222,       24,   139328 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441246,       24,   139344 }, // subset0_blinnCatwalk
+		{  41,  42,  -1,   441270,       24,   139360 }, // subset0_blinnCatwalk
+		{  44,  45,  -1,   441294,     2826,   139376 }, // subset0_shelves3_diff
+		{  35,  36,  -1,   444120,     2637,   139376 }, // subset1_shelves2_diff_0
+		{  14,  15,  -1,   446757,      636,   139376 }, // subset2_Stack__Boxes_Diff03_0
+		{  46,  47,  -1,   447393,       24,   141190 }, // subset0_blinn46
+		{  46,  47,  -1,   447417,      306,   141206 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   447723,      306,   141325 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   448029,      306,   141443 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   448335,      306,   141561 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   448641,      216,   141677 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   448857,     1812,   141759 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   450669,      306,   142479 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   450975,      222,   142604 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   451197,      132,   142704 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   451329,      222,   142754 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   451551,      306,   142854 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   451857,      132,   142975 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   451989,      222,   143025 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   452211,      306,   143125 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   452517,      306,   143247 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   452823,      132,   143370 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   452955,      222,   143420 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   453177,      132,   143520 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   453309,     1368,   143570 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   454677,     2484,   143914 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   457161,     5790,   144731 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   462951,     1836,   147045 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   464787,     3816,   147679 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   468603,    54240,   149038 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   522843,      792,   158991 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   523635,      792,   159136 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   524427,      216,   159281 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   524643,      216,   159363 }, // subset0_phongMisc_Boss_3_2048
+		{  46,  47,  -1,   524859,      216,   159445 }, // subset0_phongMisc_Boss_3_2048
+		{  48,  42,  -1,   525075,     1050,   159527 }, // subset0_LightBulbsColor
+		{  49,  50,  -1,   526125,     1128,   159773 }, // subset0_Hanghing_Light
+		{  10,  11,  -1,   527253,      540,   160003 }, // subset0_lambert1
+		{  10,  11,  -1,   527793,      225,   160123 }, // subset0_lambert1
+		{  49,  50,  -1,   528018,     2160,   160202 }, // subset0_Hanghing_Light
+		{  48,  42,  -1,   530178,     1050,   160707 }, // subset0_LightBulbsColor
+		{  49,  50,  -1,   531228,     1128,   160966 }, // subset0_Hanghing_Light
+		{  10,  11,  -1,   532356,      540,   161197 }, // subset0_lambert1
+		{  10,  11,  -1,   532896,      225,   161317 }, // subset0_lambert1
+		{  49,  50,  -1,   533121,     2160,   161391 }, // subset0_Hanghing_Light
+		{  48,  42,  -1,   535281,     1134,   161896 }, // subset0_LightBulbsColor
+		{  49,  50,  -1,   536415,     1128,   162168 }, // subset0_Hanghing_Light
+		{  49,  50,  -1,   537543,      600,   162399 }, // subset0_Hanghing_Light
+		{  49,  50,  -1,   538143,      225,   162531 }, // subset0_Hanghing_Light
+		{  49,  50,  -1,   538368,     2160,   162610 }, // subset0_Hanghing_Light
+		{  10,  51,  -1,   540528,      498,   163115 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   541026,      300,   163321 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   541326,      300,   163400 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   541626,      600,   163479 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   542226,      681,   163604 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   542907,      300,   163755 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   543207,      300,   163834 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   543507,      144,   163913 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   543651,      780,   163949 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   544431,      168,   164135 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   544599,      156,   164197 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   544755,      390,   164255 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   545145,     3702,   164393 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   548847,      468,   165239 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   549315,     1128,   165324 }, // subset0_Hanging_bundle
+		{  10,  51,  -1,   550443,      810,   165562 }, // subset0_Hanging_bundle
+		{  52,  53,  -1,   551253,      714,   165819 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   551967,      540,   165949 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   552507,     1080,   166048 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   553587,     1080,   166242 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   554667,      540,   166436 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   555207,      540,   166535 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   555747,     1080,   166642 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   556827,      540,   166836 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   557367,     1080,   166935 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   558447,     1080,   167129 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   559527,      540,   167323 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   560067,     1080,   167422 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   561147,     1080,   167616 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   562227,     1080,   167810 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   563307,     1080,   168001 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   564387,      714,   168195 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   565101,     1080,   168325 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   566181,      540,   168519 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   566721,      540,   168618 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   567261,      540,   168719 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   567801,     1080,   168818 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   568881,      540,   169012 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   569421,     1080,   169111 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   570501,      540,   169305 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   571041,      714,   169404 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   571755,     1080,   169534 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   572835,     1080,   169728 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   573915,      540,   169922 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   574455,      540,   170021 }, // subset0_Hanging_bundle_marble
+		{  52,  53,  -1,   574995,     1080,   170120 }, // subset0_Hanging_bundle_marble
+		{  10,  51,  -1,   576075,    17184,   170314 }, // subset0_Rope
+		{  10,  51,  -1,   593259,      576,   176140 }, // subset0_Rope
+		{  10,  51,  -1,   593835,     2556,   176293 }, // subset0_Rope
+		{  10,  51,  -1,   596391,     4032,   176950 }, // subset0_Rope
+		{  10,  51,  -1,   600423,     4284,   177857 }, // subset0_Rope
+		{  10,  51,  -1,   604707,     4536,   178939 }, // subset0_Rope
+		{  10,  51,  -1,   609243,     4536,   179837 }, // subset0_Rope
+		{  10,  51,  -1,   613779,      612,   180733 }, // subset0_Rope
+		{  44,  45,  -1,   614391,      396,   180879 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   614787,      600,   181009 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   615387,      600,   181216 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   615987,      744,   181423 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   616731,      729,   181680 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   617460,     1920,   181932 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   619380,      324,   182343 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   619704,     2274,   182475 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   621978,     1860,   182902 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   623838,     2376,   183256 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   626214,     2190,   183705 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   628404,     2280,   184118 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   630684,      840,   184550 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   631524,      840,   184754 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   632364,      840,   184958 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   633204,      840,   185162 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   634044,     1008,   185366 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   635052,     1332,   185608 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   636384,     1617,   185890 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   638001,     1410,   186290 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   639411,      948,   186589 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   640359,       90,   187035 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   640449,      504,   187055 }, // subset0_shelves3_diff
+		{  35,  36,  -1,   640953,      378,   187197 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   641331,      432,   187284 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   641763,      378,   187378 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   642141,     3120,   187462 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   645261,      402,   188387 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   645663,     2580,   188525 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   648243,     3180,   189008 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   651423,     2100,   189678 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   653523,     3180,   190158 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   656703,      180,   190828 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   656883,      276,   190872 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   657159,      180,   190970 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   657339,      180,   191014 }, // subset0_shelves2_diff
+		{  44,  45,  -1,   657519,      228,   191068 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   657747,      108,   191162 }, // subset0_shelves3_diff
+		{  35,  36,  -1,   657855,      192,   191197 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   658047,      192,   191271 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   658239,      192,   191345 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   658431,      168,   191419 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   658599,      168,   191485 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   658767,      168,   191551 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   658935,      192,   191617 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   659127,      192,   191691 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   659319,      168,   191765 }, // subset0_shelves2_diff
+		{  44,  45,  -1,   659487,     1617,   191831 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   661104,     1617,   192226 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   662721,     1617,   192605 }, // subset0_shelves3_diff
+		{  44,  45,  -1,   664338,       90,   192995 }, // subset0_shelves3_diff
+		{  54,  42,  -1,   664428,     1248,   193015 }, // subset0_Window
+		{  55,  56,  -1,   665676,     3312,   193319 }, // subset0_Sliding_Steel_Door
+		{  54,  57,  -1,   668988,      930,   194197 }, // subset0_window_Diff
+		{  58,  59,  -1,   669918,    12912,   194433 }, // subset0_Door2
+		{  60,  61,  -1,   682830,      969,   197161 }, // subset0_Floor
+		{  62,  63,  -1,   683799,     2037,   197482 }, // subset0_wall_4
+		{  62,  63,  -1,   685836,     3000,   198168 }, // subset0_wall_3
+		{  64,  65,  -1,   688836,     2205,   199986 }, // subset0_wall_1
+		{  64,  65,  -1,   691041,     1656,   200663 }, // subset0_wall_2
+		{  66,  67,  -1,   692697,     5424,   201041 }, // subset0_roof
+		{  68,  69,  -1,   698121,      939,   203677 }, // subset0_Pillar
+		{  66,  67,  -1,   699060,     1536,   203892 }, // subset0_roof
+		{  70,  71,  -1,   700596,      609,   204339 }, // subset0_Broken_Pillar_Diff
+		{  33,  34,  -1,   701205,     1920,   204469 }, // subset0_Back_Alley_Drum
+		{  33,  34,  -1,   703125,     1920,   205134 }, // subset0_Back_Alley_Drum
+		{  33,  34,  -1,   705045,     1920,   205799 }, // subset0_Back_Alley_Drum
+		{  35,  36,  -1,   706965,     7809,   206464 }, // subset0_shelves2_diff
+		{  14,  15,  -1,   714774,     1920,   208128 }, // subset0_Stack__Boxes_Diff03
+		{  33,  34,  -1,   716694,     1920,   208629 }, // subset0_Back_Alley_Drum
+		{  33,  34,  -1,   718614,     1920,   209294 }, // subset0_Back_Alley_Drum
+		{  33,  34,  -1,   720534,     1920,   209959 }, // subset0_Back_Alley_Drum
+		{  35,  36,  -1,   722454,     7809,   210624 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   730263,     7809,   212294 }, // subset0_shelves2_diff
+		{  35,  36,  -1,   738072,     7809,   213953 }, // subset0_shelves2_diff
+		{  32,  32,  -1,   745881,      783,   215619 }, // subset0_gameCrates_02_Diff
+		{  72,  73,  -1,   746664,    14451,   215808 }, // subset0_GolfBag:Golfclub
+		{  18,  19,  -1,   761115,     3096,   219093 }, // subset0_Back_Alley_box
+	};
 }

--- a/Samples/UWP/D3D12xGPU/src/View.cpp
+++ b/Samples/UWP/D3D12xGPU/src/View.cpp
@@ -17,61 +17,61 @@ using namespace Windows::System;
 
 inline int ConvertToPixels(float dimension, float dpi)
 {
-    return static_cast<int>(dimension * dpi / 96.0f + 0.5f);
+	return static_cast<int>(dimension * dpi / 96.0f + 0.5f);
 }
 
 View::View(UINT_PTR pSample) :
-    m_pSample(reinterpret_cast<DXSample*>(pSample)),
-    m_windowClosed(false),
-    m_windowResizing(false),
-    m_windowVisible(true),
-    m_logicalWidth(0),
-    m_logicalHeight(0)
+	m_pSample(reinterpret_cast<DXSample*>(pSample)),
+	m_windowClosed(false),
+	m_windowResizing(false),
+	m_windowVisible(true),
+	m_logicalWidth(0),
+	m_logicalHeight(0)
 {
 }
 
 void View::Initialize(CoreApplicationView^ applicationView)
 {
-    applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
+	applicationView->Activated += ref new TypedEventHandler<CoreApplicationView^, IActivatedEventArgs^>(this, &View::OnActivated);
 
-    // For simplicity, this sample ignores CoreApplication's Suspend and Resume
-    // events which a typical app should subscribe to.
+	// For simplicity, this sample ignores CoreApplication's Suspend and Resume
+	// events which a typical app should subscribe to.
 }
 
 void View::SetWindow(CoreWindow^ window)
 {
-    m_logicalWidth = window->Bounds.Width;
-    m_logicalHeight = window->Bounds.Height;
+	m_logicalWidth = window->Bounds.Width;
+	m_logicalHeight = window->Bounds.Height;
 
     auto dispatcher = CoreWindow::GetForCurrentThread()->Dispatcher;
     dispatcher->AcceleratorKeyActivated +=
         ref new TypedEventHandler<CoreDispatcher^, AcceleratorKeyEventArgs^>(this, &View::OnAcceleratorKeyActivated);
 
-    window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
-    window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
-    window->SizeChanged += ref new TypedEventHandler<CoreWindow^, WindowSizeChangedEventArgs^>(this, &View::OnSizeChanged);
-    window->VisibilityChanged += ref new TypedEventHandler<CoreWindow^, VisibilityChangedEventArgs^>(this, &View::OnVisibilityChanged);
-    window->Closed += ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &View::OnClosed);
-    window->PointerMoved += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerMoved);
-    window->PointerPressed += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerPressed);
-    window->PointerReleased += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerReleased);
+	window->KeyDown += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyDown);
+	window->KeyUp += ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &View::OnKeyUp);
+	window->SizeChanged += ref new TypedEventHandler<CoreWindow^, WindowSizeChangedEventArgs^>(this, &View::OnSizeChanged);
+	window->VisibilityChanged += ref new TypedEventHandler<CoreWindow^, VisibilityChangedEventArgs^>(this, &View::OnVisibilityChanged);
+	window->Closed += ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &View::OnClosed);
+	window->PointerMoved += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerMoved);
+	window->PointerPressed += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerPressed);
+	window->PointerReleased += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(this, &View::OnPointerReleased);
 
-    try
-    {
-        window->ResizeStarted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeStarted);
-        window->ResizeCompleted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeCompleted);
-    }
-    catch (Exception^ e)
-    {
-        // Requires Windows 10 Creators Update (10.0.15063) or later.
-    }
+	try
+	{
+		window->ResizeStarted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeStarted);
+		window->ResizeCompleted += ref new TypedEventHandler<CoreWindow^, Object^>(this, &View::OnResizeCompleted);
+	}
+	catch (Exception^ e)
+	{
+		// Requires Windows 10 Creators Update (10.0.15063) or later.
+	}
 
-    // For simplicity, this sample ignores a number of events on CoreWindow that a
-    // typical app should subscribe to.
+	// For simplicity, this sample ignores a number of events on CoreWindow that a
+	// typical app should subscribe to.
 
-    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-    displayInformation->DpiChanged += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDpiChanged);
-    displayInformation->DisplayContentsInvalidated += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDisplayContentsInvalidated);
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	displayInformation->DpiChanged += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDpiChanged);
+	displayInformation->DisplayContentsInvalidated += ref new TypedEventHandler<DisplayInformation^, Object^>(this, &View::OnDisplayContentsInvalidated);
 }
 
 void View::Load(String^ /*entryPoint*/)
@@ -80,20 +80,20 @@ void View::Load(String^ /*entryPoint*/)
 
 void View::Run()
 {
-    auto applicationView = ApplicationView::GetForCurrentView();
-    applicationView->Title = ref new String(m_pSample->GetTitle());
+	auto applicationView = ApplicationView::GetForCurrentView();
+	applicationView->Title = ref new String(m_pSample->GetTitle());
 
-    m_pSample->OnInit();
+	m_pSample->OnInit();
 
-    while (!m_windowClosed)
-    {
-        CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+	while (!m_windowClosed)
+	{
+		CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-        m_pSample->OnUpdate();
-        m_pSample->OnRender();
-    }
+		m_pSample->OnUpdate();
+		m_pSample->OnRender();
+	}
 
-    m_pSample->OnDestroy();
+	m_pSample->OnDestroy();
 }
 
 void View::Uninitialize()
@@ -102,15 +102,15 @@ void View::Uninitialize()
 
 void View::OnActivated(CoreApplicationView^ /*applicationView*/, IActivatedEventArgs^ args)
 {
-    CoreWindow::GetForCurrentThread()->Activate();
+	CoreWindow::GetForCurrentThread()->Activate();
 }
 
 void View::OnKeyDown(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
     if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
-    }
+	{
+		m_pSample->OnKeyDown(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnAcceleratorKeyActivated(CoreDispatcher^, AcceleratorKeyEventArgs^ args)
@@ -138,97 +138,97 @@ void View::OnAcceleratorKeyActivated(CoreDispatcher^, AcceleratorKeyEventArgs^ a
 
 void View::OnKeyUp(CoreWindow^ /*window*/, KeyEventArgs^ args)
 {
-    if (static_cast<UINT>(args->VirtualKey) < 256)
-    {
-        m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
-    }
+	if (static_cast<UINT>(args->VirtualKey) < 256)
+	{
+		m_pSample->OnKeyUp(static_cast<UINT8>(args->VirtualKey));
+	}
 }
 
 void View::OnSizeChanged(CoreWindow^ /*window*/, WindowSizeChangedEventArgs^ args)
 {
-    m_logicalWidth = args->Size.Width;
-    m_logicalHeight = args->Size.Height;
+	m_logicalWidth = args->Size.Width;
+	m_logicalHeight = args->Size.Height;
 
-    if (!m_windowResizing)
-    {
-        UpdateWindowSize();
-    }
+	if (!m_windowResizing)
+	{
+		UpdateWindowSize();
+	}
 }
 
 void View::OnResizeStarted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
 {
-    m_windowResizing = true;
+	m_windowResizing = true;
 }
 
 void View::OnResizeCompleted(CoreWindow^ /*window*/, Platform::Object^ /*args*/)
 {
-    m_windowResizing = false;
-    UpdateWindowSize();
+	m_windowResizing = false;
+	UpdateWindowSize();
 }
 
 void View::OnDpiChanged(DisplayInformation^ /*sender*/, Object^ /*args*/)
 {
-    UpdateWindowSize();
+	UpdateWindowSize();
 }
 
 void View::OnVisibilityChanged(CoreWindow^ /*window*/, VisibilityChangedEventArgs^ args)
 {
-    m_windowVisible = args->Visible;
-    UpdateWindowSize();
+	m_windowVisible = args->Visible;
+	UpdateWindowSize();
 }
 
 void View::OnClosed(CoreWindow^ /*window*/, CoreWindowEventArgs^ /*args*/)
 {
-    m_windowClosed = true;
+	m_windowClosed = true;
 }
 
 void View::OnPointerMoved(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
-    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-    float dpi = displayInformation->LogicalDpi;
-    m_pSample->OnMouseMove(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	float dpi = displayInformation->LogicalDpi;
+	m_pSample->OnMouseMove(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
 }
 
 void View::OnPointerPressed(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
-    // For simplicity, we only consider left button press here.
-    if(args->CurrentPoint->Properties->IsLeftButtonPressed)
-    {
-        DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-        float dpi = displayInformation->LogicalDpi;
-        m_pSample->OnLeftButtonDown(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
-    }
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonDown(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
 }
 
 void View::OnPointerReleased(CoreWindow^ /*window*/, PointerEventArgs^ args)
 {
-    // For simplicity, we only consider left button press here.
-    if(args->CurrentPoint->Properties->IsLeftButtonPressed)
-    {
-        DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-        float dpi = displayInformation->LogicalDpi;
-        m_pSample->OnLeftButtonUp(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
-    }
+	// For simplicity, we only consider left button press here.
+	if(args->CurrentPoint->Properties->IsLeftButtonPressed)
+	{
+		DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+		float dpi = displayInformation->LogicalDpi;
+		m_pSample->OnLeftButtonUp(ConvertToPixels(args->CurrentPoint->Position.X, dpi), ConvertToPixels(args->CurrentPoint->Position.Y, dpi));
+	}
 }
 
 void View::UpdateWindowSize()
 {
-    CoreWindow^ window = CoreWindow::GetForCurrentThread();
-    Windows::Foundation::Rect windowBounds = window->Bounds;
+	CoreWindow^ window = CoreWindow::GetForCurrentThread();
+	Windows::Foundation::Rect windowBounds = window->Bounds;
 
-    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
-    float dpi = displayInformation->LogicalDpi;
-    
-    m_pSample->SetWindowBounds(
-        ConvertToPixels(windowBounds.Left, dpi),
-        ConvertToPixels(windowBounds.Top, dpi),
-        ConvertToPixels(windowBounds.Right, dpi),
-        ConvertToPixels(windowBounds.Bottom, dpi));
-        
-    m_pSample->OnSizeChanged(ConvertToPixels(m_logicalWidth, dpi), ConvertToPixels(m_logicalHeight, dpi), !m_windowVisible);
+	DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+	float dpi = displayInformation->LogicalDpi;
+	
+	m_pSample->SetWindowBounds(
+		ConvertToPixels(windowBounds.Left, dpi),
+		ConvertToPixels(windowBounds.Top, dpi),
+		ConvertToPixels(windowBounds.Right, dpi),
+		ConvertToPixels(windowBounds.Bottom, dpi));
+		
+	m_pSample->OnSizeChanged(ConvertToPixels(m_logicalWidth, dpi), ConvertToPixels(m_logicalHeight, dpi), !m_windowVisible);
 }
 
 void View::OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args)
 {
-    m_pSample->OnDisplayChanged();
+	m_pSample->OnDisplayChanged();
 }

--- a/Samples/UWP/D3D12xGPU/src/View.h
+++ b/Samples/UWP/D3D12xGPU/src/View.h
@@ -24,36 +24,36 @@ using namespace Windows::UI::ViewManagement;
 ref class View sealed : public IFrameworkView
 {
 public:
-    View(UINT_PTR pSample);
+	View(UINT_PTR pSample);
 
-    virtual void Initialize(CoreApplicationView^ applicationView);
-    virtual void SetWindow(CoreWindow^ window);
-    virtual void Load(String^ entryPoint);
-    virtual void Run();
-    virtual void Uninitialize();
+	virtual void Initialize(CoreApplicationView^ applicationView);
+	virtual void SetWindow(CoreWindow^ window);
+	virtual void Load(String^ entryPoint);
+	virtual void Run();
+	virtual void Uninitialize();
 
 private:
-    void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
+	void OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args);
     void OnAcceleratorKeyActivated(CoreDispatcher^, AcceleratorKeyEventArgs^ args);
-    void OnKeyDown(CoreWindow^ window, KeyEventArgs^ args);
-    void OnKeyUp(CoreWindow^ window, KeyEventArgs^ args);
-    void OnSizeChanged(CoreWindow^ window, WindowSizeChangedEventArgs^ args);
-    void OnResizeStarted(CoreWindow^ window, Object^ args);
-    void OnResizeCompleted(CoreWindow^ window, Object^ args);
-    void OnDpiChanged(DisplayInformation^ sender, Object^ args);
-    void OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args);
-    void OnClosed(CoreWindow^ window, CoreWindowEventArgs^ args);
-    void OnPointerMoved(CoreWindow^ window, PointerEventArgs^ args);
-    void OnPointerPressed(CoreWindow^ window, PointerEventArgs^ args);
-    void OnPointerReleased(CoreWindow^ window, PointerEventArgs^ args);
-    void OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args);
-    
-    void UpdateWindowSize();
+	void OnKeyDown(CoreWindow^ window, KeyEventArgs^ args);
+	void OnKeyUp(CoreWindow^ window, KeyEventArgs^ args);
+	void OnSizeChanged(CoreWindow^ window, WindowSizeChangedEventArgs^ args);
+	void OnResizeStarted(CoreWindow^ window, Object^ args);
+	void OnResizeCompleted(CoreWindow^ window, Object^ args);
+	void OnDpiChanged(DisplayInformation^ sender, Object^ args);
+	void OnVisibilityChanged(CoreWindow^ window, VisibilityChangedEventArgs^ args);
+	void OnClosed(CoreWindow^ window, CoreWindowEventArgs^ args);
+	void OnPointerMoved(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerPressed(CoreWindow^ window, PointerEventArgs^ args);
+	void OnPointerReleased(CoreWindow^ window, PointerEventArgs^ args);
+	void OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args);
+	
+	void UpdateWindowSize();
 
-    DXSample* m_pSample;
-    bool m_windowClosed;
-    bool m_windowResizing;
-    bool m_windowVisible;
-    float m_logicalWidth;
-    float m_logicalHeight;
+	DXSample* m_pSample;
+	bool m_windowClosed;
+	bool m_windowResizing;
+	bool m_windowVisible;
+	float m_logicalWidth;
+	float m_logicalHeight;
 };

--- a/Samples/UWP/D3D12xGPU/src/ViewProvider.cpp
+++ b/Samples/UWP/D3D12xGPU/src/ViewProvider.cpp
@@ -14,11 +14,11 @@
 #include "View.h"
 
 ViewProvider::ViewProvider(UINT_PTR pSample) :
-    m_pSample(pSample)
+	m_pSample(pSample)
 {
 }
 
 Windows::ApplicationModel::Core::IFrameworkView^ ViewProvider::CreateView()
 {
-    return ref new View(m_pSample);
+	return ref new View(m_pSample);
 }

--- a/Samples/UWP/D3D12xGPU/src/ViewProvider.h
+++ b/Samples/UWP/D3D12xGPU/src/ViewProvider.h
@@ -16,9 +16,9 @@ using namespace Windows::ApplicationModel::Core;
 ref class ViewProvider sealed : IFrameworkViewSource
 {
 public:
-    ViewProvider(UINT_PTR pSample);
-    virtual IFrameworkView^ CreateView();
+	ViewProvider(UINT_PTR pSample);
+	virtual IFrameworkView^ CreateView();
 
 private:
-    UINT_PTR m_pSample;
+	UINT_PTR m_pSample;
 };

--- a/Samples/UWP/D3D12xGPU/src/d3dx12.h
+++ b/Samples/UWP/D3D12xGPU/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;


### PR DESCRIPTION
Following samples now run on high performance gpu by default and supports safe device removal
-ExecuteIndirect
-FullScreen
-HeterogenousMultiadapter
-nBodyGrabity
-psocache
-PredictionQueue
-SM6WaveIntrinsics