### PR TITLE
Several Residency Manager improvements/fixes from UE5/The Coalition

### DIFF
--- a/Samples/Desktop/D3D12Residency/src/D3D12Residency.cpp
+++ b/Samples/Desktop/D3D12Residency/src/D3D12Residency.cpp
@@ -535,8 +535,10 @@ void D3D12Residency::PopulateCommandList(std::shared_ptr<ManagedCommandList> pMa
     DXGI_QUERY_VIDEO_MEMORY_INFO memoryInfo = {};
     ThrowIfFailed(m_adapter->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &memoryInfo));
 
+    UINT64 unused, EvictedMemoryInBytes;
+    m_residencyManager.QueryResidencyStats(unused, EvictedMemoryInBytes);
     WCHAR message[200];
-    swprintf_s(message, L"Total Allocated: %llu MB | Budget: %llu MB | Using: %llu MB", m_totalAllocations >> 20, memoryInfo.Budget >> 20, memoryInfo.CurrentUsage >> 20);
+    swprintf_s(message, L"Total Allocated: %llu MB | Budget: %llu MB | Using: %llu MB | Evicted: %lld MB", m_totalAllocations >> 20, memoryInfo.Budget >> 20, memoryInfo.CurrentUsage >> 20, EvictedMemoryInBytes >> 20);
     this->SetCustomWindowText(message);
 
     auto commandList = pManagedCommandList->commandList;

--- a/Samples/Desktop/D3D12Residency/src/D3D12Residency.cpp
+++ b/Samples/Desktop/D3D12Residency/src/D3D12Residency.cpp
@@ -538,7 +538,7 @@ void D3D12Residency::PopulateCommandList(std::shared_ptr<ManagedCommandList> pMa
     UINT64 unused, EvictedMemoryInBytes;
     m_residencyManager.QueryResidencyStats(unused, EvictedMemoryInBytes);
     WCHAR message[200];
-    swprintf_s(message, L"Total Allocated: %llu MB | Budget: %llu MB | Using: %llu MB | Evicted: %lld MB", m_totalAllocations >> 20, memoryInfo.Budget >> 20, memoryInfo.CurrentUsage >> 20, EvictedMemoryInBytes >> 20);
+    swprintf_s(message, L"Total Allocated: %llu MB | Budget: %llu MB | Using: %llu MB | Evicted: %llu MB", m_totalAllocations >> 20, memoryInfo.Budget >> 20, memoryInfo.CurrentUsage >> 20, EvictedMemoryInBytes >> 20);
     this->SetCustomWindowText(message);
 
     auto commandList = pManagedCommandList->commandList;


### PR DESCRIPTION
This adds several new functions to the residency manager as well as a bug fix:

New Functionality:
 1.  The ability to query the amount of resident and evicted memory from the residency manager. The ability to view evicted memory has also been added to the sample.
2. The ability to specify a custom local memory budget. In UE5, this is can be used with value 0 when the app is detected to be out of focus so that it can trigger extremely aggressive memory eviction. This is particularly important for when using the UE5 editor and you're launching the game as a separate process.

Bug Fix:
1. Fixing the parameters for EnqueueMakeResident, according to the Epic change history this fix came from Microsoft originally so unclear why this isn't reflected in the github repo