### PR TITLE
Fallback layer fix missing space in error message

### DIFF
--- a/Libraries/D3D12RaytracingFallback/src/FallbackLayer.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/FallbackLayer.cpp
@@ -612,7 +612,7 @@ namespace FallbackLayer
         {
             ThrowFailure(E_INVALIDARG, 
                 L"DispatchRays called without a Descriptor Heap for SRV/UAV/CBV's bound, "
-                L"the compute-based implementation requires D3D12RaytracingCommandList::SetDescriptorHeaps"
+                L"the compute-based implementation requires D3D12RaytracingCommandList::SetDescriptorHeaps "
                 L"be called with a valid heap. This is required for emulated pointers to properly work"
             );
         }


### PR DESCRIPTION
Change to fix string in raytracing fallback layer DispatchRays being called without first calling SetDescriptorHeaps.

"SetDescriptorHeapsbe" becomes "SetDescriptorHeaps be"