### PR TITLE
Remove PIX misinformation from VRS sample + fix bug highlighted by Visual Studio

### DIFF
--- a/Samples/Desktop/D3D12VariableRateShading/src/D3D12VariableRateShading.cpp
+++ b/Samples/Desktop/D3D12VariableRateShading/src/D3D12VariableRateShading.cpp
@@ -67,12 +67,8 @@ D3D12VariableRateShading::D3D12VariableRateShading(UINT width, UINT height, wstr
     m_windowVisible(true),
     m_windowedMode(true)
 {
-#ifdef PIXSUPPORT
-    m_enableUI = false;
-#endif
-#ifndef PIXSUPPORT
     ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
-#endif
+
     if (!m_tearingSupport)
     {
         // Sample shows handling of use cases with tearing support, which is OS dependent and has been supported since Threshold II.

--- a/Samples/Desktop/D3D12VariableRateShading/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12VariableRateShading/src/DXSample.cpp
@@ -147,7 +147,6 @@ void DXSample::ParseCommandLineArgs(WCHAR* argv[], int argc)
 // Determines whether tearing support is available for fullscreen borderless windows.
 void DXSample::CheckTearingSupport()
 {
-#ifndef PIXSUPPORT
     ComPtr<IDXGIFactory6> factory;
     HRESULT hr = CreateDXGIFactory1(IID_PPV_ARGS(&factory));
     BOOL allowTearing = FALSE;
@@ -157,9 +156,6 @@ void DXSample::CheckTearingSupport()
     }
 
     m_tearingSupport = SUCCEEDED(hr) && allowTearing;
-#else
-    m_tearingSupport = TRUE;
-#endif
 }
 
 void DXSample::SetWindowBounds(int left, int top, int right, int bottom)

--- a/Samples/Desktop/D3D12VariableRateShading/src/DXSample.h
+++ b/Samples/Desktop/D3D12VariableRateShading/src/DXSample.h
@@ -71,7 +71,7 @@ protected:
     // Adapter info.
     bool m_useWarpDevice;
 
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without Dx11on12 UI
     bool m_enableUI;
 
 private:

--- a/Samples/Desktop/D3D12VariableRateShading/src/VariableRateShadingScene.cpp
+++ b/Samples/Desktop/D3D12VariableRateShading/src/VariableRateShadingScene.cpp
@@ -45,19 +45,6 @@ void VariableRateShadingScene::Initialize(ID3D12Device* pDevice, ID3D12CommandQu
         m_shadingRateTier = options.VariableShadingRateTier;
     }
 
-    // For now, disable variable rate shading when running under PIX.
-    // This is only needed until PIX supports VRS.
-    IID graphicsAnalysisID;
-    if (SUCCEEDED(IIDFromString(L"{9F251514-9D4D-4902-9D60-18988AB7D4B5}", &graphicsAnalysisID)))
-    {
-        ComPtr<IUnknown> graphicsAnalysis;
-        if (SUCCEEDED(DXGIGetDebugInterface1(0, graphicsAnalysisID, &graphicsAnalysis)))
-        {
-            // Running under PIX.
-            m_shadingRateTier = D3D12_VARIABLE_SHADING_RATE_TIER_NOT_SUPPORTED;
-        }
-    }
-
     // Initialize the base scene.
     ShadowsFogScatteringSquidScene::Initialize(pDevice, pDirectCommandQueue, pCommandList, frameIndex);
 }

--- a/Samples/Desktop/D3D12VariableRateShading/src/VariableRateShadingScene.h
+++ b/Samples/Desktop/D3D12VariableRateShading/src/VariableRateShadingScene.h
@@ -62,7 +62,7 @@ namespace SampleAssets
             const float width = 266.66f * scale;
             const float height = 150.0f * scale;
 
-            vertexData.empty();
+            vertexData.clear();
             vertexData.resize(4);
 
             vertexData[0].position = { x, y, z };


### PR DESCRIPTION
Misc functionality in the VRS sample was disabled when PIX was active, but there's no reason for that anymore.

The PR also fixes a std::vector::empty() call that was meant to be a std::vector::clear() call.