### PR TITLE
Add platform to the urlFragment in the readme

### DIFF
--- a/Samples/Desktop/D3D1211On12/readme.md
+++ b/Samples/Desktop/D3D1211On12/readme.md
@@ -5,7 +5,7 @@ languages:
 products:
 - windows-api-win32
 name: 11 on 12 Sample
-urlFragment: 11-on-12-sample
+urlFragment: 11-on-12-sample-win32
 description: Demonstrates how to use Direct3D 11-based rendering in combination with Direct3D 12.
 extendedZipContent:
 - path: LICENSE

--- a/Samples/Desktop/D3D12Bundles/readme.md
+++ b/Samples/Desktop/D3D12Bundles/readme.md
@@ -5,7 +5,7 @@ languages:
 products:
 - windows-api-win32
 name: Bundles Sample
-urlFragment: bundles-sample
+urlFragment: bundles-sample-win32
 description: Demonstrates the use of Direct3D 12 bundles.
 extendedZipContent:
 - path: LICENSE

--- a/Samples/UWP/D3D1211On12/readme.md
+++ b/Samples/UWP/D3D1211On12/readme.md
@@ -6,7 +6,7 @@ products:
 - windows
 - windows-uwp
 name: 11 on 12 Sample
-urlFragment: 11-on-12-sample
+urlFragment: 11-on-12-sample-uwp
 description: Demonstrates how to use Direct3D 11-based rendering in combination with Direct3D 12.
 extendedZipContent:
 - path: LICENSE

--- a/Samples/UWP/D3D12Bundles/readme.md
+++ b/Samples/UWP/D3D12Bundles/readme.md
@@ -6,7 +6,7 @@ products:
 - windows
 - windows-uwp
 name: Bundles Sample
-urlFragment: bundles-sample
+urlFragment: bundles-sample-uwp
 description: Demonstrates the use of Direct3D 12 bundles.
 extendedZipContent:
 - path: LICENSE


### PR DESCRIPTION
The samples need a different urlFragment, depending on the platform.  This fixes an issue with onboarding to the DMC samples browser.