### PR TITLE
Fix Raytracing Inverse2x2 Function

### DIFF
--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/DiffuseHitShaderLib.hlsl
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingMiniEngineSample/DiffuseHitShaderLib.hlsl
@@ -136,8 +136,8 @@ bool Inverse2x2(float2x2 mat, out float2x2 inverse)
     float rcpDeterminant = rcp(determinant);
     inverse[0][0] = mat[1][1];
     inverse[1][1] = mat[0][0];
-    inverse[1][0] = -mat[0][1];
-    inverse[0][1] = -mat[1][0];
+    inverse[1][0] = -mat[1][0];
+    inverse[0][1] = -mat[0][1];
     inverse = rcpDeterminant * inverse;
 
     return abs(determinant) > 0.00000001;

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingRealTimeDenoisedAmbientOcclusion/RTAO/Shaders/RaytracingShaderHelper.hlsli
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingRealTimeDenoisedAmbientOcclusion/RTAO/Shaders/RaytracingShaderHelper.hlsli
@@ -457,7 +457,7 @@ void UnpackEncodedNormalDepth(in uint packedEncodedNormalDepth, out float2 encod
 // 3D value noise
 // Ref: https://www.shadertoy.com/view/XsXfRH
 // The MIT License
-// Copyright © 2017 Inigo Quilez
+// Copyright Â© 2017 Inigo Quilez
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 float hash(float3 p)
 {
@@ -512,8 +512,8 @@ bool Inverse2x2(float2x2 mat, out float2x2 inverse)
     float rcpDeterminant = rcp(determinant);
     inverse[0][0] = mat[1][1];
     inverse[1][1] = mat[0][0];
-    inverse[1][0] = -mat[0][1];
-    inverse[0][1] = -mat[1][0];
+    inverse[1][0] = -mat[1][0];
+    inverse[0][1] = -mat[0][1];
     inverse = rcpDeterminant * inverse;
 
     return abs(determinant) > 0.00000001;


### PR DESCRIPTION
This solves #625, further discussion is there. This inverse may not be needed at all, but this PR fixes a math error before considering a different approach.