### PR TITLE
Fixed /analyze warning for VS 2019 in D3DX12.h

### DIFF
--- a/Libraries/D3DX12/d3dx12.h
+++ b/Libraries/D3DX12/d3dx12.h
@@ -552,6 +552,7 @@ struct CD3DX12_CLEAR_VALUE : public D3D12_CLEAR_VALUE
         UINT8 stencil )
     {
         Format = format;
+        memset( &Color, 0, sizeof( Color ) );
         /* Use memcpy to preserve NAN values */
         memcpy( &DepthStencil.Depth, &depth, sizeof( depth ) );
         DepthStencil.Stencil = stencil;
@@ -838,6 +839,7 @@ struct CD3DX12_TEXTURE_COPY_LOCATION : public D3D12_TEXTURE_COPY_LOCATION
     {
         pResource = pRes;
         Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+        PlacedFootprint = {};
         SubresourceIndex = Sub;
     }
 }; 


### PR DESCRIPTION
With VS 2019 (16.2) ``/analyze`` produces the following warnings in D3DX12.h:

```
d3dx12.h(552): warning C26495: Variable 'D3D12_CLEAR_VALUE::<unnamed-tag>::Color' is uninitialized. Always initialize a member variable (type.6).
d3dx12.h(843): warning C26495: Variable 'D3D12_TEXTURE_COPY_LOCATION::<unnamed-tag>::PlacedFootprint' is uninitialized. Always initialize a member variable (type.6).
```

The reason is that the ctors that initialize the 'smaller' variable in the union leave parts of the struct uninitialized.