### PR TITLE
D3D12RaytracingRealTimeDenoisedAmbientOcclusion - large per frame upload

### DIFF
--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingRealTimeDenoisedAmbientOcclusion/RTAO/RTAO.cpp
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingRealTimeDenoisedAmbientOcclusion/RTAO/RTAO.cpp
@@ -448,6 +448,7 @@ void RTAO::CreateSamplesRNG()
         m_samplesGPUBuffer[i].value = XMFLOAT2(p.x * 0.5f + 0.5f, p.y * 0.5f + 0.5f);
         m_hemisphereSamplesGPUBuffer[i].value = p;
     }
+    m_numAOSamplesUploadFrames = m_deviceResources->GetBackBufferCount();
 }
 
 void RTAO::GetRayGenParameters(bool* isCheckerboardSamplingEnabled, bool* checkerboardLoadEvenPixels)
@@ -547,8 +548,11 @@ void RTAO::Run(
     }
 
     // Copy dynamic buffers to GPU.
+    UpdateConstantBuffer(frameIndex);
+
+    if (m_numAOSamplesUploadFrames)
     {
-        UpdateConstantBuffer(frameIndex);
+        m_numAOSamplesUploadFrames--;
         m_hemisphereSamplesGPUBuffer.CopyStagingToGpu(frameIndex);
     }
 

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingRealTimeDenoisedAmbientOcclusion/RTAO/RTAO.h
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingRealTimeDenoisedAmbientOcclusion/RTAO/RTAO.h
@@ -108,6 +108,7 @@ private:
     StructuredBuffer<AlignedHemisphereSample3D> m_hemisphereSamplesGPUBuffer;
     BOOL m_isRecreateAOSamplesRequested = true;
 
+    UINT            m_numAOSamplesUploadFrames = 0;
     UINT		    m_numAORayGeometryHits;
     bool            m_checkerboardGenerateRaysForEvenPixels = false;
 

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingRealTimeDenoisedAmbientOcclusion/SampleCore/Shaders/util/GenerateGrassStrawsCS.hlsl
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingRealTimeDenoisedAmbientOcclusion/SampleCore/Shaders/util/GenerateGrassStrawsCS.hlsl
@@ -194,6 +194,9 @@ void main(uint2 DTid : SV_DispatchThreadID)
     {
         VertexPositionNormalTextureTangent vertex;
         vertex.position = 0;
+        vertex.normal = 0;
+        vertex.textureCoordinate = 0;
+        vertex.tangent = 0;
         uint threadID = DTid.x + DTid.y * cb.p.maxPatchDim.x;
         uint baseVertexID = threadID * N_GRASS_VERTICES;
 


### PR DESCRIPTION
Improvement for #681.

m_hemisphereSamplesGPUBuffer.CopyStagingToGpu(frameIndex) is executed three times (back buffer count) only when AO samples are recreated.

The array was previously uploaded to GPU on every frame and since the array is quite large (87031808 bytes) it caused unnecessary CPU overhead (8ms of CPU time on i7 4790K 4.4GHz 32GB RAM 2070 RTX). On simpler scenes this was main bottleneck i.e. in the default scene with grass disabled (#define RENDER_GRASS_GEOMETRY 0) framerate tripled (~100 to ~300fps) with GPU timings unaffected.

TODO:
- The array is unnecessarily triple-buffered and has to be uploaded three times on consecutive frames. Only single upload is required since the content is unchanged.
- In order to reduce size precision of the array can be reduced to half float or even 8bit SNORM.