### PR TITLE
[MeshletGenerator Commandline Tool] Fix infinite loop and incorrect usage description

### DIFF
--- a/Samples/Desktop/D3D12MeshShaders/src/WavefrontConverter/Main.cpp
+++ b/Samples/Desktop/D3D12MeshShaders/src/WavefrontConverter/Main.cpp
@@ -49,7 +49,7 @@ namespace
         std::cout << std::endl;
 
         std::cout << "Example:" << std::endl;
-        std::cout << "\tConverterApp.exe -l v|nutb -v 128 -p 128 -i -t Path/To/MyFile1.obj Path/To/MyFile2.obj " << std::endl;
+        std::cout << "\tConverterApp.exe -a v|nutb -v 128 -p 128 -i -t Path/To/MyFile1.obj Path/To/MyFile2.obj " << std::endl;
         std::cout << std::endl;
     }
 
@@ -128,7 +128,7 @@ namespace
             {
                 if (i + 1 == argc)
                 {
-                    std::cout << "Must provide a string specifying attribute layout if supplying -l switch." << std::endl;
+                    std::cout << "Must provide a string specifying attribute layout if supplying -a switch." << std::endl;
                     return 1;
                 }
 
@@ -163,6 +163,7 @@ namespace
                         options.ExportAttributes.emplace_back(std::move(stream));
                         break;
                     }
+                    ++start;
                 }
 
                 if (!stream.empty())
@@ -240,9 +241,14 @@ namespace
         {
             std::cout << "\tStream " << i << ": ";
 
-            for (auto& attr : options.ExportAttributes[i])
+            for (uint32_t j = 0; j < options.ExportAttributes[i].size(); ++j)
             {
-                std::cout << s_semanticNames[attr] << " | ";
+                const AttrStream& attrStream = options.ExportAttributes[i];
+                std::cout << s_semanticNames[attrStream[j]];
+				if (j < options.ExportAttributes[i].size() - 1)
+				{
+					std::cout << " | ";
+				}
             }
 
             std::cout << std::endl;

--- a/Samples/Desktop/D3D12MeshShaders/src/WavefrontConverter/Main.cpp
+++ b/Samples/Desktop/D3D12MeshShaders/src/WavefrontConverter/Main.cpp
@@ -170,7 +170,7 @@ namespace
                     options.ExportAttributes.emplace_back(std::move(stream));
 
                 ++i;
-			}
+            }
             else if (std::strcmp(args[i], "-i") == 0)
             {
                 std::cout << "Forcing vertex indices to 32 bits." << std::endl;
@@ -272,7 +272,7 @@ int _cdecl main(int argc, const char* args[])
 
     // Parse command line options
     ProcessOptions options;
-	int ret = ParseCommandLine(argc, args, files, options);
+    int ret = ParseCommandLine(argc, args, files, options);
     if (ret != 0)
     {
         return ret;

--- a/Samples/Desktop/D3D12MeshShaders/src/WavefrontConverter/Main.cpp
+++ b/Samples/Desktop/D3D12MeshShaders/src/WavefrontConverter/Main.cpp
@@ -247,10 +247,10 @@ namespace
             {
                 const AttrStream& attrStream = options.ExportAttributes[i];
                 std::cout << s_semanticNames[attrStream[j]];
-				if (j < options.ExportAttributes[i].size() - 1)
-				{
-					std::cout << " | ";
-				}
+                if (j < options.ExportAttributes[i].size() - 1)
+                {
+                    std::cout << " | ";
+                }
             }
 
             std::cout << std::endl;
@@ -270,10 +270,9 @@ int _cdecl main(int argc, const char* args[])
 {
     std::vector<std::string> files;
 
-    const char* arg[] = { ".", "-a", "pnutb", "C:\\Users\\simon\\Documents\\Programming\\D3D12_Research\\D3D12\\Resources\\sponza\\sponza.obj" };
     // Parse command line options
     ProcessOptions options;
-	int ret = ParseCommandLine(ARRAYSIZE(arg), arg, files, options);
+	int ret = ParseCommandLine(argc, args, files, options);
     if (ret != 0)
     {
         return ret;

--- a/Samples/Desktop/D3D12MeshShaders/src/WavefrontConverter/Main.cpp
+++ b/Samples/Desktop/D3D12MeshShaders/src/WavefrontConverter/Main.cpp
@@ -49,7 +49,7 @@ namespace
         std::cout << std::endl;
 
         std::cout << "Example:" << std::endl;
-        std::cout << "\tConverterApp.exe -a v|nutb -v 128 -p 128 -i -t Path/To/MyFile1.obj Path/To/MyFile2.obj " << std::endl;
+        std::cout << "\tConverterApp.exe -a v|nutb -v 128 -p 128 -i Path/To/MyFile1.obj Path/To/MyFile2.obj " << std::endl;
         std::cout << std::endl;
     }
 
@@ -168,7 +168,9 @@ namespace
 
                 if (!stream.empty())
                     options.ExportAttributes.emplace_back(std::move(stream));
-            }
+
+                ++i;
+			}
             else if (std::strcmp(args[i], "-i") == 0)
             {
                 std::cout << "Forcing vertex indices to 32 bits." << std::endl;
@@ -268,9 +270,10 @@ int _cdecl main(int argc, const char* args[])
 {
     std::vector<std::string> files;
 
+    const char* arg[] = { ".", "-a", "pnutb", "C:\\Users\\simon\\Documents\\Programming\\D3D12_Research\\D3D12\\Resources\\sponza\\sponza.obj" };
     // Parse command line options
     ProcessOptions options;
-    int ret = ParseCommandLine(argc, args, files, options);
+	int ret = ParseCommandLine(ARRAYSIZE(arg), arg, files, options);
     if (ret != 0)
     {
         return ret;


### PR DESCRIPTION
The Meshlet commandline tool generator had an infinite loop while parsing stream layout.
The usage description also had a small typo mixing up the '-a' and '-l' argument.
Misc output formatting touch-up when describing stream layouts