### PR TITLE
Reverting previous change, since actually it wil be NodeLaunch parameter that'll be lowercase

### DIFF
--- a/Samples/Desktop/preview/D3D12HelloWorkGraphs/D3D12HelloWorkGraphs.hlsl
+++ b/Samples/Desktop/preview/D3D12HelloWorkGraphs/D3D12HelloWorkGraphs.hlsl
@@ -56,7 +56,7 @@ static const uint c_numEntryRecords = 4;
 // Each thread group sends 2 records to secondNode asking it to do some work.
 // --------------------------------------------------------------------------------------------------------------------------------
 [Shader("node")]
-[NodeLaunch("Broadcasting")]
+[NodeLaunch("broadcasting")]
 [NodeMaxDispatchGrid(16,1,1)] // Contrived value, input records from the app only top out at grid size of 4.  
                               // This declaration should be as accurate as possible, but not too small (undefined behavior).
 [NumThreads(2,1,1)]
@@ -85,7 +85,7 @@ void firstNode(
 // Logs to the UAV and then sends a task to thirdNode
 // --------------------------------------------------------------------------------------------------------------------------------
 [Shader("node")]
-[NodeLaunch("Thread")]
+[NodeLaunch("thread")]
 void secondNode(
     ThreadNodeInputRecord<secondNodeInput> inputData,
     [MaxRecords(1)] NodeOutput<thirdNodeInput> thirdNode)
@@ -109,7 +109,7 @@ groupshared uint g_sum[c_numEntryRecords];
 // The thread group size happens to match this max input array size of 32, but doesn't have to.
 // --------------------------------------------------------------------------------------------------------------------------------
 [Shader("node")]
-[NodeLaunch("Coalescing")]
+[NodeLaunch("coalescing")]
 [NumThreads(32,1,1)]
 void thirdNode(
     [MaxRecords(32)] GroupNodeInputRecords<thirdNodeInput> inputData,

--- a/Samples/Desktop/preview/D3D12WorkGraphsSandbox/D3D12WorkGraphsSandbox.hlsl
+++ b/Samples/Desktop/preview/D3D12WorkGraphsSandbox/D3D12WorkGraphsSandbox.hlsl
@@ -126,7 +126,7 @@ struct interiorRecord2 // just contriving to make it clear the same record doesn
 
 
 [Shader("node")]
-[NodeLaunch("Broadcasting")]
+[NodeLaunch("broadcasting")]
 [NodeLocalRootArgumentsTableIndex(1)] // fixed table location, others will autopopulate if not specified
 [NodeDispatchGrid(10, 10, 10)]
 [NumThreads(2,1,1)]
@@ -167,7 +167,7 @@ void firstNode(
 }
 
 [Shader("node")]
-[NodeLaunch("Thread")]
+[NodeLaunch("thread")]
 void secondNode()
 {
     // Accumulate data to UAV
@@ -217,7 +217,7 @@ void thirdNodeAnotherShader(
 
 [Shader("node")]
 [NodeIsProgramEntry] // A node can be a program entry even if it is also interior to the graph
-[NodeLaunch("Thread")]
+[NodeLaunch("thread")]
 [NodeMaxRecursionDepth(3)]
 void fourthNode(
     ThreadNodeInputRecord<interiorRecord2> inputData,
@@ -244,7 +244,7 @@ void fourthNode(
 // Here's a node that's disconnected from the others in the graph.
 // A single work graph can have disconnected subgraphs that can run in parallel.
 [Shader("node")]
-[NodeLaunch("Broadcasting")]
+[NodeLaunch("broadcasting")]
 // NodeMaxDispatchGrid means grid size is in the input record, see SV_DispatchGrid in entryRecord2
 [NodeMaxDispatchGrid(100,100,100)] // normally, make this as tightly defined as possible
 [NumThreads(1, 1, 1)]


### PR DESCRIPTION
Reverting previous change, since expected behavior will actually be that the sting attributes in Shader("node") AND NodeLaunch("coalescing") will be case sensitive and lower case.