### PR TITLE
SceneConstantBuffer::padding 9 => 36

### DIFF
--- a/Samples/Desktop/D3D12ExecuteIndirect/src/compute.hlsl
+++ b/Samples/Desktop/D3D12ExecuteIndirect/src/compute.hlsl
@@ -17,7 +17,7 @@ struct SceneConstantBuffer
     float4 offset;
     float4 color;
     float4x4 projection;
-    float4 padding[9];
+    float4 padding[36];
 };
 
 struct IndirectCommand


### PR DESCRIPTION
To be 256-byte aligned, the padding should be 36, as in D3D12ExecuteIndirect.h.