### PR TITLE
Fix vs2019 samples build

### DIFF
--- a/Samples/Desktop/D3D1211On12/src/DXSampleHelper.h
+++ b/Samples/Desktop/D3D1211On12/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12Bundles/src/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12Bundles/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12DepthBoundsTest/src/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12DepthBoundsTest/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12DynamicIndexing/src/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12DynamicIndexing/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12ExecuteIndirect/src/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12Fullscreen/src/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12Fullscreen/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12HDR/src/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12HDR/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloBundles/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTexture/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTriangle/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloWindow/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12HeterogeneousMultiadapter/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12Multithreading/src/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12Multithreading/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12PipelineStateCache/src/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12PipelineStateCache/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12PredicationQueries/src/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12PredicationQueries/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingHelloWorld/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingHelloWorld/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account
@@ -17,14 +18,15 @@
 // referenced by the GPU.
 using Microsoft::WRL::ComPtr;
 
+inline std::string HrToString(HRESULT hr)
+{
+    char s_str[64] = {};
+    sprintf_s(s_str, "HRESULT of 0x%08X", static_cast<UINT>(hr));
+    return std::string(s_str);
+}
+
 class HrException : public std::runtime_error
 {
-    inline std::string HrToString(HRESULT hr)
-    {
-        char s_str[64] = {};
-        sprintf_s(s_str, "HRESULT of 0x%08X", static_cast<UINT>(hr));
-        return std::string(s_str);
-    }
 public:
     HrException(HRESULT hr) : std::runtime_error(HrToString(hr)), m_hr(hr) {}
     HRESULT Error() const { return m_hr; }
@@ -41,26 +43,6 @@ inline void ThrowIfFailed(HRESULT hr)
         throw HrException(hr);
     }
 }
-
-inline void ThrowIfFailed(HRESULT hr, const wchar_t* msg)
-{
-    if (FAILED(hr))
-    {
-        OutputDebugString(msg);
-        throw HrException(hr);
-    }
-}
-
-inline void ThrowIfFalse(bool value)
-{
-    ThrowIfFailed(value ? S_OK : E_FAIL);
-}
-
-inline void ThrowIfFalse(bool value, const wchar_t* msg)
-{
-    ThrowIfFailed(value ? S_OK : E_FAIL, msg);
-}
-
 
 inline void GetAssetsPath(_Out_writes_(pathSize) WCHAR* path, UINT pathSize)
 {
@@ -152,15 +134,10 @@ inline void SetNameIndexed(ID3D12Object*, LPCWSTR, UINT)
 #define NAME_D3D12_OBJECT(x) SetName((x).Get(), L#x)
 #define NAME_D3D12_OBJECT_INDEXED(x, n) SetNameIndexed((x)[n].Get(), L#x, n)
 
-inline UINT Align(UINT size, UINT alignment)
-{
-    return (size + (alignment - 1)) & ~(alignment - 1);
-}
-
 inline UINT CalculateConstantBufferByteSize(UINT byteSize)
 {
     // Constant buffer size is required to be aligned.
-    return Align(byteSize, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
+    return (byteSize + (D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1)) & ~(D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1);
 }
 
 #ifdef D3D_COMPILE_STANDARD_FILE_INCLUDE
@@ -212,137 +189,3 @@ void ResetUniquePtrArray(T* uniquePtrArray)
         i.reset();
     }
 }
-
-class GpuUploadBuffer
-{
-public:
-    ComPtr<ID3D12Resource> GetResource() { return m_resource; }
-
-protected:
-    ComPtr<ID3D12Resource> m_resource;
-
-    GpuUploadBuffer() {}
-    ~GpuUploadBuffer()
-    {
-        if (m_resource.Get())
-        {
-            m_resource->Unmap(0, nullptr);
-        }
-    }
-
-    void Allocate(ID3D12Device* device, UINT bufferSize, LPCWSTR resourceName = nullptr)
-    {
-        auto uploadHeapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
-
-        auto bufferDesc = CD3DX12_RESOURCE_DESC::Buffer(bufferSize);
-        ThrowIfFailed(device->CreateCommittedResource(
-            &uploadHeapProperties,
-            D3D12_HEAP_FLAG_NONE,
-            &bufferDesc,
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_resource)));
-        m_resource->SetName(resourceName);
-    }
-
-    uint8_t* MapCpuWriteOnly()
-    {
-        uint8_t* mappedData;
-        // We don't unmap this until the app closes. Keeping buffer mapped for the lifetime of the resource is okay.
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_resource->Map(0, &readRange, reinterpret_cast<void**>(&mappedData)));
-        return mappedData;
-    }
-};
-
-struct D3DBuffer
-{
-    ComPtr<ID3D12Resource> resource;
-    D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptorHandle;
-    D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptorHandle;
-};
-
-// Helper class to create and update a constant buffer with proper constant buffer alignments.
-// Usage: ToDo
-//    ConstantBuffer<...> cb;
-//    cb.Create(...);
-//    cb.staging.var = ...; | cb->var = ... ; 
-//    cb.CopyStagingToGPU(...);
-template <class T>
-class ConstantBuffer : public GpuUploadBuffer
-{
-    uint8_t* m_mappedConstantData;
-    UINT m_alignedInstanceSize;
-    UINT m_numInstances;
-
-public:
-    ConstantBuffer() : m_alignedInstanceSize(0), m_numInstances(0), m_mappedConstantData(nullptr) {}
-
-    void Create(ID3D12Device* device, UINT numInstances = 1, LPCWSTR resourceName = nullptr)
-    {
-        m_numInstances = numInstances;
-        UINT alignedSize = Align(sizeof(T), D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
-        UINT bufferSize = numInstances * alignedSize;
-        Allocate(device, bufferSize, resourceName);
-        m_mappedConstantData = MapCpuWriteOnly();
-    }
-
-    void CopyStagingToGpu(UINT instanceIndex = 0)
-    {
-        memcpy(m_mappedConstantData + instanceIndex * m_alignedInstanceSize, &staging, sizeof(T));
-    }
-
-    // Accessors
-    T staging;
-    T* operator->() { return &staging; }
-    UINT NumInstances() { return m_numInstances; }
-    D3D12_GPU_VIRTUAL_ADDRESS GpuVirtualAddress(UINT instanceIndex = 0)
-    {
-        return m_resource->GetGPUVirtualAddress() + instanceIndex * m_alignedInstanceSize;
-    }
-};
-
-
-// Helper class to create and update a structured buffer.
-// Usage: ToDo
-//    ConstantBuffer<...> cb;
-//    cb.Create(...);
-//    cb.staging.var = ...; | cb->var = ... ; 
-//    cb.CopyStagingToGPU(...);
-template <class T>
-class StructuredBuffer : public GpuUploadBuffer
-{
-    T* m_mappedBuffers;
-    std::vector<T> m_staging;
-    UINT m_numInstances;
-
-public:
-    // Performance tip: Align structures on sizeof(float4) boundary.
-    // Ref: https://developer.nvidia.com/content/understanding-structured-buffer-performance
-    static_assert(sizeof(T) % 16 == 0, L"Align structure buffers on 16 byte boundary for performance reasons.");
-
-    StructuredBuffer() : m_mappedBuffers(nullptr), m_numInstances(0) {}
-
-    void Create(ID3D12Device* device, UINT numElements, UINT numInstances = 1, LPCWSTR resourceName = nullptr)
-    {
-        m_staging.resize(numElements);
-        UINT bufferSize = numInstances * numElements * sizeof(T);
-        Allocate(device, bufferSize, resourceName);
-        m_mappedBuffers = reinterpret_cast<T*>(MapCpuWriteOnly());
-    }
-
-    void CopyStagingToGpu(UINT instanceIndex = 0)
-    {
-        memcpy(m_mappedBuffers + instanceIndex, &m_staging[0], InstanceSize());
-    }
-
-    // Accessors
-    T& operator[](UINT elementIndex) { return m_staging[elementIndex]; }
-    size_t NumElementsPerInstance() { return m_staging.size(); }
-    UINT NumInstances() { return m_staging.size(); }
-    size_t InstanceSize() { return NumElementsPerInstance() * sizeof(T); }
-    D3D12_GPU_VIRTUAL_ADDRESS GpuVirtualAddress(UINT instanceIndex = 0)
-    {
-        return m_resource->GetGPUVirtualAddress() + instanceIndex * InstanceSize();
-    }
-};

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingHelloWorld/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingHelloWorld/DXSampleHelper.h
@@ -18,15 +18,14 @@
 // referenced by the GPU.
 using Microsoft::WRL::ComPtr;
 
-inline std::string HrToString(HRESULT hr)
-{
-    char s_str[64] = {};
-    sprintf_s(s_str, "HRESULT of 0x%08X", static_cast<UINT>(hr));
-    return std::string(s_str);
-}
-
 class HrException : public std::runtime_error
 {
+    inline std::string HrToString(HRESULT hr)
+    {
+        char s_str[64] = {};
+        sprintf_s(s_str, "HRESULT of 0x%08X", static_cast<UINT>(hr));
+        return std::string(s_str);
+    }
 public:
     HrException(HRESULT hr) : std::runtime_error(HrToString(hr)), m_hr(hr) {}
     HRESULT Error() const { return m_hr; }
@@ -43,6 +42,26 @@ inline void ThrowIfFailed(HRESULT hr)
         throw HrException(hr);
     }
 }
+
+inline void ThrowIfFailed(HRESULT hr, const wchar_t* msg)
+{
+    if (FAILED(hr))
+    {
+        OutputDebugString(msg);
+        throw HrException(hr);
+    }
+}
+
+inline void ThrowIfFalse(bool value)
+{
+    ThrowIfFailed(value ? S_OK : E_FAIL);
+}
+
+inline void ThrowIfFalse(bool value, const wchar_t* msg)
+{
+    ThrowIfFailed(value ? S_OK : E_FAIL, msg);
+}
+
 
 inline void GetAssetsPath(_Out_writes_(pathSize) WCHAR* path, UINT pathSize)
 {
@@ -134,10 +153,15 @@ inline void SetNameIndexed(ID3D12Object*, LPCWSTR, UINT)
 #define NAME_D3D12_OBJECT(x) SetName((x).Get(), L#x)
 #define NAME_D3D12_OBJECT_INDEXED(x, n) SetNameIndexed((x)[n].Get(), L#x, n)
 
+inline UINT Align(UINT size, UINT alignment)
+{
+    return (size + (alignment - 1)) & ~(alignment - 1);
+}
+
 inline UINT CalculateConstantBufferByteSize(UINT byteSize)
 {
     // Constant buffer size is required to be aligned.
-    return (byteSize + (D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1)) & ~(D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1);
+    return Align(byteSize, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
 }
 
 #ifdef D3D_COMPILE_STANDARD_FILE_INCLUDE
@@ -189,3 +213,137 @@ void ResetUniquePtrArray(T* uniquePtrArray)
         i.reset();
     }
 }
+
+class GpuUploadBuffer
+{
+public:
+    ComPtr<ID3D12Resource> GetResource() { return m_resource; }
+
+protected:
+    ComPtr<ID3D12Resource> m_resource;
+
+    GpuUploadBuffer() {}
+    ~GpuUploadBuffer()
+    {
+        if (m_resource.Get())
+        {
+            m_resource->Unmap(0, nullptr);
+        }
+    }
+
+    void Allocate(ID3D12Device* device, UINT bufferSize, LPCWSTR resourceName = nullptr)
+    {
+        auto uploadHeapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+
+        auto bufferDesc = CD3DX12_RESOURCE_DESC::Buffer(bufferSize);
+        ThrowIfFailed(device->CreateCommittedResource(
+            &uploadHeapProperties,
+            D3D12_HEAP_FLAG_NONE,
+            &bufferDesc,
+            D3D12_RESOURCE_STATE_GENERIC_READ,
+            nullptr,
+            IID_PPV_ARGS(&m_resource)));
+        m_resource->SetName(resourceName);
+    }
+
+    uint8_t* MapCpuWriteOnly()
+    {
+        uint8_t* mappedData;
+        // We don't unmap this until the app closes. Keeping buffer mapped for the lifetime of the resource is okay.
+        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
+        ThrowIfFailed(m_resource->Map(0, &readRange, reinterpret_cast<void**>(&mappedData)));
+        return mappedData;
+    }
+};
+
+struct D3DBuffer
+{
+    ComPtr<ID3D12Resource> resource;
+    D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptorHandle;
+    D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptorHandle;
+};
+
+// Helper class to create and update a constant buffer with proper constant buffer alignments.
+// Usage: ToDo
+//    ConstantBuffer<...> cb;
+//    cb.Create(...);
+//    cb.staging.var = ...; | cb->var = ... ; 
+//    cb.CopyStagingToGPU(...);
+template <class T>
+class ConstantBuffer : public GpuUploadBuffer
+{
+    uint8_t* m_mappedConstantData;
+    UINT m_alignedInstanceSize;
+    UINT m_numInstances;
+
+public:
+    ConstantBuffer() : m_alignedInstanceSize(0), m_numInstances(0), m_mappedConstantData(nullptr) {}
+
+    void Create(ID3D12Device* device, UINT numInstances = 1, LPCWSTR resourceName = nullptr)
+    {
+        m_numInstances = numInstances;
+        UINT alignedSize = Align(sizeof(T), D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
+        UINT bufferSize = numInstances * alignedSize;
+        Allocate(device, bufferSize, resourceName);
+        m_mappedConstantData = MapCpuWriteOnly();
+    }
+
+    void CopyStagingToGpu(UINT instanceIndex = 0)
+    {
+        memcpy(m_mappedConstantData + instanceIndex * m_alignedInstanceSize, &staging, sizeof(T));
+    }
+
+    // Accessors
+    T staging;
+    T* operator->() { return &staging; }
+    UINT NumInstances() { return m_numInstances; }
+    D3D12_GPU_VIRTUAL_ADDRESS GpuVirtualAddress(UINT instanceIndex = 0)
+    {
+        return m_resource->GetGPUVirtualAddress() + instanceIndex * m_alignedInstanceSize;
+    }
+};
+
+
+// Helper class to create and update a structured buffer.
+// Usage: ToDo
+//    ConstantBuffer<...> cb;
+//    cb.Create(...);
+//    cb.staging.var = ...; | cb->var = ... ; 
+//    cb.CopyStagingToGPU(...);
+template <class T>
+class StructuredBuffer : public GpuUploadBuffer
+{
+    T* m_mappedBuffers;
+    std::vector<T> m_staging;
+    UINT m_numInstances;
+
+public:
+    // Performance tip: Align structures on sizeof(float4) boundary.
+    // Ref: https://developer.nvidia.com/content/understanding-structured-buffer-performance
+    static_assert(sizeof(T) % 16 == 0, L"Align structure buffers on 16 byte boundary for performance reasons.");
+
+    StructuredBuffer() : m_mappedBuffers(nullptr), m_numInstances(0) {}
+
+    void Create(ID3D12Device* device, UINT numElements, UINT numInstances = 1, LPCWSTR resourceName = nullptr)
+    {
+        m_staging.resize(numElements);
+        UINT bufferSize = numInstances * numElements * sizeof(T);
+        Allocate(device, bufferSize, resourceName);
+        m_mappedBuffers = reinterpret_cast<T*>(MapCpuWriteOnly());
+    }
+
+    void CopyStagingToGpu(UINT instanceIndex = 0)
+    {
+        memcpy(m_mappedBuffers + instanceIndex, &m_staging[0], InstanceSize());
+    }
+
+    // Accessors
+    T& operator[](UINT elementIndex) { return m_staging[elementIndex]; }
+    size_t NumElementsPerInstance() { return m_staging.size(); }
+    UINT NumInstances() { return m_staging.size(); }
+    size_t InstanceSize() { return NumElementsPerInstance() * sizeof(T); }
+    D3D12_GPU_VIRTUAL_ADDRESS GpuVirtualAddress(UINT instanceIndex = 0)
+    {
+        return m_resource->GetGPUVirtualAddress() + instanceIndex * InstanceSize();
+    }
+};

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingProceduralGeometry/util/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingProceduralGeometry/util/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account
@@ -17,14 +18,15 @@
 // referenced by the GPU.
 using Microsoft::WRL::ComPtr;
 
+inline std::string HrToString(HRESULT hr)
+{
+    char s_str[64] = {};
+    sprintf_s(s_str, "HRESULT of 0x%08X", static_cast<UINT>(hr));
+    return std::string(s_str);
+}
+
 class HrException : public std::runtime_error
 {
-    inline std::string HrToString(HRESULT hr)
-    {
-        char s_str[64] = {};
-        sprintf_s(s_str, "HRESULT of 0x%08X", static_cast<UINT>(hr));
-        return std::string(s_str);
-    }
 public:
     HrException(HRESULT hr) : std::runtime_error(HrToString(hr)), m_hr(hr) {}
     HRESULT Error() const { return m_hr; }
@@ -41,26 +43,6 @@ inline void ThrowIfFailed(HRESULT hr)
         throw HrException(hr);
     }
 }
-
-inline void ThrowIfFailed(HRESULT hr, const wchar_t* msg)
-{
-    if (FAILED(hr))
-    {
-        OutputDebugString(msg);
-        throw HrException(hr);
-    }
-}
-
-inline void ThrowIfFalse(bool value)
-{
-    ThrowIfFailed(value ? S_OK : E_FAIL);
-}
-
-inline void ThrowIfFalse(bool value, const wchar_t* msg)
-{
-    ThrowIfFailed(value ? S_OK : E_FAIL, msg);
-}
-
 
 inline void GetAssetsPath(_Out_writes_(pathSize) WCHAR* path, UINT pathSize)
 {
@@ -152,15 +134,10 @@ inline void SetNameIndexed(ID3D12Object*, LPCWSTR, UINT)
 #define NAME_D3D12_OBJECT(x) SetName((x).Get(), L#x)
 #define NAME_D3D12_OBJECT_INDEXED(x, n) SetNameIndexed((x)[n].Get(), L#x, n)
 
-inline UINT Align(UINT size, UINT alignment)
-{
-    return (size + (alignment - 1)) & ~(alignment - 1);
-}
-
 inline UINT CalculateConstantBufferByteSize(UINT byteSize)
 {
     // Constant buffer size is required to be aligned.
-    return Align(byteSize, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
+    return (byteSize + (D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1)) & ~(D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1);
 }
 
 #ifdef D3D_COMPILE_STANDARD_FILE_INCLUDE
@@ -212,139 +189,3 @@ void ResetUniquePtrArray(T* uniquePtrArray)
         i.reset();
     }
 }
-
-class GpuUploadBuffer
-{
-public:
-    ComPtr<ID3D12Resource> GetResource() { return m_resource; }
-    virtual void Release() { m_resource.Reset(); }
-protected:
-    ComPtr<ID3D12Resource> m_resource;
-
-    GpuUploadBuffer() {}
-    ~GpuUploadBuffer()
-    {
-        if (m_resource.Get())
-        {
-            m_resource->Unmap(0, nullptr);
-        }
-    }
-
-    void Allocate(ID3D12Device* device, UINT bufferSize, LPCWSTR resourceName = nullptr)
-    {
-        auto uploadHeapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
-
-        auto bufferDesc = CD3DX12_RESOURCE_DESC::Buffer(bufferSize);
-        ThrowIfFailed(device->CreateCommittedResource(
-            &uploadHeapProperties,
-            D3D12_HEAP_FLAG_NONE,
-            &bufferDesc,
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_resource)));
-        m_resource->SetName(resourceName);
-    }
-
-    uint8_t* MapCpuWriteOnly()
-    {
-        uint8_t* mappedData;
-        // We don't unmap this until the app closes. Keeping buffer mapped for the lifetime of the resource is okay.
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_resource->Map(0, &readRange, reinterpret_cast<void**>(&mappedData)));
-        return mappedData;
-    }
-};
-
-struct D3DBuffer
-{
-    ComPtr<ID3D12Resource> resource;
-    D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptorHandle;
-    D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptorHandle;
-};
-
-// Helper class to create and update a constant buffer with proper constant buffer alignments.
-// Usage: 
-//    ConstantBuffer<...> cb;
-//    cb.Create(...);
-//    cb.staging.var = ... ; | cb->var = ... ; 
-//    cb.CopyStagingToGPU(...);
-//    Set...View(..., cb.GputVirtualAddress());
-template <class T>
-class ConstantBuffer : public GpuUploadBuffer
-{
-    uint8_t* m_mappedConstantData;
-    UINT m_alignedInstanceSize;
-    UINT m_numInstances;
-
-public:
-    ConstantBuffer() : m_alignedInstanceSize(0), m_numInstances(0), m_mappedConstantData(nullptr) {}
-
-    void Create(ID3D12Device* device, UINT numInstances = 1, LPCWSTR resourceName = nullptr)
-    {
-        m_numInstances = numInstances;
-        m_alignedInstanceSize = Align(sizeof(T), D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
-        UINT bufferSize = numInstances * m_alignedInstanceSize;
-        Allocate(device, bufferSize, resourceName);
-        m_mappedConstantData = MapCpuWriteOnly();
-    }
-
-    void CopyStagingToGpu(UINT instanceIndex = 0)
-    {
-        memcpy(m_mappedConstantData + instanceIndex * m_alignedInstanceSize, &staging, sizeof(T));
-    }
-
-    // Accessors
-    T staging;
-    T* operator->() { return &staging; }
-    UINT NumInstances() { return m_numInstances; }
-    D3D12_GPU_VIRTUAL_ADDRESS GpuVirtualAddress(UINT instanceIndex = 0)
-    {
-        return m_resource->GetGPUVirtualAddress() + instanceIndex * m_alignedInstanceSize;
-    }
-};
-
-
-// Helper class to create and update a structured buffer.
-// Usage: 
-//    StructuredBuffer<...> sb;
-//    sb.Create(...);
-//    sb[index].var = ... ; 
-//    sb.CopyStagingToGPU(...);
-//    Set...View(..., sb.GputVirtualAddress());
-template <class T>
-class StructuredBuffer : public GpuUploadBuffer
-{
-    T* m_mappedBuffers;
-    std::vector<T> m_staging;
-    UINT m_numInstances;
-
-public:
-    // Performance tip: Align structures on sizeof(float4) boundary.
-    // Ref: https://developer.nvidia.com/content/understanding-structured-buffer-performance
-    static_assert(sizeof(T) % 16 == 0, L"Align structure buffers on 16 byte boundary for performance reasons.");
-
-    StructuredBuffer() : m_mappedBuffers(nullptr), m_numInstances(0) {}
-
-    void Create(ID3D12Device* device, UINT numElements, UINT numInstances = 1, LPCWSTR resourceName = nullptr)
-    {
-        m_staging.resize(numElements);
-        UINT bufferSize = numInstances * numElements * sizeof(T);
-        Allocate(device, bufferSize, resourceName);
-        m_mappedBuffers = reinterpret_cast<T*>(MapCpuWriteOnly());
-    }
-
-    void CopyStagingToGpu(UINT instanceIndex = 0)
-    {
-        memcpy(m_mappedBuffers + instanceIndex * NumElementsPerInstance(), &m_staging[0], InstanceSize());
-    }
-
-    // Accessors
-    T& operator[](UINT elementIndex) { return m_staging[elementIndex]; }
-    size_t NumElementsPerInstance() { return m_staging.size(); }
-    UINT NumInstances() { return m_staging.size(); }
-    size_t InstanceSize() { return NumElementsPerInstance() * sizeof(T); }
-    D3D12_GPU_VIRTUAL_ADDRESS GpuVirtualAddress(UINT instanceIndex = 0)
-    {
-        return m_resource->GetGPUVirtualAddress() + instanceIndex * InstanceSize();
-    }
-};

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingProceduralGeometry/util/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingProceduralGeometry/util/DXSampleHelper.h
@@ -18,15 +18,14 @@
 // referenced by the GPU.
 using Microsoft::WRL::ComPtr;
 
-inline std::string HrToString(HRESULT hr)
-{
-    char s_str[64] = {};
-    sprintf_s(s_str, "HRESULT of 0x%08X", static_cast<UINT>(hr));
-    return std::string(s_str);
-}
-
 class HrException : public std::runtime_error
 {
+    inline std::string HrToString(HRESULT hr)
+    {
+        char s_str[64] = {};
+        sprintf_s(s_str, "HRESULT of 0x%08X", static_cast<UINT>(hr));
+        return std::string(s_str);
+    }
 public:
     HrException(HRESULT hr) : std::runtime_error(HrToString(hr)), m_hr(hr) {}
     HRESULT Error() const { return m_hr; }
@@ -43,6 +42,26 @@ inline void ThrowIfFailed(HRESULT hr)
         throw HrException(hr);
     }
 }
+
+inline void ThrowIfFailed(HRESULT hr, const wchar_t* msg)
+{
+    if (FAILED(hr))
+    {
+        OutputDebugString(msg);
+        throw HrException(hr);
+    }
+}
+
+inline void ThrowIfFalse(bool value)
+{
+    ThrowIfFailed(value ? S_OK : E_FAIL);
+}
+
+inline void ThrowIfFalse(bool value, const wchar_t* msg)
+{
+    ThrowIfFailed(value ? S_OK : E_FAIL, msg);
+}
+
 
 inline void GetAssetsPath(_Out_writes_(pathSize) WCHAR* path, UINT pathSize)
 {
@@ -134,10 +153,15 @@ inline void SetNameIndexed(ID3D12Object*, LPCWSTR, UINT)
 #define NAME_D3D12_OBJECT(x) SetName((x).Get(), L#x)
 #define NAME_D3D12_OBJECT_INDEXED(x, n) SetNameIndexed((x)[n].Get(), L#x, n)
 
+inline UINT Align(UINT size, UINT alignment)
+{
+    return (size + (alignment - 1)) & ~(alignment - 1);
+}
+
 inline UINT CalculateConstantBufferByteSize(UINT byteSize)
 {
     // Constant buffer size is required to be aligned.
-    return (byteSize + (D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1)) & ~(D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1);
+    return Align(byteSize, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
 }
 
 #ifdef D3D_COMPILE_STANDARD_FILE_INCLUDE
@@ -189,3 +213,139 @@ void ResetUniquePtrArray(T* uniquePtrArray)
         i.reset();
     }
 }
+
+class GpuUploadBuffer
+{
+public:
+    ComPtr<ID3D12Resource> GetResource() { return m_resource; }
+    virtual void Release() { m_resource.Reset(); }
+protected:
+    ComPtr<ID3D12Resource> m_resource;
+
+    GpuUploadBuffer() {}
+    ~GpuUploadBuffer()
+    {
+        if (m_resource.Get())
+        {
+            m_resource->Unmap(0, nullptr);
+        }
+    }
+
+    void Allocate(ID3D12Device* device, UINT bufferSize, LPCWSTR resourceName = nullptr)
+    {
+        auto uploadHeapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+
+        auto bufferDesc = CD3DX12_RESOURCE_DESC::Buffer(bufferSize);
+        ThrowIfFailed(device->CreateCommittedResource(
+            &uploadHeapProperties,
+            D3D12_HEAP_FLAG_NONE,
+            &bufferDesc,
+            D3D12_RESOURCE_STATE_GENERIC_READ,
+            nullptr,
+            IID_PPV_ARGS(&m_resource)));
+        m_resource->SetName(resourceName);
+    }
+
+    uint8_t* MapCpuWriteOnly()
+    {
+        uint8_t* mappedData;
+        // We don't unmap this until the app closes. Keeping buffer mapped for the lifetime of the resource is okay.
+        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
+        ThrowIfFailed(m_resource->Map(0, &readRange, reinterpret_cast<void**>(&mappedData)));
+        return mappedData;
+    }
+};
+
+struct D3DBuffer
+{
+    ComPtr<ID3D12Resource> resource;
+    D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptorHandle;
+    D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptorHandle;
+};
+
+// Helper class to create and update a constant buffer with proper constant buffer alignments.
+// Usage: 
+//    ConstantBuffer<...> cb;
+//    cb.Create(...);
+//    cb.staging.var = ... ; | cb->var = ... ; 
+//    cb.CopyStagingToGPU(...);
+//    Set...View(..., cb.GputVirtualAddress());
+template <class T>
+class ConstantBuffer : public GpuUploadBuffer
+{
+    uint8_t* m_mappedConstantData;
+    UINT m_alignedInstanceSize;
+    UINT m_numInstances;
+
+public:
+    ConstantBuffer() : m_alignedInstanceSize(0), m_numInstances(0), m_mappedConstantData(nullptr) {}
+
+    void Create(ID3D12Device* device, UINT numInstances = 1, LPCWSTR resourceName = nullptr)
+    {
+        m_numInstances = numInstances;
+        m_alignedInstanceSize = Align(sizeof(T), D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
+        UINT bufferSize = numInstances * m_alignedInstanceSize;
+        Allocate(device, bufferSize, resourceName);
+        m_mappedConstantData = MapCpuWriteOnly();
+    }
+
+    void CopyStagingToGpu(UINT instanceIndex = 0)
+    {
+        memcpy(m_mappedConstantData + instanceIndex * m_alignedInstanceSize, &staging, sizeof(T));
+    }
+
+    // Accessors
+    T staging;
+    T* operator->() { return &staging; }
+    UINT NumInstances() { return m_numInstances; }
+    D3D12_GPU_VIRTUAL_ADDRESS GpuVirtualAddress(UINT instanceIndex = 0)
+    {
+        return m_resource->GetGPUVirtualAddress() + instanceIndex * m_alignedInstanceSize;
+    }
+};
+
+
+// Helper class to create and update a structured buffer.
+// Usage: 
+//    StructuredBuffer<...> sb;
+//    sb.Create(...);
+//    sb[index].var = ... ; 
+//    sb.CopyStagingToGPU(...);
+//    Set...View(..., sb.GputVirtualAddress());
+template <class T>
+class StructuredBuffer : public GpuUploadBuffer
+{
+    T* m_mappedBuffers;
+    std::vector<T> m_staging;
+    UINT m_numInstances;
+
+public:
+    // Performance tip: Align structures on sizeof(float4) boundary.
+    // Ref: https://developer.nvidia.com/content/understanding-structured-buffer-performance
+    static_assert(sizeof(T) % 16 == 0, L"Align structure buffers on 16 byte boundary for performance reasons.");
+
+    StructuredBuffer() : m_mappedBuffers(nullptr), m_numInstances(0) {}
+
+    void Create(ID3D12Device* device, UINT numElements, UINT numInstances = 1, LPCWSTR resourceName = nullptr)
+    {
+        m_staging.resize(numElements);
+        UINT bufferSize = numInstances * numElements * sizeof(T);
+        Allocate(device, bufferSize, resourceName);
+        m_mappedBuffers = reinterpret_cast<T*>(MapCpuWriteOnly());
+    }
+
+    void CopyStagingToGpu(UINT instanceIndex = 0)
+    {
+        memcpy(m_mappedBuffers + instanceIndex * NumElementsPerInstance(), &m_staging[0], InstanceSize());
+    }
+
+    // Accessors
+    T& operator[](UINT elementIndex) { return m_staging[elementIndex]; }
+    size_t NumElementsPerInstance() { return m_staging.size(); }
+    UINT NumInstances() { return m_staging.size(); }
+    size_t InstanceSize() { return NumElementsPerInstance() * sizeof(T); }
+    D3D12_GPU_VIRTUAL_ADDRESS GpuVirtualAddress(UINT instanceIndex = 0)
+    {
+        return m_resource->GetGPUVirtualAddress() + instanceIndex * InstanceSize();
+    }
+};

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account
@@ -17,14 +18,15 @@
 // referenced by the GPU.
 using Microsoft::WRL::ComPtr;
 
+inline std::string HrToString(HRESULT hr)
+{
+    char s_str[64] = {};
+    sprintf_s(s_str, "HRESULT of 0x%08X", static_cast<UINT>(hr));
+    return std::string(s_str);
+}
+
 class HrException : public std::runtime_error
 {
-    inline std::string HrToString(HRESULT hr)
-    {
-        char s_str[64] = {};
-        sprintf_s(s_str, "HRESULT of 0x%08X", static_cast<UINT>(hr));
-        return std::string(s_str);
-    }
 public:
     HrException(HRESULT hr) : std::runtime_error(HrToString(hr)), m_hr(hr) {}
     HRESULT Error() const { return m_hr; }
@@ -41,26 +43,6 @@ inline void ThrowIfFailed(HRESULT hr)
         throw HrException(hr);
     }
 }
-
-inline void ThrowIfFailed(HRESULT hr, const wchar_t* msg)
-{
-    if (FAILED(hr))
-    {
-        OutputDebugString(msg);
-        throw HrException(hr);
-    }
-}
-
-inline void ThrowIfFalse(bool value)
-{
-    ThrowIfFailed(value ? S_OK : E_FAIL);
-}
-
-inline void ThrowIfFalse(bool value, const wchar_t* msg)
-{
-    ThrowIfFailed(value ? S_OK : E_FAIL, msg);
-}
-
 
 inline void GetAssetsPath(_Out_writes_(pathSize) WCHAR* path, UINT pathSize)
 {
@@ -152,15 +134,10 @@ inline void SetNameIndexed(ID3D12Object*, LPCWSTR, UINT)
 #define NAME_D3D12_OBJECT(x) SetName((x).Get(), L#x)
 #define NAME_D3D12_OBJECT_INDEXED(x, n) SetNameIndexed((x)[n].Get(), L#x, n)
 
-inline UINT Align(UINT size, UINT alignment)
-{
-    return (size + (alignment - 1)) & ~(alignment - 1);
-}
-
 inline UINT CalculateConstantBufferByteSize(UINT byteSize)
 {
     // Constant buffer size is required to be aligned.
-    return Align(byteSize, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
+    return (byteSize + (D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1)) & ~(D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1);
 }
 
 #ifdef D3D_COMPILE_STANDARD_FILE_INCLUDE
@@ -212,137 +189,3 @@ void ResetUniquePtrArray(T* uniquePtrArray)
         i.reset();
     }
 }
-
-class GpuUploadBuffer
-{
-public:
-    ComPtr<ID3D12Resource> GetResource() { return m_resource; }
-
-protected:
-    ComPtr<ID3D12Resource> m_resource;
-
-    GpuUploadBuffer() {}
-    ~GpuUploadBuffer()
-    {
-        if (m_resource.Get())
-        {
-            m_resource->Unmap(0, nullptr);
-        }
-    }
-
-    void Allocate(ID3D12Device* device, UINT bufferSize, LPCWSTR resourceName = nullptr)
-    {
-        auto uploadHeapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
-
-        auto bufferDesc = CD3DX12_RESOURCE_DESC::Buffer(bufferSize);
-        ThrowIfFailed(device->CreateCommittedResource(
-            &uploadHeapProperties,
-            D3D12_HEAP_FLAG_NONE,
-            &bufferDesc,
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(&m_resource)));
-        m_resource->SetName(resourceName);
-    }
-
-    uint8_t* MapCpuWriteOnly()
-    {
-        uint8_t* mappedData;
-        // We don't unmap this until the app closes. Keeping buffer mapped for the lifetime of the resource is okay.
-        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        ThrowIfFailed(m_resource->Map(0, &readRange, reinterpret_cast<void**>(&mappedData)));
-        return mappedData;
-    }
-};
-
-struct D3DBuffer
-{
-    ComPtr<ID3D12Resource> resource;
-    D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptorHandle;
-    D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptorHandle;
-};
-
-// Helper class to create and update a constant buffer with proper constant buffer alignments.
-// Usage: ToDo
-//    ConstantBuffer<...> cb;
-//    cb.Create(...);
-//    cb.staging.var = ...; | cb->var = ... ; 
-//    cb.CopyStagingToGPU(...);
-template <class T>
-class ConstantBuffer : public GpuUploadBuffer
-{
-    uint8_t* m_mappedConstantData;
-    UINT m_alignedInstanceSize;
-    UINT m_numInstances;
-
-public:
-    ConstantBuffer() : m_alignedInstanceSize(0), m_numInstances(0), m_mappedConstantData(nullptr) {}
-
-    void Create(ID3D12Device* device, UINT numInstances = 1, LPCWSTR resourceName = nullptr)
-    {
-        m_numInstances = numInstances;
-        UINT alignedSize = Align(sizeof(T), D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
-        UINT bufferSize = numInstances * alignedSize;
-        Allocate(device, bufferSize, resourceName);
-        m_mappedConstantData = MapCpuWriteOnly();
-    }
-
-    void CopyStagingToGpu(UINT instanceIndex = 0)
-    {
-        memcpy(m_mappedConstantData + instanceIndex * m_alignedInstanceSize, &staging, sizeof(T));
-    }
-
-    // Accessors
-    T staging;
-    T* operator->() { return &staging; }
-    UINT NumInstances() { return m_numInstances; }
-    D3D12_GPU_VIRTUAL_ADDRESS GpuVirtualAddress(UINT instanceIndex = 0)
-    {
-        return m_resource->GetGPUVirtualAddress() + instanceIndex * m_alignedInstanceSize;
-    }
-};
-
-
-// Helper class to create and update a structured buffer.
-// Usage: ToDo
-//    ConstantBuffer<...> cb;
-//    cb.Create(...);
-//    cb.staging.var = ...; | cb->var = ... ; 
-//    cb.CopyStagingToGPU(...);
-template <class T>
-class StructuredBuffer : public GpuUploadBuffer
-{
-    T* m_mappedBuffers;
-    std::vector<T> m_staging;
-    UINT m_numInstances;
-
-public:
-    // Performance tip: Align structures on sizeof(float4) boundary.
-    // Ref: https://developer.nvidia.com/content/understanding-structured-buffer-performance
-    static_assert(sizeof(T) % 16 == 0, L"Align structure buffers on 16 byte boundary for performance reasons.");
-
-    StructuredBuffer() : m_mappedBuffers(nullptr), m_numInstances(0) {}
-
-    void Create(ID3D12Device* device, UINT numElements, UINT numInstances = 1, LPCWSTR resourceName = nullptr)
-    {
-        m_staging.resize(numElements);
-        UINT bufferSize = numInstances * numElements * sizeof(T);
-        Allocate(device, bufferSize, resourceName);
-        m_mappedBuffers = reinterpret_cast<T*>(MapCpuWriteOnly());
-    }
-
-    void CopyStagingToGpu(UINT instanceIndex = 0)
-    {
-        memcpy(m_mappedBuffers + instanceIndex, &m_staging[0], InstanceSize());
-    }
-
-    // Accessors
-    T& operator[](UINT elementIndex) { return m_staging[elementIndex]; }
-    size_t NumElementsPerInstance() { return m_staging.size(); }
-    UINT NumInstances() { return m_staging.size(); }
-    size_t InstanceSize() { return NumElementsPerInstance() * sizeof(T); }
-    D3D12_GPU_VIRTUAL_ADDRESS GpuVirtualAddress(UINT instanceIndex = 0)
-    {
-        return m_resource->GetGPUVirtualAddress() + instanceIndex * InstanceSize();
-    }
-};

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/DXSampleHelper.h
@@ -18,15 +18,14 @@
 // referenced by the GPU.
 using Microsoft::WRL::ComPtr;
 
-inline std::string HrToString(HRESULT hr)
-{
-    char s_str[64] = {};
-    sprintf_s(s_str, "HRESULT of 0x%08X", static_cast<UINT>(hr));
-    return std::string(s_str);
-}
-
 class HrException : public std::runtime_error
 {
+    inline std::string HrToString(HRESULT hr)
+    {
+        char s_str[64] = {};
+        sprintf_s(s_str, "HRESULT of 0x%08X", static_cast<UINT>(hr));
+        return std::string(s_str);
+    }
 public:
     HrException(HRESULT hr) : std::runtime_error(HrToString(hr)), m_hr(hr) {}
     HRESULT Error() const { return m_hr; }
@@ -43,6 +42,26 @@ inline void ThrowIfFailed(HRESULT hr)
         throw HrException(hr);
     }
 }
+
+inline void ThrowIfFailed(HRESULT hr, const wchar_t* msg)
+{
+    if (FAILED(hr))
+    {
+        OutputDebugString(msg);
+        throw HrException(hr);
+    }
+}
+
+inline void ThrowIfFalse(bool value)
+{
+    ThrowIfFailed(value ? S_OK : E_FAIL);
+}
+
+inline void ThrowIfFalse(bool value, const wchar_t* msg)
+{
+    ThrowIfFailed(value ? S_OK : E_FAIL, msg);
+}
+
 
 inline void GetAssetsPath(_Out_writes_(pathSize) WCHAR* path, UINT pathSize)
 {
@@ -134,10 +153,15 @@ inline void SetNameIndexed(ID3D12Object*, LPCWSTR, UINT)
 #define NAME_D3D12_OBJECT(x) SetName((x).Get(), L#x)
 #define NAME_D3D12_OBJECT_INDEXED(x, n) SetNameIndexed((x)[n].Get(), L#x, n)
 
+inline UINT Align(UINT size, UINT alignment)
+{
+    return (size + (alignment - 1)) & ~(alignment - 1);
+}
+
 inline UINT CalculateConstantBufferByteSize(UINT byteSize)
 {
     // Constant buffer size is required to be aligned.
-    return (byteSize + (D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1)) & ~(D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1);
+    return Align(byteSize, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
 }
 
 #ifdef D3D_COMPILE_STANDARD_FILE_INCLUDE
@@ -189,3 +213,137 @@ void ResetUniquePtrArray(T* uniquePtrArray)
         i.reset();
     }
 }
+
+class GpuUploadBuffer
+{
+public:
+    ComPtr<ID3D12Resource> GetResource() { return m_resource; }
+
+protected:
+    ComPtr<ID3D12Resource> m_resource;
+
+    GpuUploadBuffer() {}
+    ~GpuUploadBuffer()
+    {
+        if (m_resource.Get())
+        {
+            m_resource->Unmap(0, nullptr);
+        }
+    }
+
+    void Allocate(ID3D12Device* device, UINT bufferSize, LPCWSTR resourceName = nullptr)
+    {
+        auto uploadHeapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+
+        auto bufferDesc = CD3DX12_RESOURCE_DESC::Buffer(bufferSize);
+        ThrowIfFailed(device->CreateCommittedResource(
+            &uploadHeapProperties,
+            D3D12_HEAP_FLAG_NONE,
+            &bufferDesc,
+            D3D12_RESOURCE_STATE_GENERIC_READ,
+            nullptr,
+            IID_PPV_ARGS(&m_resource)));
+        m_resource->SetName(resourceName);
+    }
+
+    uint8_t* MapCpuWriteOnly()
+    {
+        uint8_t* mappedData;
+        // We don't unmap this until the app closes. Keeping buffer mapped for the lifetime of the resource is okay.
+        CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
+        ThrowIfFailed(m_resource->Map(0, &readRange, reinterpret_cast<void**>(&mappedData)));
+        return mappedData;
+    }
+};
+
+struct D3DBuffer
+{
+    ComPtr<ID3D12Resource> resource;
+    D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptorHandle;
+    D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptorHandle;
+};
+
+// Helper class to create and update a constant buffer with proper constant buffer alignments.
+// Usage: ToDo
+//    ConstantBuffer<...> cb;
+//    cb.Create(...);
+//    cb.staging.var = ...; | cb->var = ... ; 
+//    cb.CopyStagingToGPU(...);
+template <class T>
+class ConstantBuffer : public GpuUploadBuffer
+{
+    uint8_t* m_mappedConstantData;
+    UINT m_alignedInstanceSize;
+    UINT m_numInstances;
+
+public:
+    ConstantBuffer() : m_alignedInstanceSize(0), m_numInstances(0), m_mappedConstantData(nullptr) {}
+
+    void Create(ID3D12Device* device, UINT numInstances = 1, LPCWSTR resourceName = nullptr)
+    {
+        m_numInstances = numInstances;
+        UINT alignedSize = Align(sizeof(T), D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
+        UINT bufferSize = numInstances * alignedSize;
+        Allocate(device, bufferSize, resourceName);
+        m_mappedConstantData = MapCpuWriteOnly();
+    }
+
+    void CopyStagingToGpu(UINT instanceIndex = 0)
+    {
+        memcpy(m_mappedConstantData + instanceIndex * m_alignedInstanceSize, &staging, sizeof(T));
+    }
+
+    // Accessors
+    T staging;
+    T* operator->() { return &staging; }
+    UINT NumInstances() { return m_numInstances; }
+    D3D12_GPU_VIRTUAL_ADDRESS GpuVirtualAddress(UINT instanceIndex = 0)
+    {
+        return m_resource->GetGPUVirtualAddress() + instanceIndex * m_alignedInstanceSize;
+    }
+};
+
+
+// Helper class to create and update a structured buffer.
+// Usage: ToDo
+//    ConstantBuffer<...> cb;
+//    cb.Create(...);
+//    cb.staging.var = ...; | cb->var = ... ; 
+//    cb.CopyStagingToGPU(...);
+template <class T>
+class StructuredBuffer : public GpuUploadBuffer
+{
+    T* m_mappedBuffers;
+    std::vector<T> m_staging;
+    UINT m_numInstances;
+
+public:
+    // Performance tip: Align structures on sizeof(float4) boundary.
+    // Ref: https://developer.nvidia.com/content/understanding-structured-buffer-performance
+    static_assert(sizeof(T) % 16 == 0, L"Align structure buffers on 16 byte boundary for performance reasons.");
+
+    StructuredBuffer() : m_mappedBuffers(nullptr), m_numInstances(0) {}
+
+    void Create(ID3D12Device* device, UINT numElements, UINT numInstances = 1, LPCWSTR resourceName = nullptr)
+    {
+        m_staging.resize(numElements);
+        UINT bufferSize = numInstances * numElements * sizeof(T);
+        Allocate(device, bufferSize, resourceName);
+        m_mappedBuffers = reinterpret_cast<T*>(MapCpuWriteOnly());
+    }
+
+    void CopyStagingToGpu(UINT instanceIndex = 0)
+    {
+        memcpy(m_mappedBuffers + instanceIndex, &m_staging[0], InstanceSize());
+    }
+
+    // Accessors
+    T& operator[](UINT elementIndex) { return m_staging[elementIndex]; }
+    size_t NumElementsPerInstance() { return m_staging.size(); }
+    UINT NumInstances() { return m_staging.size(); }
+    size_t InstanceSize() { return NumElementsPerInstance() * sizeof(T); }
+    D3D12_GPU_VIRTUAL_ADDRESS GpuVirtualAddress(UINT instanceIndex = 0)
+    {
+        return m_resource->GetGPUVirtualAddress() + instanceIndex * InstanceSize();
+    }
+};

--- a/Samples/Desktop/D3D12ReservedResources/src/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12ReservedResources/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12Residency/src/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12Residency/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12SM6WaveIntrinsics/src/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12SM6WaveIntrinsics/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12SmallResources/src/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12SmallResources/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12nBodyGravity/src/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12nBodyGravity/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/Desktop/D3D12xGPU/src/DXSampleHelper.h
+++ b/Samples/Desktop/D3D12xGPU/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D1211On12/src/DXSampleHelper.h
+++ b/Samples/UWP/D3D1211On12/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12Bundles/src/DXSampleHelper.h
+++ b/Samples/UWP/D3D12Bundles/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12DepthBoundsTest/src/DXSampleHelper.h
+++ b/Samples/UWP/D3D12DepthBoundsTest/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12DynamicIndexing/src/DXSampleHelper.h
+++ b/Samples/UWP/D3D12DynamicIndexing/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12ExecuteIndirect/src/DXSampleHelper.h
+++ b/Samples/UWP/D3D12ExecuteIndirect/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12Fullscreen/src/DXSampleHelper.h
+++ b/Samples/UWP/D3D12Fullscreen/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12HDR/src/DXSampleHelper.h
+++ b/Samples/UWP/D3D12HDR/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12HelloWorld/src/HelloBundles/DXSampleHelper.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloBundles/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/DXSampleHelper.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloConstBuffers/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/DXSampleHelper.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloFrameBuffering/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTexture/DXSampleHelper.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTexture/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/DXSampleHelper.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloTriangle/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12HelloWorld/src/HelloWindow/DXSampleHelper.h
+++ b/Samples/UWP/D3D12HelloWorld/src/HelloWindow/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12HeterogeneousMultiadapter/src/DXSampleHelper.h
+++ b/Samples/UWP/D3D12HeterogeneousMultiadapter/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/DXSampleHelper.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSampleHelper.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/DXSampleHelper.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12PipelineStateCache/src/DXSampleHelper.h
+++ b/Samples/UWP/D3D12PipelineStateCache/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12PredicationQueries/src/DXSampleHelper.h
+++ b/Samples/UWP/D3D12PredicationQueries/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12ReservedResources/src/DXSampleHelper.h
+++ b/Samples/UWP/D3D12ReservedResources/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12Residency/src/DXSampleHelper.h
+++ b/Samples/UWP/D3D12Residency/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/DXSampleHelper.h
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12SmallResources/src/DXSampleHelper.h
+++ b/Samples/UWP/D3D12SmallResources/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12nBodyGravity/src/DXSampleHelper.h
+++ b/Samples/UWP/D3D12nBodyGravity/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account

--- a/Samples/UWP/D3D12xGPU/src/DXSampleHelper.h
+++ b/Samples/UWP/D3D12xGPU/src/DXSampleHelper.h
@@ -10,6 +10,7 @@
 //*********************************************************
 
 #pragma once
+#include <stdexcept>
 
 // Note that while ComPtr is used to manage the lifetime of resources on the CPU,
 // it has no understanding of the lifetime of resources on the GPU. Apps must account


### PR DESCRIPTION
std::runtime_error can't be resolved without including stdexcept