### PR TITLE
add device removal support to samples

### DIFF
--- a/Samples/Desktop/D3D1211On12/src/D3D1211On12.cpp
+++ b/Samples/Desktop/D3D1211On12/src/D3D1211On12.cpp
@@ -180,7 +180,10 @@ void D3D1211on12::LoadPipeline()
     // D2D's render targets.
     float dpiX;
     float dpiY;
+#pragma warning(push)
+#pragma warning(disable : 4996) // GetDesktopDpi is deprecated.
     m_d2dFactory->GetDesktopDpi(&dpiX, &dpiY);
+#pragma warning(pop)
     D2D1_BITMAP_PROPERTIES1 bitmapProperties = D2D1::BitmapProperties1(
         D2D1_BITMAP_OPTIONS_TARGET | D2D1_BITMAP_OPTIONS_CANNOT_DRAW,
         D2D1::PixelFormat(DXGI_FORMAT_UNKNOWN, D2D1_ALPHA_MODE_PREMULTIPLIED),

--- a/Samples/Desktop/D3D1211On12/src/DXSample.cpp
+++ b/Samples/Desktop/D3D1211On12/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D1211On12/src/DXSample.h
+++ b/Samples/Desktop/D3D1211On12/src/DXSample.h
@@ -38,7 +38,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/Desktop/D3D1211On12/src/d3dx12.h
+++ b/Samples/Desktop/D3D1211On12/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D1211On12/src/stdafx.h
+++ b/Samples/Desktop/D3D1211On12/src/stdafx.h
@@ -25,7 +25,7 @@
 #include <dwrite.h>
 #include <d3d11on12.h>
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"

--- a/Samples/Desktop/D3D12Bundles/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12Bundles/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12Bundles/src/DXSample.h
+++ b/Samples/Desktop/D3D12Bundles/src/DXSample.h
@@ -38,7 +38,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/Desktop/D3D12Bundles/src/d3dx12.h
+++ b/Samples/Desktop/D3D12Bundles/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12Bundles/src/stdafx.h
+++ b/Samples/Desktop/D3D12Bundles/src/stdafx.h
@@ -22,7 +22,7 @@
 #include <windows.h>
 
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"

--- a/Samples/Desktop/D3D12DepthBoundsTest/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12DepthBoundsTest/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12DepthBoundsTest/src/DXSample.h
+++ b/Samples/Desktop/D3D12DepthBoundsTest/src/DXSample.h
@@ -38,7 +38,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/Desktop/D3D12DepthBoundsTest/src/d3dx12.h
+++ b/Samples/Desktop/D3D12DepthBoundsTest/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12DepthBoundsTest/src/stdafx.h
+++ b/Samples/Desktop/D3D12DepthBoundsTest/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>

--- a/Samples/Desktop/D3D12DynamicIndexing/src/D3D12DynamicIndexing.cpp
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/D3D12DynamicIndexing.cpp
@@ -513,17 +513,12 @@ void D3D12DynamicIndexing::LoadAssets()
         depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
         depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
 
-        D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
-        depthOptimizedClearValue.Format = DXGI_FORMAT_D32_FLOAT;
-        depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
-        depthOptimizedClearValue.DepthStencil.Stencil = 0;
-
         ThrowIfFailed(m_device->CreateCommittedResource(
             &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
             D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
+            &CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT, m_width, m_height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL | D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE), // Performance tip: Deny shader resource access to resources that don't need shader resource views.
             D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            &depthOptimizedClearValue,
+            &CD3DX12_CLEAR_VALUE(DXGI_FORMAT_D32_FLOAT, 1.0f, 0), // Performance tip: Tell the runtime at resource creation the desired clear value.
             IID_PPV_ARGS(&m_depthStencil)
             ));
 
@@ -726,6 +721,7 @@ void D3D12DynamicIndexing::PopulateCommandList(FrameResource* pFrameResource)
     m_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);
     m_commandList->ClearDepthStencilView(m_dsvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
 
+    PIXBeginEvent(m_commandList.Get(), 0, L"Draw cities");
     if (UseBundles)
     {
         // Execute the prebuilt bundle.
@@ -734,9 +730,10 @@ void D3D12DynamicIndexing::PopulateCommandList(FrameResource* pFrameResource)
     else
     {
         // Populate a new command list.
-        pFrameResource->PopulateCommandList(m_commandList.Get(), m_pipelineState.Get(), m_currentFrameResourceIndex, m_numIndices, &m_indexBufferView,
+        pFrameResource->PopulateCommandList(m_commandList.Get(), m_currentFrameResourceIndex, m_numIndices, &m_indexBufferView,
             &m_vertexBufferView, m_cbvSrvHeap.Get(), m_cbvSrvDescriptorSize, m_samplerHeap.Get(), m_rootSignature.Get());
     }
+    PIXEndEvent(m_commandList.Get());
 
     // Indicate that the back buffer will now be used to present.
     m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));

--- a/Samples/Desktop/D3D12DynamicIndexing/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12DynamicIndexing/src/DXSample.h
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/DXSample.h
@@ -38,7 +38,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/Desktop/D3D12DynamicIndexing/src/FrameResource.cpp
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/FrameResource.cpp
@@ -62,7 +62,7 @@ void FrameResource::InitBundle(ID3D12Device* pDevice, ID3D12PipelineState* pPso,
     ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_BUNDLE, m_bundleAllocator.Get(), pPso, IID_PPV_ARGS(&m_bundle)));
     NAME_D3D12_OBJECT(m_bundle);
 
-    PopulateCommandList(m_bundle.Get(), pPso, frameResourceIndex, numIndices, pIndexBufferViewDesc,
+    PopulateCommandList(m_bundle.Get(), frameResourceIndex, numIndices, pIndexBufferViewDesc,
         pVertexBufferViewDesc, pCbvSrvDescriptorHeap, cbvSrvDescriptorSize, pSamplerDescriptorHeap, pRootSignature);
 
     ThrowIfFailed(m_bundle->Close());
@@ -84,7 +84,7 @@ void FrameResource::SetCityPositions(FLOAT intervalX, FLOAT intervalZ)
     }
 }
 
-void FrameResource::PopulateCommandList(ID3D12GraphicsCommandList* pCommandList, ID3D12PipelineState* pPso,
+void FrameResource::PopulateCommandList(ID3D12GraphicsCommandList* pCommandList,
     UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
     ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature)
 {
@@ -105,13 +105,10 @@ void FrameResource::PopulateCommandList(ID3D12GraphicsCommandList* pCommandList,
     UINT frameResourceDescriptorOffset = (m_cityMaterialCount + 1) + (frameResourceIndex * m_cityRowCount * m_cityColumnCount);
     CD3DX12_GPU_DESCRIPTOR_HANDLE cbvSrvHandle(pCbvSrvDescriptorHeap->GetGPUDescriptorHandleForHeapStart(), frameResourceDescriptorOffset, cbvSrvDescriptorSize);
 
-    PIXBeginEvent(pCommandList, 0, L"Draw cities");
     for (UINT i = 0; i < m_cityRowCount; i++)
     {
         for (UINT j = 0; j < m_cityColumnCount; j++)
         {
-            pCommandList->SetPipelineState(pPso);
-
             // Set the city's root constant for dynamically indexing into the material array.
             pCommandList->SetGraphicsRoot32BitConstant(3, (i * m_cityColumnCount) + j, 0);
 
@@ -122,7 +119,6 @@ void FrameResource::PopulateCommandList(ID3D12GraphicsCommandList* pCommandList,
             pCommandList->DrawIndexedInstanced(numIndices, 1, 0, 0, 0);
         }
     }
-    PIXEndEvent(pCommandList);
 }
 
 void XM_CALLCONV FrameResource::UpdateConstantBuffers(FXMMATRIX view, CXMMATRIX projection)

--- a/Samples/Desktop/D3D12DynamicIndexing/src/FrameResource.h
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/FrameResource.h
@@ -47,7 +47,7 @@ public:
         UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
         ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature);
 
-    void PopulateCommandList(ID3D12GraphicsCommandList* pCommandList, ID3D12PipelineState* pPso,
+    void PopulateCommandList(ID3D12GraphicsCommandList* pCommandList,
         UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
         ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature);
 

--- a/Samples/Desktop/D3D12DynamicIndexing/src/d3dx12.h
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12DynamicIndexing/src/stdafx.h
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/stdafx.h
@@ -22,7 +22,7 @@
 #include <windows.h>
 
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.cpp
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.cpp
@@ -41,6 +41,8 @@ D3D12ExecuteIndirect::D3D12ExecuteIndirect(UINT width, UINT height, std::wstring
     m_cullingScissorRect.left = static_cast<LONG>(center - (center * CullingCutoff));
     m_cullingScissorRect.right = static_cast<LONG>(center + (center * CullingCutoff));
     m_cullingScissorRect.bottom = static_cast<LONG>(height);
+
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
 }
 
 void D3D12ExecuteIndirect::OnInit()
@@ -86,7 +88,7 @@ void D3D12ExecuteIndirect::LoadPipeline()
     else
     {
         ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+        GetHardwareAdapter(factory.Get(), &hardwareAdapter, true);
 
         ThrowIfFailed(D3D12CreateDevice(
             hardwareAdapter.Get(),
@@ -611,37 +613,77 @@ void D3D12ExecuteIndirect::OnUpdate()
 // Render the scene.
 void D3D12ExecuteIndirect::OnRender()
 {
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandLists();
-
-    // Execute the compute work.
-    if (m_enableCulling)
+    try
     {
-        PIXBeginEvent(m_commandQueue.Get(), 0, L"Cull invisible triangles");
+        // Record all the commands we need to render the scene into the command list.
+        PopulateCommandLists();
 
-        ID3D12CommandList* ppCommandLists[] = { m_computeCommandList.Get() };
-        m_computeCommandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+        // Execute the compute work.
+        if (m_enableCulling)
+        {
+            PIXBeginEvent(m_commandQueue.Get(), 0, L"Cull invisible triangles");
+
+            ID3D12CommandList* ppCommandLists[] = { m_computeCommandList.Get() };
+            m_computeCommandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+
+            PIXEndEvent(m_commandQueue.Get());
+
+            m_computeCommandQueue->Signal(m_computeFence.Get(), m_fenceValues[m_frameIndex]);
+
+            // Execute the rendering work only when the compute work is complete.
+            m_commandQueue->Wait(m_computeFence.Get(), m_fenceValues[m_frameIndex]);
+        }
+
+        PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+
+        // Execute the rendering work.
+        ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+        m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
         PIXEndEvent(m_commandQueue.Get());
 
-        m_computeCommandQueue->Signal(m_computeFence.Get(), m_fenceValues[m_frameIndex]);
+        // Present the frame.
+        ThrowIfFailed(m_swapChain->Present(1, 0));
 
-        // Execute the rendering work only when the compute work is complete.
-        m_commandQueue->Wait(m_computeFence.Get(), m_fenceValues[m_frameIndex]);
+        MoveToNextFrame();
     }
+    catch (HrException& e)
+    {
+        if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
+        {
+            RestoreD3DResources();
+        }
+        else
+        {
+            throw;
+        }
+    }
+}
 
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+// Release sample's D3D objects.
+void D3D12ExecuteIndirect::ReleaseD3DResources()
+{
+    m_fence.Reset();
+    ResetComPtrArray(&m_renderTargets);
+    m_commandQueue.Reset();
+    m_swapChain.Reset();
+    m_device.Reset();
+}
 
-    // Execute the rendering work.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
-
-    PIXEndEvent(m_commandQueue.Get());
-
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
-
-    MoveToNextFrame();
+// Tears down D3D resources and reinitializes them.
+void D3D12ExecuteIndirect::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
+    {
+        WaitForGpu();
+    }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
 }
 
 void D3D12ExecuteIndirect::OnDestroy()

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.h
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.h
@@ -152,6 +152,8 @@ private:
 
     void LoadPipeline();
     void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
     float GetRandomFloat(float min, float max);
     void PopulateCommandLists();
     void WaitForGpu();

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/DXSample.h
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/DXSample.h
@@ -38,7 +38,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/d3dx12.h
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/stdafx.h
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include "d3dx12.h"

--- a/Samples/Desktop/D3D12Fullscreen/src/D3D12Fullscreen.h
+++ b/Samples/Desktop/D3D12Fullscreen/src/D3D12Fullscreen.h
@@ -119,6 +119,8 @@ private:
 
     void LoadPipeline();
     void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
     void LoadSizeDependentResources();
     void LoadSceneResolutionDependentResources();
     void PopulateCommandLists();

--- a/Samples/Desktop/D3D12Fullscreen/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12Fullscreen/src/DXSample.cpp
@@ -52,31 +52,66 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12Fullscreen/src/DXSample.h
+++ b/Samples/Desktop/D3D12Fullscreen/src/DXSample.h
@@ -49,7 +49,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/Desktop/D3D12Fullscreen/src/d3dx12.h
+++ b/Samples/Desktop/D3D12Fullscreen/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12HDR/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12HDR/src/DXSample.cpp
@@ -52,31 +52,66 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12HDR/src/DXSample.h
+++ b/Samples/Desktop/D3D12HDR/src/DXSample.h
@@ -49,7 +49,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/Desktop/D3D12HDR/src/d3dx12.h
+++ b/Samples/Desktop/D3D12HDR/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/DXSample.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/DXSample.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/DXSample.h
@@ -38,7 +38,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/d3dx12.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/stdafx.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/stdafx.h
@@ -22,7 +22,7 @@
 #include <windows.h>
 
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/DXSample.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/DXSample.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/DXSample.h
@@ -38,7 +38,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/d3dx12.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/stdafx.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/stdafx.h
@@ -22,7 +22,7 @@
 #include <windows.h>
 
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/DXSample.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/DXSample.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/DXSample.h
@@ -38,7 +38,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/d3dx12.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/stdafx.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/stdafx.h
@@ -22,7 +22,7 @@
 #include <windows.h>
 
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/DXSample.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/DXSample.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/DXSample.h
@@ -38,7 +38,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/d3dx12.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/stdafx.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/stdafx.h
@@ -22,7 +22,7 @@
 #include <windows.h>
 
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/DXSample.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/DXSample.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/DXSample.h
@@ -38,7 +38,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/d3dx12.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/stdafx.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/stdafx.h
@@ -22,7 +22,7 @@
 #include <windows.h>
 
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/DXSample.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/DXSample.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/DXSample.h
@@ -38,7 +38,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/d3dx12.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/stdafx.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/stdafx.h
@@ -22,7 +22,7 @@
 #include <windows.h>
 
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"

--- a/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/D3D12HeterogeneousMultiadapter.h
+++ b/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/D3D12HeterogeneousMultiadapter.h
@@ -170,6 +170,8 @@ private:
     HRESULT GetHardwareAdapters(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppPrimaryAdapter, _Outptr_result_maybenull_ IDXGIAdapter1** ppSecondaryAdapter);
     void LoadPipeline();
     void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
     float GetRandomFloat(float min, float max);
     void PopulateCommandLists();
     void UpdateWindowTitle();

--- a/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/DXSample.h
+++ b/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/DXSample.h
@@ -38,7 +38,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/d3dx12.h
+++ b/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/stdafx.h
+++ b/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include "d3dx12.h"

--- a/Samples/Desktop/D3D12LinkedGpus/src/D3DX12AffinityLayer/d3dx12.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/D3DX12AffinityLayer/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/DXSample.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/DXSample.cpp
@@ -52,31 +52,66 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/DXSample.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/DXSample.h
@@ -49,7 +49,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/d3dx12.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.cpp
@@ -52,31 +52,66 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.h
@@ -49,7 +49,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/d3dx12.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/DXSample.cpp
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/DXSample.cpp
@@ -52,31 +52,66 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/DXSample.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/DXSample.h
@@ -49,7 +49,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/d3dx12.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.h
+++ b/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.h
@@ -139,6 +139,9 @@ private:
 
     void LoadPipeline();
     void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
+    void WaitForGpu();
     void LoadContexts();
     void BeginFrame();
     void MidFrame();

--- a/Samples/Desktop/D3D12Multithreading/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12Multithreading/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12Multithreading/src/DXSample.h
+++ b/Samples/Desktop/D3D12Multithreading/src/DXSample.h
@@ -38,7 +38,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/Desktop/D3D12Multithreading/src/d3dx12.h
+++ b/Samples/Desktop/D3D12Multithreading/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12Multithreading/src/stdafx.h
+++ b/Samples/Desktop/D3D12Multithreading/src/stdafx.h
@@ -22,7 +22,7 @@
 #include <windows.h>
 
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"

--- a/Samples/Desktop/D3D12PipelineStateCache/src/D3D12PipelineStateCache.cpp
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/D3D12PipelineStateCache.cpp
@@ -29,6 +29,8 @@ D3D12PipelineStateCache::D3D12PipelineStateCache(UINT width, UINT height, std::w
     m_fenceValues{}
 {
     memset(m_enabledEffects, true, sizeof(m_enabledEffects));
+
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
 }
 
 void D3D12PipelineStateCache::OnInit()
@@ -80,7 +82,7 @@ void D3D12PipelineStateCache::LoadPipeline()
     else
     {
         ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+        GetHardwareAdapter(factory.Get(), &hardwareAdapter, true);
 
         ThrowIfFailed(D3D12CreateDevice(
             hardwareAdapter.Get(),
@@ -391,25 +393,66 @@ void D3D12PipelineStateCache::OnUpdate()
 // Render the scene.
 void D3D12PipelineStateCache::OnRender()
 {
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+    try
+    {
+        PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
 
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+        // Record all the commands we need to render the scene into the command list.
+        PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+        // Execute the command list.
+        ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+        m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    PIXEndEvent(m_commandQueue.Get());
+        PIXEndEvent(m_commandQueue.Get());
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+        // Present the frame.
+        ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    m_drawIndex = 0;
-    m_psoLibrary.EndFrame();
+        m_drawIndex = 0;
+        m_psoLibrary.EndFrame();
 
-    MoveToNextFrame();
+        MoveToNextFrame();
+    }
+    catch (HrException& e)
+    {
+        if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
+        {
+            RestoreD3DResources();
+        }
+        else
+        {
+            throw;
+        }
+    }
 }
+
+// Release sample's D3D objects.
+void D3D12PipelineStateCache::ReleaseD3DResources()
+{
+    m_fence.Reset();
+    ResetComPtrArray(&m_renderTargets);
+    m_commandQueue.Reset();
+    m_swapChain.Reset();
+    m_device.Reset();
+}
+
+// Tears down D3D resources and reinitializes them.
+void D3D12PipelineStateCache::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
+    {
+        WaitForGpu();
+    }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
+}
+
 
 void D3D12PipelineStateCache::OnDestroy()
 {

--- a/Samples/Desktop/D3D12PipelineStateCache/src/D3D12PipelineStateCache.h
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/D3D12PipelineStateCache.h
@@ -110,6 +110,8 @@ private:
 
     void LoadPipeline();
     void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
     void PopulateCommandList();
     void ToggleEffect(EffectPipelineType type);
     void UpdateWindowTextPso();

--- a/Samples/Desktop/D3D12PipelineStateCache/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12PipelineStateCache/src/DXSample.h
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/DXSample.h
@@ -38,7 +38,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/Desktop/D3D12PipelineStateCache/src/d3dx12.h
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12PipelineStateCache/src/stdafx.h
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>

--- a/Samples/Desktop/D3D12PredicationQueries/src/D3D12PredicationQueries.cpp
+++ b/Samples/Desktop/D3D12PredicationQueries/src/D3D12PredicationQueries.cpp
@@ -22,6 +22,7 @@ D3D12PredicationQueries::D3D12PredicationQueries(UINT width, UINT height, std::w
     m_constantBufferData{},
     m_fenceValues{}
 {
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
 }
 
 void D3D12PredicationQueries::OnInit()
@@ -67,7 +68,7 @@ void D3D12PredicationQueries::LoadPipeline()
     else
     {
         ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+        GetHardwareAdapter(factory.Get(), &hardwareAdapter, true);
 
         ThrowIfFailed(D3D12CreateDevice(
             hardwareAdapter.Get(),
@@ -461,21 +462,61 @@ void D3D12PredicationQueries::OnUpdate()
 // Render the scene.
 void D3D12PredicationQueries::OnRender()
 {
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+    try
+    {
+        PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
 
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+        // Record all the commands we need to render the scene into the command list.
+        PopulateCommandList();
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+        // Execute the command list.
+        ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+        m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-    PIXEndEvent(m_commandQueue.Get());
+        PIXEndEvent(m_commandQueue.Get());
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+        // Present the frame.
+        ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    MoveToNextFrame();
+        MoveToNextFrame();
+    }
+    catch (HrException& e)
+    {
+        if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
+        {
+            RestoreD3DResources();
+        }
+        else
+        {
+            throw;
+        }
+    }
+}
+
+// Release sample's D3D objects.
+void D3D12PredicationQueries::ReleaseD3DResources()
+{
+    m_fence.Reset();
+    ResetComPtrArray(&m_renderTargets);
+    m_commandQueue.Reset();
+    m_swapChain.Reset();
+    m_device.Reset();
+}
+
+// Tears down D3D resources and reinitializes them.
+void D3D12PredicationQueries::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
+    {
+        WaitForGpu();
+    }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
 }
 
 void D3D12PredicationQueries::OnDestroy()

--- a/Samples/Desktop/D3D12PredicationQueries/src/D3D12PredicationQueries.h
+++ b/Samples/Desktop/D3D12PredicationQueries/src/D3D12PredicationQueries.h
@@ -92,6 +92,8 @@ private:
 
     void LoadPipeline();
     void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
     void PopulateCommandList();
     void WaitForGpu();
     void MoveToNextFrame();

--- a/Samples/Desktop/D3D12PredicationQueries/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12PredicationQueries/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12PredicationQueries/src/DXSample.h
+++ b/Samples/Desktop/D3D12PredicationQueries/src/DXSample.h
@@ -38,7 +38,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/Desktop/D3D12PredicationQueries/src/d3dx12.h
+++ b/Samples/Desktop/D3D12PredicationQueries/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12PredicationQueries/src/stdafx.h
+++ b/Samples/Desktop/D3D12PredicationQueries/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>

--- a/Samples/Desktop/D3D12ReservedResources/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12ReservedResources/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12ReservedResources/src/DXSample.h
+++ b/Samples/Desktop/D3D12ReservedResources/src/DXSample.h
@@ -38,7 +38,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/Desktop/D3D12ReservedResources/src/d3dx12.h
+++ b/Samples/Desktop/D3D12ReservedResources/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12ReservedResources/src/stdafx.h
+++ b/Samples/Desktop/D3D12ReservedResources/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include "d3dx12.h"

--- a/Samples/Desktop/D3D12Residency/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12Residency/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12Residency/src/DXSample.h
+++ b/Samples/Desktop/D3D12Residency/src/DXSample.h
@@ -38,7 +38,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/Desktop/D3D12Residency/src/d3dx12.h
+++ b/Samples/Desktop/D3D12Residency/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12Residency/src/stdafx.h
+++ b/Samples/Desktop/D3D12Residency/src/stdafx.h
@@ -22,7 +22,7 @@
 #include <windows.h>
 
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"

--- a/Samples/Desktop/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.cpp
+++ b/Samples/Desktop/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.cpp
@@ -44,6 +44,7 @@ D3D12SM6WaveIntrinsics::D3D12SM6WaveIntrinsics(UINT width, UINT height, std::wst
     m_mouseLeftButtonDown(false),
     m_rendermode{ 1 }
 {
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
 }
 
 void D3D12SM6WaveIntrinsics::OnInit()
@@ -69,7 +70,7 @@ void D3D12SM6WaveIntrinsics::CreateDevice(const ComPtr<IDXGIFactory4>& factory)
     else
     {
         ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+        GetHardwareAdapter(factory.Get(), &hardwareAdapter, true);
 
         ThrowIfFailed(D3D12CreateDevice(
             hardwareAdapter.Get(),
@@ -602,14 +603,56 @@ void D3D12SM6WaveIntrinsics::OnUpdate()
 // Render the scene.
 void D3D12SM6WaveIntrinsics::OnRender()
 {
-    RenderUI();
-    // Record all the commands we need to render the scene into the command list.
-    RenderScene();
+    try
+    {
+        RenderUI();
+        // Record all the commands we need to render the scene into the command list.
+        RenderScene();
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+        // Present the frame.
+        ThrowIfFailed(m_swapChain->Present(1, 0));
 
-    MoveToNextFrame();
+        MoveToNextFrame();
+    }
+    catch (HrException& e)
+    {
+        if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
+        {
+            RestoreD3DResources();
+        }
+        else
+        {
+            throw;
+        }
+    }
+}
+
+// Release sample's D3D objects.
+void D3D12SM6WaveIntrinsics::ReleaseD3DResources()
+{
+    m_fence.Reset();
+    m_renderPass1RenderTargets.Reset();
+    m_uiRenderTarget.Reset();
+    ResetComPtrArray(&m_renderPass2RenderTargets);
+    m_commandQueue.Reset();
+    m_swapChain.Reset();
+    m_d3d12Device.Reset();
+}
+
+// Tears down D3D resources and reinitializes them.
+void D3D12SM6WaveIntrinsics::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
+    {
+        WaitForGpu();
+    }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
 }
 
 void D3D12SM6WaveIntrinsics::OnDestroy()

--- a/Samples/Desktop/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.h
+++ b/Samples/Desktop/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.h
@@ -123,6 +123,8 @@ private:
     void CreateDevice(const ComPtr<IDXGIFactory4>& factory);
     void LoadPipeline();
     void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
     void LoadSizeDependentResources();
     void MoveToNextFrame();
     void WaitForGpu();

--- a/Samples/Desktop/D3D12SM6WaveIntrinsics/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12SM6WaveIntrinsics/src/DXSample.cpp
@@ -52,31 +52,66 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12SM6WaveIntrinsics/src/DXSample.h
+++ b/Samples/Desktop/D3D12SM6WaveIntrinsics/src/DXSample.h
@@ -49,7 +49,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/Desktop/D3D12SM6WaveIntrinsics/src/d3dx12.h
+++ b/Samples/Desktop/D3D12SM6WaveIntrinsics/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12SmallResources/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12SmallResources/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12SmallResources/src/DXSample.h
+++ b/Samples/Desktop/D3D12SmallResources/src/DXSample.h
@@ -38,7 +38,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/Desktop/D3D12SmallResources/src/d3dx12.h
+++ b/Samples/Desktop/D3D12SmallResources/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12SmallResources/src/stdafx.h
+++ b/Samples/Desktop/D3D12SmallResources/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>

--- a/Samples/Desktop/D3D12nBodyGravity/src/D3D12nBodyGravity.cpp
+++ b/Samples/Desktop/D3D12nBodyGravity/src/D3D12nBodyGravity.cpp
@@ -46,6 +46,8 @@ D3D12nBodyGravity::D3D12nBodyGravity(UINT width, UINT height, std::wstring name)
     {
         m_heightInstances--;
     }
+
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
 }
 
 void D3D12nBodyGravity::OnInit()
@@ -95,7 +97,7 @@ void D3D12nBodyGravity::LoadPipeline()
     else
     {
         ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+        GetHardwareAdapter(factory.Get(), &hardwareAdapter, true);
 
         ThrowIfFailed(D3D12CreateDevice(
             hardwareAdapter.Get(),
@@ -616,40 +618,94 @@ void D3D12nBodyGravity::OnUpdate()
 // Render the scene.
 void D3D12nBodyGravity::OnRender()
 {
-    // Let the compute thread know that a new frame is being rendered.
-    for (int n = 0; n < ThreadCount; n++)
+    try
     {
-        InterlockedExchange(&m_renderContextFenceValues[n], m_renderContextFenceValue);
-    }
-
-    // Compute work must be completed before the frame can render or else the SRV 
-    // will be in the wrong state.
-    for (UINT n = 0; n < ThreadCount; n++)
-    {
-        UINT64 threadFenceValue = InterlockedGetValue(&m_threadFenceValues[n]);
-        if (m_threadFences[n]->GetCompletedValue() < threadFenceValue)
+        // Let the compute thread know that a new frame is being rendered.
+        for (int n = 0; n < ThreadCount; n++)
         {
-            // Instruct the rendering command queue to wait for the current 
-            // compute work to complete.
-            ThrowIfFailed(m_commandQueue->Wait(m_threadFences[n].Get(), threadFenceValue));
+            InterlockedExchange(&m_renderContextFenceValues[n], m_renderContextFenceValue);
+        }
+
+        // Compute work must be completed before the frame can render or else the SRV 
+        // will be in the wrong state.
+        for (UINT n = 0; n < ThreadCount; n++)
+        {
+            UINT64 threadFenceValue = InterlockedGetValue(&m_threadFenceValues[n]);
+            if (m_threadFences[n]->GetCompletedValue() < threadFenceValue)
+            {
+                // Instruct the rendering command queue to wait for the current 
+                // compute work to complete.
+                ThrowIfFailed(m_commandQueue->Wait(m_threadFences[n].Get(), threadFenceValue));
+            }
+        }
+
+        PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+
+        // Record all the commands we need to render the scene into the command list.
+        PopulateCommandList();
+
+        // Execute the command list.
+        ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
+        m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+
+        PIXEndEvent(m_commandQueue.Get());
+
+        // Present the frame.
+        ThrowIfFailed(m_swapChain->Present(1, 0));
+
+        MoveToNextFrame();
+    }
+    catch (HrException& e)
+    {
+        if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
+        {
+            RestoreD3DResources();
+        }
+        else
+        {
+            throw;
         }
     }
+}
 
-    PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+// Release sample's D3D objects.
+void D3D12nBodyGravity::ReleaseD3DResources()
+{
+    m_renderContextFence.Reset();
+    ResetComPtrArray(&m_renderTargets);
+    m_commandQueue.Reset();
+    m_swapChain.Reset();
+    m_device.Reset();
+}
 
-    // Record all the commands we need to render the scene into the command list.
-    PopulateCommandList();
+// Tears down D3D resources and reinitializes them.
+void D3D12nBodyGravity::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
+    {
+        WaitForGpu();
+    }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
+}
 
-    // Execute the command list.
-    ID3D12CommandList* ppCommandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+// Wait for pending GPU work to complete.
+void D3D12nBodyGravity::WaitForGpu()
+{
+    // Schedule a Signal command in the queue.
+    ThrowIfFailed(m_commandQueue->Signal(m_renderContextFence.Get(), m_renderContextFenceValues[m_frameIndex]));
 
-    PIXEndEvent(m_commandQueue.Get());
+    // Wait until the fence has been processed.
+    ThrowIfFailed(m_renderContextFence->SetEventOnCompletion(m_renderContextFenceValues[m_frameIndex], m_renderContextFenceEvent));
+    WaitForSingleObjectEx(m_renderContextFenceEvent, INFINITE, FALSE);
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
-
-    MoveToNextFrame();
+    // Increment the fence value for the current frame.
+    m_renderContextFenceValues[m_frameIndex]++;
 }
 
 // Fill the command list with all the render commands and dependent state.

--- a/Samples/Desktop/D3D12nBodyGravity/src/D3D12nBodyGravity.h
+++ b/Samples/Desktop/D3D12nBodyGravity/src/D3D12nBodyGravity.h
@@ -170,6 +170,9 @@ private:
 
     void LoadPipeline();
     void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
+    void WaitForGpu();
     void CreateAsyncContexts();
     void CreateVertexBuffer();
     float RandomPercent();

--- a/Samples/Desktop/D3D12nBodyGravity/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12nBodyGravity/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12nBodyGravity/src/DXSample.h
+++ b/Samples/Desktop/D3D12nBodyGravity/src/DXSample.h
@@ -38,7 +38,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/Desktop/D3D12nBodyGravity/src/d3dx12.h
+++ b/Samples/Desktop/D3D12nBodyGravity/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/Desktop/D3D12nBodyGravity/src/stdafx.h
+++ b/Samples/Desktop/D3D12nBodyGravity/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>

--- a/Samples/Desktop/D3D12xGPU/readme.md
+++ b/Samples/Desktop/D3D12xGPU/readme.md
@@ -14,5 +14,5 @@ As the sample is able to survive an adapter removal event, it declares that it s
 * [1-9] - adapter selection, when manual override is enabled.
 
 ## Requirements
-* Windows 10 October 2018 Update or higher
-* [Visual Studio 2017](https://www.visualstudio.com/) with the [Windows 10 October 2018 Update SDK (17763)](https://developer.microsoft.com/en-US/windows/downloads/windows-10-sdk)
+* Windows 10 17655 or higher (available via [Windows Insider Program](https://insider.windows.com/en-us/))
+* [Visual Studio 2017](https://www.visualstudio.com/) with the Windows 10 17655 SDK

--- a/Samples/Desktop/D3D12xGPU/src/Common.hlsli
+++ b/Samples/Desktop/D3D12xGPU/src/Common.hlsli
@@ -1,0 +1,123 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#define NUM_LIGHTS 1
+#define SHADOW_DEPTH_BIAS 0.00005f
+
+struct LightState
+{
+    float3 position;
+    float3 direction;
+    float4 color;
+    float4 falloff;
+    float4x4 view;
+    float4x4 projection;
+};
+
+cbuffer SceneConstantBuffer : register(b0)
+{
+    float4x4 model;
+    float4x4 view;
+    float4x4 projection;
+    float4 ambientColor;
+    bool sampleShadowMap;
+    LightState lights[NUM_LIGHTS];
+    float4 viewport;
+    float4 clipPlane;
+};
+
+// Sample normal map, convert to signed, apply tangent-to-world space transform.
+float3 CalcPerPixelNormal(float2 vTexcoord, float3 vVertNormal, float3 vVertTangent)
+{
+    // Compute per-pixel normal.
+    float3 vBumpNormal = (float3)normalMap.Sample(sampleWrap, vTexcoord);
+    vBumpNormal = 2.0f * vBumpNormal - 1.0f;
+
+    // Compute tangent frame.
+    vVertNormal = normalize(vVertNormal);
+    vVertTangent = normalize(vVertTangent);
+
+    float3 vVertBinormal = normalize(cross(vVertTangent, vVertNormal));
+    float3x3 mTangentSpaceToWorldSpace = float3x3(vVertTangent, vVertBinormal, vVertNormal);
+
+    return mul(vBumpNormal, mTangentSpaceToWorldSpace);
+}
+
+// Diffuse lighting calculation, with angle and distance falloff.
+float4 CalcLightingColor(float3 vLightPos, float3 vLightDir, float4 vLightColor, float4 vFalloffs, float3 vPosWorld, float3 vPerPixelNormal)
+{
+    float3 vLightToPixelUnNormalized = vPosWorld - vLightPos;
+
+    // Dist falloff = 0 at vFalloffs.x, 1 at vFalloffs.x - vFalloffs.y
+    float fDist = length(vLightToPixelUnNormalized);
+
+    float fDistFalloff = saturate((vFalloffs.x - fDist) / vFalloffs.y);
+
+    // Normalize from here on.
+    float3 vLightToPixelNormalized = vLightToPixelUnNormalized / fDist;
+
+    // Angle falloff = 0 at vFalloffs.z, 1 at vFalloffs.z - vFalloffs.w
+    float fCosAngle = dot(vLightToPixelNormalized, vLightDir / length(vLightDir));
+    float fAngleFalloff = saturate((fCosAngle - vFalloffs.z) / vFalloffs.w);
+
+    // Diffuse contribution.
+    float fNDotL = saturate(-dot(vLightToPixelNormalized, vPerPixelNormal));
+
+    // Ignore angle falloff for a point light.
+    fAngleFalloff = 1.0f;  
+
+    return vLightColor * fNDotL * fDistFalloff * fAngleFalloff;
+}
+
+// Test how much pixel is in shadow, using 2x2 percentage-closer filtering.
+float4 CalcUnshadowedAmountPCF2x2(int lightIndex, float4 vPosWorld)
+{
+    // Compute pixel position in light space.
+    float4 vLightSpacePos = vPosWorld;
+    vLightSpacePos = mul(vLightSpacePos, lights[lightIndex].view);
+    vLightSpacePos = mul(vLightSpacePos, lights[lightIndex].projection);
+
+    vLightSpacePos.xyz /= vLightSpacePos.w;
+
+    // Translate from homogeneous coords to texture coords.
+    float2 vShadowTexCoord = 0.5f * vLightSpacePos.xy + 0.5f;
+    vShadowTexCoord.y = 1.0f - vShadowTexCoord.y;
+
+    // Depth bias to avoid pixel self-shadowing.
+    float vLightSpaceDepth = vLightSpacePos.z - SHADOW_DEPTH_BIAS;
+
+    // Find sub-pixel weights.
+    float2 vShadowMapDims = float2(viewport.x, viewport.y); //float2(1280.0f, 720.0f);             // need to keep in sync with .cpp file
+    float4 vSubPixelCoords = float4(1.0f, 1.0f, 1.0f, 1.0f);
+    vSubPixelCoords.xy = frac(vShadowMapDims * vShadowTexCoord);
+    vSubPixelCoords.zw = 1.0f - vSubPixelCoords.xy;
+    float4 vBilinearWeights = vSubPixelCoords.zxzx * vSubPixelCoords.wwyy;
+
+    // 2x2 percentage closer filtering.
+    float2 vTexelUnits = 1.0f / vShadowMapDims;
+    float4 vShadowDepths;
+    if (vShadowTexCoord.x <= 0.0f || vShadowTexCoord.x >= 1.0f || vShadowTexCoord.y <= 0.0f || vShadowTexCoord.y >= 1.0f || vLightSpaceDepth > 1.0f)
+    {
+        // Hack for a point light with a shadow map only for a single face.
+        // Don't apply any shadow outside the shadow map.
+        return float4(1.0, 1.0, 1.0, 1.0);
+    }
+    else
+    {
+        vShadowDepths.x = shadowMap.Sample(sampleClamp, vShadowTexCoord).x;
+        vShadowDepths.y = shadowMap.Sample(sampleClamp, vShadowTexCoord + float2(vTexelUnits.x, 0.0f)).x;
+        vShadowDepths.z = shadowMap.Sample(sampleClamp, vShadowTexCoord + float2(0.0f, vTexelUnits.y)).x;
+        vShadowDepths.w = shadowMap.Sample(sampleClamp, vShadowTexCoord + vTexelUnits).x;
+    }
+    // What weighted fraction of the 4 samples are nearer to the light than this pixel?
+    float4 vShadowTests = (vShadowDepths >= vLightSpaceDepth) ? 1.0f : 0.0f;
+    return dot(vBilinearWeights, vShadowTests);
+}

--- a/Samples/Desktop/D3D12xGPU/src/D3D12xGPU.h
+++ b/Samples/Desktop/D3D12xGPU/src/D3D12xGPU.h
@@ -111,6 +111,6 @@ private:
     void SelectAdapter(UINT index);
     void SelectGPUPreference(UINT index);
     void CalculateFrameStats(); 
-    void WaitForGpu();
+    void WaitForGpu(ID3D12CommandQueue* pCommandQueue);
     void MoveToNextFrame();
 };

--- a/Samples/Desktop/D3D12xGPU/src/D3D12xGPU.vcxproj
+++ b/Samples/Desktop/D3D12xGPU/src/D3D12xGPU.vcxproj
@@ -113,6 +113,7 @@
     <ClInclude Include="FrameResource.h" />
     <ClInclude Include="ShadowsFogScatteringSquidScene.h" />
     <ClInclude Include="SquidRoom.h" />
+    <ClInclude Include="GPUTimer.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="UILayer.cpp" />
@@ -127,9 +128,23 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="Win32Application.cpp" />
+    <ClCompile Include="GPUTimer.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="Common.hlsli">
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+      <FileType>Document</FileType>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">copy %(Identity) "$(OutDir)" &gt; NUL</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)\%(Identity)</Outputs>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatOutputAsContent>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">copy %(Identity) "$(OutDir)" &gt; NUL</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)\%(Identity)</Outputs>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</TreatOutputAsContent>
+    </CustomBuild>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="ShadowsAndScenePass.hlsl">

--- a/Samples/Desktop/D3D12xGPU/src/D3D12xGPU.vcxproj.filters
+++ b/Samples/Desktop/D3D12xGPU/src/D3D12xGPU.vcxproj.filters
@@ -63,6 +63,9 @@
     <ClInclude Include="ShadowsFogScatteringSquidScene.h">
       <Filter>Header Files\Util</Filter>
     </ClInclude>
+    <ClInclude Include="GPUTimer.h">
+      <Filter>Header Files\Util</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="DXSample.cpp">
@@ -92,6 +95,9 @@
     <ClCompile Include="ShadowsFogScatteringSquidScene.cpp">
       <Filter>Source Files\Util</Filter>
     </ClCompile>
+    <ClCompile Include="GPUTimer.cpp">
+      <Filter>Source Files\Util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -101,6 +107,9 @@
       <Filter>Assets\Shaders</Filter>
     </CustomBuild>
     <CustomBuild Include="ShadowsAndScenePass.hlsl">
+      <Filter>Assets\Shaders</Filter>
+    </CustomBuild>
+    <CustomBuild Include="Common.hlsli">
       <Filter>Assets\Shaders</Filter>
     </CustomBuild>
   </ItemGroup>

--- a/Samples/Desktop/D3D12xGPU/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12xGPU/src/DXSample.cpp
@@ -52,31 +52,66 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/Desktop/D3D12xGPU/src/DXSample.h
+++ b/Samples/Desktop/D3D12xGPU/src/DXSample.h
@@ -49,7 +49,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/Desktop/D3D12xGPU/src/FrameResource.cpp
+++ b/Samples/Desktop/D3D12xGPU/src/FrameResource.cpp
@@ -16,290 +16,63 @@
 
 using namespace SceneEnums;
 
-FrameResource::FrameResource(ID3D12Device* pDevice, ComPtr<ID3D12PipelineState> pPipelineStates[RenderPass::Count], ID3D12DescriptorHeap* pDsvHeap, ID3D12DescriptorHeap* pCbvSrvHeap, UINT frameIndex) :
-    m_frameResourceIndex(frameIndex)
+FrameResource::FrameResource(ID3D12Device* pDevice, ID3D12CommandQueue* pCommandQueue)
+    : m_gpuTimer(pDevice, pCommandQueue, 3)
 {
-    for (UINT i = 0; i < RenderPass::Count; i++)
-    {
-        m_pipelineStates[i] = pPipelineStates[i];
-    }
-
-    for (UINT i = 0; i < CommandListCount; i++)
-    {
-        ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[i])));
-        ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[i].Get(), m_pipelineStates[i].Get(), IID_PPV_ARGS(&m_commandLists[i])));
-        NAME_D3D12_OBJECT_INDEXED(m_commandLists, i);
-
-        // Close these command lists; don't record into them for now.
-        ThrowIfFailed(m_commandLists[i]->Close());
-    }
+    ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+    NAME_D3D12_OBJECT(m_commandAllocator);
 
     for (UINT i = 0; i < NumContexts; i++)
     {
-        // Create command list allocators for worker threads. One alloc is 
-        // for the shadow pass command list, and one is for the scene pass.
-        ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_shadowCommandAllocators[i])));
-        ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[i])));
-
-        ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_shadowCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Shadow].Get(), IID_PPV_ARGS(&m_shadowCommandLists[i])));
-        ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_sceneCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Scene].Get(), IID_PPV_ARGS(&m_sceneCommandLists[i])));
-
-        NAME_D3D12_OBJECT_INDEXED(m_shadowCommandLists, i);
-        NAME_D3D12_OBJECT_INDEXED(m_sceneCommandLists, i);
-
-        // Close these command lists; don't record into them for now. We will 
-        // reset them to a recording state when we start the render loop.
-        ThrowIfFailed(m_shadowCommandLists[i]->Close());
-        ThrowIfFailed(m_sceneCommandLists[i]->Close());
+        // Create command list allocators for worker threads. One per open command list.
+        ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_contextCommandAllocators[i])));
+        NAME_D3D12_OBJECT_INDEXED(m_contextCommandAllocators, i);
     }
-    ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_postprocessCommandAllocator)));
-    ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_postprocessCommandAllocator.Get(), m_pipelineStates[RenderPass::Postprocess].Get(), IID_PPV_ARGS(&m_postprocessCommandList)));
-    NAME_D3D12_OBJECT(m_postprocessCommandList);
-    ThrowIfFailed(m_postprocessCommandList->Close());
 
-    const UINT textureCount = _countof(SampleAssets::Textures);    // Diffuse + normal textures near the start of the heap.  Ideally, track descriptor heap contents/offsets at a higher level.
-    const UINT cbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    const UINT dsvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_DSV);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE cbvSrvCpuHandle(pCbvSrvHeap->GetCPUDescriptorHandleForHeapStart());
-    CD3DX12_GPU_DESCRIPTOR_HANDLE cbvSrvGpuHandle(pCbvSrvHeap->GetGPUDescriptorHandleForHeapStart());
-    CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(pDsvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameResourceIndex * NumDepthBuffers, dsvDescriptorSize);
-    m_nullSrvHandle = cbvSrvGpuHandle;
-    cbvSrvCpuHandle.Offset(NumNullSrvs + textureCount + (m_frameResourceIndex * (NumDepthBuffers + NumConstantBuffers)), cbvSrvDescriptorSize);
-    cbvSrvGpuHandle.Offset(NumNullSrvs + textureCount + (m_frameResourceIndex * (NumDepthBuffers + NumConstantBuffers)), cbvSrvDescriptorSize);
-   
-    // Initialize descript heap handles for depth resources.
-    // The resources and views are created later as they are window size dependent.
-    {
-        // Shadow depth resource.
-        m_depthDSVs[DepthGenPass::Shadow] = dsvHandle;
-        m_depthSRVs[DepthGenPass::Shadow] = cbvSrvCpuHandle;
-        m_depthSrvHandles[DepthGenPass::Shadow] = cbvSrvGpuHandle;
-     
-        dsvHandle.Offset(dsvDescriptorSize);
-        cbvSrvCpuHandle.Offset(cbvSrvDescriptorSize);
-        cbvSrvGpuHandle.Offset(cbvSrvDescriptorSize);
-
-        // Scene depth resource.
-        m_depthDSVs[DepthGenPass::Scene] = dsvHandle;
-        m_depthSRVs[DepthGenPass::Scene] = cbvSrvCpuHandle;
-        m_depthSrvHandles[DepthGenPass::Scene] = cbvSrvGpuHandle;
-    }
-        
     // Create constant buffers.
     {
-        // Shadow generation constant buffer.
-        cbvSrvCpuHandle.Offset(cbvSrvDescriptorSize);
-        cbvSrvGpuHandle.Offset(cbvSrvDescriptorSize);
-        ThrowIfFailed(CreateConstantBuffer(pDevice, sizeof(SceneConstantBuffer), &m_constantBuffers[RenderPass::Shadow], cbvSrvCpuHandle, D3D12_RESOURCE_STATE_GENERIC_READ));
-        m_cbvHandles[RenderPass::Shadow] = cbvSrvGpuHandle;
+        ThrowIfFailed(CreateConstantBuffer(pDevice, sizeof(SceneConstantBuffer), &m_constantBuffers[RenderPass::Shadow], nullptr, D3D12_RESOURCE_STATE_GENERIC_READ));
         NAME_D3D12_OBJECT(m_constantBuffers[RenderPass::Shadow]);
         
         // Scene render constant buffer.
-        cbvSrvCpuHandle.Offset(cbvSrvDescriptorSize);
-        cbvSrvGpuHandle.Offset(cbvSrvDescriptorSize);
-        ThrowIfFailed(CreateConstantBuffer(pDevice, sizeof(SceneConstantBuffer), &m_constantBuffers[RenderPass::Scene], cbvSrvCpuHandle, D3D12_RESOURCE_STATE_GENERIC_READ));
-        m_cbvHandles[RenderPass::Scene] = cbvSrvGpuHandle;
+        ThrowIfFailed(CreateConstantBuffer(pDevice, sizeof(SceneConstantBuffer), &m_constantBuffers[RenderPass::Scene], nullptr, D3D12_RESOURCE_STATE_GENERIC_READ));
         NAME_D3D12_OBJECT(m_constantBuffers[RenderPass::Scene]);
 
         // Postprocess pass constant buffer.
-        cbvSrvCpuHandle.Offset(cbvSrvDescriptorSize);
-        cbvSrvGpuHandle.Offset(cbvSrvDescriptorSize);
-        ThrowIfFailed(CreateConstantBuffer(pDevice, sizeof(PostprocessConstantBuffer), &m_constantBuffers[RenderPass::Postprocess], cbvSrvCpuHandle, D3D12_RESOURCE_STATE_GENERIC_READ));
-        m_cbvHandles[RenderPass::Postprocess] = cbvSrvGpuHandle;
+        ThrowIfFailed(CreateConstantBuffer(pDevice, sizeof(PostprocessConstantBuffer), &m_constantBuffers[RenderPass::Postprocess], nullptr, D3D12_RESOURCE_STATE_GENERIC_READ));
         NAME_D3D12_OBJECT(m_constantBuffers[RenderPass::Postprocess]);
 
         // Map the constant buffers and cache their heap pointers.
         // We don't unmap this until the app closes. Keeping buffer mapped for the lifetime of the resource is okay.
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
+        const CD3DX12_RANGE readRange(0, 0); // We do not intend to read from this resource on the CPU.
         ThrowIfFailed(m_constantBuffers[RenderPass::Shadow]->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBuffersWO[RenderPass::Shadow])));
         ThrowIfFailed(m_constantBuffers[RenderPass::Scene]->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBuffersWO[RenderPass::Scene])));
         ThrowIfFailed(m_constantBuffers[RenderPass::Postprocess]->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBuffersWO[RenderPass::Postprocess])));
-        
     }
-
-    // Batch up command lists for execution later.
-    const UINT batchSize = _countof(m_sceneCommandLists) + _countof(m_shadowCommandLists) + CommandListCount;
-    m_batchSubmit[0] = m_commandLists[CommandListPre].Get();
-    memcpy(m_batchSubmit + 1, m_shadowCommandLists, _countof(m_shadowCommandLists) * sizeof(ID3D12CommandList*));
-    m_batchSubmit[_countof(m_shadowCommandLists) + 1] = m_commandLists[CommandListMid].Get();
-    memcpy(m_batchSubmit + _countof(m_shadowCommandLists) + 2, m_sceneCommandLists, _countof(m_sceneCommandLists) * sizeof(ID3D12CommandList*));
-    m_batchSubmit[batchSize - 1] = m_commandLists[CommandListPost].Get();
 }
 
 FrameResource::~FrameResource()
 {
-    for (int i = 0; i < CommandListCount; i++)
-    {
-        m_commandAllocators[i] = nullptr;
-        m_commandLists[i] = nullptr;
-    }
+}
 
-    m_constantBuffers[RenderPass::Shadow] = nullptr;
-    m_constantBuffers[RenderPass::Scene] = nullptr;
+void FrameResource::InitFrame()
+{
+    // Reset the main thread command allocator.
+    m_commandAllocator->Reset();
 
+    // Reset the worker command allocators.
     for (int i = 0; i < NumContexts; i++)
     {
-        m_shadowCommandLists[i] = nullptr;
-        m_shadowCommandAllocators[i] = nullptr;
-
-        m_sceneCommandLists[i] = nullptr;
-        m_sceneCommandAllocators[i] = nullptr;
+        ThrowIfFailed(m_contextCommandAllocators[i]->Reset());
     }
-    m_postprocessCommandAllocator = nullptr;
-    m_postprocessCommandList = nullptr;
-
-    m_depthTextures[DepthGenPass::Shadow] = nullptr;
 }
 
-void FrameResource::LoadSizeDependentResources(ID3D12Device* pDevice, UINT width, UINT height)
+void FrameResource::BeginFrame(ID3D12GraphicsCommandList* pCommandList)
 {
-    // Create depth stencil resources.
-
-    // Shadow depth resource.
-    ThrowIfFailed(CreateDepthStencilTexture2D(pDevice, width, height, DXGI_FORMAT_R32_TYPELESS, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_R32_FLOAT, &m_depthTextures[DepthGenPass::Shadow], m_depthDSVs[DepthGenPass::Shadow], m_depthSRVs[DepthGenPass::Shadow]));
-    NAME_D3D12_OBJECT(m_depthTextures[DepthGenPass::Shadow]);
-
-    // Scene depth resource.
-    ThrowIfFailed(CreateDepthStencilTexture2D(pDevice, width, height, DXGI_FORMAT_R32_TYPELESS, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_R32_FLOAT, &m_depthTextures[DepthGenPass::Scene], m_depthDSVs[DepthGenPass::Scene], m_depthSRVs[DepthGenPass::Scene]));
-    NAME_D3D12_OBJECT(m_depthTextures[DepthGenPass::Scene]);
-}
-
-void FrameResource::ReleaseSizeDependentResources()
-{
-    m_depthTextures[DepthGenPass::Shadow].Reset();
-    m_depthTextures[DepthGenPass::Scene].Reset();
-}
-
-void FrameResource::ClearDepthStencilViews(ID3D12GraphicsCommandList* pCommandList)
-{
-    pCommandList->ClearDepthStencilView(m_depthDSVs[DepthGenPass::Shadow], D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
-    pCommandList->ClearDepthStencilView(m_depthDSVs[DepthGenPass::Scene], D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
-}
-
-// Builds and writes constant buffers from scratch to the proper slots for 
-// this frame resource.
-void FrameResource::WriteConstantBuffers(D3D12_VIEWPORT* pViewport, Camera* pSceneCamera, Camera lightCams[NumLights], LightState lights[NumLights])
-{
-    SceneConstantBuffer sceneConsts = {}; 
-    SceneConstantBuffer shadowConsts = {};
-    PostprocessConstantBuffer postprocessConsts = {};
-    
-    // Scale down the world a bit.
-    ::XMStoreFloat4x4(&sceneConsts.model, XMMatrixScaling(0.1f, 0.1f, 0.1f));
-    ::XMStoreFloat4x4(&shadowConsts.model, XMMatrixScaling(0.1f, 0.1f, 0.1f));
-
-    // The scene pass is drawn from the camera.
-    pSceneCamera->Get3DViewProjMatrices(&sceneConsts.view, &sceneConsts.projection, 90.0f, pViewport->Width, pViewport->Height);
-
-    // The light pass is drawn from the first light.
-    lightCams[0].Get3DViewProjMatrices(&shadowConsts.view, &shadowConsts.projection, 90.0f, pViewport->Width, pViewport->Height);
-
-    for (int i = 0; i < NumLights; i++)
-    {
-        memcpy(&sceneConsts.lights[i], &lights[i], sizeof(LightState));
-        memcpy(&shadowConsts.lights[i], &lights[i], sizeof(LightState));
+    m_gpuTimer.BeginFrame(pCommandList);
     }
 
-    // The shadow pass won't sample the shadow map, but rather write to it.
-    shadowConsts.sampleShadowMap = FALSE;
-
-    // The scene pass samples the shadow map.
-    sceneConsts.sampleShadowMap = TRUE;
-
-    shadowConsts.ambientColor = sceneConsts.ambientColor = { 0.1f, 0.2f, 0.3f, 1.0f };
-
-    postprocessConsts.lightPosition = lights[0].position;
-    XMStoreFloat4(&postprocessConsts.cameraPosition, pSceneCamera->mEye);
-    float fovAngleY = 90.0f;
-    float fovRadiansY = fovAngleY * XM_PI / 180.0f;
-    XMMATRIX view = XMMatrixLookAtRH(pSceneCamera->mEye, pSceneCamera->mAt, pSceneCamera->mUp);
-    XMVECTOR determinant = XMMatrixDeterminant(view);
-    XMMATRIX viewInverse = XMMatrixInverse(&determinant, view);
-
-    XMMATRIX proj = XMMatrixPerspectiveFovRH(fovRadiansY, pViewport->Width / pViewport->Height, 0.01f, 125.0f);
-    determinant = XMMatrixDeterminant(proj);
-    XMMATRIX projInverse = XMMatrixInverse(&determinant, proj);
-
-    float nearZ1 = 1.0f;
-    XMMATRIX projAtNearZ1 = XMMatrixPerspectiveFovRH(fovRadiansY, pViewport->Width/ pViewport->Height, nearZ1, 125.0f);
-    XMMATRIX viewProjAtNearZ1 = view * projAtNearZ1;
-    determinant = XMMatrixDeterminant(viewProjAtNearZ1);
-    XMMATRIX viewProjInverseAtNearZ1 = XMMatrixInverse(&determinant, viewProjAtNearZ1);
-
-    // Copy over a transposed row-major inverse matrix, since HLSL assumes col-major order.
-    XMStoreFloat4x4(&postprocessConsts.viewInverse, XMMatrixTranspose(viewInverse));
-    XMStoreFloat4x4(&postprocessConsts.projInverse, XMMatrixTranspose(projInverse));
-    XMStoreFloat4x4(&postprocessConsts.viewProjInverseAtNearZ1, XMMatrixTranspose(viewProjInverseAtNearZ1));
-
-    memcpy(m_pConstantBuffersWO[RenderPass::Scene], &sceneConsts, sizeof(sceneConsts));
-    memcpy(m_pConstantBuffersWO[RenderPass::Shadow], &shadowConsts, sizeof(shadowConsts));
-    memcpy(m_pConstantBuffersWO[RenderPass::Postprocess], &postprocessConsts, sizeof(postprocessConsts));
-}
-
-void FrameResource::Init()
+void FrameResource::EndFrame(ID3D12GraphicsCommandList* pCommandList)
 {
-    // Reset the command allocators and lists for the main thread.
-    for (int i = 0; i < CommandListCount; i++)
-    {
-        ThrowIfFailed(m_commandAllocators[i]->Reset());
-        ThrowIfFailed(m_commandLists[i]->Reset(m_commandAllocators[i].Get(), m_pipelineStates[RenderPass::Scene].Get()));
-    }
-    
-    // Reset the worker command allocators and lists.
-    for (int i = 0; i < NumContexts; i++)
-    {
-        ThrowIfFailed(m_shadowCommandAllocators[i]->Reset());
-        ThrowIfFailed(m_shadowCommandLists[i]->Reset(m_shadowCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Shadow].Get()));
-
-        ThrowIfFailed(m_sceneCommandAllocators[i]->Reset());
-        ThrowIfFailed(m_sceneCommandLists[i]->Reset(m_sceneCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Scene].Get()));
-    }
-
-    ThrowIfFailed(m_postprocessCommandAllocator->Reset());
-    ThrowIfFailed(m_postprocessCommandList->Reset(m_postprocessCommandAllocator.Get(), m_pipelineStates[RenderPass::Postprocess].Get()));
-}
-
-void FrameResource::SwapBarriers()
-{
-    // Transition the shadow map from writeable to readable.
-    m_commandLists[CommandListMid]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_depthTextures[DepthGenPass::Shadow].Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
-}
-
-
-void FrameResource::Finish()
-{
-    m_commandLists[CommandListPost]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_depthTextures[DepthGenPass::Shadow].Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE));
-}
-
-// Sets up the descriptor tables for the worker command list to use 
-// resources provided by frame resource.
-void FrameResource::Bind(ID3D12GraphicsCommandList* pCommandList, RenderPass::Value renderPass, D3D12_CPU_DESCRIPTOR_HANDLE* pRtvHandle)
-{
-    switch (renderPass)
-    {
-    case RenderPass::Shadow:
-    {
-        pCommandList->SetGraphicsRootDescriptorTable(1, m_cbvHandles[RenderPass::Shadow]);
-        pCommandList->SetGraphicsRootDescriptorTable(2, m_nullSrvHandle);                                // Set a null SRV for the shadow texture.
-
-        pCommandList->OMSetRenderTargets(0, nullptr, FALSE, &m_depthDSVs[DepthGenPass::Shadow]);        // No render target needed for the shadow pass.
-        break;
-    }
-    case RenderPass::Scene:
-    {
-        pCommandList->SetGraphicsRootDescriptorTable(1, m_cbvHandles[RenderPass::Scene]);
-        pCommandList->SetGraphicsRootDescriptorTable(2, m_depthSrvHandles[DepthGenPass::Shadow]);        // Set the shadow texture as an SRV.
-
-        pCommandList->OMSetRenderTargets(1, pRtvHandle, FALSE, &m_depthDSVs[DepthGenPass::Scene]);
-        break;
-    }
-    case RenderPass::Postprocess:
-    {
-        pCommandList->SetGraphicsRootDescriptorTable(0, m_depthSrvHandles[DepthGenPass::Scene]);
-        pCommandList->SetGraphicsRootDescriptorTable(1, m_cbvHandles[RenderPass::Postprocess]);
-
-        pCommandList->OMSetRenderTargets(1, pRtvHandle, FALSE, nullptr);                                // No depth stencil needed for the postprocess pass.
-        break;
-    }
-    }
+    m_gpuTimer.EndFrame(pCommandList);
 }

--- a/Samples/Desktop/D3D12xGPU/src/FrameResource.h
+++ b/Samples/Desktop/D3D12xGPU/src/FrameResource.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "ShadowsFogScatteringSquidScene.h"
+#include "GPUTimer.h"
 
 using namespace DirectX;
 using namespace Microsoft::WRL;
@@ -19,126 +20,35 @@ using namespace Microsoft::WRL;
 class FrameResource
 {
 public:
-    ID3D12CommandList * m_batchSubmit[NumContexts * 2 + CommandListCount];   // *2: shadowCommandLists, sceneCommandLists
-
-    ComPtr<ID3D12CommandAllocator> m_commandAllocators[CommandListCount];
-    ComPtr<ID3D12GraphicsCommandList> m_commandLists[CommandListCount];
-
-    ComPtr<ID3D12CommandAllocator> m_shadowCommandAllocators[NumContexts];
-    ComPtr<ID3D12GraphicsCommandList> m_shadowCommandLists[NumContexts];
-
-    ComPtr<ID3D12CommandAllocator> m_sceneCommandAllocators[NumContexts];
-    ComPtr<ID3D12GraphicsCommandList> m_sceneCommandLists[NumContexts];
-
-    ComPtr<ID3D12CommandAllocator> m_postprocessCommandAllocator;
-    ComPtr<ID3D12GraphicsCommandList> m_postprocessCommandList;
-
-    ComPtr<ID3D12Resource> m_renderTarget;
-    D3D12_CPU_DESCRIPTOR_HANDLE m_renderTargetView;
-    ComPtr<ID3D12PipelineState> m_pipelineStates[SceneEnums::RenderPass::Count];
-    D3D12_GPU_DESCRIPTOR_HANDLE m_nullSrvHandle;                        // Null SRV for out of bounds behavior.
+    // Performance tip: Minimize the number of command allocators and command lists.
+    // Each open command list needs it's own command allocator.
+    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+    ComPtr<ID3D12CommandAllocator> m_contextCommandAllocators[NumContexts];
 
     ComPtr<ID3D12Resource> m_constantBuffers[SceneEnums::RenderPass::Count];
-    SceneConstantBuffer* m_pConstantBuffersWO[SceneEnums::RenderPass::Count];        // WRITE-ONLY pointers to the constant buffers
-    D3D12_GPU_DESCRIPTOR_HANDLE m_cbvHandles[SceneEnums::RenderPass::Count];
-    
-    ComPtr<ID3D12Resource> m_depthTextures[SceneEnums::DepthGenPass::Count];
-    D3D12_CPU_DESCRIPTOR_HANDLE m_depthDSVs[SceneEnums::DepthGenPass::Count];
-    D3D12_CPU_DESCRIPTOR_HANDLE m_depthSRVs[SceneEnums::DepthGenPass::Count];
-    D3D12_GPU_DESCRIPTOR_HANDLE m_depthSrvHandles[SceneEnums::DepthGenPass::Count];
+    void* m_pConstantBuffersWO[SceneEnums::RenderPass::Count]; // WRITE-ONLY pointers to the constant buffers
 
-    UINT m_frameResourceIndex;
+    DX::GPUTimer m_gpuTimer;
 
 public:
-    FrameResource(ID3D12Device* pDevice, ComPtr<ID3D12PipelineState> pPipelineStates[SceneEnums::RenderPass::Count], ID3D12DescriptorHeap* pDsvHeap, ID3D12DescriptorHeap* pCbvSrvHeap, UINT frameResourceIndex);
-    ~FrameResource();
+    FrameResource(ID3D12Device* pDevice, ID3D12CommandQueue* pCommandQueue);
+    virtual ~FrameResource();
 
-    void LoadSizeDependentResources(ID3D12Device* pDevice, UINT width, UINT height);
-    void ReleaseSizeDependentResources();
-   
-    void ClearDepthStencilViews(ID3D12GraphicsCommandList* pCommandList);
-    void Bind(ID3D12GraphicsCommandList* pCommandList, SceneEnums::RenderPass::Value renderPass, D3D12_CPU_DESCRIPTOR_HANDLE* pRtvHandle);
-    void Init();
-    void SwapBarriers();
-    void Finish();
-    void WriteConstantBuffers(D3D12_VIEWPORT* pViewport, Camera* pSceneCamera, Camera lightCams[NumLights], LightState lights[NumLights]);
+    virtual void InitFrame();
+    virtual void BeginFrame(ID3D12GraphicsCommandList* pCommandList);
+    virtual void EndFrame(ID3D12GraphicsCommandList* pCommandList);
+
+    inline D3D12_GPU_VIRTUAL_ADDRESS GetConstantBufferGPUVirtualAddress(SceneEnums::RenderPass::Value renderPass) const
+    {
+        return m_constantBuffers[renderPass]->GetGPUVirtualAddress();
+    }
 };
-
-
-inline HRESULT CreateDepthStencilTexture2D(
-    ID3D12Device* pDevice,
-    UINT width,
-    UINT height,
-    DXGI_FORMAT typelessFormat,
-    DXGI_FORMAT dsvFormat,
-    DXGI_FORMAT srvFormat,
-    ID3D12Resource** ppResource,
-    D3D12_CPU_DESCRIPTOR_HANDLE cpuDSVHandle,
-    D3D12_CPU_DESCRIPTOR_HANDLE cpuSRVHandle,
-    D3D12_RESOURCE_STATES initState = D3D12_RESOURCE_STATE_DEPTH_WRITE,
-    float initDepthValue = 1.0f,
-    UINT8 initStencilValue = 0)
-{
-    try
-    {
-        *ppResource = nullptr;
-
-        CD3DX12_RESOURCE_DESC texDesc(
-            D3D12_RESOURCE_DIMENSION_TEXTURE2D,
-            0,
-            width,
-            height,
-            1,
-            1,
-            typelessFormat,
-            1,
-            0,
-            D3D12_TEXTURE_LAYOUT_UNKNOWN,
-            D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
-
-        D3D12_CLEAR_VALUE clearValue;        // Performance tip: Tell the runtime at resource creation the desired clear value.
-        clearValue.Format = dsvFormat;
-        clearValue.DepthStencil.Depth = initDepthValue;
-        clearValue.DepthStencil.Stencil = initStencilValue;
-
-        ThrowIfFailed(pDevice->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &texDesc,
-            initState,
-            &clearValue,
-            IID_PPV_ARGS(ppResource)));
-
-        ThrowIfFailed((*ppResource)->SetName(L"DepthStencilResource"));
-
-        // Create a depth stencil view (DSV).
-        D3D12_DEPTH_STENCIL_VIEW_DESC dsvDesc = {};
-        dsvDesc.Format = dsvFormat;
-        dsvDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
-        dsvDesc.Texture2D.MipSlice = 0;
-        pDevice->CreateDepthStencilView(*ppResource, &dsvDesc, cpuDSVHandle);
-
-        // Create a shader resource view (SRV).
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Format = srvFormat;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = 1;
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        pDevice->CreateShaderResourceView(*ppResource, &srvDesc, cpuSRVHandle);
-    }
-    catch (HrException& e)
-    {
-        SAFE_RELEASE(*ppResource);
-        return e.Error();
-    }
-    return S_OK;
-}
 
 inline HRESULT CreateConstantBuffer(
     ID3D12Device* pDevice,
     UINT size,
     ID3D12Resource** ppResource,
-    D3D12_CPU_DESCRIPTOR_HANDLE cpuCBVHandle,
+    D3D12_CPU_DESCRIPTOR_HANDLE* pCpuCbvHandle = nullptr,
     D3D12_RESOURCE_STATES initState = D3D12_RESOURCE_STATE_GENERIC_READ)
 {
     try
@@ -154,15 +64,14 @@ inline HRESULT CreateConstantBuffer(
             nullptr,
             IID_PPV_ARGS(ppResource)));
 
-        // Create the constant buffer views: one for the shadow pass and
-        // another for the scene pass.
-        D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
-        cbvDesc.SizeInBytes = alignedSize;
-
-        // Describe and create the shadow constant buffer view (CBV) and 
-        // cache the GPU descriptor handle.
-        cbvDesc.BufferLocation = (*ppResource)->GetGPUVirtualAddress();
-        pDevice->CreateConstantBufferView(&cbvDesc, cpuCBVHandle);
+        if (pCpuCbvHandle)
+        {
+            // Describe and create the shadow constant buffer view (CBV).
+            D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
+            cbvDesc.SizeInBytes = alignedSize;
+            cbvDesc.BufferLocation = (*ppResource)->GetGPUVirtualAddress();
+            pDevice->CreateConstantBufferView(&cbvDesc, *pCpuCbvHandle);
+        }
     }
     catch (HrException& e)
     {

--- a/Samples/Desktop/D3D12xGPU/src/GPUTimer.cpp
+++ b/Samples/Desktop/D3D12xGPU/src/GPUTimer.cpp
@@ -1,0 +1,149 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#include "stdafx.h"
+#include "GPUTimer.h"
+#include "DXSampleHelper.h"
+
+#include <exception>
+#include <stdexcept>
+
+using namespace DX;
+
+using Microsoft::WRL::ComPtr;
+
+namespace
+{
+    inline float lerp(float a, float b, float f)
+    {
+        return (1.f - f) * a + f * b;
+    }
+
+    inline float UpdateRunningAverage(float avg, float value)
+    {
+        return lerp(value, avg, 0.95f);
+    }
+};
+
+void GPUTimer::Init(_In_ ID3D12Device* pDevice, _In_ ID3D12CommandQueue* pCommandQueue, UINT maxFrameCount)
+{
+    assert(pDevice != nullptr && pCommandQueue != nullptr);
+    m_maxframeCount = maxFrameCount;
+
+    UINT64 gpuFreq;
+    ThrowIfFailed(pCommandQueue->GetTimestampFrequency(&gpuFreq));
+    m_gpuFreqInv = 1000.0 / double(gpuFreq);
+
+    D3D12_QUERY_HEAP_DESC desc = {};
+    desc.Type = D3D12_QUERY_HEAP_TYPE_TIMESTAMP;
+    desc.Count = c_timerSlots;
+    ThrowIfFailed(pDevice->CreateQueryHeap(&desc, IID_PPV_ARGS(&m_heap)));
+    SetName(m_heap.Get(), L"GPUTimerHeap");
+
+    // We allocate m_maxframeCount + 1 instances as an instance is guaranteed to be written to if maxPresentFrameCount frames
+    // have been submitted since. This is due to a fact that Present stalls when none of the m_maxframeCount frames are done/available.
+    const size_t nPerFrameInstances = m_maxframeCount + 1;
+    ThrowIfFailed(pDevice->CreateCommittedResource(
+        &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK),
+        D3D12_HEAP_FLAG_NONE,
+        &CD3DX12_RESOURCE_DESC::Buffer(nPerFrameInstances * c_timerSlots * sizeof(UINT64)),
+        D3D12_RESOURCE_STATE_COPY_DEST,
+        nullptr,
+        IID_PPV_ARGS(&m_buffer))
+    );
+    SetName(m_heap.Get(), L"GPUTimerBuffer");
+}
+
+void GPUTimer::Destroy()
+{
+    m_heap.Reset();
+    m_buffer.Reset();
+}
+
+void GPUTimer::BeginFrame(_In_ ID3D12GraphicsCommandList* pCommandList)
+{
+    UNREFERENCED_PARAMETER(pCommandList);
+}
+
+void GPUTimer::EndFrame(_In_ ID3D12GraphicsCommandList* pCommandList)
+{
+    // Resolve queries for the current frame.
+    static UINT resolveToFrameID = 0;
+    const UINT64 resolveToBaseAddress = resolveToFrameID * c_timerSlots * sizeof(UINT64);
+    pCommandList->ResolveQueryData(m_heap.Get(), D3D12_QUERY_TYPE_TIMESTAMP, 0, c_timerSlots, m_buffer.Get(), resolveToBaseAddress);
+
+    // Grab read-back data for the queries from a finished frame m_maxframeCount ago.
+    const UINT readBackFrameID = (resolveToFrameID + 1) % (m_maxframeCount + 1);
+    const SIZE_T readBackBaseOffset = readBackFrameID * c_timerSlots * sizeof(UINT64);
+    const D3D12_RANGE dataRange =
+    {
+        readBackBaseOffset,
+        readBackBaseOffset + c_timerSlots * sizeof(UINT64),
+    };
+
+    UINT64* timingData;
+    ThrowIfFailed(m_buffer->Map(0, &dataRange, reinterpret_cast<void**>(&timingData)));
+    memcpy(m_timing, timingData, sizeof(UINT64) * c_timerSlots);
+    m_buffer->Unmap(0, nullptr);
+
+    for (UINT j = 0; j < c_maxTimers; ++j)
+    {
+        const UINT64 start = m_timing[j * 2];
+        const UINT64 end = m_timing[j * 2 + 1];
+        const float value = float(double(end - start) * m_gpuFreqInv);
+        m_avg[j] = UpdateRunningAverage(m_avg[j], value);
+    }
+
+    resolveToFrameID = readBackFrameID;
+}
+
+void GPUTimer::Start(_In_ ID3D12GraphicsCommandList* pCommandList, UINT timerid)
+{
+    if (timerid >= c_maxTimers)
+    {
+        throw std::out_of_range("Timer ID out of range");
+    }
+
+    pCommandList->EndQuery(m_heap.Get(), D3D12_QUERY_TYPE_TIMESTAMP, timerid * 2);
+}
+
+void GPUTimer::Stop(_In_ ID3D12GraphicsCommandList* pCommandList, UINT timerid)
+{
+    if (timerid >= c_maxTimers)
+    {
+        throw std::out_of_range("Timer ID out of range");
+    }
+
+    pCommandList->EndQuery(m_heap.Get(), D3D12_QUERY_TYPE_TIMESTAMP, timerid * 2 + 1);
+}
+
+void GPUTimer::ResetAverage()
+{
+    memset(m_avg, 0, sizeof(m_avg));
+}
+
+double GPUTimer::GetElapsedMS(UINT timerid) const
+{
+    if (timerid >= c_maxTimers)
+    {
+        return 0.0;
+    }
+ 
+    const UINT64 start = m_timing[timerid * 2];
+    const UINT64 end = m_timing[timerid * 2 + 1];
+
+    if (end < start)
+    {
+        return 0.0;
+    }
+
+    return double(end - start) * m_gpuFreqInv;
+}

--- a/Samples/Desktop/D3D12xGPU/src/GPUTimer.h
+++ b/Samples/Desktop/D3D12xGPU/src/GPUTimer.h
@@ -1,0 +1,77 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#pragma once
+
+namespace DX
+{
+    class GPUTimer
+    {
+    public:
+        static const size_t c_maxTimers = 8;
+
+        GPUTimer() :
+            m_gpuFreqInv(1.f),
+            m_avg{},
+            m_timing{},
+            m_maxframeCount(0)
+        {}
+
+        GPUTimer(ID3D12Device* pDevice, ID3D12CommandQueue* pCommandQueue, UINT maxFrameCount) :
+            m_gpuFreqInv(1.f),
+            m_avg{},
+            m_timing{}
+        {
+            Init(pDevice, pCommandQueue, maxFrameCount);
+        }
+
+        GPUTimer(const GPUTimer&) = delete;
+        GPUTimer& operator=(const GPUTimer&) = delete;
+
+        GPUTimer(GPUTimer&&) = default;
+        GPUTimer& operator=(GPUTimer&&) = default;
+
+        ~GPUTimer() { Destroy(); }
+
+        void Init(_In_ ID3D12Device* pDevice, _In_ ID3D12CommandQueue* pCommandQueue, UINT maxFrameCount);
+        void Destroy();
+
+        // Indicate beginning & end of frame.
+        void BeginFrame(_In_ ID3D12GraphicsCommandList* pCommandList);
+        void EndFrame(_In_ ID3D12GraphicsCommandList* pCommandList);
+
+        // Start/stop a particular performance timer (don't start same index more than once in a single frame).
+        void Start(_In_ ID3D12GraphicsCommandList* pCommandList, UINT timerid = 0);
+        void Stop(_In_ ID3D12GraphicsCommandList* pCommandList, UINT timerid = 0);
+
+        // Reset running average.
+        void ResetAverage();
+
+        // Returns delta time in milliseconds.
+        double GetElapsedMS(UINT timerid = 0) const;
+
+        // Returns running average in milliseconds.
+        float GetAverageMS(UINT timerid = 0) const
+        {
+            return (timerid < c_maxTimers) ? m_avg[timerid] : 0.f;
+        }
+
+    private:
+        static const size_t c_timerSlots = c_maxTimers * 2;
+
+        Microsoft::WRL::ComPtr<ID3D12QueryHeap> m_heap;
+        Microsoft::WRL::ComPtr<ID3D12Resource> m_buffer;
+        double m_gpuFreqInv;
+        float m_avg[c_maxTimers];
+        UINT64 m_timing[c_timerSlots];
+        size_t m_maxframeCount;
+    };
+}

--- a/Samples/Desktop/D3D12xGPU/src/PostprocessPass.hlsl
+++ b/Samples/Desktop/D3D12xGPU/src/PostprocessPass.hlsl
@@ -21,6 +21,7 @@ cbuffer SceneConstantBuffer : register(b0)
     float4x4 viewInverse;
     float4x4 projInverse;
     float4x4 viewProjInverseAtNearZ1;
+    float fogDensity;
 };
 
 struct PSInput
@@ -104,7 +105,6 @@ float4 PSMain(PSInput input) : SV_TARGET
     // Alpha blend the scattered light with the dest color from the scene render pass.
     // Apply a fog effect by attenuating dest color contribution.
     // Alpha blend operation: BLEND_ONE * BLEND_SRC_COLOR + SRC_ALPHA * BLEND_DEST_COLOR
-    float fogDensity = 0.04f;
     float destColorAttenuation = FogAttenuation(fogDensity, cameraToPixelDistance);
     return float4(color, destColorAttenuation);
 }

--- a/Samples/Desktop/D3D12xGPU/src/ShadowsAndScenePass.hlsl
+++ b/Samples/Desktop/D3D12xGPU/src/ShadowsAndScenePass.hlsl
@@ -9,35 +9,16 @@
 //
 //*********************************************************
 
-Texture2D shadowMap : register(t0);
-Texture2D diffuseMap : register(t1);
-Texture2D normalMap : register(t2);
+Texture2D diffuseMap : register(t0);
+Texture2D normalMap : register(t1);
+Texture2D shadowMap : register(t2);
 
 SamplerState sampleClamp : register(s0);
 SamplerState sampleWrap : register(s1);
 
-#define NUM_LIGHTS 1
-#define SHADOW_DEPTH_BIAS 0.00005f
-
-struct LightState
-{
-    float3 position;
-    float3 direction;
-    float4 color;
-    float4 falloff;
-    float4x4 view;
-    float4x4 projection;
-};
-
-cbuffer SceneConstantBuffer : register(b0)
-{
-    float4x4 model;
-    float4x4 view;
-    float4x4 projection;
-    float4 ambientColor;
-    bool sampleShadowMap;
-    LightState lights[NUM_LIGHTS];
-};
+#ifndef WITH_CLIPDISTANCE
+#define WITH_CLIPDISTANCE 0
+#endif
 
 struct PSInput
 {
@@ -46,106 +27,22 @@ struct PSInput
     float2 uv : TEXCOORD0;
     float3 normal : NORMAL;
     float3 tangent : TANGENT;
+#if WITH_CLIPDISTANCE
+    float clipDistance : SV_CLIPDISTANCE0;
+#endif
 };
 
-
-// Sample normal map, convert to signed, apply tangent-to-world space transform.
-float3 CalcPerPixelNormal(float2 vTexcoord, float3 vVertNormal, float3 vVertTangent)
-{
-    // Compute tangent frame.
-    vVertNormal = normalize(vVertNormal);
-    vVertTangent = normalize(vVertTangent);
-
-    float3 vVertBinormal = normalize(cross(vVertTangent, vVertNormal));
-    float3x3 mTangentSpaceToWorldSpace = float3x3(vVertTangent, vVertBinormal, vVertNormal);
-
-    // Compute per-pixel normal.
-    float3 vBumpNormal = (float3)normalMap.Sample(sampleWrap, vTexcoord);
-    vBumpNormal = 2.0f * vBumpNormal - 1.0f;
-
-    return mul(vBumpNormal, mTangentSpaceToWorldSpace);
-}
-
-// Diffuse lighting calculation, with angle and distance falloff.
-float4 CalcLightingColor(float3 vLightPos, float3 vLightDir, float4 vLightColor, float4 vFalloffs, float3 vPosWorld, float3 vPerPixelNormal)
-{
-    float3 vLightToPixelUnNormalized = vPosWorld - vLightPos;
-
-    // Dist falloff = 0 at vFalloffs.x, 1 at vFalloffs.x - vFalloffs.y
-    float fDist = length(vLightToPixelUnNormalized);
-
-    float fDistFalloff = saturate((vFalloffs.x - fDist) / vFalloffs.y);
-
-    // Normalize from here on.
-    float3 vLightToPixelNormalized = vLightToPixelUnNormalized / fDist;
-
-    // Angle falloff = 0 at vFalloffs.z, 1 at vFalloffs.z - vFalloffs.w
-    float fCosAngle = dot(vLightToPixelNormalized, vLightDir / length(vLightDir));
-    float fAngleFalloff = saturate((fCosAngle - vFalloffs.z) / vFalloffs.w);
-
-    // Diffuse contribution.
-    float fNDotL = saturate(-dot(vLightToPixelNormalized, vPerPixelNormal));
-
-    // Ignore angle falloff for a point light.
-    fAngleFalloff = 1.0f;  
-
-    return vLightColor * fNDotL * fDistFalloff * fAngleFalloff;
-}
-
-// Test how much pixel is in shadow, using 2x2 percentage-closer filtering.
-float4 CalcUnshadowedAmountPCF2x2(int lightIndex, float4 vPosWorld)
-{
-    // Compute pixel position in light space.
-    float4 vLightSpacePos = vPosWorld;
-    vLightSpacePos = mul(vLightSpacePos, lights[lightIndex].view);
-    vLightSpacePos = mul(vLightSpacePos, lights[lightIndex].projection);
-
-    vLightSpacePos.xyz /= vLightSpacePos.w;
-
-    // Translate from homogeneous coords to texture coords.
-    float2 vShadowTexCoord = 0.5f * vLightSpacePos.xy + 0.5f;
-    vShadowTexCoord.y = 1.0f - vShadowTexCoord.y;
-
-    // Depth bias to avoid pixel self-shadowing.
-    float vLightSpaceDepth = vLightSpacePos.z - SHADOW_DEPTH_BIAS;
-
-    // Find sub-pixel weights.
-    float2 vShadowMapDims = float2(1280.0f, 720.0f);             // need to keep in sync with .cpp file
-    float4 vSubPixelCoords = float4(1.0f, 1.0f, 1.0f, 1.0f);
-    vSubPixelCoords.xy = frac(vShadowMapDims * vShadowTexCoord);
-    vSubPixelCoords.zw = 1.0f - vSubPixelCoords.xy;
-    float4 vBilinearWeights = vSubPixelCoords.zxzx * vSubPixelCoords.wwyy;
-
-    // 2x2 percentage closer filtering.
-    float2 vTexelUnits = 1.0f / vShadowMapDims;
-    float4 vShadowDepths;
-    if (vShadowTexCoord.x <= 0.0f || vShadowTexCoord.x >= 1.0f || vShadowTexCoord.y <= 0.0f || vShadowTexCoord.y >= 1.0f || vLightSpaceDepth > 1.0f)
-    {
-        // Hack for a point light with a shadow map only for a single face.
-        // Don't apply any shadow outside the shadow map.
-        return float4(1.0, 1.0, 1.0, 1.0);
-    }
-    else
-    {
-        vShadowDepths.x = shadowMap.Sample(sampleClamp, vShadowTexCoord).x;
-        vShadowDepths.y = shadowMap.Sample(sampleClamp, vShadowTexCoord + float2(vTexelUnits.x, 0.0f)).x;
-        vShadowDepths.z = shadowMap.Sample(sampleClamp, vShadowTexCoord + float2(0.0f, vTexelUnits.y)).x;
-        vShadowDepths.w = shadowMap.Sample(sampleClamp, vShadowTexCoord + vTexelUnits).x;
-    }
-    // What weighted fraction of the 4 samples are nearer to the light than this pixel?
-    float4 vShadowTests = (vShadowDepths >= vLightSpaceDepth) ? 1.0f : 0.0f;
-    return dot(vBilinearWeights, vShadowTests);
-}
+#include "Common.hlsli"
 
 PSInput VSMain(float3 position : POSITION, float3 normal : NORMAL, float2 uv : TEXCOORD0, float3 tangent : TANGENT)
 {
     PSInput result;
 
-    float4 newPosition = float4(position, 1.0f);
+    float4 inputPosition = float4(position, 1.0f);
 
     normal.z *= -1.0f;
-    newPosition = mul(newPosition, model);
 
+    float4 newPosition = mul(inputPosition, model);
     result.worldpos = newPosition;
 
     newPosition = mul(newPosition, view);
@@ -155,6 +52,10 @@ PSInput VSMain(float3 position : POSITION, float3 normal : NORMAL, float2 uv : T
     result.uv = uv;
     result.normal = normal;
     result.tangent = tangent;
+
+#if WITH_CLIPDISTANCE
+    result.clipDistance = dot(result.worldpos, clipPlane);
+#endif
 
     return result;
 }

--- a/Samples/Desktop/D3D12xGPU/src/ShadowsFogScatteringSquidScene.h
+++ b/Samples/Desktop/D3D12xGPU/src/ShadowsFogScatteringSquidScene.h
@@ -29,15 +29,11 @@ class DXSample;
 
 #define SINGLETHREADED FALSE
 
-static const UINT NumNullSrvs = 2;        // Null descriptors at the start of the heap.
+static const UINT NumNullSrvs = 2; // Null descriptors at the start of the heap.
 static const UINT NumContexts = 3;
 
 // Currently the rendering code can only handle a single point light.
-static const UINT NumLights = 1;        // Keep this in sync with "ShadowsAndScenePass.hlsl".
-            
-
-static const UINT NumDepthBuffers = 2;      // Shadow + Scene pass
-static const UINT NumConstantBuffers = 3;   // Scene, shadows and postprocess
+static const UINT NumLights = 1; // Keep this in sync with "ShadowsAndScenePass.hlsl".
 
 // Command list submissions from main thread.
 static const int CommandListCount = 3;
@@ -56,11 +52,15 @@ namespace SceneEnums
     }
 
     namespace RootSignature {
-        enum { SceneAndShadowPass = 0, PostprocessPass, Count };
+        enum { ShadowPass = 0, ScenePass, PostprocessPass, Count };
     };
 
     namespace VertexBuffer {
         enum Value { SceneGeometry = 0, ScreenQuad, Count };
+    }
+
+    namespace Timestamp {
+        enum Value { ScenePass = 0, PostprocessPass, Count };
     }
 }
 
@@ -70,7 +70,6 @@ struct LightState
     XMFLOAT4 direction;
     XMFLOAT4 color;
     XMFLOAT4 falloff;
-
     XMFLOAT4X4 view;
     XMFLOAT4X4 projection;
 };
@@ -84,8 +83,9 @@ struct SceneConstantBuffer
     BOOL sampleShadowMap;
     BOOL padding[3];        // Must be aligned to be made up of N float4s.
     LightState lights[NumLights];
+    XMFLOAT4 viewport;
+    XMFLOAT4 clipPlane;
 };
-
 
 struct PostprocessConstantBuffer
 {
@@ -94,6 +94,7 @@ struct PostprocessConstantBuffer
     XMFLOAT4X4 viewInverse;
     XMFLOAT4X4 projInverse;
     XMFLOAT4X4 viewProjInverseAtNearZ1;
+    float fogDensity;
 };
 
 struct InputState
@@ -109,32 +110,44 @@ class ShadowsFogScatteringSquidScene
 {
 public:
     ShadowsFogScatteringSquidScene(UINT frameCount, DXSample* pSample);
-    ~ShadowsFogScatteringSquidScene();
+    virtual ~ShadowsFogScatteringSquidScene();
 
-    void Initialize(ID3D12Device* pDevice, ID3D12CommandQueue* pCommandQueue, UINT frameIndex);
-    void LoadSizeDependentResources(ID3D12Device* pDevice, ComPtr<ID3D12Resource>* ppRenderTargets, UINT width, UINT height);
-    void ReleaseSizeDependentResources();
+    virtual void Initialize(ID3D12Device* pDevice, ID3D12CommandQueue* pDirectCommandQueue, ID3D12GraphicsCommandList* pCommandList, UINT frameIndex);
+    virtual void LoadSizeDependentResources(ID3D12Device* pDevice, ComPtr<ID3D12Resource>* ppRenderTargets, UINT width, UINT height);
+    virtual void ReleaseSizeDependentResources();
     void SetFrameIndex(UINT frameIndex);
     void ReleaseD3DObjects();    
     void KeyDown(UINT8 key);
     void KeyUp(UINT8 key);
-    void Update(double elapsedTime);
-    void Render(ID3D12CommandQueue* pCommandQueue, bool setBackbufferReadyForPresent);
+    virtual void Update(double elapsedTime);
+    virtual void Render(ID3D12CommandQueue* pCommandQueue, bool setBackbufferReadyForPresent);
     static ShadowsFogScatteringSquidScene* Get() { return s_app; }
 
-private:
+    float m_fogDensity;
+
+    float GetScenePassGPUTimeInMs() const;
+    float GetPostprocessPassGPUTimeInMs() const;
+
+protected:
     UINT m_frameCount;
 
     struct Vertex
     {
         XMFLOAT4 position;
     };
-    // Pipeline objects
+
+    ID3D12CommandList * m_batchSubmit[NumContexts * 2 + CommandListCount];   // *2: shadowCommandLists, sceneCommandLists
+
+    // Pipeline objects.
     CD3DX12_VIEWPORT m_viewport;
     CD3DX12_RECT m_scissorRect;
 
     // D3D objects.
+    ComPtr<ID3D12GraphicsCommandList> m_commandLists[CommandListCount];
+    ComPtr<ID3D12GraphicsCommandList> m_shadowCommandLists[NumContexts];
+    ComPtr<ID3D12GraphicsCommandList> m_sceneCommandLists[NumContexts];
     std::vector<ComPtr<ID3D12Resource>> m_renderTargets;
+    ComPtr<ID3D12Resource> m_depthTextures[SceneEnums::DepthGenPass::Count];
     ComPtr<ID3D12RootSignature> m_rootSignatures[SceneEnums::RootSignature::Count];
     ComPtr<ID3D12PipelineState> m_pipelineStates[SceneEnums::RenderPass::Count];
     ComPtr<ID3D12Resource> m_vertexBuffers[SceneEnums::VertexBuffer::Count];
@@ -153,11 +166,17 @@ private:
     ComPtr<ID3D12DescriptorHeap> m_samplerHeap;
     UINT m_rtvDescriptorSize;
     UINT m_cbvSrvDescriptorSize;
+    D3D12_CPU_DESCRIPTOR_HANDLE m_depthDsvs[SceneEnums::DepthGenPass::Count];
+    D3D12_CPU_DESCRIPTOR_HANDLE m_depthSrvCpuHandles[SceneEnums::DepthGenPass::Count];
+    D3D12_GPU_DESCRIPTOR_HANDLE m_depthSrvGpuHandles[SceneEnums::DepthGenPass::Count];
     
     // Frame resources.
     std::vector<std::unique_ptr<FrameResource>> m_frameResources;
     FrameResource* m_pCurrentFrameResource;
     UINT m_frameIndex;
+    SceneConstantBuffer m_shadowConstantBuffer; // Shadow copy.
+    SceneConstantBuffer m_sceneConstantBuffer; // Shadow copy.
+    PostprocessConstantBuffer m_postprocessConstantBuffer; // Shadow copy.
 
     // App resources.
     DXSample*  m_pSample;
@@ -165,6 +184,7 @@ private:
     LightState m_lights[NumLights];
     Camera m_lightCameras[NumLights];
     Camera m_camera;
+    static const float s_clearColor[4];
 
     // Window state
     bool m_windowVisible;
@@ -178,23 +198,116 @@ private:
     ThreadParameter m_threadParameters[NumContexts];
     HANDLE m_workerBeginRenderFrame[NumContexts];
     HANDLE m_workerFinishShadowPass[NumContexts];
-    HANDLE m_workerFinishedRenderFrame[NumContexts];
+    HANDLE m_workerFinishedScenePass[NumContexts];
     HANDLE m_threadHandles[NumContexts];
     static ShadowsFogScatteringSquidScene* s_app;        // Singleton object so that worker threads can share members.
 
+    virtual void UpdateConstantBuffers(); // Updates the shadow copies of the constant buffers.
+    virtual void CommitConstantBuffers(); // Commits the shadows copies of the constant buffers to GPU-visible memory for the current frame.
+    
+    virtual void DrawInScattering(ID3D12GraphicsCommandList* pCommandList, const D3D12_CPU_DESCRIPTOR_HANDLE& renderTargetHandle);
+
     void WorkerThread(int threadIndex);
-    void SetCommonPipelineState(ID3D12GraphicsCommandList* pCommandList);
     void LoadContexts();
-    void PostprocessPass(ID3D12CommandQueue* pCommandQueue, bool setBackbufferReadyForPresent);    
-    void BeginFrame();
-    void MidFrame();
-    void EndFrame();
-    void InitializeCameraAndLights();
-    void CreateDescriptorHeaps(ID3D12Device* pDevice);
-    void CreateRootSignatures(ID3D12Device* pDevice);
-    void CreatePipelineStates(ID3D12Device* pDevice);
-    void CreateFrameResources(ID3D12Device* pDevice);
-    void CreateAssetResources(ID3D12Device* pDevice, ID3D12GraphicsCommandList* pAssetLoadingCmdList);
-    void CreatePostprocessPassResources(ID3D12Device* pDevice);
-    void CreateSamplers(ID3D12Device* pDevice);
+
+    virtual void ShadowPass(ID3D12GraphicsCommandList* pCommandList, int threadIndex);
+    virtual void ScenePass(ID3D12GraphicsCommandList* pCommandList, int threadIndex);
+    virtual void PostprocessPass(ID3D12GraphicsCommandList* pCommandList);
+
+    virtual void BeginFrame();
+    virtual void MidFrame();
+    virtual void EndFrame(bool setBackbufferReadyForPresent);
+    virtual void InitializeCameraAndLights();
+
+    virtual void CreateDescriptorHeaps(ID3D12Device* pDevice);
+    virtual void CreateCommandLists(ID3D12Device* pDevice);
+    virtual void CreateRootSignatures(ID3D12Device* pDevice);
+    virtual void CreatePipelineStates(ID3D12Device* pDevice);
+    virtual void CreateFrameResources(ID3D12Device* pDevice, ID3D12CommandQueue* pCommandQueue);
+    virtual void CreateAssetResources(ID3D12Device* pDevice, ID3D12GraphicsCommandList* pCommandList);
+    virtual void CreatePostprocessPassResources(ID3D12Device* pDevice);
+    virtual void CreateSamplers(ID3D12Device* pDevice);
+
+    inline HRESULT CreateDepthStencilTexture2D(
+        ID3D12Device* pDevice,
+        UINT width,
+        UINT height,
+        DXGI_FORMAT typelessFormat,
+        DXGI_FORMAT dsvFormat,
+        DXGI_FORMAT srvFormat,
+        ID3D12Resource** ppResource,
+        D3D12_CPU_DESCRIPTOR_HANDLE cpuDsvHandle,
+        D3D12_CPU_DESCRIPTOR_HANDLE cpuSrvHandle,
+        D3D12_RESOURCE_STATES initState = D3D12_RESOURCE_STATE_DEPTH_WRITE,
+        float initDepthValue = 1.0f,
+        UINT8 initStencilValue = 0)
+    {
+        try
+        {
+            *ppResource = nullptr;
+    
+            CD3DX12_RESOURCE_DESC texDesc(
+                D3D12_RESOURCE_DIMENSION_TEXTURE2D,
+                0,
+                width,
+                height,
+                1,
+                1,
+                typelessFormat,
+                1,
+                0,
+                D3D12_TEXTURE_LAYOUT_UNKNOWN,
+                D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
+    
+            ThrowIfFailed(pDevice->CreateCommittedResource(
+                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+                D3D12_HEAP_FLAG_NONE,
+                &texDesc,
+                initState,
+                &CD3DX12_CLEAR_VALUE(dsvFormat, initDepthValue, initStencilValue), // Performance tip: Tell the runtime at resource creation the desired clear value.
+                IID_PPV_ARGS(ppResource)));
+    
+            // Create a depth stencil view (DSV).
+            D3D12_DEPTH_STENCIL_VIEW_DESC dsvDesc = {};
+            dsvDesc.Format = dsvFormat;
+            dsvDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+            dsvDesc.Texture2D.MipSlice = 0;
+            pDevice->CreateDepthStencilView(*ppResource, &dsvDesc, cpuDsvHandle);
+    
+            // Create a shader resource view (SRV).
+            D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+            srvDesc.Format = srvFormat;
+            srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+            srvDesc.Texture2D.MipLevels = 1;
+            srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+            pDevice->CreateShaderResourceView(*ppResource, &srvDesc, cpuSrvHandle);
+        }
+        catch (HrException& e)
+        {
+            SAFE_RELEASE(*ppResource);
+            return e.Error();
+        }
+        return S_OK;
+    }
+
+    inline CD3DX12_CPU_DESCRIPTOR_HANDLE GetCurrentBackBufferRtvCpuHandle()
+    {
+        return CD3DX12_CPU_DESCRIPTOR_HANDLE(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+    }
+
+    // How much to scale each dimension in the world.
+    inline float GetWorldScale() const
+    {
+        return 0.1f;
+    }
+
+    virtual UINT GetNumRtvDescriptors() const
+    {
+        return m_frameCount;
+    }
+
+    virtual UINT GetNumCbvSrvUavDescriptors() const
+    {
+        return NumNullSrvs + _countof(m_depthSrvCpuHandles) + _countof(SampleAssets::Textures);
+    }
 };

--- a/Samples/Desktop/D3D12xGPU/src/d3dx12.h
+++ b/Samples/Desktop/D3D12xGPU/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D1211On12/src/D3D1211On12.cpp
+++ b/Samples/UWP/D3D1211On12/src/D3D1211On12.cpp
@@ -176,7 +176,10 @@ void D3D1211on12::LoadPipeline()
     // D2D's render targets.
     float dpiX;
     float dpiY;
+#pragma warning(push)
+#pragma warning(disable : 4996) // GetDesktopDpi is deprecated.
     m_d2dFactory->GetDesktopDpi(&dpiX, &dpiY);
+#pragma warning(pop)
     D2D1_BITMAP_PROPERTIES1 bitmapProperties = D2D1::BitmapProperties1(
         D2D1_BITMAP_OPTIONS_TARGET | D2D1_BITMAP_OPTIONS_CANNOT_DRAW,
         D2D1::PixelFormat(DXGI_FORMAT_UNKNOWN, D2D1_ALPHA_MODE_PREMULTIPLIED),

--- a/Samples/UWP/D3D1211On12/src/D3D1211On12.vcxproj
+++ b/Samples/UWP/D3D1211On12/src/D3D1211On12.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D1211On12</ProjectName>

--- a/Samples/UWP/D3D1211On12/src/DXSample.cpp
+++ b/Samples/UWP/D3D1211On12/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D1211On12/src/DXSample.h
+++ b/Samples/UWP/D3D1211On12/src/DXSample.h
@@ -37,7 +37,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/UWP/D3D1211On12/src/d3dx12.h
+++ b/Samples/UWP/D3D1211On12/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D1211On12/src/stdafx.h
+++ b/Samples/UWP/D3D1211On12/src/stdafx.h
@@ -25,7 +25,7 @@
 #include <dwrite.h>
 #include <d3d11on12.h>
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"

--- a/Samples/UWP/D3D12Bundles/src/D3D12Bundles.vcxproj
+++ b/Samples/UWP/D3D12Bundles/src/D3D12Bundles.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12Bundles</ProjectName>

--- a/Samples/UWP/D3D12Bundles/src/DXSample.cpp
+++ b/Samples/UWP/D3D12Bundles/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12Bundles/src/DXSample.h
+++ b/Samples/UWP/D3D12Bundles/src/DXSample.h
@@ -37,7 +37,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/UWP/D3D12Bundles/src/d3dx12.h
+++ b/Samples/UWP/D3D12Bundles/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12Bundles/src/stdafx.h
+++ b/Samples/UWP/D3D12Bundles/src/stdafx.h
@@ -22,7 +22,7 @@
 #include <windows.h>
 
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"

--- a/Samples/UWP/D3D12DepthBoundsTest/src/D3D12DepthBoundsTest.vcxproj
+++ b/Samples/UWP/D3D12DepthBoundsTest/src/D3D12DepthBoundsTest.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12DepthBoundsTest</ProjectName>

--- a/Samples/UWP/D3D12DepthBoundsTest/src/DXSample.cpp
+++ b/Samples/UWP/D3D12DepthBoundsTest/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12DepthBoundsTest/src/DXSample.h
+++ b/Samples/UWP/D3D12DepthBoundsTest/src/DXSample.h
@@ -37,7 +37,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/UWP/D3D12DepthBoundsTest/src/d3dx12.h
+++ b/Samples/UWP/D3D12DepthBoundsTest/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12DepthBoundsTest/src/stdafx.h
+++ b/Samples/UWP/D3D12DepthBoundsTest/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>

--- a/Samples/UWP/D3D12DynamicIndexing/src/D3D12DynamicIndexing.vcxproj
+++ b/Samples/UWP/D3D12DynamicIndexing/src/D3D12DynamicIndexing.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12DynamicIndexing</ProjectName>

--- a/Samples/UWP/D3D12DynamicIndexing/src/DXSample.cpp
+++ b/Samples/UWP/D3D12DynamicIndexing/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12DynamicIndexing/src/DXSample.h
+++ b/Samples/UWP/D3D12DynamicIndexing/src/DXSample.h
@@ -37,7 +37,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/UWP/D3D12DynamicIndexing/src/FrameResource.cpp
+++ b/Samples/UWP/D3D12DynamicIndexing/src/FrameResource.cpp
@@ -62,7 +62,7 @@ void FrameResource::InitBundle(ID3D12Device* pDevice, ID3D12PipelineState* pPso,
     ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_BUNDLE, m_bundleAllocator.Get(), pPso, IID_PPV_ARGS(&m_bundle)));
     NAME_D3D12_OBJECT(m_bundle);
 
-    PopulateCommandList(m_bundle.Get(), pPso, frameResourceIndex, numIndices, pIndexBufferViewDesc,
+    PopulateCommandList(m_bundle.Get(), frameResourceIndex, numIndices, pIndexBufferViewDesc,
         pVertexBufferViewDesc, pCbvSrvDescriptorHeap, cbvSrvDescriptorSize, pSamplerDescriptorHeap, pRootSignature);
 
     ThrowIfFailed(m_bundle->Close());
@@ -84,7 +84,7 @@ void FrameResource::SetCityPositions(FLOAT intervalX, FLOAT intervalZ)
     }
 }
 
-void FrameResource::PopulateCommandList(ID3D12GraphicsCommandList* pCommandList, ID3D12PipelineState* pPso,
+void FrameResource::PopulateCommandList(ID3D12GraphicsCommandList* pCommandList,
     UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
     ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature)
 {
@@ -105,13 +105,10 @@ void FrameResource::PopulateCommandList(ID3D12GraphicsCommandList* pCommandList,
     UINT frameResourceDescriptorOffset = (m_cityMaterialCount + 1) + (frameResourceIndex * m_cityRowCount * m_cityColumnCount);
     CD3DX12_GPU_DESCRIPTOR_HANDLE cbvSrvHandle(pCbvSrvDescriptorHeap->GetGPUDescriptorHandleForHeapStart(), frameResourceDescriptorOffset, cbvSrvDescriptorSize);
 
-    PIXBeginEvent(pCommandList, 0, L"Draw cities");
     for (UINT i = 0; i < m_cityRowCount; i++)
     {
         for (UINT j = 0; j < m_cityColumnCount; j++)
         {
-            pCommandList->SetPipelineState(pPso);
-
             // Set the city's root constant for dynamically indexing into the material array.
             pCommandList->SetGraphicsRoot32BitConstant(3, (i * m_cityColumnCount) + j, 0);
 
@@ -122,7 +119,6 @@ void FrameResource::PopulateCommandList(ID3D12GraphicsCommandList* pCommandList,
             pCommandList->DrawIndexedInstanced(numIndices, 1, 0, 0, 0);
         }
     }
-    PIXEndEvent(pCommandList);
 }
 
 void XM_CALLCONV FrameResource::UpdateConstantBuffers(FXMMATRIX view, CXMMATRIX projection)

--- a/Samples/UWP/D3D12DynamicIndexing/src/FrameResource.h
+++ b/Samples/UWP/D3D12DynamicIndexing/src/FrameResource.h
@@ -47,7 +47,7 @@ public:
         UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
         ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature);
 
-    void PopulateCommandList(ID3D12GraphicsCommandList* pCommandList, ID3D12PipelineState* pPso,
+    void PopulateCommandList(ID3D12GraphicsCommandList* pCommandList,
         UINT frameResourceIndex, UINT numIndices, D3D12_INDEX_BUFFER_VIEW* pIndexBufferViewDesc, D3D12_VERTEX_BUFFER_VIEW* pVertexBufferViewDesc,
         ID3D12DescriptorHeap* pCbvSrvDescriptorHeap, UINT cbvSrvDescriptorSize, ID3D12DescriptorHeap* pSamplerDescriptorHeap, ID3D12RootSignature* pRootSignature);
 

--- a/Samples/UWP/D3D12DynamicIndexing/src/d3dx12.h
+++ b/Samples/UWP/D3D12DynamicIndexing/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12DynamicIndexing/src/stdafx.h
+++ b/Samples/UWP/D3D12DynamicIndexing/src/stdafx.h
@@ -22,7 +22,7 @@
 #include <windows.h>
 
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"

--- a/Samples/UWP/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.h
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.h
@@ -152,6 +152,8 @@ private:
 
     void LoadPipeline();
     void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
     float GetRandomFloat(float min, float max);
     void PopulateCommandLists();
     void WaitForGpu();

--- a/Samples/UWP/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.vcxproj
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/D3D12ExecuteIndirect.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12ExecuteIndirect</ProjectName>

--- a/Samples/UWP/D3D12ExecuteIndirect/src/DXSample.cpp
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12ExecuteIndirect/src/DXSample.h
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/DXSample.h
@@ -37,7 +37,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/UWP/D3D12ExecuteIndirect/src/d3dx12.h
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12ExecuteIndirect/src/stdafx.h
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include "d3dx12.h"

--- a/Samples/UWP/D3D12Fullscreen/src/D3D12Fullscreen.cpp
+++ b/Samples/UWP/D3D12Fullscreen/src/D3D12Fullscreen.cpp
@@ -46,6 +46,7 @@ D3D12Fullscreen::D3D12Fullscreen(UINT width, UINT height, std::wstring name) :
     m_sceneConstantBufferData{},
     m_fenceValues{}
 {
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
 }
 
 void D3D12Fullscreen::OnInit()
@@ -91,7 +92,7 @@ void D3D12Fullscreen::LoadPipeline()
     else
     {
         ComPtr<IDXGIAdapter1> hardwareAdapter;
-        GetHardwareAdapter(factory.Get(), &hardwareAdapter);
+        GetHardwareAdapter(factory.Get(), &hardwareAdapter, true);
 
         ThrowIfFailed(D3D12CreateDevice(
             hardwareAdapter.Get(),
@@ -543,28 +544,68 @@ void D3D12Fullscreen::OnRender()
 {
     if (m_windowVisible)
     {
-        PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
+        try
+        {
+            PIXBeginEvent(m_commandQueue.Get(), 0, L"Render");
 
-        // Record all the commands we need to render the scene into the command lists.
-        PopulateCommandLists();
+            // Record all the commands we need to render the scene into the command lists.
+            PopulateCommandLists();
 
-        // Execute the command lists.
-        ID3D12CommandList* ppCommandLists[] = { m_sceneCommandList.Get(), m_postCommandList.Get() };
-        m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+            // Execute the command lists.
+            ID3D12CommandList* ppCommandLists[] = { m_sceneCommandList.Get(), m_postCommandList.Get() };
+            m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
-        PIXEndEvent(m_commandQueue.Get());
+            PIXEndEvent(m_commandQueue.Get());
 
-        // When using sync interval 0, it is recommended to always pass the tearing
-        // flag when it is supported, even when presenting in windowed mode.
-        // However, this flag cannot be used if the app is in fullscreen mode as a
-        // result of calling SetFullscreenState.
-        UINT presentFlags = (m_tearingSupport && m_windowedMode) ? DXGI_PRESENT_ALLOW_TEARING : 0;
+            // When using sync interval 0, it is recommended to always pass the tearing
+            // flag when it is supported, even when presenting in windowed mode.
+            // However, this flag cannot be used if the app is in fullscreen mode as a
+            // result of calling SetFullscreenState.
+            UINT presentFlags = (m_tearingSupport && m_windowedMode) ? DXGI_PRESENT_ALLOW_TEARING : 0;
 
-        // Present the frame.
-        ThrowIfFailed(m_swapChain->Present(0, presentFlags));
+            // Present the frame.
+            ThrowIfFailed(m_swapChain->Present(0, presentFlags));
 
-        MoveToNextFrame();
+            MoveToNextFrame();
+        }
+        catch (HrException& e)
+        {
+            if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
+            {
+                RestoreD3DResources();
+            }
+            else
+            {
+                throw;
+            }
+        }
     }
+}
+
+// Release sample's D3D objects.
+void D3D12Fullscreen::ReleaseD3DResources()
+{
+    m_fence.Reset();
+    ResetComPtrArray(&m_renderTargets);
+    m_commandQueue.Reset();
+    m_swapChain.Reset();
+    m_device.Reset();
+}
+
+// Tears down D3D resources and reinitializes them.
+void D3D12Fullscreen::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
+    {
+        WaitForGpu();
+    }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
 }
 
 void D3D12Fullscreen::OnSizeChanged(UINT width, UINT height, bool minimized)

--- a/Samples/UWP/D3D12Fullscreen/src/D3D12Fullscreen.h
+++ b/Samples/UWP/D3D12Fullscreen/src/D3D12Fullscreen.h
@@ -119,6 +119,8 @@ private:
 
     void LoadPipeline();
     void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
     void LoadSizeDependentResources();
     void LoadSceneResolutionDependentResources();
     void PopulateCommandLists();

--- a/Samples/UWP/D3D12Fullscreen/src/D3D12Fullscreen.vcxproj
+++ b/Samples/UWP/D3D12Fullscreen/src/D3D12Fullscreen.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12Fullscreen</ProjectName>

--- a/Samples/UWP/D3D12Fullscreen/src/DXSample.cpp
+++ b/Samples/UWP/D3D12Fullscreen/src/DXSample.cpp
@@ -52,31 +52,66 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12Fullscreen/src/DXSample.h
+++ b/Samples/UWP/D3D12Fullscreen/src/DXSample.h
@@ -48,7 +48,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/UWP/D3D12Fullscreen/src/d3dx12.h
+++ b/Samples/UWP/D3D12Fullscreen/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12HDR/src/D3D12HDR.vcxproj
+++ b/Samples/UWP/D3D12HDR/src/D3D12HDR.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.15063.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12HDR</ProjectName>

--- a/Samples/UWP/D3D12HDR/src/DXSample.cpp
+++ b/Samples/UWP/D3D12HDR/src/DXSample.cpp
@@ -52,31 +52,66 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12HDR/src/DXSample.h
+++ b/Samples/UWP/D3D12HDR/src/DXSample.h
@@ -48,7 +48,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/UWP/D3D12HDR/src/d3dx12.h
+++ b/Samples/UWP/D3D12HDR/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.vcxproj
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloBundles/D3D12HelloBundles.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12HelloBundles</ProjectName>

--- a/Samples/UWP/D3D12HelloWorld/src/HelloBundles/DXSample.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloBundles/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12HelloWorld/src/HelloBundles/DXSample.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloBundles/DXSample.h
@@ -37,7 +37,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/UWP/D3D12HelloWorld/src/HelloBundles/d3dx12.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloBundles/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12HelloWorld/src/HelloBundles/stdafx.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloBundles/stdafx.h
@@ -22,7 +22,7 @@
 #include <windows.h>
 
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"

--- a/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.vcxproj
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12HelloConstBuffers</ProjectName>

--- a/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/DXSample.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/DXSample.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/DXSample.h
@@ -37,7 +37,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/d3dx12.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/stdafx.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/stdafx.h
@@ -22,7 +22,7 @@
 #include <windows.h>
 
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"

--- a/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/D3D12HelloFrameBuffering.vcxproj
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/D3D12HelloFrameBuffering.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12HelloFrameBuffering</ProjectName>

--- a/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/DXSample.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/DXSample.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/DXSample.h
@@ -37,7 +37,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/d3dx12.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/stdafx.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/stdafx.h
@@ -22,7 +22,7 @@
 #include <windows.h>
 
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.vcxproj
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTexture/D3D12HelloTexture.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12HelloTexture</ProjectName>

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTexture/DXSample.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTexture/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTexture/DXSample.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTexture/DXSample.h
@@ -37,7 +37,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTexture/d3dx12.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTexture/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTexture/stdafx.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTexture/stdafx.h
@@ -22,7 +22,7 @@
 #include <windows.h>
 
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.vcxproj
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/D3D12HelloTriangle.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12HelloTriangle</ProjectName>

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/DXSample.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/DXSample.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/DXSample.h
@@ -37,7 +37,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/d3dx12.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/stdafx.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/stdafx.h
@@ -22,7 +22,7 @@
 #include <windows.h>
 
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"

--- a/Samples/UWP/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.vcxproj
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloWindow/D3D12HelloWindow.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12HelloWindow</ProjectName>

--- a/Samples/UWP/D3D12HelloWorld/src/HelloWindow/DXSample.cpp
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloWindow/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12HelloWorld/src/HelloWindow/DXSample.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloWindow/DXSample.h
@@ -37,7 +37,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/UWP/D3D12HelloWorld/src/HelloWindow/d3dx12.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloWindow/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12HelloWorld/src/HelloWindow/stdafx.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloWindow/stdafx.h
@@ -22,7 +22,7 @@
 #include <windows.h>
 
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/D3D12HeterogeneousMultiadapter.cpp
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/D3D12HeterogeneousMultiadapter.cpp
@@ -40,6 +40,7 @@ D3D12HeterogeneousMultiadapter::D3D12HeterogeneousMultiadapter(int width, int he
     m_frameFenceValues{}
 {
     m_constantBufferData.resize(MaxTriangleCount);
+    ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
 }
 
 void D3D12HeterogeneousMultiadapter::OnInit()
@@ -67,8 +68,30 @@ HRESULT D3D12HeterogeneousMultiadapter::GetHardwareAdapters(IDXGIFactory2* pFact
     // in this sample.
 
     ThrowIfFailed(pFactory->EnumAdapters1(0, ppSecondaryAdapter));
-    ThrowIfFailed(pFactory->EnumAdapters1(1, ppPrimaryAdapter));
+    DXGI_ADAPTER_DESC1 descSecondary;
+    ThrowIfFailed((*ppSecondaryAdapter)->GetDesc1(&descSecondary));
 
+    *ppPrimaryAdapter = nullptr;
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(adapterIndex, DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE, IID_PPV_ARGS(&adapter)); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 descPrimary;
+            ThrowIfFailed(adapter->GetDesc1(&descPrimary));
+            if (descPrimary.AdapterLuid.HighPart != descSecondary.AdapterLuid.HighPart || descPrimary.AdapterLuid.LowPart != descSecondary.AdapterLuid.LowPart)
+            {
+                break;
+            }
+        }
+        *ppPrimaryAdapter = adapter.Detach();
+    }
+    else
+    {
+        ThrowIfFailed(pFactory->EnumAdapters1(1, ppPrimaryAdapter));
+    }
     return S_OK;
 }
 
@@ -947,50 +970,96 @@ void D3D12HeterogeneousMultiadapter::OnUpdate()
 // Render the scene.
 void D3D12HeterogeneousMultiadapter::OnRender()
 {
-    // Record all the commands we need to render the scene into the command lists.
-    PopulateCommandLists();
-
-    // Execute the command lists.
+    try
     {
-        {
-            ID3D12CommandList* ppRenderCommandLists[] = { m_directCommandLists[Primary].Get() };
-            m_directCommandQueues[Primary]->ExecuteCommandLists(_countof(ppRenderCommandLists), ppRenderCommandLists);
+        // Record all the commands we need to render the scene into the command lists.
+        PopulateCommandLists();
 
-            // Signal the copy queue to indicate render is complete.
-            ThrowIfFailed(m_directCommandQueues[Primary]->Signal(m_renderFence.Get(), m_currentRenderFenceValue));
+        // Execute the command lists.
+        {
+            {
+                ID3D12CommandList* ppRenderCommandLists[] = { m_directCommandLists[Primary].Get() };
+                m_directCommandQueues[Primary]->ExecuteCommandLists(_countof(ppRenderCommandLists), ppRenderCommandLists);
+
+                // Signal the copy queue to indicate render is complete.
+                ThrowIfFailed(m_directCommandQueues[Primary]->Signal(m_renderFence.Get(), m_currentRenderFenceValue));
+            }
+
+            {
+                // GPU Wait for the primary adapter to finish rendering.
+                ThrowIfFailed(m_copyCommandQueue->Wait(m_renderFence.Get(), m_currentRenderFenceValue));
+                m_currentRenderFenceValue++;
+
+                ID3D12CommandList* ppCopyCommandLists[] = { m_copyCommandList.Get() };
+                m_copyCommandQueue->ExecuteCommandLists(_countof(ppCopyCommandLists), ppCopyCommandLists);
+
+                // Signal the secondary adapter to indicate the copy is complete.
+                ThrowIfFailed(m_copyCommandQueue->Signal(m_crossAdapterFences[Primary].Get(), m_currentCrossAdapterFenceValue));
+            }
+
+            {
+                // GPU Wait for the primary adapter to finish copying.
+                ThrowIfFailed(m_directCommandQueues[Secondary]->Wait(m_crossAdapterFences[Secondary].Get(), m_currentCrossAdapterFenceValue));
+                m_currentCrossAdapterFenceValue++;
+
+                ID3D12CommandList* ppBlurCommandLists[] = { m_directCommandLists[Secondary].Get() };
+                m_directCommandQueues[Secondary]->ExecuteCommandLists(_countof(ppBlurCommandLists), ppBlurCommandLists);
+            }
         }
 
+        // Present the frame.
+        ThrowIfFailed(m_swapChain->Present(1, 0));
+
+        // Signal the frame is complete.
+        ThrowIfFailed(m_directCommandQueues[Secondary]->Signal(m_frameFence.Get(), m_currentPresentFenceValue));
+        m_frameFenceValues[m_frameIndex] = m_currentPresentFenceValue;
+        m_currentPresentFenceValue++;
+
+        MoveToNextFrame();
+    }
+    catch (HrException& e)
+    {
+        if (e.Error() == DXGI_ERROR_DEVICE_REMOVED || e.Error() == DXGI_ERROR_DEVICE_RESET)
         {
-            // GPU Wait for the primary adapter to finish rendering.
-            ThrowIfFailed(m_copyCommandQueue->Wait(m_renderFence.Get(), m_currentRenderFenceValue));
-            m_currentRenderFenceValue++;
-
-            ID3D12CommandList* ppCopyCommandLists[] = { m_copyCommandList.Get() };
-            m_copyCommandQueue->ExecuteCommandLists(_countof(ppCopyCommandLists), ppCopyCommandLists);
-
-            // Signal the secondary adapter to indicate the copy is complete.
-            ThrowIfFailed(m_copyCommandQueue->Signal(m_crossAdapterFences[Primary].Get(), m_currentCrossAdapterFenceValue));
+            RestoreD3DResources();
         }
-
+        else
         {
-            // GPU Wait for the primary adapter to finish copying.
-            ThrowIfFailed(m_directCommandQueues[Secondary]->Wait(m_crossAdapterFences[Secondary].Get(), m_currentCrossAdapterFenceValue));
-            m_currentCrossAdapterFenceValue++;
-
-            ID3D12CommandList* ppBlurCommandLists[] = { m_directCommandLists[Secondary].Get() };
-            m_directCommandQueues[Secondary]->ExecuteCommandLists(_countof(ppBlurCommandLists), ppBlurCommandLists);
+            throw;
         }
     }
+}
 
-    // Present the frame.
-    ThrowIfFailed(m_swapChain->Present(1, 0));
+// Release sample's D3D objects.
+void D3D12HeterogeneousMultiadapter::ReleaseD3DResources()
+{
+    m_frameFence.Reset();
+    m_swapChain.Reset();
+    ResetComPtrArray(&m_devices);
+    ResetComPtrArray(&m_directCommandQueues);
+    for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+    {
+        ResetComPtrArray(&m_renderTargets[i]);
+    }
+}
 
-    // Signal the frame is complete.
-    ThrowIfFailed(m_directCommandQueues[Secondary]->Signal(m_frameFence.Get(), m_currentPresentFenceValue));
-    m_frameFenceValues[m_frameIndex] = m_currentPresentFenceValue;
-    m_currentPresentFenceValue++;
-
-    MoveToNextFrame();
+// Tears down D3D resources and reinitializes them.
+void D3D12HeterogeneousMultiadapter::RestoreD3DResources()
+{
+    // Give GPU a chance to finish its execution in progress.
+    try
+    {
+        for (UINT i = 0; i < GraphicsAdaptersCount; i++)
+        {
+            WaitForGpu(static_cast<GraphicsAdapter>(i));
+        }
+    }
+    catch (HrException&)
+    {
+        // Do nothing, currently attached adapter is unresponsive.
+    }
+    ReleaseD3DResources();
+    OnInit();
 }
 
 void D3D12HeterogeneousMultiadapter::OnDestroy()

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/D3D12HeterogeneousMultiadapter.h
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/D3D12HeterogeneousMultiadapter.h
@@ -170,6 +170,8 @@ private:
     HRESULT GetHardwareAdapters(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppPrimaryAdapter, _Outptr_result_maybenull_ IDXGIAdapter1** ppSecondaryAdapter);
     void LoadPipeline();
     void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
     float GetRandomFloat(float min, float max);
     void PopulateCommandLists();
     void UpdateWindowTitle();

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/D3D12HeterogeneousMultiadapter.vcxproj
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/D3D12HeterogeneousMultiadapter.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12HeterogeneousMultiadapter</ProjectName>

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/DXSample.cpp
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/DXSample.h
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/DXSample.h
@@ -37,7 +37,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/d3dx12.h
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/stdafx.h
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include "d3dx12.h"

--- a/Samples/UWP/D3D12LinkedGpus/src/D3DX12AffinityLayer/D3DX12AffinityLayer.vcxproj
+++ b/Samples/UWP/D3D12LinkedGpus/src/D3DX12AffinityLayer/D3DX12AffinityLayer.vcxproj
@@ -36,7 +36,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/Samples/UWP/D3D12LinkedGpus/src/D3DX12AffinityLayer/d3dx12.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/D3DX12AffinityLayer/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/D3D12LinkedGpus.vcxproj
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/D3D12LinkedGpus.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12LinkedGpus</ProjectName>

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/DXSample.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/DXSample.cpp
@@ -52,31 +52,66 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/DXSample.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/DXSample.h
@@ -48,7 +48,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/d3dx12.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/D3D12LinkedGpusAffinity.vcxproj
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/D3D12LinkedGpusAffinity.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12LinkedGpusAffinity</ProjectName>

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.cpp
@@ -52,31 +52,66 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.h
@@ -48,7 +48,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/d3dx12.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/D3D12SingleGpu.vcxproj
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/D3D12SingleGpu.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12SingleGpu</ProjectName>

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/DXSample.cpp
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/DXSample.cpp
@@ -52,31 +52,66 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/DXSample.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/DXSample.h
@@ -48,7 +48,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/d3dx12.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12PipelineStateCache/src/D3D12PipelineStateCache.h
+++ b/Samples/UWP/D3D12PipelineStateCache/src/D3D12PipelineStateCache.h
@@ -110,6 +110,8 @@ private:
 
     void LoadPipeline();
     void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
     void PopulateCommandList();
     void ToggleEffect(EffectPipelineType type);
     void UpdateWindowTextPso();

--- a/Samples/UWP/D3D12PipelineStateCache/src/D3D12PipelineStateCache.vcxproj
+++ b/Samples/UWP/D3D12PipelineStateCache/src/D3D12PipelineStateCache.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12PipelineStateCache</ProjectName>

--- a/Samples/UWP/D3D12PipelineStateCache/src/DXSample.cpp
+++ b/Samples/UWP/D3D12PipelineStateCache/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12PipelineStateCache/src/DXSample.h
+++ b/Samples/UWP/D3D12PipelineStateCache/src/DXSample.h
@@ -37,7 +37,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/UWP/D3D12PipelineStateCache/src/d3dx12.h
+++ b/Samples/UWP/D3D12PipelineStateCache/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12PipelineStateCache/src/stdafx.h
+++ b/Samples/UWP/D3D12PipelineStateCache/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>

--- a/Samples/UWP/D3D12PredicationQueries/src/D3D12PredicationQueries.h
+++ b/Samples/UWP/D3D12PredicationQueries/src/D3D12PredicationQueries.h
@@ -92,6 +92,8 @@ private:
 
     void LoadPipeline();
     void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
     void PopulateCommandList();
     void WaitForGpu();
     void MoveToNextFrame();

--- a/Samples/UWP/D3D12PredicationQueries/src/D3D12PredicationQueries.vcxproj
+++ b/Samples/UWP/D3D12PredicationQueries/src/D3D12PredicationQueries.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12PredicationQueries</ProjectName>

--- a/Samples/UWP/D3D12PredicationQueries/src/DXSample.cpp
+++ b/Samples/UWP/D3D12PredicationQueries/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12PredicationQueries/src/DXSample.h
+++ b/Samples/UWP/D3D12PredicationQueries/src/DXSample.h
@@ -37,7 +37,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/UWP/D3D12PredicationQueries/src/d3dx12.h
+++ b/Samples/UWP/D3D12PredicationQueries/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12PredicationQueries/src/stdafx.h
+++ b/Samples/UWP/D3D12PredicationQueries/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>

--- a/Samples/UWP/D3D12ReservedResources/src/D3D12ReservedResources.vcxproj
+++ b/Samples/UWP/D3D12ReservedResources/src/D3D12ReservedResources.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12ReservedResources</ProjectName>

--- a/Samples/UWP/D3D12ReservedResources/src/DXSample.cpp
+++ b/Samples/UWP/D3D12ReservedResources/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12ReservedResources/src/DXSample.h
+++ b/Samples/UWP/D3D12ReservedResources/src/DXSample.h
@@ -37,7 +37,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/UWP/D3D12ReservedResources/src/d3dx12.h
+++ b/Samples/UWP/D3D12ReservedResources/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12ReservedResources/src/stdafx.h
+++ b/Samples/UWP/D3D12ReservedResources/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include "d3dx12.h"

--- a/Samples/UWP/D3D12Residency/src/D3D12Residency.vcxproj
+++ b/Samples/UWP/D3D12Residency/src/D3D12Residency.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12Residency</ProjectName>

--- a/Samples/UWP/D3D12Residency/src/DXSample.cpp
+++ b/Samples/UWP/D3D12Residency/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12Residency/src/DXSample.h
+++ b/Samples/UWP/D3D12Residency/src/DXSample.h
@@ -37,7 +37,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/UWP/D3D12Residency/src/d3dx12.h
+++ b/Samples/UWP/D3D12Residency/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12Residency/src/stdafx.h
+++ b/Samples/UWP/D3D12Residency/src/stdafx.h
@@ -22,7 +22,7 @@
 #include <windows.h>
 
 #include <d3d12.h>
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.h
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.h
@@ -123,6 +123,8 @@ private:
     void CreateDevice(const ComPtr<IDXGIFactory4>& factory);
     void LoadPipeline();
     void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
     void LoadSizeDependentResources();
     void MoveToNextFrame();
     void WaitForGpu();

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.vcxproj
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/D3D12SM6WaveIntrinsics.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12SM6WaveIntrinsics</ProjectName>

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/DXSample.cpp
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/DXSample.cpp
@@ -52,31 +52,66 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/DXSample.h
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/DXSample.h
@@ -48,7 +48,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/d3dx12.h
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12SmallResources/src/D3D12SmallResources.vcxproj
+++ b/Samples/UWP/D3D12SmallResources/src/D3D12SmallResources.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12SmallResources</ProjectName>

--- a/Samples/UWP/D3D12SmallResources/src/DXSample.cpp
+++ b/Samples/UWP/D3D12SmallResources/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12SmallResources/src/DXSample.h
+++ b/Samples/UWP/D3D12SmallResources/src/DXSample.h
@@ -37,7 +37,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/UWP/D3D12SmallResources/src/d3dx12.h
+++ b/Samples/UWP/D3D12SmallResources/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12SmallResources/src/stdafx.h
+++ b/Samples/UWP/D3D12SmallResources/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>

--- a/Samples/UWP/D3D12nBodyGravity/src/D3D12nBodyGravity.h
+++ b/Samples/UWP/D3D12nBodyGravity/src/D3D12nBodyGravity.h
@@ -170,6 +170,9 @@ private:
 
     void LoadPipeline();
     void LoadAssets();
+    void RestoreD3DResources();
+    void ReleaseD3DResources();
+    void WaitForGpu();
     void CreateAsyncContexts();
     void CreateVertexBuffer();
     float RandomPercent();

--- a/Samples/UWP/D3D12nBodyGravity/src/D3D12nBodyGravity.vcxproj
+++ b/Samples/UWP/D3D12nBodyGravity/src/D3D12nBodyGravity.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12nBodyGravity</ProjectName>

--- a/Samples/UWP/D3D12nBodyGravity/src/DXSample.cpp
+++ b/Samples/UWP/D3D12nBodyGravity/src/DXSample.cpp
@@ -40,31 +40,67 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
+    
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12nBodyGravity/src/DXSample.h
+++ b/Samples/UWP/D3D12nBodyGravity/src/DXSample.h
@@ -37,7 +37,12 @@ public:
 
 protected:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
 
     // Viewport dimensions.

--- a/Samples/UWP/D3D12nBodyGravity/src/d3dx12.h
+++ b/Samples/UWP/D3D12nBodyGravity/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;

--- a/Samples/UWP/D3D12nBodyGravity/src/stdafx.h
+++ b/Samples/UWP/D3D12nBodyGravity/src/stdafx.h
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <dxgi1_4.h>
+#include <dxgi1_6.h>
 #include <d3d12.h>
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>

--- a/Samples/UWP/D3D12xGPU/readme.md
+++ b/Samples/UWP/D3D12xGPU/readme.md
@@ -14,5 +14,5 @@ As the sample is able to survive an adapter removal event, it declares that it s
 * [1-9] - adapter selection, when manual override is enabled.
 
 ## Requirements
-* Windows 10 October 2018 Update or higher
-* [Visual Studio 2017](https://www.visualstudio.com/) with the [Windows 10 October 2018 Update SDK (17763)](https://developer.microsoft.com/en-US/windows/downloads/windows-10-sdk)
+* Windows 10 17655 or higher (available via [Windows Insider Program](https://insider.windows.com/en-us/))
+* [Visual Studio 2017](https://www.visualstudio.com/) with the Windows 10 17655 SDK

--- a/Samples/UWP/D3D12xGPU/src/Common.hlsli
+++ b/Samples/UWP/D3D12xGPU/src/Common.hlsli
@@ -1,0 +1,123 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#define NUM_LIGHTS 1
+#define SHADOW_DEPTH_BIAS 0.00005f
+
+struct LightState
+{
+    float3 position;
+    float3 direction;
+    float4 color;
+    float4 falloff;
+    float4x4 view;
+    float4x4 projection;
+};
+
+cbuffer SceneConstantBuffer : register(b0)
+{
+    float4x4 model;
+    float4x4 view;
+    float4x4 projection;
+    float4 ambientColor;
+    bool sampleShadowMap;
+    LightState lights[NUM_LIGHTS];
+    float4 viewport;
+    float4 clipPlane;
+};
+
+// Sample normal map, convert to signed, apply tangent-to-world space transform.
+float3 CalcPerPixelNormal(float2 vTexcoord, float3 vVertNormal, float3 vVertTangent)
+{
+    // Compute per-pixel normal.
+    float3 vBumpNormal = (float3)normalMap.Sample(sampleWrap, vTexcoord);
+    vBumpNormal = 2.0f * vBumpNormal - 1.0f;
+
+    // Compute tangent frame.
+    vVertNormal = normalize(vVertNormal);
+    vVertTangent = normalize(vVertTangent);
+
+    float3 vVertBinormal = normalize(cross(vVertTangent, vVertNormal));
+    float3x3 mTangentSpaceToWorldSpace = float3x3(vVertTangent, vVertBinormal, vVertNormal);
+
+    return mul(vBumpNormal, mTangentSpaceToWorldSpace);
+}
+
+// Diffuse lighting calculation, with angle and distance falloff.
+float4 CalcLightingColor(float3 vLightPos, float3 vLightDir, float4 vLightColor, float4 vFalloffs, float3 vPosWorld, float3 vPerPixelNormal)
+{
+    float3 vLightToPixelUnNormalized = vPosWorld - vLightPos;
+
+    // Dist falloff = 0 at vFalloffs.x, 1 at vFalloffs.x - vFalloffs.y
+    float fDist = length(vLightToPixelUnNormalized);
+
+    float fDistFalloff = saturate((vFalloffs.x - fDist) / vFalloffs.y);
+
+    // Normalize from here on.
+    float3 vLightToPixelNormalized = vLightToPixelUnNormalized / fDist;
+
+    // Angle falloff = 0 at vFalloffs.z, 1 at vFalloffs.z - vFalloffs.w
+    float fCosAngle = dot(vLightToPixelNormalized, vLightDir / length(vLightDir));
+    float fAngleFalloff = saturate((fCosAngle - vFalloffs.z) / vFalloffs.w);
+
+    // Diffuse contribution.
+    float fNDotL = saturate(-dot(vLightToPixelNormalized, vPerPixelNormal));
+
+    // Ignore angle falloff for a point light.
+    fAngleFalloff = 1.0f;  
+
+    return vLightColor * fNDotL * fDistFalloff * fAngleFalloff;
+}
+
+// Test how much pixel is in shadow, using 2x2 percentage-closer filtering.
+float4 CalcUnshadowedAmountPCF2x2(int lightIndex, float4 vPosWorld)
+{
+    // Compute pixel position in light space.
+    float4 vLightSpacePos = vPosWorld;
+    vLightSpacePos = mul(vLightSpacePos, lights[lightIndex].view);
+    vLightSpacePos = mul(vLightSpacePos, lights[lightIndex].projection);
+
+    vLightSpacePos.xyz /= vLightSpacePos.w;
+
+    // Translate from homogeneous coords to texture coords.
+    float2 vShadowTexCoord = 0.5f * vLightSpacePos.xy + 0.5f;
+    vShadowTexCoord.y = 1.0f - vShadowTexCoord.y;
+
+    // Depth bias to avoid pixel self-shadowing.
+    float vLightSpaceDepth = vLightSpacePos.z - SHADOW_DEPTH_BIAS;
+
+    // Find sub-pixel weights.
+    float2 vShadowMapDims = float2(viewport.x, viewport.y); //float2(1280.0f, 720.0f);             // need to keep in sync with .cpp file
+    float4 vSubPixelCoords = float4(1.0f, 1.0f, 1.0f, 1.0f);
+    vSubPixelCoords.xy = frac(vShadowMapDims * vShadowTexCoord);
+    vSubPixelCoords.zw = 1.0f - vSubPixelCoords.xy;
+    float4 vBilinearWeights = vSubPixelCoords.zxzx * vSubPixelCoords.wwyy;
+
+    // 2x2 percentage closer filtering.
+    float2 vTexelUnits = 1.0f / vShadowMapDims;
+    float4 vShadowDepths;
+    if (vShadowTexCoord.x <= 0.0f || vShadowTexCoord.x >= 1.0f || vShadowTexCoord.y <= 0.0f || vShadowTexCoord.y >= 1.0f || vLightSpaceDepth > 1.0f)
+    {
+        // Hack for a point light with a shadow map only for a single face.
+        // Don't apply any shadow outside the shadow map.
+        return float4(1.0, 1.0, 1.0, 1.0);
+    }
+    else
+    {
+        vShadowDepths.x = shadowMap.Sample(sampleClamp, vShadowTexCoord).x;
+        vShadowDepths.y = shadowMap.Sample(sampleClamp, vShadowTexCoord + float2(vTexelUnits.x, 0.0f)).x;
+        vShadowDepths.z = shadowMap.Sample(sampleClamp, vShadowTexCoord + float2(0.0f, vTexelUnits.y)).x;
+        vShadowDepths.w = shadowMap.Sample(sampleClamp, vShadowTexCoord + vTexelUnits).x;
+    }
+    // What weighted fraction of the 4 samples are nearer to the light than this pixel?
+    float4 vShadowTests = (vShadowDepths >= vLightSpaceDepth) ? 1.0f : 0.0f;
+    return dot(vBilinearWeights, vShadowTests);
+}

--- a/Samples/UWP/D3D12xGPU/src/D3D12xGPU.cpp
+++ b/Samples/UWP/D3D12xGPU/src/D3D12xGPU.cpp
@@ -171,10 +171,33 @@ void D3D12xGPU::LoadAssets()
     {
         m_scene = make_unique<ShadowsFogScatteringSquidScene>(FrameCount, this);
     }
-    m_scene->Initialize(m_device.Get(), m_commandQueue.Get(), m_frameIndex );
+
+    // Create a temporary command queue and command list for initializing data on the GPU.
+    // Performance tip: Copy command queues are optimized for transfer over PCIe.
+    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_COPY;
+
+    ComPtr<ID3D12CommandQueue> copyCommandQueue;
+    ThrowIfFailed(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&copyCommandQueue)));
+    NAME_D3D12_OBJECT(copyCommandQueue);
+
+    ComPtr<ID3D12CommandAllocator> commandAllocator;
+    ThrowIfFailed(m_device->CreateCommandAllocator(queueDesc.Type, IID_PPV_ARGS(&commandAllocator)));
+    NAME_D3D12_OBJECT(commandAllocator);
+
+    ComPtr<ID3D12GraphicsCommandList> commandList;
+    ThrowIfFailed(m_device->CreateCommandList(0, queueDesc.Type, commandAllocator.Get(), nullptr, IID_PPV_ARGS(&commandList)));
+    NAME_D3D12_OBJECT(commandList);
+
+    m_scene->Initialize(m_device.Get(), m_commandQueue.Get(), commandList.Get(), m_frameIndex);
+
+    ThrowIfFailed(commandList->Close());
+
+    ID3D12CommandList* ppCommandLists[] = { commandList.Get() };
+    copyCommandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
     // Wait until assets have been uploaded to the GPU.
-    WaitForGpu();
+    WaitForGpu(copyCommandQueue.Get());
 }
 
 // Load resources that are dependent on the size of the main window.
@@ -364,7 +387,7 @@ void D3D12xGPU::OnSizeChanged(UINT width, UINT height, bool minimized)
         try
         {
             // Flush all current GPU commands.
-            WaitForGpu();
+            WaitForGpu(m_commandQueue.Get());
 
             // Release the resources holding references to the swap chain (requirement of
             // IDXGISwapChain::ResizeBuffers) and reset the frame fence values to the
@@ -488,7 +511,7 @@ void D3D12xGPU::RecreateD3Dresources()
     // Give GPU a chance to finish its execution in progress.
     try
     {
-        WaitForGpu();
+        WaitForGpu(m_commandQueue.Get());
     }
     catch (HrException&)
     {
@@ -504,7 +527,7 @@ void D3D12xGPU::OnDestroy()
     // cleaned up by the destructor.
     try
     {
-        WaitForGpu();
+        WaitForGpu(m_commandQueue.Get());
     }
     catch (HrException&)
     {
@@ -687,10 +710,10 @@ void D3D12xGPU::CalculateFrameStats()
 }
 
 // Wait for pending GPU work to complete.
-void D3D12xGPU::WaitForGpu()
+void D3D12xGPU::WaitForGpu(ID3D12CommandQueue* pCommandQueue)
 {
     // Schedule a Signal command in the queue.
-    ThrowIfFailed(m_commandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
+    ThrowIfFailed(pCommandQueue->Signal(m_fence.Get(), m_fenceValues[m_frameIndex]));
 
     // Wait until the fence has been processed.
     ThrowIfFailed(m_fence->SetEventOnCompletion(m_fenceValues[m_frameIndex], m_fenceEvent));

--- a/Samples/UWP/D3D12xGPU/src/D3D12xGPU.h
+++ b/Samples/UWP/D3D12xGPU/src/D3D12xGPU.h
@@ -111,6 +111,6 @@ private:
     void SelectAdapter(UINT index);
     void SelectGPUPreference(UINT index);
     void CalculateFrameStats(); 
-    void WaitForGpu();
+    void WaitForGpu(ID3D12CommandQueue* pCommandQueue);
     void MoveToNextFrame();
 };

--- a/Samples/UWP/D3D12xGPU/src/D3D12xGPU.vcxproj
+++ b/Samples/UWP/D3D12xGPU/src/D3D12xGPU.vcxproj
@@ -35,7 +35,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.17655.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <ProjectName>D3D12xGPU</ProjectName>
@@ -279,6 +279,7 @@
     <ClInclude Include="FrameResource.h" />
     <ClInclude Include="ShadowsFogScatteringSquidScene.h" />
     <ClInclude Include="SquidRoom.h" />
+    <ClInclude Include="GPUTimer.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="UILayer.cpp" />
@@ -298,11 +299,28 @@
     </ClCompile>
     <ClCompile Include="View.cpp" />
     <ClCompile Include="ViewProvider.cpp" />
+    <ClCompile Include="GPUTimer.cpp" />
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">
       <SubType>Designer</SubType>
     </AppxManifest>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="Common.hlsli">
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+      <FileType>Document</FileType>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">copy %(Identity) "$(OutDir)" &gt; NUL</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)\%(Identity)</Outputs>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatOutputAsContent>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">copy %(Identity) "$(OutDir)" &gt; NUL</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)\%(Identity)</Outputs>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</TreatOutputAsContent>
+    </CustomBuild>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="ShadowsAndScenePass.hlsl">

--- a/Samples/UWP/D3D12xGPU/src/D3D12xGPU.vcxproj.filters
+++ b/Samples/UWP/D3D12xGPU/src/D3D12xGPU.vcxproj.filters
@@ -60,6 +60,9 @@
     <ClCompile Include="FrameResource.cpp">
       <Filter>Source Files\Util</Filter>
     </ClCompile>
+    <ClCompile Include="GPUTimer.cpp">
+      <Filter>Source Files\Util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="d3dx12.h">
@@ -101,6 +104,9 @@
     <ClInclude Include="ShadowsFogScatteringSquidScene.h">
       <Filter>Header Files\Util</Filter>
     </ClInclude>
+    <ClInclude Include="GPUTimer.h">
+      <Filter>Header Files\Util</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest" />
@@ -129,10 +135,16 @@
     <CustomBuild Include="ShadowsAndScenePass.hlsl">
       <Filter>Assets\Shaders</Filter>
     </CustomBuild>
+    <CustomBuild Include="Common.hlsli">
+      <Filter>Assets\Shaders</Filter>
+    </CustomBuild>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="SquidRoom.bin">
       <Filter>Assets\Scene</Filter>
     </CustomBuild>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/Samples/UWP/D3D12xGPU/src/DXSample.cpp
+++ b/Samples/UWP/D3D12xGPU/src/DXSample.cpp
@@ -52,31 +52,66 @@ std::wstring DXSample::GetAssetFullPath(LPCWSTR assetName)
 // Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
 // If no such adapter can be found, *ppAdapter will be set to nullptr.
 _Use_decl_annotations_
-void DXSample::GetHardwareAdapter(IDXGIFactory2* pFactory, IDXGIAdapter1** ppAdapter)
+void DXSample::GetHardwareAdapter(
+    IDXGIFactory2* pFactory,
+    IDXGIAdapter1** ppAdapter,
+    bool requestHighPerformanceAdapter)
 {
-    ComPtr<IDXGIAdapter1> adapter;
     *ppAdapter = nullptr;
 
-    for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+    ComPtr<IDXGIAdapter1> adapter;
+
+    ComPtr<IDXGIFactory6> factory6;
+    if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6))))
     {
-        DXGI_ADAPTER_DESC1 desc;
-        ThrowIfFailed(adapter->GetDesc1(&desc));
-
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+        for (
+            UINT adapterIndex = 0;
+            DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(
+                adapterIndex,
+                requestHighPerformanceAdapter == true ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                IID_PPV_ARGS(&adapter));
+            ++adapterIndex)
         {
-            // Don't select the Basic Render Driver adapter.
-            // If you want a software adapter, pass in "/warp" on the command line.
-            continue;
-        }
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
-        // Check to see if the adapter supports Direct3D 12, but don't create the
-        // actual device yet.
-        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
-        {
-            break;
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
         }
     }
+    else
+    {
+        for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter); ++adapterIndex)
+        {
+            DXGI_ADAPTER_DESC1 desc;
+            adapter->GetDesc1(&desc);
 
+            if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+            {
+                // Don't select the Basic Render Driver adapter.
+                // If you want a software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+            {
+                break;
+            }
+        }
+    }
     *ppAdapter = adapter.Detach();
 }
 

--- a/Samples/UWP/D3D12xGPU/src/DXSample.h
+++ b/Samples/UWP/D3D12xGPU/src/DXSample.h
@@ -48,7 +48,11 @@ public:
     std::wstring GetAssetFullPath(LPCWSTR assetName);
 
 protected:
-    void GetHardwareAdapter(_In_ IDXGIFactory2* pFactory, _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter);
+    void GetHardwareAdapter(
+        _In_ IDXGIFactory2* pFactory,
+        _Outptr_result_maybenull_ IDXGIAdapter1** ppAdapter,
+        bool requestHighPerformanceAdapter = false);
+
     void SetCustomWindowText(LPCWSTR text);
     void CheckTearingSupport();
 

--- a/Samples/UWP/D3D12xGPU/src/FrameResource.cpp
+++ b/Samples/UWP/D3D12xGPU/src/FrameResource.cpp
@@ -16,290 +16,63 @@
 
 using namespace SceneEnums;
 
-FrameResource::FrameResource(ID3D12Device* pDevice, ComPtr<ID3D12PipelineState> pPipelineStates[RenderPass::Count], ID3D12DescriptorHeap* pDsvHeap, ID3D12DescriptorHeap* pCbvSrvHeap, UINT frameIndex) :
-    m_frameResourceIndex(frameIndex)
+FrameResource::FrameResource(ID3D12Device* pDevice, ID3D12CommandQueue* pCommandQueue)
+    : m_gpuTimer(pDevice, pCommandQueue, 3)
 {
-    for (UINT i = 0; i < RenderPass::Count; i++)
-    {
-        m_pipelineStates[i] = pPipelineStates[i];
-    }
-
-    for (UINT i = 0; i < CommandListCount; i++)
-    {
-        ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocators[i])));
-        ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocators[i].Get(), m_pipelineStates[i].Get(), IID_PPV_ARGS(&m_commandLists[i])));
-        NAME_D3D12_OBJECT_INDEXED(m_commandLists, i);
-
-        // Close these command lists; don't record into them for now.
-        ThrowIfFailed(m_commandLists[i]->Close());
-    }
+    ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+    NAME_D3D12_OBJECT(m_commandAllocator);
 
     for (UINT i = 0; i < NumContexts; i++)
     {
-        // Create command list allocators for worker threads. One alloc is 
-        // for the shadow pass command list, and one is for the scene pass.
-        ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_shadowCommandAllocators[i])));
-        ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_sceneCommandAllocators[i])));
-
-        ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_shadowCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Shadow].Get(), IID_PPV_ARGS(&m_shadowCommandLists[i])));
-        ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_sceneCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Scene].Get(), IID_PPV_ARGS(&m_sceneCommandLists[i])));
-
-        NAME_D3D12_OBJECT_INDEXED(m_shadowCommandLists, i);
-        NAME_D3D12_OBJECT_INDEXED(m_sceneCommandLists, i);
-
-        // Close these command lists; don't record into them for now. We will 
-        // reset them to a recording state when we start the render loop.
-        ThrowIfFailed(m_shadowCommandLists[i]->Close());
-        ThrowIfFailed(m_sceneCommandLists[i]->Close());
+        // Create command list allocators for worker threads. One per open command list.
+        ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_contextCommandAllocators[i])));
+        NAME_D3D12_OBJECT_INDEXED(m_contextCommandAllocators, i);
     }
-    ThrowIfFailed(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_postprocessCommandAllocator)));
-    ThrowIfFailed(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_postprocessCommandAllocator.Get(), m_pipelineStates[RenderPass::Postprocess].Get(), IID_PPV_ARGS(&m_postprocessCommandList)));
-    NAME_D3D12_OBJECT(m_postprocessCommandList);
-    ThrowIfFailed(m_postprocessCommandList->Close());
 
-    const UINT textureCount = _countof(SampleAssets::Textures);    // Diffuse + normal textures near the start of the heap.  Ideally, track descriptor heap contents/offsets at a higher level.
-    const UINT cbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    const UINT dsvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_DSV);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE cbvSrvCpuHandle(pCbvSrvHeap->GetCPUDescriptorHandleForHeapStart());
-    CD3DX12_GPU_DESCRIPTOR_HANDLE cbvSrvGpuHandle(pCbvSrvHeap->GetGPUDescriptorHandleForHeapStart());
-    CD3DX12_CPU_DESCRIPTOR_HANDLE dsvHandle(pDsvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameResourceIndex * NumDepthBuffers, dsvDescriptorSize);
-    m_nullSrvHandle = cbvSrvGpuHandle;
-    cbvSrvCpuHandle.Offset(NumNullSrvs + textureCount + (m_frameResourceIndex * (NumDepthBuffers + NumConstantBuffers)), cbvSrvDescriptorSize);
-    cbvSrvGpuHandle.Offset(NumNullSrvs + textureCount + (m_frameResourceIndex * (NumDepthBuffers + NumConstantBuffers)), cbvSrvDescriptorSize);
-   
-    // Initialize descript heap handles for depth resources.
-    // The resources and views are created later as they are window size dependent.
-    {
-        // Shadow depth resource.
-        m_depthDSVs[DepthGenPass::Shadow] = dsvHandle;
-        m_depthSRVs[DepthGenPass::Shadow] = cbvSrvCpuHandle;
-        m_depthSrvHandles[DepthGenPass::Shadow] = cbvSrvGpuHandle;
-     
-        dsvHandle.Offset(dsvDescriptorSize);
-        cbvSrvCpuHandle.Offset(cbvSrvDescriptorSize);
-        cbvSrvGpuHandle.Offset(cbvSrvDescriptorSize);
-
-        // Scene depth resource.
-        m_depthDSVs[DepthGenPass::Scene] = dsvHandle;
-        m_depthSRVs[DepthGenPass::Scene] = cbvSrvCpuHandle;
-        m_depthSrvHandles[DepthGenPass::Scene] = cbvSrvGpuHandle;
-    }
-        
     // Create constant buffers.
     {
-        // Shadow generation constant buffer.
-        cbvSrvCpuHandle.Offset(cbvSrvDescriptorSize);
-        cbvSrvGpuHandle.Offset(cbvSrvDescriptorSize);
-        ThrowIfFailed(CreateConstantBuffer(pDevice, sizeof(SceneConstantBuffer), &m_constantBuffers[RenderPass::Shadow], cbvSrvCpuHandle, D3D12_RESOURCE_STATE_GENERIC_READ));
-        m_cbvHandles[RenderPass::Shadow] = cbvSrvGpuHandle;
+        ThrowIfFailed(CreateConstantBuffer(pDevice, sizeof(SceneConstantBuffer), &m_constantBuffers[RenderPass::Shadow], nullptr, D3D12_RESOURCE_STATE_GENERIC_READ));
         NAME_D3D12_OBJECT(m_constantBuffers[RenderPass::Shadow]);
         
         // Scene render constant buffer.
-        cbvSrvCpuHandle.Offset(cbvSrvDescriptorSize);
-        cbvSrvGpuHandle.Offset(cbvSrvDescriptorSize);
-        ThrowIfFailed(CreateConstantBuffer(pDevice, sizeof(SceneConstantBuffer), &m_constantBuffers[RenderPass::Scene], cbvSrvCpuHandle, D3D12_RESOURCE_STATE_GENERIC_READ));
-        m_cbvHandles[RenderPass::Scene] = cbvSrvGpuHandle;
+        ThrowIfFailed(CreateConstantBuffer(pDevice, sizeof(SceneConstantBuffer), &m_constantBuffers[RenderPass::Scene], nullptr, D3D12_RESOURCE_STATE_GENERIC_READ));
         NAME_D3D12_OBJECT(m_constantBuffers[RenderPass::Scene]);
 
         // Postprocess pass constant buffer.
-        cbvSrvCpuHandle.Offset(cbvSrvDescriptorSize);
-        cbvSrvGpuHandle.Offset(cbvSrvDescriptorSize);
-        ThrowIfFailed(CreateConstantBuffer(pDevice, sizeof(PostprocessConstantBuffer), &m_constantBuffers[RenderPass::Postprocess], cbvSrvCpuHandle, D3D12_RESOURCE_STATE_GENERIC_READ));
-        m_cbvHandles[RenderPass::Postprocess] = cbvSrvGpuHandle;
+        ThrowIfFailed(CreateConstantBuffer(pDevice, sizeof(PostprocessConstantBuffer), &m_constantBuffers[RenderPass::Postprocess], nullptr, D3D12_RESOURCE_STATE_GENERIC_READ));
         NAME_D3D12_OBJECT(m_constantBuffers[RenderPass::Postprocess]);
 
         // Map the constant buffers and cache their heap pointers.
         // We don't unmap this until the app closes. Keeping buffer mapped for the lifetime of the resource is okay.
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
+        const CD3DX12_RANGE readRange(0, 0); // We do not intend to read from this resource on the CPU.
         ThrowIfFailed(m_constantBuffers[RenderPass::Shadow]->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBuffersWO[RenderPass::Shadow])));
         ThrowIfFailed(m_constantBuffers[RenderPass::Scene]->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBuffersWO[RenderPass::Scene])));
         ThrowIfFailed(m_constantBuffers[RenderPass::Postprocess]->Map(0, &readRange, reinterpret_cast<void**>(&m_pConstantBuffersWO[RenderPass::Postprocess])));
-        
     }
-
-    // Batch up command lists for execution later.
-    const UINT batchSize = _countof(m_sceneCommandLists) + _countof(m_shadowCommandLists) + CommandListCount;
-    m_batchSubmit[0] = m_commandLists[CommandListPre].Get();
-    memcpy(m_batchSubmit + 1, m_shadowCommandLists, _countof(m_shadowCommandLists) * sizeof(ID3D12CommandList*));
-    m_batchSubmit[_countof(m_shadowCommandLists) + 1] = m_commandLists[CommandListMid].Get();
-    memcpy(m_batchSubmit + _countof(m_shadowCommandLists) + 2, m_sceneCommandLists, _countof(m_sceneCommandLists) * sizeof(ID3D12CommandList*));
-    m_batchSubmit[batchSize - 1] = m_commandLists[CommandListPost].Get();
 }
 
 FrameResource::~FrameResource()
 {
-    for (int i = 0; i < CommandListCount; i++)
-    {
-        m_commandAllocators[i] = nullptr;
-        m_commandLists[i] = nullptr;
-    }
+}
 
-    m_constantBuffers[RenderPass::Shadow] = nullptr;
-    m_constantBuffers[RenderPass::Scene] = nullptr;
+void FrameResource::InitFrame()
+{
+    // Reset the main thread command allocator.
+    m_commandAllocator->Reset();
 
+    // Reset the worker command allocators.
     for (int i = 0; i < NumContexts; i++)
     {
-        m_shadowCommandLists[i] = nullptr;
-        m_shadowCommandAllocators[i] = nullptr;
-
-        m_sceneCommandLists[i] = nullptr;
-        m_sceneCommandAllocators[i] = nullptr;
+        ThrowIfFailed(m_contextCommandAllocators[i]->Reset());
     }
-    m_postprocessCommandAllocator = nullptr;
-    m_postprocessCommandList = nullptr;
-
-    m_depthTextures[DepthGenPass::Shadow] = nullptr;
 }
 
-void FrameResource::LoadSizeDependentResources(ID3D12Device* pDevice, UINT width, UINT height)
+void FrameResource::BeginFrame(ID3D12GraphicsCommandList* pCommandList)
 {
-    // Create depth stencil resources.
-
-    // Shadow depth resource.
-    ThrowIfFailed(CreateDepthStencilTexture2D(pDevice, width, height, DXGI_FORMAT_R32_TYPELESS, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_R32_FLOAT, &m_depthTextures[DepthGenPass::Shadow], m_depthDSVs[DepthGenPass::Shadow], m_depthSRVs[DepthGenPass::Shadow]));
-    NAME_D3D12_OBJECT(m_depthTextures[DepthGenPass::Shadow]);
-
-    // Scene depth resource.
-    ThrowIfFailed(CreateDepthStencilTexture2D(pDevice, width, height, DXGI_FORMAT_R32_TYPELESS, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_R32_FLOAT, &m_depthTextures[DepthGenPass::Scene], m_depthDSVs[DepthGenPass::Scene], m_depthSRVs[DepthGenPass::Scene]));
-    NAME_D3D12_OBJECT(m_depthTextures[DepthGenPass::Scene]);
-}
-
-void FrameResource::ReleaseSizeDependentResources()
-{
-    m_depthTextures[DepthGenPass::Shadow].Reset();
-    m_depthTextures[DepthGenPass::Scene].Reset();
-}
-
-void FrameResource::ClearDepthStencilViews(ID3D12GraphicsCommandList* pCommandList)
-{
-    pCommandList->ClearDepthStencilView(m_depthDSVs[DepthGenPass::Shadow], D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
-    pCommandList->ClearDepthStencilView(m_depthDSVs[DepthGenPass::Scene], D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
-}
-
-// Builds and writes constant buffers from scratch to the proper slots for 
-// this frame resource.
-void FrameResource::WriteConstantBuffers(D3D12_VIEWPORT* pViewport, Camera* pSceneCamera, Camera lightCams[NumLights], LightState lights[NumLights])
-{
-    SceneConstantBuffer sceneConsts = {}; 
-    SceneConstantBuffer shadowConsts = {};
-    PostprocessConstantBuffer postprocessConsts = {};
-    
-    // Scale down the world a bit.
-    ::XMStoreFloat4x4(&sceneConsts.model, XMMatrixScaling(0.1f, 0.1f, 0.1f));
-    ::XMStoreFloat4x4(&shadowConsts.model, XMMatrixScaling(0.1f, 0.1f, 0.1f));
-
-    // The scene pass is drawn from the camera.
-    pSceneCamera->Get3DViewProjMatrices(&sceneConsts.view, &sceneConsts.projection, 90.0f, pViewport->Width, pViewport->Height);
-
-    // The light pass is drawn from the first light.
-    lightCams[0].Get3DViewProjMatrices(&shadowConsts.view, &shadowConsts.projection, 90.0f, pViewport->Width, pViewport->Height);
-
-    for (int i = 0; i < NumLights; i++)
-    {
-        memcpy(&sceneConsts.lights[i], &lights[i], sizeof(LightState));
-        memcpy(&shadowConsts.lights[i], &lights[i], sizeof(LightState));
+    m_gpuTimer.BeginFrame(pCommandList);
     }
 
-    // The shadow pass won't sample the shadow map, but rather write to it.
-    shadowConsts.sampleShadowMap = FALSE;
-
-    // The scene pass samples the shadow map.
-    sceneConsts.sampleShadowMap = TRUE;
-
-    shadowConsts.ambientColor = sceneConsts.ambientColor = { 0.1f, 0.2f, 0.3f, 1.0f };
-
-    postprocessConsts.lightPosition = lights[0].position;
-    XMStoreFloat4(&postprocessConsts.cameraPosition, pSceneCamera->mEye);
-    float fovAngleY = 90.0f;
-    float fovRadiansY = fovAngleY * XM_PI / 180.0f;
-    XMMATRIX view = XMMatrixLookAtRH(pSceneCamera->mEye, pSceneCamera->mAt, pSceneCamera->mUp);
-    XMVECTOR determinant = XMMatrixDeterminant(view);
-    XMMATRIX viewInverse = XMMatrixInverse(&determinant, view);
-
-    XMMATRIX proj = XMMatrixPerspectiveFovRH(fovRadiansY, pViewport->Width / pViewport->Height, 0.01f, 125.0f);
-    determinant = XMMatrixDeterminant(proj);
-    XMMATRIX projInverse = XMMatrixInverse(&determinant, proj);
-
-    float nearZ1 = 1.0f;
-    XMMATRIX projAtNearZ1 = XMMatrixPerspectiveFovRH(fovRadiansY, pViewport->Width/ pViewport->Height, nearZ1, 125.0f);
-    XMMATRIX viewProjAtNearZ1 = view * projAtNearZ1;
-    determinant = XMMatrixDeterminant(viewProjAtNearZ1);
-    XMMATRIX viewProjInverseAtNearZ1 = XMMatrixInverse(&determinant, viewProjAtNearZ1);
-
-    // Copy over a transposed row-major inverse matrix, since HLSL assumes col-major order.
-    XMStoreFloat4x4(&postprocessConsts.viewInverse, XMMatrixTranspose(viewInverse));
-    XMStoreFloat4x4(&postprocessConsts.projInverse, XMMatrixTranspose(projInverse));
-    XMStoreFloat4x4(&postprocessConsts.viewProjInverseAtNearZ1, XMMatrixTranspose(viewProjInverseAtNearZ1));
-
-    memcpy(m_pConstantBuffersWO[RenderPass::Scene], &sceneConsts, sizeof(sceneConsts));
-    memcpy(m_pConstantBuffersWO[RenderPass::Shadow], &shadowConsts, sizeof(shadowConsts));
-    memcpy(m_pConstantBuffersWO[RenderPass::Postprocess], &postprocessConsts, sizeof(postprocessConsts));
-}
-
-void FrameResource::Init()
+void FrameResource::EndFrame(ID3D12GraphicsCommandList* pCommandList)
 {
-    // Reset the command allocators and lists for the main thread.
-    for (int i = 0; i < CommandListCount; i++)
-    {
-        ThrowIfFailed(m_commandAllocators[i]->Reset());
-        ThrowIfFailed(m_commandLists[i]->Reset(m_commandAllocators[i].Get(), m_pipelineStates[RenderPass::Scene].Get()));
-    }
-    
-    // Reset the worker command allocators and lists.
-    for (int i = 0; i < NumContexts; i++)
-    {
-        ThrowIfFailed(m_shadowCommandAllocators[i]->Reset());
-        ThrowIfFailed(m_shadowCommandLists[i]->Reset(m_shadowCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Shadow].Get()));
-
-        ThrowIfFailed(m_sceneCommandAllocators[i]->Reset());
-        ThrowIfFailed(m_sceneCommandLists[i]->Reset(m_sceneCommandAllocators[i].Get(), m_pipelineStates[RenderPass::Scene].Get()));
-    }
-
-    ThrowIfFailed(m_postprocessCommandAllocator->Reset());
-    ThrowIfFailed(m_postprocessCommandList->Reset(m_postprocessCommandAllocator.Get(), m_pipelineStates[RenderPass::Postprocess].Get()));
-}
-
-void FrameResource::SwapBarriers()
-{
-    // Transition the shadow map from writeable to readable.
-    m_commandLists[CommandListMid]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_depthTextures[DepthGenPass::Shadow].Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
-}
-
-
-void FrameResource::Finish()
-{
-    m_commandLists[CommandListPost]->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_depthTextures[DepthGenPass::Shadow].Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE));
-}
-
-// Sets up the descriptor tables for the worker command list to use 
-// resources provided by frame resource.
-void FrameResource::Bind(ID3D12GraphicsCommandList* pCommandList, RenderPass::Value renderPass, D3D12_CPU_DESCRIPTOR_HANDLE* pRtvHandle)
-{
-    switch (renderPass)
-    {
-    case RenderPass::Shadow:
-    {
-        pCommandList->SetGraphicsRootDescriptorTable(1, m_cbvHandles[RenderPass::Shadow]);
-        pCommandList->SetGraphicsRootDescriptorTable(2, m_nullSrvHandle);                                // Set a null SRV for the shadow texture.
-
-        pCommandList->OMSetRenderTargets(0, nullptr, FALSE, &m_depthDSVs[DepthGenPass::Shadow]);        // No render target needed for the shadow pass.
-        break;
-    }
-    case RenderPass::Scene:
-    {
-        pCommandList->SetGraphicsRootDescriptorTable(1, m_cbvHandles[RenderPass::Scene]);
-        pCommandList->SetGraphicsRootDescriptorTable(2, m_depthSrvHandles[DepthGenPass::Shadow]);        // Set the shadow texture as an SRV.
-
-        pCommandList->OMSetRenderTargets(1, pRtvHandle, FALSE, &m_depthDSVs[DepthGenPass::Scene]);
-        break;
-    }
-    case RenderPass::Postprocess:
-    {
-        pCommandList->SetGraphicsRootDescriptorTable(0, m_depthSrvHandles[DepthGenPass::Scene]);
-        pCommandList->SetGraphicsRootDescriptorTable(1, m_cbvHandles[RenderPass::Postprocess]);
-
-        pCommandList->OMSetRenderTargets(1, pRtvHandle, FALSE, nullptr);                                // No depth stencil needed for the postprocess pass.
-        break;
-    }
-    }
+    m_gpuTimer.EndFrame(pCommandList);
 }

--- a/Samples/UWP/D3D12xGPU/src/FrameResource.h
+++ b/Samples/UWP/D3D12xGPU/src/FrameResource.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "ShadowsFogScatteringSquidScene.h"
+#include "GPUTimer.h"
 
 using namespace DirectX;
 using namespace Microsoft::WRL;
@@ -19,126 +20,35 @@ using namespace Microsoft::WRL;
 class FrameResource
 {
 public:
-    ID3D12CommandList * m_batchSubmit[NumContexts * 2 + CommandListCount];   // *2: shadowCommandLists, sceneCommandLists
-
-    ComPtr<ID3D12CommandAllocator> m_commandAllocators[CommandListCount];
-    ComPtr<ID3D12GraphicsCommandList> m_commandLists[CommandListCount];
-
-    ComPtr<ID3D12CommandAllocator> m_shadowCommandAllocators[NumContexts];
-    ComPtr<ID3D12GraphicsCommandList> m_shadowCommandLists[NumContexts];
-
-    ComPtr<ID3D12CommandAllocator> m_sceneCommandAllocators[NumContexts];
-    ComPtr<ID3D12GraphicsCommandList> m_sceneCommandLists[NumContexts];
-
-    ComPtr<ID3D12CommandAllocator> m_postprocessCommandAllocator;
-    ComPtr<ID3D12GraphicsCommandList> m_postprocessCommandList;
-
-    ComPtr<ID3D12Resource> m_renderTarget;
-    D3D12_CPU_DESCRIPTOR_HANDLE m_renderTargetView;
-    ComPtr<ID3D12PipelineState> m_pipelineStates[SceneEnums::RenderPass::Count];
-    D3D12_GPU_DESCRIPTOR_HANDLE m_nullSrvHandle;                        // Null SRV for out of bounds behavior.
+    // Performance tip: Minimize the number of command allocators and command lists.
+    // Each open command list needs it's own command allocator.
+    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
+    ComPtr<ID3D12CommandAllocator> m_contextCommandAllocators[NumContexts];
 
     ComPtr<ID3D12Resource> m_constantBuffers[SceneEnums::RenderPass::Count];
-    SceneConstantBuffer* m_pConstantBuffersWO[SceneEnums::RenderPass::Count];        // WRITE-ONLY pointers to the constant buffers
-    D3D12_GPU_DESCRIPTOR_HANDLE m_cbvHandles[SceneEnums::RenderPass::Count];
-    
-    ComPtr<ID3D12Resource> m_depthTextures[SceneEnums::DepthGenPass::Count];
-    D3D12_CPU_DESCRIPTOR_HANDLE m_depthDSVs[SceneEnums::DepthGenPass::Count];
-    D3D12_CPU_DESCRIPTOR_HANDLE m_depthSRVs[SceneEnums::DepthGenPass::Count];
-    D3D12_GPU_DESCRIPTOR_HANDLE m_depthSrvHandles[SceneEnums::DepthGenPass::Count];
+    void* m_pConstantBuffersWO[SceneEnums::RenderPass::Count]; // WRITE-ONLY pointers to the constant buffers
 
-    UINT m_frameResourceIndex;
+    DX::GPUTimer m_gpuTimer;
 
 public:
-    FrameResource(ID3D12Device* pDevice, ComPtr<ID3D12PipelineState> pPipelineStates[SceneEnums::RenderPass::Count], ID3D12DescriptorHeap* pDsvHeap, ID3D12DescriptorHeap* pCbvSrvHeap, UINT frameResourceIndex);
-    ~FrameResource();
+    FrameResource(ID3D12Device* pDevice, ID3D12CommandQueue* pCommandQueue);
+    virtual ~FrameResource();
 
-    void LoadSizeDependentResources(ID3D12Device* pDevice, UINT width, UINT height);
-    void ReleaseSizeDependentResources();
-   
-    void ClearDepthStencilViews(ID3D12GraphicsCommandList* pCommandList);
-    void Bind(ID3D12GraphicsCommandList* pCommandList, SceneEnums::RenderPass::Value renderPass, D3D12_CPU_DESCRIPTOR_HANDLE* pRtvHandle);
-    void Init();
-    void SwapBarriers();
-    void Finish();
-    void WriteConstantBuffers(D3D12_VIEWPORT* pViewport, Camera* pSceneCamera, Camera lightCams[NumLights], LightState lights[NumLights]);
+    virtual void InitFrame();
+    virtual void BeginFrame(ID3D12GraphicsCommandList* pCommandList);
+    virtual void EndFrame(ID3D12GraphicsCommandList* pCommandList);
+
+    inline D3D12_GPU_VIRTUAL_ADDRESS GetConstantBufferGPUVirtualAddress(SceneEnums::RenderPass::Value renderPass) const
+    {
+        return m_constantBuffers[renderPass]->GetGPUVirtualAddress();
+    }
 };
-
-
-inline HRESULT CreateDepthStencilTexture2D(
-    ID3D12Device* pDevice,
-    UINT width,
-    UINT height,
-    DXGI_FORMAT typelessFormat,
-    DXGI_FORMAT dsvFormat,
-    DXGI_FORMAT srvFormat,
-    ID3D12Resource** ppResource,
-    D3D12_CPU_DESCRIPTOR_HANDLE cpuDSVHandle,
-    D3D12_CPU_DESCRIPTOR_HANDLE cpuSRVHandle,
-    D3D12_RESOURCE_STATES initState = D3D12_RESOURCE_STATE_DEPTH_WRITE,
-    float initDepthValue = 1.0f,
-    UINT8 initStencilValue = 0)
-{
-    try
-    {
-        *ppResource = nullptr;
-
-        CD3DX12_RESOURCE_DESC texDesc(
-            D3D12_RESOURCE_DIMENSION_TEXTURE2D,
-            0,
-            width,
-            height,
-            1,
-            1,
-            typelessFormat,
-            1,
-            0,
-            D3D12_TEXTURE_LAYOUT_UNKNOWN,
-            D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
-
-        D3D12_CLEAR_VALUE clearValue;        // Performance tip: Tell the runtime at resource creation the desired clear value.
-        clearValue.Format = dsvFormat;
-        clearValue.DepthStencil.Depth = initDepthValue;
-        clearValue.DepthStencil.Stencil = initStencilValue;
-
-        ThrowIfFailed(pDevice->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-            D3D12_HEAP_FLAG_NONE,
-            &texDesc,
-            initState,
-            &clearValue,
-            IID_PPV_ARGS(ppResource)));
-
-        ThrowIfFailed((*ppResource)->SetName(L"DepthStencilResource"));
-
-        // Create a depth stencil view (DSV).
-        D3D12_DEPTH_STENCIL_VIEW_DESC dsvDesc = {};
-        dsvDesc.Format = dsvFormat;
-        dsvDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
-        dsvDesc.Texture2D.MipSlice = 0;
-        pDevice->CreateDepthStencilView(*ppResource, &dsvDesc, cpuDSVHandle);
-
-        // Create a shader resource view (SRV).
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Format = srvFormat;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = 1;
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        pDevice->CreateShaderResourceView(*ppResource, &srvDesc, cpuSRVHandle);
-    }
-    catch (HrException& e)
-    {
-        SAFE_RELEASE(*ppResource);
-        return e.Error();
-    }
-    return S_OK;
-}
 
 inline HRESULT CreateConstantBuffer(
     ID3D12Device* pDevice,
     UINT size,
     ID3D12Resource** ppResource,
-    D3D12_CPU_DESCRIPTOR_HANDLE cpuCBVHandle,
+    D3D12_CPU_DESCRIPTOR_HANDLE* pCpuCbvHandle = nullptr,
     D3D12_RESOURCE_STATES initState = D3D12_RESOURCE_STATE_GENERIC_READ)
 {
     try
@@ -154,15 +64,14 @@ inline HRESULT CreateConstantBuffer(
             nullptr,
             IID_PPV_ARGS(ppResource)));
 
-        // Create the constant buffer views: one for the shadow pass and
-        // another for the scene pass.
-        D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
-        cbvDesc.SizeInBytes = alignedSize;
-
-        // Describe and create the shadow constant buffer view (CBV) and 
-        // cache the GPU descriptor handle.
-        cbvDesc.BufferLocation = (*ppResource)->GetGPUVirtualAddress();
-        pDevice->CreateConstantBufferView(&cbvDesc, cpuCBVHandle);
+        if (pCpuCbvHandle)
+        {
+            // Describe and create the shadow constant buffer view (CBV).
+            D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
+            cbvDesc.SizeInBytes = alignedSize;
+            cbvDesc.BufferLocation = (*ppResource)->GetGPUVirtualAddress();
+            pDevice->CreateConstantBufferView(&cbvDesc, *pCpuCbvHandle);
+        }
     }
     catch (HrException& e)
     {

--- a/Samples/UWP/D3D12xGPU/src/GPUTimer.cpp
+++ b/Samples/UWP/D3D12xGPU/src/GPUTimer.cpp
@@ -1,0 +1,149 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#include "stdafx.h"
+#include "GPUTimer.h"
+#include "DXSampleHelper.h"
+
+#include <exception>
+#include <stdexcept>
+
+using namespace DX;
+
+using Microsoft::WRL::ComPtr;
+
+namespace
+{
+    inline float lerp(float a, float b, float f)
+    {
+        return (1.f - f) * a + f * b;
+    }
+
+    inline float UpdateRunningAverage(float avg, float value)
+    {
+        return lerp(value, avg, 0.95f);
+    }
+};
+
+void GPUTimer::Init(_In_ ID3D12Device* pDevice, _In_ ID3D12CommandQueue* pCommandQueue, UINT maxFrameCount)
+{
+    assert(pDevice != nullptr && pCommandQueue != nullptr);
+    m_maxframeCount = maxFrameCount;
+
+    UINT64 gpuFreq;
+    ThrowIfFailed(pCommandQueue->GetTimestampFrequency(&gpuFreq));
+    m_gpuFreqInv = 1000.0 / double(gpuFreq);
+
+    D3D12_QUERY_HEAP_DESC desc = {};
+    desc.Type = D3D12_QUERY_HEAP_TYPE_TIMESTAMP;
+    desc.Count = c_timerSlots;
+    ThrowIfFailed(pDevice->CreateQueryHeap(&desc, IID_PPV_ARGS(&m_heap)));
+    SetName(m_heap.Get(), L"GPUTimerHeap");
+
+    // We allocate m_maxframeCount + 1 instances as an instance is guaranteed to be written to if maxPresentFrameCount frames
+    // have been submitted since. This is due to a fact that Present stalls when none of the m_maxframeCount frames are done/available.
+    const size_t nPerFrameInstances = m_maxframeCount + 1;
+    ThrowIfFailed(pDevice->CreateCommittedResource(
+        &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK),
+        D3D12_HEAP_FLAG_NONE,
+        &CD3DX12_RESOURCE_DESC::Buffer(nPerFrameInstances * c_timerSlots * sizeof(UINT64)),
+        D3D12_RESOURCE_STATE_COPY_DEST,
+        nullptr,
+        IID_PPV_ARGS(&m_buffer))
+    );
+    SetName(m_heap.Get(), L"GPUTimerBuffer");
+}
+
+void GPUTimer::Destroy()
+{
+    m_heap.Reset();
+    m_buffer.Reset();
+}
+
+void GPUTimer::BeginFrame(_In_ ID3D12GraphicsCommandList* pCommandList)
+{
+    UNREFERENCED_PARAMETER(pCommandList);
+}
+
+void GPUTimer::EndFrame(_In_ ID3D12GraphicsCommandList* pCommandList)
+{
+    // Resolve queries for the current frame.
+    static UINT resolveToFrameID = 0;
+    const UINT64 resolveToBaseAddress = resolveToFrameID * c_timerSlots * sizeof(UINT64);
+    pCommandList->ResolveQueryData(m_heap.Get(), D3D12_QUERY_TYPE_TIMESTAMP, 0, c_timerSlots, m_buffer.Get(), resolveToBaseAddress);
+
+    // Grab read-back data for the queries from a finished frame m_maxframeCount ago.
+    const UINT readBackFrameID = (resolveToFrameID + 1) % (m_maxframeCount + 1);
+    const SIZE_T readBackBaseOffset = readBackFrameID * c_timerSlots * sizeof(UINT64);
+    const D3D12_RANGE dataRange =
+    {
+        readBackBaseOffset,
+        readBackBaseOffset + c_timerSlots * sizeof(UINT64),
+    };
+
+    UINT64* timingData;
+    ThrowIfFailed(m_buffer->Map(0, &dataRange, reinterpret_cast<void**>(&timingData)));
+    memcpy(m_timing, timingData, sizeof(UINT64) * c_timerSlots);
+    m_buffer->Unmap(0, nullptr);
+
+    for (UINT j = 0; j < c_maxTimers; ++j)
+    {
+        const UINT64 start = m_timing[j * 2];
+        const UINT64 end = m_timing[j * 2 + 1];
+        const float value = float(double(end - start) * m_gpuFreqInv);
+        m_avg[j] = UpdateRunningAverage(m_avg[j], value);
+    }
+
+    resolveToFrameID = readBackFrameID;
+}
+
+void GPUTimer::Start(_In_ ID3D12GraphicsCommandList* pCommandList, UINT timerid)
+{
+    if (timerid >= c_maxTimers)
+    {
+        throw std::out_of_range("Timer ID out of range");
+    }
+
+    pCommandList->EndQuery(m_heap.Get(), D3D12_QUERY_TYPE_TIMESTAMP, timerid * 2);
+}
+
+void GPUTimer::Stop(_In_ ID3D12GraphicsCommandList* pCommandList, UINT timerid)
+{
+    if (timerid >= c_maxTimers)
+    {
+        throw std::out_of_range("Timer ID out of range");
+    }
+
+    pCommandList->EndQuery(m_heap.Get(), D3D12_QUERY_TYPE_TIMESTAMP, timerid * 2 + 1);
+}
+
+void GPUTimer::ResetAverage()
+{
+    memset(m_avg, 0, sizeof(m_avg));
+}
+
+double GPUTimer::GetElapsedMS(UINT timerid) const
+{
+    if (timerid >= c_maxTimers)
+    {
+        return 0.0;
+    }
+ 
+    const UINT64 start = m_timing[timerid * 2];
+    const UINT64 end = m_timing[timerid * 2 + 1];
+
+    if (end < start)
+    {
+        return 0.0;
+    }
+
+    return double(end - start) * m_gpuFreqInv;
+}

--- a/Samples/UWP/D3D12xGPU/src/GPUTimer.h
+++ b/Samples/UWP/D3D12xGPU/src/GPUTimer.h
@@ -1,0 +1,77 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#pragma once
+
+namespace DX
+{
+    class GPUTimer
+    {
+    public:
+        static const size_t c_maxTimers = 8;
+
+        GPUTimer() :
+            m_gpuFreqInv(1.f),
+            m_avg{},
+            m_timing{},
+            m_maxframeCount(0)
+        {}
+
+        GPUTimer(ID3D12Device* pDevice, ID3D12CommandQueue* pCommandQueue, UINT maxFrameCount) :
+            m_gpuFreqInv(1.f),
+            m_avg{},
+            m_timing{}
+        {
+            Init(pDevice, pCommandQueue, maxFrameCount);
+        }
+
+        GPUTimer(const GPUTimer&) = delete;
+        GPUTimer& operator=(const GPUTimer&) = delete;
+
+        GPUTimer(GPUTimer&&) = default;
+        GPUTimer& operator=(GPUTimer&&) = default;
+
+        ~GPUTimer() { Destroy(); }
+
+        void Init(_In_ ID3D12Device* pDevice, _In_ ID3D12CommandQueue* pCommandQueue, UINT maxFrameCount);
+        void Destroy();
+
+        // Indicate beginning & end of frame.
+        void BeginFrame(_In_ ID3D12GraphicsCommandList* pCommandList);
+        void EndFrame(_In_ ID3D12GraphicsCommandList* pCommandList);
+
+        // Start/stop a particular performance timer (don't start same index more than once in a single frame).
+        void Start(_In_ ID3D12GraphicsCommandList* pCommandList, UINT timerid = 0);
+        void Stop(_In_ ID3D12GraphicsCommandList* pCommandList, UINT timerid = 0);
+
+        // Reset running average.
+        void ResetAverage();
+
+        // Returns delta time in milliseconds.
+        double GetElapsedMS(UINT timerid = 0) const;
+
+        // Returns running average in milliseconds.
+        float GetAverageMS(UINT timerid = 0) const
+        {
+            return (timerid < c_maxTimers) ? m_avg[timerid] : 0.f;
+        }
+
+    private:
+        static const size_t c_timerSlots = c_maxTimers * 2;
+
+        Microsoft::WRL::ComPtr<ID3D12QueryHeap> m_heap;
+        Microsoft::WRL::ComPtr<ID3D12Resource> m_buffer;
+        double m_gpuFreqInv;
+        float m_avg[c_maxTimers];
+        UINT64 m_timing[c_timerSlots];
+        size_t m_maxframeCount;
+    };
+}

--- a/Samples/UWP/D3D12xGPU/src/PostprocessPass.hlsl
+++ b/Samples/UWP/D3D12xGPU/src/PostprocessPass.hlsl
@@ -21,6 +21,7 @@ cbuffer SceneConstantBuffer : register(b0)
     float4x4 viewInverse;
     float4x4 projInverse;
     float4x4 viewProjInverseAtNearZ1;
+    float fogDensity;
 };
 
 struct PSInput
@@ -104,7 +105,6 @@ float4 PSMain(PSInput input) : SV_TARGET
     // Alpha blend the scattered light with the dest color from the scene render pass.
     // Apply a fog effect by attenuating dest color contribution.
     // Alpha blend operation: BLEND_ONE * BLEND_SRC_COLOR + SRC_ALPHA * BLEND_DEST_COLOR
-    float fogDensity = 0.04f;
     float destColorAttenuation = FogAttenuation(fogDensity, cameraToPixelDistance);
     return float4(color, destColorAttenuation);
 }

--- a/Samples/UWP/D3D12xGPU/src/ShadowsAndScenePass.hlsl
+++ b/Samples/UWP/D3D12xGPU/src/ShadowsAndScenePass.hlsl
@@ -9,35 +9,16 @@
 //
 //*********************************************************
 
-Texture2D shadowMap : register(t0);
-Texture2D diffuseMap : register(t1);
-Texture2D normalMap : register(t2);
+Texture2D diffuseMap : register(t0);
+Texture2D normalMap : register(t1);
+Texture2D shadowMap : register(t2);
 
 SamplerState sampleClamp : register(s0);
 SamplerState sampleWrap : register(s1);
 
-#define NUM_LIGHTS 1
-#define SHADOW_DEPTH_BIAS 0.00005f
-
-struct LightState
-{
-    float3 position;
-    float3 direction;
-    float4 color;
-    float4 falloff;
-    float4x4 view;
-    float4x4 projection;
-};
-
-cbuffer SceneConstantBuffer : register(b0)
-{
-    float4x4 model;
-    float4x4 view;
-    float4x4 projection;
-    float4 ambientColor;
-    bool sampleShadowMap;
-    LightState lights[NUM_LIGHTS];
-};
+#ifndef WITH_CLIPDISTANCE
+#define WITH_CLIPDISTANCE 0
+#endif
 
 struct PSInput
 {
@@ -46,106 +27,22 @@ struct PSInput
     float2 uv : TEXCOORD0;
     float3 normal : NORMAL;
     float3 tangent : TANGENT;
+#if WITH_CLIPDISTANCE
+    float clipDistance : SV_CLIPDISTANCE0;
+#endif
 };
 
-
-// Sample normal map, convert to signed, apply tangent-to-world space transform.
-float3 CalcPerPixelNormal(float2 vTexcoord, float3 vVertNormal, float3 vVertTangent)
-{
-    // Compute tangent frame.
-    vVertNormal = normalize(vVertNormal);
-    vVertTangent = normalize(vVertTangent);
-
-    float3 vVertBinormal = normalize(cross(vVertTangent, vVertNormal));
-    float3x3 mTangentSpaceToWorldSpace = float3x3(vVertTangent, vVertBinormal, vVertNormal);
-
-    // Compute per-pixel normal.
-    float3 vBumpNormal = (float3)normalMap.Sample(sampleWrap, vTexcoord);
-    vBumpNormal = 2.0f * vBumpNormal - 1.0f;
-
-    return mul(vBumpNormal, mTangentSpaceToWorldSpace);
-}
-
-// Diffuse lighting calculation, with angle and distance falloff.
-float4 CalcLightingColor(float3 vLightPos, float3 vLightDir, float4 vLightColor, float4 vFalloffs, float3 vPosWorld, float3 vPerPixelNormal)
-{
-    float3 vLightToPixelUnNormalized = vPosWorld - vLightPos;
-
-    // Dist falloff = 0 at vFalloffs.x, 1 at vFalloffs.x - vFalloffs.y
-    float fDist = length(vLightToPixelUnNormalized);
-
-    float fDistFalloff = saturate((vFalloffs.x - fDist) / vFalloffs.y);
-
-    // Normalize from here on.
-    float3 vLightToPixelNormalized = vLightToPixelUnNormalized / fDist;
-
-    // Angle falloff = 0 at vFalloffs.z, 1 at vFalloffs.z - vFalloffs.w
-    float fCosAngle = dot(vLightToPixelNormalized, vLightDir / length(vLightDir));
-    float fAngleFalloff = saturate((fCosAngle - vFalloffs.z) / vFalloffs.w);
-
-    // Diffuse contribution.
-    float fNDotL = saturate(-dot(vLightToPixelNormalized, vPerPixelNormal));
-
-    // Ignore angle falloff for a point light.
-    fAngleFalloff = 1.0f;  
-
-    return vLightColor * fNDotL * fDistFalloff * fAngleFalloff;
-}
-
-// Test how much pixel is in shadow, using 2x2 percentage-closer filtering.
-float4 CalcUnshadowedAmountPCF2x2(int lightIndex, float4 vPosWorld)
-{
-    // Compute pixel position in light space.
-    float4 vLightSpacePos = vPosWorld;
-    vLightSpacePos = mul(vLightSpacePos, lights[lightIndex].view);
-    vLightSpacePos = mul(vLightSpacePos, lights[lightIndex].projection);
-
-    vLightSpacePos.xyz /= vLightSpacePos.w;
-
-    // Translate from homogeneous coords to texture coords.
-    float2 vShadowTexCoord = 0.5f * vLightSpacePos.xy + 0.5f;
-    vShadowTexCoord.y = 1.0f - vShadowTexCoord.y;
-
-    // Depth bias to avoid pixel self-shadowing.
-    float vLightSpaceDepth = vLightSpacePos.z - SHADOW_DEPTH_BIAS;
-
-    // Find sub-pixel weights.
-    float2 vShadowMapDims = float2(1280.0f, 720.0f);             // need to keep in sync with .cpp file
-    float4 vSubPixelCoords = float4(1.0f, 1.0f, 1.0f, 1.0f);
-    vSubPixelCoords.xy = frac(vShadowMapDims * vShadowTexCoord);
-    vSubPixelCoords.zw = 1.0f - vSubPixelCoords.xy;
-    float4 vBilinearWeights = vSubPixelCoords.zxzx * vSubPixelCoords.wwyy;
-
-    // 2x2 percentage closer filtering.
-    float2 vTexelUnits = 1.0f / vShadowMapDims;
-    float4 vShadowDepths;
-    if (vShadowTexCoord.x <= 0.0f || vShadowTexCoord.x >= 1.0f || vShadowTexCoord.y <= 0.0f || vShadowTexCoord.y >= 1.0f || vLightSpaceDepth > 1.0f)
-    {
-        // Hack for a point light with a shadow map only for a single face.
-        // Don't apply any shadow outside the shadow map.
-        return float4(1.0, 1.0, 1.0, 1.0);
-    }
-    else
-    {
-        vShadowDepths.x = shadowMap.Sample(sampleClamp, vShadowTexCoord).x;
-        vShadowDepths.y = shadowMap.Sample(sampleClamp, vShadowTexCoord + float2(vTexelUnits.x, 0.0f)).x;
-        vShadowDepths.z = shadowMap.Sample(sampleClamp, vShadowTexCoord + float2(0.0f, vTexelUnits.y)).x;
-        vShadowDepths.w = shadowMap.Sample(sampleClamp, vShadowTexCoord + vTexelUnits).x;
-    }
-    // What weighted fraction of the 4 samples are nearer to the light than this pixel?
-    float4 vShadowTests = (vShadowDepths >= vLightSpaceDepth) ? 1.0f : 0.0f;
-    return dot(vBilinearWeights, vShadowTests);
-}
+#include "Common.hlsli"
 
 PSInput VSMain(float3 position : POSITION, float3 normal : NORMAL, float2 uv : TEXCOORD0, float3 tangent : TANGENT)
 {
     PSInput result;
 
-    float4 newPosition = float4(position, 1.0f);
+    float4 inputPosition = float4(position, 1.0f);
 
     normal.z *= -1.0f;
-    newPosition = mul(newPosition, model);
 
+    float4 newPosition = mul(inputPosition, model);
     result.worldpos = newPosition;
 
     newPosition = mul(newPosition, view);
@@ -155,6 +52,10 @@ PSInput VSMain(float3 position : POSITION, float3 normal : NORMAL, float2 uv : T
     result.uv = uv;
     result.normal = normal;
     result.tangent = tangent;
+
+#if WITH_CLIPDISTANCE
+    result.clipDistance = dot(result.worldpos, clipPlane);
+#endif
 
     return result;
 }

--- a/Samples/UWP/D3D12xGPU/src/ShadowsFogScatteringSquidScene.h
+++ b/Samples/UWP/D3D12xGPU/src/ShadowsFogScatteringSquidScene.h
@@ -29,15 +29,11 @@ class DXSample;
 
 #define SINGLETHREADED FALSE
 
-static const UINT NumNullSrvs = 2;        // Null descriptors at the start of the heap.
+static const UINT NumNullSrvs = 2; // Null descriptors at the start of the heap.
 static const UINT NumContexts = 3;
 
 // Currently the rendering code can only handle a single point light.
-static const UINT NumLights = 1;        // Keep this in sync with "ShadowsAndScenePass.hlsl".
-            
-
-static const UINT NumDepthBuffers = 2;      // Shadow + Scene pass
-static const UINT NumConstantBuffers = 3;   // Scene, shadows and postprocess
+static const UINT NumLights = 1; // Keep this in sync with "ShadowsAndScenePass.hlsl".
 
 // Command list submissions from main thread.
 static const int CommandListCount = 3;
@@ -56,11 +52,15 @@ namespace SceneEnums
     }
 
     namespace RootSignature {
-        enum { SceneAndShadowPass = 0, PostprocessPass, Count };
+        enum { ShadowPass = 0, ScenePass, PostprocessPass, Count };
     };
 
     namespace VertexBuffer {
         enum Value { SceneGeometry = 0, ScreenQuad, Count };
+    }
+
+    namespace Timestamp {
+        enum Value { ScenePass = 0, PostprocessPass, Count };
     }
 }
 
@@ -70,7 +70,6 @@ struct LightState
     XMFLOAT4 direction;
     XMFLOAT4 color;
     XMFLOAT4 falloff;
-
     XMFLOAT4X4 view;
     XMFLOAT4X4 projection;
 };
@@ -84,8 +83,9 @@ struct SceneConstantBuffer
     BOOL sampleShadowMap;
     BOOL padding[3];        // Must be aligned to be made up of N float4s.
     LightState lights[NumLights];
+    XMFLOAT4 viewport;
+    XMFLOAT4 clipPlane;
 };
-
 
 struct PostprocessConstantBuffer
 {
@@ -94,6 +94,7 @@ struct PostprocessConstantBuffer
     XMFLOAT4X4 viewInverse;
     XMFLOAT4X4 projInverse;
     XMFLOAT4X4 viewProjInverseAtNearZ1;
+    float fogDensity;
 };
 
 struct InputState
@@ -109,32 +110,44 @@ class ShadowsFogScatteringSquidScene
 {
 public:
     ShadowsFogScatteringSquidScene(UINT frameCount, DXSample* pSample);
-    ~ShadowsFogScatteringSquidScene();
+    virtual ~ShadowsFogScatteringSquidScene();
 
-    void Initialize(ID3D12Device* pDevice, ID3D12CommandQueue* pCommandQueue, UINT frameIndex);
-    void LoadSizeDependentResources(ID3D12Device* pDevice, ComPtr<ID3D12Resource>* ppRenderTargets, UINT width, UINT height);
-    void ReleaseSizeDependentResources();
+    virtual void Initialize(ID3D12Device* pDevice, ID3D12CommandQueue* pDirectCommandQueue, ID3D12GraphicsCommandList* pCommandList, UINT frameIndex);
+    virtual void LoadSizeDependentResources(ID3D12Device* pDevice, ComPtr<ID3D12Resource>* ppRenderTargets, UINT width, UINT height);
+    virtual void ReleaseSizeDependentResources();
     void SetFrameIndex(UINT frameIndex);
     void ReleaseD3DObjects();    
     void KeyDown(UINT8 key);
     void KeyUp(UINT8 key);
-    void Update(double elapsedTime);
-    void Render(ID3D12CommandQueue* pCommandQueue, bool setBackbufferReadyForPresent);
+    virtual void Update(double elapsedTime);
+    virtual void Render(ID3D12CommandQueue* pCommandQueue, bool setBackbufferReadyForPresent);
     static ShadowsFogScatteringSquidScene* Get() { return s_app; }
 
-private:
+    float m_fogDensity;
+
+    float GetScenePassGPUTimeInMs() const;
+    float GetPostprocessPassGPUTimeInMs() const;
+
+protected:
     UINT m_frameCount;
 
     struct Vertex
     {
         XMFLOAT4 position;
     };
-    // Pipeline objects
+
+    ID3D12CommandList * m_batchSubmit[NumContexts * 2 + CommandListCount];   // *2: shadowCommandLists, sceneCommandLists
+
+    // Pipeline objects.
     CD3DX12_VIEWPORT m_viewport;
     CD3DX12_RECT m_scissorRect;
 
     // D3D objects.
+    ComPtr<ID3D12GraphicsCommandList> m_commandLists[CommandListCount];
+    ComPtr<ID3D12GraphicsCommandList> m_shadowCommandLists[NumContexts];
+    ComPtr<ID3D12GraphicsCommandList> m_sceneCommandLists[NumContexts];
     std::vector<ComPtr<ID3D12Resource>> m_renderTargets;
+    ComPtr<ID3D12Resource> m_depthTextures[SceneEnums::DepthGenPass::Count];
     ComPtr<ID3D12RootSignature> m_rootSignatures[SceneEnums::RootSignature::Count];
     ComPtr<ID3D12PipelineState> m_pipelineStates[SceneEnums::RenderPass::Count];
     ComPtr<ID3D12Resource> m_vertexBuffers[SceneEnums::VertexBuffer::Count];
@@ -153,11 +166,17 @@ private:
     ComPtr<ID3D12DescriptorHeap> m_samplerHeap;
     UINT m_rtvDescriptorSize;
     UINT m_cbvSrvDescriptorSize;
+    D3D12_CPU_DESCRIPTOR_HANDLE m_depthDsvs[SceneEnums::DepthGenPass::Count];
+    D3D12_CPU_DESCRIPTOR_HANDLE m_depthSrvCpuHandles[SceneEnums::DepthGenPass::Count];
+    D3D12_GPU_DESCRIPTOR_HANDLE m_depthSrvGpuHandles[SceneEnums::DepthGenPass::Count];
     
     // Frame resources.
     std::vector<std::unique_ptr<FrameResource>> m_frameResources;
     FrameResource* m_pCurrentFrameResource;
     UINT m_frameIndex;
+    SceneConstantBuffer m_shadowConstantBuffer; // Shadow copy.
+    SceneConstantBuffer m_sceneConstantBuffer; // Shadow copy.
+    PostprocessConstantBuffer m_postprocessConstantBuffer; // Shadow copy.
 
     // App resources.
     DXSample*  m_pSample;
@@ -165,6 +184,7 @@ private:
     LightState m_lights[NumLights];
     Camera m_lightCameras[NumLights];
     Camera m_camera;
+    static const float s_clearColor[4];
 
     // Window state
     bool m_windowVisible;
@@ -178,23 +198,116 @@ private:
     ThreadParameter m_threadParameters[NumContexts];
     HANDLE m_workerBeginRenderFrame[NumContexts];
     HANDLE m_workerFinishShadowPass[NumContexts];
-    HANDLE m_workerFinishedRenderFrame[NumContexts];
+    HANDLE m_workerFinishedScenePass[NumContexts];
     HANDLE m_threadHandles[NumContexts];
     static ShadowsFogScatteringSquidScene* s_app;        // Singleton object so that worker threads can share members.
 
+    virtual void UpdateConstantBuffers(); // Updates the shadow copies of the constant buffers.
+    virtual void CommitConstantBuffers(); // Commits the shadows copies of the constant buffers to GPU-visible memory for the current frame.
+    
+    virtual void DrawInScattering(ID3D12GraphicsCommandList* pCommandList, const D3D12_CPU_DESCRIPTOR_HANDLE& renderTargetHandle);
+
     void WorkerThread(int threadIndex);
-    void SetCommonPipelineState(ID3D12GraphicsCommandList* pCommandList);
     void LoadContexts();
-    void PostprocessPass(ID3D12CommandQueue* pCommandQueue, bool setBackbufferReadyForPresent);    
-    void BeginFrame();
-    void MidFrame();
-    void EndFrame();
-    void InitializeCameraAndLights();
-    void CreateDescriptorHeaps(ID3D12Device* pDevice);
-    void CreateRootSignatures(ID3D12Device* pDevice);
-    void CreatePipelineStates(ID3D12Device* pDevice);
-    void CreateFrameResources(ID3D12Device* pDevice);
-    void CreateAssetResources(ID3D12Device* pDevice, ID3D12GraphicsCommandList* pAssetLoadingCmdList);
-    void CreatePostprocessPassResources(ID3D12Device* pDevice);
-    void CreateSamplers(ID3D12Device* pDevice);
+
+    virtual void ShadowPass(ID3D12GraphicsCommandList* pCommandList, int threadIndex);
+    virtual void ScenePass(ID3D12GraphicsCommandList* pCommandList, int threadIndex);
+    virtual void PostprocessPass(ID3D12GraphicsCommandList* pCommandList);
+
+    virtual void BeginFrame();
+    virtual void MidFrame();
+    virtual void EndFrame(bool setBackbufferReadyForPresent);
+    virtual void InitializeCameraAndLights();
+
+    virtual void CreateDescriptorHeaps(ID3D12Device* pDevice);
+    virtual void CreateCommandLists(ID3D12Device* pDevice);
+    virtual void CreateRootSignatures(ID3D12Device* pDevice);
+    virtual void CreatePipelineStates(ID3D12Device* pDevice);
+    virtual void CreateFrameResources(ID3D12Device* pDevice, ID3D12CommandQueue* pCommandQueue);
+    virtual void CreateAssetResources(ID3D12Device* pDevice, ID3D12GraphicsCommandList* pCommandList);
+    virtual void CreatePostprocessPassResources(ID3D12Device* pDevice);
+    virtual void CreateSamplers(ID3D12Device* pDevice);
+
+    inline HRESULT CreateDepthStencilTexture2D(
+        ID3D12Device* pDevice,
+        UINT width,
+        UINT height,
+        DXGI_FORMAT typelessFormat,
+        DXGI_FORMAT dsvFormat,
+        DXGI_FORMAT srvFormat,
+        ID3D12Resource** ppResource,
+        D3D12_CPU_DESCRIPTOR_HANDLE cpuDsvHandle,
+        D3D12_CPU_DESCRIPTOR_HANDLE cpuSrvHandle,
+        D3D12_RESOURCE_STATES initState = D3D12_RESOURCE_STATE_DEPTH_WRITE,
+        float initDepthValue = 1.0f,
+        UINT8 initStencilValue = 0)
+    {
+        try
+        {
+            *ppResource = nullptr;
+    
+            CD3DX12_RESOURCE_DESC texDesc(
+                D3D12_RESOURCE_DIMENSION_TEXTURE2D,
+                0,
+                width,
+                height,
+                1,
+                1,
+                typelessFormat,
+                1,
+                0,
+                D3D12_TEXTURE_LAYOUT_UNKNOWN,
+                D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
+    
+            ThrowIfFailed(pDevice->CreateCommittedResource(
+                &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+                D3D12_HEAP_FLAG_NONE,
+                &texDesc,
+                initState,
+                &CD3DX12_CLEAR_VALUE(dsvFormat, initDepthValue, initStencilValue), // Performance tip: Tell the runtime at resource creation the desired clear value.
+                IID_PPV_ARGS(ppResource)));
+    
+            // Create a depth stencil view (DSV).
+            D3D12_DEPTH_STENCIL_VIEW_DESC dsvDesc = {};
+            dsvDesc.Format = dsvFormat;
+            dsvDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+            dsvDesc.Texture2D.MipSlice = 0;
+            pDevice->CreateDepthStencilView(*ppResource, &dsvDesc, cpuDsvHandle);
+    
+            // Create a shader resource view (SRV).
+            D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+            srvDesc.Format = srvFormat;
+            srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+            srvDesc.Texture2D.MipLevels = 1;
+            srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+            pDevice->CreateShaderResourceView(*ppResource, &srvDesc, cpuSrvHandle);
+        }
+        catch (HrException& e)
+        {
+            SAFE_RELEASE(*ppResource);
+            return e.Error();
+        }
+        return S_OK;
+    }
+
+    inline CD3DX12_CPU_DESCRIPTOR_HANDLE GetCurrentBackBufferRtvCpuHandle()
+    {
+        return CD3DX12_CPU_DESCRIPTOR_HANDLE(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
+    }
+
+    // How much to scale each dimension in the world.
+    inline float GetWorldScale() const
+    {
+        return 0.1f;
+    }
+
+    virtual UINT GetNumRtvDescriptors() const
+    {
+        return m_frameCount;
+    }
+
+    virtual UINT GetNumCbvSrvUavDescriptors() const
+    {
+        return NumNullSrvs + _countof(m_depthSrvCpuHandles) + _countof(SampleAssets::Textures);
+    }
 };

--- a/Samples/UWP/D3D12xGPU/src/d3dx12.h
+++ b/Samples/UWP/D3D12xGPU/src/d3dx12.h
@@ -2169,6 +2169,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
 struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
 
+#pragma warning(push)
+#pragma warning(disable : 4324)
 template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, typename DefaultArg = InnerStructType>
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
@@ -2182,6 +2184,7 @@ public:
     operator InnerStructType() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
 };
+#pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< UINT,                               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK>                         CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< ID3D12RootSignature*,               D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE>                    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE;
@@ -2691,7 +2694,7 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
-    if (!(a.StencilBeginningAccess == b.DepthBeginningAccess)) return false;
+    if (!(a.StencilBeginningAccess == b.StencilBeginningAccess)) return false;
     if (!(a.DepthEndingAccess == b.DepthEndingAccess)) return false;
     if (!(a.StencilEndingAccess == b.StencilEndingAccess)) return false;
     return true;


### PR DESCRIPTION
D3D Sample add functionality to enumerate gpu by preference and support device removal
List of samples that prefer high performance and support safe device removal:
ExecuteIndirect
FullScreen
HeterogenousMultiadapter
Multithreading
nBodyGrabity
psocache
PredicationQueue
SM6WaveIntrinsics