### PR TITLE
Fixed a bug in GraphicsContext::SetPipelineState().

### DIFF
--- a/MiniEngine/Core/CommandContext.cpp
+++ b/MiniEngine/Core/CommandContext.cpp
@@ -112,12 +112,14 @@ uint64_t CommandContext::Flush(bool WaitForCompletion)
     if (m_CurGraphicsRootSignature)
     {
         m_CommandList->SetGraphicsRootSignature(m_CurGraphicsRootSignature);
-        m_CommandList->SetPipelineState(m_CurGraphicsPipelineState);
     }
     if (m_CurComputeRootSignature)
     {
-        m_CommandList->SetComputeRootSignature(m_CurComputeRootSignature);
-        m_CommandList->SetPipelineState(m_CurComputePipelineState);
+        m_CommandList->SetComputeRootSignature(m_CurComputeRootSignature);    
+    }
+    if (m_CurPipelineState)
+    {
+        m_CommandList->SetPipelineState(m_CurPipelineState);
     }
 
     BindDescriptorHeaps();
@@ -168,9 +170,8 @@ CommandContext::CommandContext(D3D12_COMMAND_LIST_TYPE Type) :
     ZeroMemory(m_CurrentDescriptorHeaps, sizeof(m_CurrentDescriptorHeaps));
 
     m_CurGraphicsRootSignature = nullptr;
-    m_CurGraphicsPipelineState = nullptr;
+    m_CurPipelineState = nullptr;
     m_CurComputeRootSignature = nullptr;
-    m_CurComputePipelineState = nullptr;
     m_NumBarriersToFlush = 0;
 }
 
@@ -194,9 +195,8 @@ void CommandContext::Reset( void )
     m_CommandList->Reset(m_CurrentAllocator, nullptr);
 
     m_CurGraphicsRootSignature = nullptr;
-    m_CurGraphicsPipelineState = nullptr;
+    m_CurPipelineState = nullptr;
     m_CurComputeRootSignature = nullptr;
-    m_CurComputePipelineState = nullptr;
     m_NumBarriersToFlush = 0;
 
     BindDescriptorHeaps();

--- a/MiniEngine/Core/CommandContext.h
+++ b/MiniEngine/Core/CommandContext.h
@@ -149,6 +149,7 @@ public:
     void PIXEndEvent(void);
     void PIXSetMarker(const wchar_t* label);
 
+    void SetPipelineState(const PSO& PSO);
     void SetDescriptorHeap( D3D12_DESCRIPTOR_HEAP_TYPE Type, ID3D12DescriptorHeap* HeapPtr );
     void SetDescriptorHeaps( UINT HeapCount, D3D12_DESCRIPTOR_HEAP_TYPE Type[], ID3D12DescriptorHeap* HeapPtrs[] );
 
@@ -163,9 +164,8 @@ protected:
     ID3D12CommandAllocator* m_CurrentAllocator;
 
     ID3D12RootSignature* m_CurGraphicsRootSignature;
-    ID3D12PipelineState* m_CurGraphicsPipelineState;
+    ID3D12PipelineState* m_CurPipelineState;
     ID3D12RootSignature* m_CurComputeRootSignature;
-    ID3D12PipelineState* m_CurComputePipelineState;
 
     DynamicDescriptorHeap m_DynamicViewDescriptorHeap;        // HEAP_TYPE_CBV_SRV_UAV
     DynamicDescriptorHeap m_DynamicSamplerDescriptorHeap;    // HEAP_TYPE_SAMPLER
@@ -222,7 +222,6 @@ public:
     void SetBlendFactor( Color BlendFactor );
     void SetPrimitiveTopology( D3D12_PRIMITIVE_TOPOLOGY Topology );
 
-    void SetPipelineState( const GraphicsPSO& PSO );
     void SetConstantArray( UINT RootIndex, UINT NumConstants, const void* pConstants );
     void SetConstant( UINT RootIndex, DWParam Val, UINT Offset = 0 );
     void SetConstants( UINT RootIndex, DWParam X );
@@ -271,7 +270,6 @@ public:
 
     void SetRootSignature( const RootSignature& RootSig );
 
-    void SetPipelineState( const ComputePSO& PSO );
     void SetConstantArray( UINT RootIndex, UINT NumConstants, const void* pConstants );
     void SetConstant( UINT RootIndex, DWParam Val, UINT Offset = 0 );
     void SetConstants( UINT RootIndex, DWParam X );
@@ -332,24 +330,14 @@ inline void ComputeContext::SetRootSignature( const RootSignature& RootSig )
     m_DynamicSamplerDescriptorHeap.ParseComputeRootSignature(RootSig);
 }
 
-inline void GraphicsContext::SetPipelineState( const GraphicsPSO& PSO )
+inline void CommandContext::SetPipelineState( const PSO& PSO )
 {
     ID3D12PipelineState* PipelineState = PSO.GetPipelineStateObject();
-    if (PipelineState == m_CurGraphicsPipelineState)
+    if (PipelineState == m_CurPipelineState)
         return;
 
     m_CommandList->SetPipelineState(PipelineState);
-    m_CurGraphicsPipelineState = PipelineState;
-}
-
-inline void ComputeContext::SetPipelineState( const ComputePSO& PSO )
-{
-    ID3D12PipelineState* PipelineState = PSO.GetPipelineStateObject();
-    if (PipelineState == m_CurComputePipelineState)
-        return;
-
-    m_CommandList->SetPipelineState(PipelineState);
-    m_CurComputePipelineState = PipelineState;
+    m_CurPipelineState = PipelineState;
 }
 
 inline void GraphicsContext::SetViewportAndScissor( UINT x, UINT y, UINT w, UINT h )


### PR DESCRIPTION
 The code incorrectly assumed that setting a compute PSO did not clobber the last graphics PSO. (The DX12 command list does not track graphics and compute PSO seperately. There is only one.) So when setting graphics PSO A, then compute PSO B, then graphics PSO A, it would incorrectly drop the setting of the last graphics PSO A as redundant and try to draw with the compute PSO B bound.  This caused corruption in apps with compute and graphics work on the same queue.