### PR TITLE
Makes NVidia Card Default in Ambient Occlusion example.

### DIFF
--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingRealTimeDenoisedAmbientOcclusion/Main.cpp
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingRealTimeDenoisedAmbientOcclusion/Main.cpp
@@ -12,7 +12,9 @@
 #include "stdafx.h"
 #include "D3D12RaytracingRealTimeDenoisedAmbientOcclusion.h"
 #include "Sampler.h"
-
+extern "C" {
+    _declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+}
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingRealTimeDenoisedAmbientOcclusion/Main.cpp
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingRealTimeDenoisedAmbientOcclusion/Main.cpp
@@ -12,9 +12,11 @@
 #include "stdafx.h"
 #include "D3D12RaytracingRealTimeDenoisedAmbientOcclusion.h"
 #include "Sampler.h"
+//makes it so Nvidia graphics card is used by default rather than intagrated intel or amd. 
 extern "C" {
     _declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
 }
+
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
 {

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingRealTimeDenoisedAmbientOcclusion/Main.cpp
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingRealTimeDenoisedAmbientOcclusion/Main.cpp
@@ -12,10 +12,6 @@
 #include "stdafx.h"
 #include "D3D12RaytracingRealTimeDenoisedAmbientOcclusion.h"
 #include "Sampler.h"
-//makes it so Nvidia graphics card is used by default rather than intagrated intel or amd. 
-extern "C" {
-    _declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
-}
 
 _Use_decl_annotations_
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingRealTimeDenoisedAmbientOcclusion/SampleCore/util/DeviceResources.cpp
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingRealTimeDenoisedAmbientOcclusion/SampleCore/util/DeviceResources.cpp
@@ -638,8 +638,15 @@ void DeviceResources::InitializeAdapter(IDXGIAdapter1** ppAdapter)
     *ppAdapter = nullptr;
 
     ComPtr<IDXGIAdapter1> adapter;
-    for (UINT adapterID = 0; DXGI_ERROR_NOT_FOUND != m_dxgiFactory->EnumAdapters1(adapterID, &adapter); ++adapterID)
+    ComPtr<IDXGIFactory6> factory6;
+    HRESULT hr = m_dxgiFactory.As(&factory6);
+    if (FAILED(hr))
     {
+        throw exception("DXGI 1.6 not supported");
+    }
+    for (UINT adapterID = 0; DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(adapterID, DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE, IID_PPV_ARGS(&adapter)); ++adapterID)
+    {
+   
         if (m_adapterIDoverride != UINT_MAX && adapterID != m_adapterIDoverride)
         {
             continue;


### PR DESCRIPTION
I'm not sure if this is the proper way to make this fix, but it worked for me. There may be unintended consequences though but I cant imagine what they would be.