### PR TITLE
Converting Raytracing Simple Lighting Sample to use Library Subobjects

### DIFF
--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/D3D12RaytracingSimpleLighting.h
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/D3D12RaytracingSimpleLighting.h
@@ -89,7 +89,7 @@ private:
 
     // Root signatures
     ComPtr<ID3D12RootSignature> m_raytracingGlobalRootSignature;
-    ComPtr<ID3D12RootSignature> m_raytracingLocalRootSignature;
+    //ComPtr<ID3D12RootSignature> m_raytracingLocalRootSignature;
 
     // Descriptors
     ComPtr<ID3D12DescriptorHeap> m_descriptorHeap;
@@ -128,6 +128,13 @@ private:
     ComPtr<ID3D12Resource> m_hitGroupShaderTable;
     ComPtr<ID3D12Resource> m_rayGenShaderTable;
     
+    // Library subobjects
+    static const wchar_t*  c_globalRootSignatureName;
+    static const wchar_t*  c_localRootSignatureName;
+    static const wchar_t*  c_localRootSignatureAssociationName;
+    static const wchar_t*  c_shaderConfigName;
+    static const wchar_t*  c_pipelineConfigName;
+
     // Application state
     RaytracingAPI m_raytracingAPI;
     bool m_forceComputeFallback;
@@ -151,7 +158,6 @@ private:
     void CreateRaytracingInterfaces();
     void SerializeAndCreateRaytracingRootSignature(D3D12_ROOT_SIGNATURE_DESC& desc, ComPtr<ID3D12RootSignature>* rootSig);
     void CreateRootSignatures();
-    void CreateLocalRootSignatureSubobjects(CD3D12_STATE_OBJECT_DESC* raytracingPipeline);
     void CreateRaytracingPipelineStateObject();
     void CreateDescriptorHeap();
     void CreateRaytracingOutputResource();

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/D3D12RaytracingSimpleLighting.vcxproj
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/D3D12RaytracingSimpleLighting.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>D3D12Raytracing</RootNamespace>
     <ProjectName>D3D12RaytracingSimpleLighting</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18334.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/Raytracing.hlsl
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/Raytracing.hlsl
@@ -15,6 +15,44 @@
 #define HLSL
 #include "RaytracingHlslCompat.h"
 
+// Subobjects definitions at library scope. 
+GlobalRootSignature MyGlobalRootSignature =
+{
+    "DescriptorTable( UAV( u0 ) ),"                        // Output texture
+    "SRV( t0 ),"                                           // Acceleration structure
+    "CBV( b0 ),"                                           // Scene constants
+    "DescriptorTable( SRV( t1, numDescriptors = 2 ) )"     // Static index and vertex buffers.
+};
+
+LocalRootSignature MyLocalRootSignature = 
+{
+    "RootConstants( num32BitConstants = 4, b1 )"           // Cube constants        
+};
+
+TriangleHitGroup MyHitGroup =
+{
+    "",                     // AnyHit
+    "MyClosestHitShader",   // ClosestHit
+};
+
+SubobjectToExportsAssociation  MyLocalRootSignatureAssociation =
+{
+    "MyLocalRootSignature",  // subobject name
+    "MyHitGroup"             // export association 
+};
+
+RaytracingShaderConfig  MyShaderConfig =
+{
+    16, // max payload size
+    8   // max attribute size
+};
+
+RaytracingPipelineConfig MyPipelineConfig =
+{
+    1 // max trace recursion depth
+};
+
+
 RaytracingAccelerationStructure Scene : register(t0, space0);
 RWTexture2D<float4> RenderTarget : register(u0);
 ByteAddressBuffer Indices : register(t1, space0);


### PR DESCRIPTION
Converted collection scope subobjects to library subobjects, i.e. defined them in hlsl shader. Removed the cpp definitions, instead subobjects can be exported from library shader. 