### PR TITLE
The CB resource does not need to be 1024 * 64?

### DIFF
--- a/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloConstBuffers/D3D12HelloConstBuffers.cpp
@@ -273,7 +273,7 @@ void D3D12HelloConstBuffers::LoadAssets()
         ThrowIfFailed(m_device->CreateCommittedResource(
             &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
             D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(1024 * 64),
+            &CD3DX12_RESOURCE_DESC::Buffer((sizeof(SceneConstantBuffer) + 255) & ~255),
             D3D12_RESOURCE_STATE_GENERIC_READ,
             nullptr,
             IID_PPV_ARGS(&m_constantBuffer)));


### PR DESCRIPTION
The constant buffer resource does not need to be 1024 * 64?