### PR TITLE
Fix Shadow Mapping bug in MiniEngine for Non-legacy renderer

### DIFF
--- a/MiniEngine/Core/Math/Frustum.cpp
+++ b/MiniEngine/Core/Math/Frustum.cpp
@@ -81,13 +81,16 @@ Frustum::Frustum( const Matrix4& ProjMat )
     // Identify if the projection is perspective or orthographic by looking at the 4th row.
     if (ProjMatF[3] == 0.0f && ProjMatF[7] == 0.0f && ProjMatF[11] == 0.0f && ProjMatF[15] == 1.0f)
     {
-        // Orthographic
-        float Left	 = (-1.0f - ProjMatF[12]) * RcpXX;
-        float Right	 = ( 1.0f - ProjMatF[12]) * RcpXX;
-        float Top	 = ( 1.0f - ProjMatF[13]) * RcpYY;
-        float Bottom = (-1.0f - ProjMatF[13]) * RcpYY;
-        float Front	 = ( 0.0f - ProjMatF[14]) * RcpZZ;
-        float Back   = ( 1.0f - ProjMatF[14]) * RcpZZ;
+        // Orthographic Frustum Extraction
+        //  In ModelViewer, we set the shadowcenter to be the origin. Thus the frustum planes are symmetrical x, y and z axis.
+        //  Also, for Top and Bottom, it is the Top that is negative due to: ProjMatF[10] = -2/(far - near), in an orthographic projmat.
+
+        float Left	 = -RcpXX;
+        float Right	 = RcpXX;
+        float Top	   = -RcpYY;
+        float Bottom = RcpYY;
+        float Front	 = 0.5f * RcpZZ;
+        float Back   = 0.5f -RcpZZ;
 
         // Check for reverse Z here.  The bounding planes need to point into the frustum.
         if (Front < Back)

--- a/MiniEngine/Model/Shaders/DefaultPS.hlsl
+++ b/MiniEngine/Model/Shaders/DefaultPS.hlsl
@@ -263,7 +263,7 @@ float4 main(VSOutput vsOutput) : SV_Target0
     // Begin accumulating light starting with emissive
     float3 colorAccum = emissive;
 
-#if 0
+#if 1
     float sunShadow = texSunShadow.SampleCmpLevelZero( shadowSampler, vsOutput.sunShadowCoord.xy, vsOutput.sunShadowCoord.z );
     colorAccum += ShadeDirectionalLight(Surface, SunDirection, sunShadow * SunIntensity);
 

--- a/MiniEngine/ModelViewer/ModelViewer.cpp
+++ b/MiniEngine/ModelViewer/ModelViewer.cpp
@@ -34,7 +34,7 @@
 #include "ShadowCamera.h"
 #include "Display.h"
 
-#define LEGACY_RENDERER
+//#define LEGACY_RENDERER
 
 using namespace GameCore;
 using namespace Math;
@@ -276,7 +276,13 @@ void ModelViewer::RenderScene( void )
         Vector3 SunDirection = Normalize(Vector3( costheta * cosphi, sinphi, sintheta * cosphi ));
         Vector3 ShadowBounds = Vector3(m_ModelInst.GetRadius());
         //m_SunShadowCamera.UpdateMatrix(-SunDirection, m_ModelInst.GetCenter(), ShadowBounds,
-        m_SunShadowCamera.UpdateMatrix(-SunDirection, Vector3(0, -500.0f, 0), Vector3(5000, 3000, 3000),
+        
+        // Make sure that the x and z coordinates are 0 for the shadowcenter 
+        // in order for the orthographic frustum to be correctly calculated.
+        Vector3 origin = Vector3(0);
+        Vector3 ShadowCenter = origin;
+
+        m_SunShadowCamera.UpdateMatrix(-SunDirection, ShadowCenter, Vector3(5000, 3000, 3000),
             (uint32_t)g_ShadowBuffer.GetWidth(), (uint32_t)g_ShadowBuffer.GetHeight(), 16);
 
         GlobalConstants globals;


### PR DESCRIPTION
In the current state of MiniEngine, for arbitrary .glTF models that use the non-legacy rendering path, shadow mapping is broken. The issue was caused by an incorrect orthogonal frustum being calculated for Shadow Cameras, in ../Frustum.cpp. This resulted in the Shadow Buffer containing little to no information due to frustum-culling of meshes with the incorrect frustum. 

This patch fixes that bug, allowing for correct shadow mapping for .glTF file rendering in the non-legacy rendering path of MiniEngine!