### PR TITLE
D3DX12 - Fix for assignment operator in CD3DX12_PIPELINE_STATE_STREAM…

### DIFF
--- a/Libraries/D3DX12/d3dx12.h
+++ b/Libraries/D3DX12/d3dx12.h
@@ -2182,7 +2182,7 @@ private:
 public:
     CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT() noexcept : _Type(Type), _Inner(DefaultArg()) {}
     CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT(InnerStructType const& i) : _Type(Type), _Inner(i) {}
-    CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT& operator=(InnerStructType const& i) { _Inner = i; return *this; }
+    CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT& operator=(InnerStructType const& i) { _Type = Type; _Inner = i; return *this; }
     operator InnerStructType const&() const { return _Inner; }
     operator InnerStructType&() { return _Inner; }
     InnerStructType* operator&() { return &_Inner; }


### PR DESCRIPTION
Fix for issue reported [here](https://github.com/microsoft/DirectX-Graphics-Samples/issues/520)

> Already fixed in various internal repos as well.