### PR TITLE
Fix recognition of WM_QUIT

### DIFF
--- a/MiniEngine/Core/GameCore.cpp
+++ b/MiniEngine/Core/GameCore.cpp
@@ -136,12 +136,17 @@ namespace GameCore
         do
         {
             MSG msg = {};
+            bool done = false;
             while (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE))
             {
                 TranslateMessage(&msg);
                 DispatchMessage(&msg);
+
+                if (msg.message == WM_QUIT)
+                    done = true;
             }
-            if (msg.message == WM_QUIT)
+
+            if (done)
                 break;
         }
         while (UpdateApplication(app));	// Returns false to quit loop


### PR DESCRIPTION
If multiple messages are received at the same time as the quit message, then we can miss it because we only check the last message received. To repro this, alt-F4 while moving the mouse. Fix by just keeping track of whether we ever saw WM_QUIT in the message dispatch loop.