### PR TITLE
D3DX12.H: Fixed -Wsign-conversion warning with x86 clang/LLVM

### DIFF
--- a/Libraries/D3DX12/d3dx12.h
+++ b/Libraries/D3DX12/d3dx12.h
@@ -2013,11 +2013,11 @@ inline void MemcpySubresource(
     for (UINT z = 0; z < NumSlices; ++z)
     {
         auto pDestSlice = static_cast<BYTE*>(pDest->pData) + pDest->SlicePitch * z;
-        auto pSrcSlice = (static_cast<const BYTE*>(pResourceData) + pSrc->Offset) + pSrc->DepthPitch * LONG_PTR(z);
+        auto pSrcSlice = (static_cast<const BYTE*>(pResourceData) + pSrc->Offset) + pSrc->DepthPitch * ULONG_PTR(z);
         for (UINT y = 0; y < NumRows; ++y)
         {
             memcpy(pDestSlice + pDest->RowPitch * y,
-                pSrcSlice + pSrc->RowPitch * LONG_PTR(y),
+                pSrcSlice + pSrc->RowPitch * ULONG_PTR(y),
                 RowSizeInBytes);
         }
     }


### PR DESCRIPTION
When building with x86 clang/LLVM v10 you get the following warnings:

```
warning : implicit conversion changes signedness: 'LONG_PTR' (aka 'long') to 'unsigned long' [-Wsign-conversion]
          auto pSrcSlice = (static_cast<const BYTE*>(pResourceData) + pSrc->Offset) + pSrc->DepthPitch * LONG_PTR(z);
                                                                                                       ~ ^~~~~~~~~~~
warning : implicit conversion changes signedness: 'LONG_PTR' (aka 'long') to 'unsigned long' [-Wsign-conversion]
                  pSrcSlice + pSrc->RowPitch * LONG_PTR(y),
```

x64 clang/LLVM doesn't complain and neither does MSVC, but it is technically correct that the source is mixing signed and unsigned types.

> This fix should also be made to DirectX-Headers on GitHub as well as in the Windows source tree.