### PR TITLE
Fix lib dependencies for release build of certain HelloWorld samples

### DIFF
--- a/Samples/Desktop/D3D12HelloWorld/src/HelloMeshNodes/D3D12HelloMeshNodes.vcxproj
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloMeshNodes/D3D12HelloMeshNodes.vcxproj
@@ -98,7 +98,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>d3d12.lib;dxgi.lib;d3dcompiler.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;d3d12.lib;dxgi.lib;d3dcompiler.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>d3d12.dll</DelayLoadDLLs>
     </Link>
     <CustomBuildStep>

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloVADecode/D3D12HelloVADecode.vcxproj
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloVADecode/D3D12HelloVADecode.vcxproj
@@ -108,7 +108,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>d3d12.lib;dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d12.lib;dxgi.lib;va.lib;va_win32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>d3d12.dll</DelayLoadDLLs>
     </Link>
     <CustomBuildStep>

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloVAEncode/D3D12HelloVAEncode.vcxproj
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloVAEncode/D3D12HelloVAEncode.vcxproj
@@ -108,7 +108,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>d3d12.lib;dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d12.lib;dxgi.lib;va.lib;va_win32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>d3d12.dll</DelayLoadDLLs>
     </Link>
     <CustomBuildStep>

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloVAResourceInterop/D3D12HelloVAResourceInterop.vcxproj
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloVAResourceInterop/D3D12HelloVAResourceInterop.vcxproj
@@ -108,7 +108,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>d3d12.lib;dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d12.lib;dxgi.lib;va.lib;va_win32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>d3d12.dll</DelayLoadDLLs>
     </Link>
     <CustomBuildStep>


### PR DESCRIPTION
Currently Release|x64 build breaks for D3D12HelloWorld due to missing dependencies. This patch makes the Release|X64 dependencies the same as Debug|x64 for a few failing samples.