### PR TITLE
Raytracing Procedural Geometry Sample: Fix crash due to resolving query without ending it first

### DIFF
--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingProceduralGeometry/util/PerformanceTimers.h
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingProceduralGeometry/util/PerformanceTimers.h
@@ -117,6 +117,7 @@ namespace DX
 
     private:
         static const size_t c_timerSlots = c_maxTimers * 2;
+        uint32_t m_timersThisFrame = 0;
 
         Microsoft::WRL::ComPtr<ID3D12QueryHeap> m_heap;
         Microsoft::WRL::ComPtr<ID3D12Resource>  m_buffer;


### PR DESCRIPTION
Hi there,

I was having issues with the Raytracing Procedural Geometry sample crashing. It was caused by calling ResolveQueryData for queries in the heap that had not been ended. I implemented a simple fix to only resolve queries that were used in the previous frame - it isn't robust for all possible uses of GPUTimer but it fixes the sample correctly.

Thank you :)