### PR TITLE
m_PSO does not get initialized when creating a new PSO object. 

### DIFF
--- a/MiniEngine/Core/PipelineState.h
+++ b/MiniEngine/Core/PipelineState.h
@@ -28,7 +28,7 @@ class PSO
 {
 public:
 
-    PSO(const wchar_t* Name) : m_Name(Name), m_RootSignature(nullptr) {}
+    PSO(const wchar_t* Name) : m_Name(Name), m_RootSignature(nullptr), m_PSO(nullptr) {}
 
     static void DestroyAll( void );
 


### PR DESCRIPTION
This can lead to some oddities when making copies of a non-finalized PSO object. 

Let me know if these small changes line these are not allowed. I am just sending in PRs to cover issues I have come across while trying to use MiniEngine for my own projects.