### PR TITLE
Fix wrong example in the help

### DIFF
--- a/Samples/Desktop/D3D12MeshShaders/src/WavefrontConverter/Main.cpp
+++ b/Samples/Desktop/D3D12MeshShaders/src/WavefrontConverter/Main.cpp
@@ -49,7 +49,7 @@ namespace
         std::cout << std::endl;
 
         std::cout << "Example:" << std::endl;
-        std::cout << "\tConverterApp.exe -a v:nutb -v 128 -p 128 -i Path/To/MyFile1.obj Path/To/MyFile2.obj " << std::endl;
+        std::cout << "\tConverterApp.exe -a p:nutb -v 128 -p 128 -i Path/To/MyFile1.obj Path/To/MyFile2.obj " << std::endl;
         std::cout << std::endl;
     }
 


### PR DESCRIPTION
The p is necessary for position, the v is not a valid option. And since v will be discarded, and position is not specified, the application will just exit.