### PR TITLE
Fixed COM pointer leak in d3dx12affinity_d3dx12.h.

### DIFF
--- a/Libraries/D3DX12AffinityLayer/Desktop/d3dx12affinity_d3dx12.h
+++ b/Libraries/D3DX12AffinityLayer/Desktop/d3dx12affinity_d3dx12.h
@@ -255,6 +255,7 @@ inline UINT64 GetRequiredIntermediateSize(
     CD3DX12AffinityDevice* pDevice;
     pDestinationResource->GetDevice(&pDevice);
     pDevice->GetCopyableFootprints(&Desc, FirstSubresource, NumSubresources, 0, nullptr, nullptr, nullptr, &RequiredSize);
+    pDevice->Release();
 
     return RequiredSize;
 }
@@ -348,6 +349,7 @@ inline UINT64 UpdateSubresources(
     CD3DX12AffinityDevice* pDevice;
     pDestinationResource->GetDevice(&pDevice);
     pDevice->GetCopyableFootprints(&Desc, FirstSubresource, NumSubresources, IntermediateOffset, pLayouts, pNumRows, pRowSizesInBytes, &RequiredSize);
+    pDevice->Release();
 
     UINT64 Result = UpdateSubresources(pCmdList, pDestinationResource, pIntermediate, FirstSubresource, NumSubresources, RequiredSize, pLayouts, pNumRows, pRowSizesInBytes, pSrcData);
     HeapFree(GetProcessHeap(), 0, pMem);

--- a/Libraries/D3DX12AffinityLayer/UWP/d3dx12affinity_d3dx12.h
+++ b/Libraries/D3DX12AffinityLayer/UWP/d3dx12affinity_d3dx12.h
@@ -255,6 +255,7 @@ inline UINT64 GetRequiredIntermediateSize(
     CD3DX12AffinityDevice* pDevice;
     pDestinationResource->GetDevice(&pDevice);
     pDevice->GetCopyableFootprints(&Desc, FirstSubresource, NumSubresources, 0, nullptr, nullptr, nullptr, &RequiredSize);
+    pDevice->Release();
 
     return RequiredSize;
 }
@@ -348,6 +349,7 @@ inline UINT64 UpdateSubresources(
     CD3DX12AffinityDevice* pDevice;
     pDestinationResource->GetDevice(&pDevice);
     pDevice->GetCopyableFootprints(&Desc, FirstSubresource, NumSubresources, IntermediateOffset, pLayouts, pNumRows, pRowSizesInBytes, &RequiredSize);
+    pDevice->Release();
 
     UINT64 Result = UpdateSubresources(pCmdList, pDestinationResource, pIntermediate, FirstSubresource, NumSubresources, RequiredSize, pLayouts, pNumRows, pRowSizesInBytes, pSrcData);
     HeapFree(GetProcessHeap(), 0, pMem);

--- a/Samples/Desktop/D3D12LinkedGpus/src/D3DX12AffinityLayer/d3dx12affinity_d3dx12.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/D3DX12AffinityLayer/d3dx12affinity_d3dx12.h
@@ -255,6 +255,7 @@ inline UINT64 GetRequiredIntermediateSize(
     CD3DX12AffinityDevice* pDevice;
     pDestinationResource->GetDevice(&pDevice);
     pDevice->GetCopyableFootprints(&Desc, FirstSubresource, NumSubresources, 0, nullptr, nullptr, nullptr, &RequiredSize);
+    pDevice->Release();
 
     return RequiredSize;
 }
@@ -348,6 +349,7 @@ inline UINT64 UpdateSubresources(
     CD3DX12AffinityDevice* pDevice;
     pDestinationResource->GetDevice(&pDevice);
     pDevice->GetCopyableFootprints(&Desc, FirstSubresource, NumSubresources, IntermediateOffset, pLayouts, pNumRows, pRowSizesInBytes, &RequiredSize);
+    pDevice->Release();
 
     UINT64 Result = UpdateSubresources(pCmdList, pDestinationResource, pIntermediate, FirstSubresource, NumSubresources, RequiredSize, pLayouts, pNumRows, pRowSizesInBytes, pSrcData);
     HeapFree(GetProcessHeap(), 0, pMem);


### PR DESCRIPTION
There is a COM memory lead in both the `GetRequiredIntermediateSize` and `UpdateSubresources` methods that is fixed in this commit.