### PR TITLE
Add missing warp device selection to the work graphs samples

### DIFF
--- a/Samples/Desktop/D3D12HelloWorld/src/HelloWorkGraphs/D3D12HelloWorkGraphs.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloWorkGraphs/D3D12HelloWorkGraphs.cpp
@@ -23,12 +23,16 @@
 #include "dxcapi.h"
 #include "d3d12.h"
 #include "d3dx12.h"
+#include <dxgi1_6.h>
 
 extern "C" { __declspec(dllexport) extern const UINT D3D12SDKVersion = 613; }
 extern "C" { __declspec(dllexport) extern const char* D3D12SDKPath = u8".\\D3D12\\"; }
 
 using namespace std;
 LPCWSTR g_File = L"D3D12HelloWorkGraphs.hlsl";
+
+// use a warp device instead of a hardware device
+bool g_useWarpDevice = false;
 
 //=================================================================================================================================
 // Helper / setup code, not specific to work graphs
@@ -176,7 +180,20 @@ void InitDeviceAndContext(D3DContext& D3D)
 
     D3D_FEATURE_LEVEL FL = D3D_FEATURE_LEVEL_11_0;
     CComPtr<ID3D12Device> spDevice;
-    VERIFY_SUCCEEDED(D3D12CreateDevice(NULL, FL, IID_PPV_ARGS(&spDevice)));
+
+    if (g_useWarpDevice)
+    {
+        CComPtr<IDXGIFactory4> factory;
+        VERIFY_SUCCEEDED(CreateDXGIFactory2(0, IID_PPV_ARGS(&factory)));
+
+        CComPtr<IDXGIAdapter> warpAdapter;
+        VERIFY_SUCCEEDED(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+        VERIFY_SUCCEEDED(D3D12CreateDevice(warpAdapter, FL, IID_PPV_ARGS(&spDevice)));
+    }
+    else
+    {
+        VERIFY_SUCCEEDED(D3D12CreateDevice(NULL, FL, IID_PPV_ARGS(&spDevice)));
+    }
     D3D.spDevice = spDevice;
 
     VERIFY_SUCCEEDED(D3D.spDevice->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&D3D.spFence)));

--- a/Samples/Desktop/D3D12HelloWorld/src/WorkGraphsSandbox/D3D12WorkGraphsSandbox.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/WorkGraphsSandbox/D3D12WorkGraphsSandbox.cpp
@@ -22,6 +22,7 @@
 #include "dxcapi.h"
 #include "d3d12.h"
 #include "d3dx12.h"
+#include <dxgi1_6.h>
 
 extern "C" { __declspec(dllexport) extern const UINT D3D12SDKVersion = 613; }
 extern "C" { __declspec(dllexport) extern const char* D3D12SDKPath = u8".\\D3D12\\"; }
@@ -30,6 +31,9 @@ using namespace std;
 const char* g_File = "D3D12WorkGraphsSandbox.hlsl";
 wstring g_wFile;
 bool g_bUseCollections = false;
+
+// use a warp device instead of a hardware device
+bool g_useWarpDevice = false;
 
 //=================================================================================================================================
 // Helper / setup code, not specific to work graphs
@@ -213,7 +217,20 @@ void InitDeviceAndContext(D3DContext& D3D)
 
     D3D_FEATURE_LEVEL FL = D3D_FEATURE_LEVEL_11_0;
     CComPtr<ID3D12Device> spDevice;
-    VERIFY_SUCCEEDED(D3D12CreateDevice(NULL, FL, IID_PPV_ARGS(&spDevice)));
+
+    if (g_useWarpDevice)
+    {
+        CComPtr<IDXGIFactory4> factory;
+        VERIFY_SUCCEEDED(CreateDXGIFactory2(0, IID_PPV_ARGS(&factory)));
+
+        CComPtr<IDXGIAdapter> warpAdapter;
+        VERIFY_SUCCEEDED(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)));
+        VERIFY_SUCCEEDED(D3D12CreateDevice(warpAdapter, FL, IID_PPV_ARGS(&spDevice)));
+    }
+    else
+    {
+        VERIFY_SUCCEEDED(D3D12CreateDevice(NULL, FL, IID_PPV_ARGS(&spDevice)));
+    }
     D3D.spDevice = spDevice;
 
     D3D.spInfoQueue = spDevice;


### PR DESCRIPTION
Adds the ability to use a warp device in the work graphs samples, just like in the other samples.