### PR TITLE
[Bug] Fixing a bit of uninitialized data in the DynamicDescriptorHeap class.

### DIFF
--- a/MiniEngine/Core/DynamicDescriptorHeap.h
+++ b/MiniEngine/Core/DynamicDescriptorHeap.h
@@ -119,6 +119,7 @@ private:
         void ClearCache()
         {
             m_RootDescriptorTablesBitMap = 0;
+            m_StaleRootParamsBitMap = 0;
             m_MaxCachedDescriptors = 0;
         }
 


### PR DESCRIPTION
Came across this bug while attempting to create a new MiniEngine project. It is possible for `m_StaleRootParamsBitMap` to remain uninitialized if a `Draw` call is made before the proper PSO and Root signature is created. 

A small issue, but this confounded me for a while, as the exception you will hit does not lead you down a path to fix it. It was not until I stepped through the debugger that I found `m_StaleRootParamsBitMap` was `0xcdcdcdcd`