### PR TITLE
Removed ATL dependency from D3D12Raytracing

### DIFF
--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingHelloWorld/stdafx.h
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingHelloWorld/stdafx.h
@@ -33,12 +33,10 @@
 #include <memory>
 #include <unordered_map>
 #include <vector>
-#include <atlbase.h>
 #include <assert.h>
 
 #include <dxgi1_6.h>
 #include <d3d12.h>
-#include <atlbase.h>    // Make sure you install "C++ ATL for latest build tools" with VS Installer
 #include "d3dx12.h"
 
 #ifdef _DEBUG

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingLibrarySubobjects/stdafx.h
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingLibrarySubobjects/stdafx.h
@@ -33,12 +33,10 @@
 #include <memory>
 #include <unordered_map>
 #include <vector>
-#include <atlbase.h>
 #include <assert.h>
 
 #include <dxgi1_6.h>
 #include <d3d12.h>
-#include <atlbase.h>
 #include "d3dx12.h"
 
 #include <DirectXMath.h>

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingProceduralGeometry/stdafx.h
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingProceduralGeometry/stdafx.h
@@ -33,14 +33,12 @@
 #include <memory>
 #include <unordered_map>
 #include <vector>
-#include <atlbase.h>
 #include <assert.h>
 #include <array>
 #include <unordered_map>
 
 #include <dxgi1_6.h>
 #include <d3d12.h>
-#include <atlbase.h>
 #include "d3dx12.h"
 
 #include <DirectXMath.h>

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingRealTimeDenoisedAmbientOcclusion/stdafx.h
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingRealTimeDenoisedAmbientOcclusion/stdafx.h
@@ -40,7 +40,6 @@
 #include <unordered_map>
 #include <vector>
 #include <algorithm>
-#include <atlbase.h>
 #include <assert.h>
 #include <array>
 #include <unordered_map>
@@ -58,7 +57,6 @@
 
 #include <dxgi1_6.h>
 #include <d3d12.h>
-#include <atlbase.h>
 #include "d3dx12.h"	
 #include <pix3.h>
 

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/stdafx.h
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/stdafx.h
@@ -33,12 +33,10 @@
 #include <memory>
 #include <unordered_map>
 #include <vector>
-#include <atlbase.h>
 #include <assert.h>
 
 #include <dxgi1_6.h>
 #include <d3d12.h>
-#include <atlbase.h>
 #include "d3dx12.h"
 
 #include <DirectXMath.h>


### PR DESCRIPTION
Replaced ATL::CComPtr with Microsoft::WRL::ComPtr to eliminate the dependency on ATL, which must be explicitly installed for each toolset.