### PR TITLE
Fix EnqueueMakeResident not using the same parameters as MakeResident

### DIFF
--- a/Libraries/D3DX12Residency/d3dx12Residency.h
+++ b/Libraries/D3DX12Residency/d3dx12Residency.h
@@ -1296,8 +1296,8 @@ namespace D3DX12Residency
                                     if (Device3)
                                     {
                                         hr = Device3->EnqueueMakeResident(D3D12_RESIDENCY_FLAG_NONE,
-                                                                          NumObjectsInBatch,
-                                                                          &pMakeResidentList[BatchStart].pUnderlying,
+                                                                          NumObjects,
+                                                                          &pMakeResidentList[MakeResidentIndex].pUnderlying,
                                                                           AsyncThreadFence.pFence,
                                                                           AsyncThreadFence.FenceValue + 1);
                                         if (SUCCEEDED(hr))


### PR DESCRIPTION
Fix the residency library not using the correct parameters when using **EnqueueMakeResident** instead of **MakeResident**.
( related issue : https://github.com/microsoft/DirectX-Graphics-Samples/issues/784 )