### PR TITLE
Fallback layer avoid calling SetComputeRoot32BitConstants with no data

### DIFF
--- a/Libraries/D3D12RaytracingFallback/src/UberShaderRayTracingProgram.cpp
+++ b/Libraries/D3D12RaytracingFallback/src/UberShaderRayTracingProgram.cpp
@@ -258,8 +258,11 @@ namespace FallbackLayer
             AccelerationStructuresEntries[entriesAdded++] = entry.second;
         }
 
-        pCommandList->SetComputeRoot32BitConstants(
-            m_patchRootSignatureParameterStart + AccelerationStructuresList, (UINT)(AccelerationStructuresEntries.size() * (SizeOfInUint32(*AccelerationStructuresEntries.data()))), AccelerationStructuresEntries.data(), 0);
+        if (!AccelerationStructuresEntries.empty())
+        {
+            pCommandList->SetComputeRoot32BitConstants(
+                m_patchRootSignatureParameterStart + AccelerationStructuresList, (UINT)(AccelerationStructuresEntries.size() * (SizeOfInUint32(*AccelerationStructuresEntries.data()))), AccelerationStructuresEntries.data(), 0);
+        }
 
 #ifdef DEBUG
         m_pPredispatchCallback(pCommandList, m_patchRootSignatureParameterStart);


### PR DESCRIPTION
If `AccelerationStructuresEntries` is empty, don't call `SetComputeRoot32BitConstants`

Fixes a crash on Intel Iris Xe graphics when using the Fallback Layer without using any bound acceleration structures due to the call `SetComputeRoot32BitConstants` crashing due to not checking if `pSrcData` was null. Spec indicates this parameter is required, so a branch is added to avoid the call.