### PR TITLE
Add sample for Tight Aligned resources

### DIFF
--- a/Samples/Desktop/D3D12HelloWorld/src/D3D12HelloWorld.sln
+++ b/Samples/Desktop/D3D12HelloWorld/src/D3D12HelloWorld.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30621.155.26403.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35707.178 d17.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "D3D12HelloTriangle", "HelloTriangle\D3D12HelloTriangle.vcxproj", "{5018F6A3-6533-4744-B1FD-727D199FD2E9}"
 EndProject
@@ -21,13 +21,15 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "D3D12HelloVADecode", "Hello
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "D3D12HelloVAResourceInterop", "HelloVAResourceInterop\D3D12HelloVAResourceInterop.vcxproj", "{17171787-C5D2-4014-9D1D-BC43074F36A1}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "D3D12HelloWorkGraphs", "HelloWorkGraphs\D3D12HelloWorkGraphs.vcxproj", "{05080adc-d456-4058-8064-4791865f796b}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "D3D12HelloWorkGraphs", "HelloWorkGraphs\D3D12HelloWorkGraphs.vcxproj", "{05080ADC-D456-4058-8064-4791865F796B}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "D3D12WorkGraphsSandbox", "WorkGraphsSandbox\D3D12WorkGraphsSandbox.vcxproj", "{2725e8ec-0892-499b-acd5-0ea18157682a}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "D3D12WorkGraphsSandbox", "WorkGraphsSandbox\D3D12WorkGraphsSandbox.vcxproj", "{2725E8EC-0892-499B-ACD5-0EA18157682A}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "D3D12HelloGenericPrograms", "HelloGenericPrograms\D3D12HelloGenericPrograms.vcxproj", "{7db43f09-7bd6-4e69-8987-9a919a142852}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "D3D12HelloGenericPrograms", "HelloGenericPrograms\D3D12HelloGenericPrograms.vcxproj", "{7DB43F09-7BD6-4E69-8987-9A919A142852}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "D3D12HelloMeshNodes", "HelloMeshNodes\D3D12HelloMeshNodes.vcxproj", "{b9680899-f009-406b-beee-d0214c1e7592}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "D3D12HelloMeshNodes", "HelloMeshNodes\D3D12HelloMeshNodes.vcxproj", "{B9680899-F009-406B-BEEE-D0214C1E7592}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "D3D12HelloTightAlignment", "HelloTightAlignment\D3D12HelloTightAlignment.vcxproj", "{69B1A348-DF87-4335-BC68-FE8C060C7A60}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -71,22 +73,26 @@ Global
 		{17171787-C5D2-4014-9D1D-BC43074F36A1}.Debug|x64.Build.0 = Debug|x64
 		{17171787-C5D2-4014-9D1D-BC43074F36A1}.Release|x64.ActiveCfg = Release|x64
 		{17171787-C5D2-4014-9D1D-BC43074F36A1}.Release|x64.Build.0 = Release|x64
-		{05080adc-d456-4058-8064-4791865f796b}.Debug|x64.ActiveCfg = Debug|x64
-		{05080adc-d456-4058-8064-4791865f796b}.Debug|x64.Build.0 = Debug|x64
-		{05080adc-d456-4058-8064-4791865f796b}.Release|x64.ActiveCfg = Release|x64
-		{05080adc-d456-4058-8064-4791865f796b}.Release|x64.Build.0 = Release|x64
-		{2725e8ec-0892-499b-acd5-0ea18157682a}.Debug|x64.ActiveCfg = Debug|x64
-		{2725e8ec-0892-499b-acd5-0ea18157682a}.Debug|x64.Build.0 = Debug|x64
-		{2725e8ec-0892-499b-acd5-0ea18157682a}.Release|x64.ActiveCfg = Release|x64
-		{2725e8ec-0892-499b-acd5-0ea18157682a}.Release|x64.Build.0 = Release|x64
-		{7db43f09-7bd6-4e69-8987-9a919a142852}.Debug|x64.ActiveCfg = Debug|x64
-		{7db43f09-7bd6-4e69-8987-9a919a142852}.Debug|x64.Build.0 = Debug|x64
-		{7db43f09-7bd6-4e69-8987-9a919a142852}.Release|x64.ActiveCfg = Release|x64
-		{7db43f09-7bd6-4e69-8987-9a919a142852}.Release|x64.Build.0 = Release|x64
-		{b9680899-f009-406b-beee-d0214c1e7592}.Debug|x64.ActiveCfg = Debug|x64
-		{b9680899-f009-406b-beee-d0214c1e7592}.Debug|x64.Build.0 = Debug|x64
-		{b9680899-f009-406b-beee-d0214c1e7592}.Release|x64.ActiveCfg = Release|x64
-		{b9680899-f009-406b-beee-d0214c1e7592}.Release|x64.Build.0 = Release|x64
+		{05080ADC-D456-4058-8064-4791865F796B}.Debug|x64.ActiveCfg = Debug|x64
+		{05080ADC-D456-4058-8064-4791865F796B}.Debug|x64.Build.0 = Debug|x64
+		{05080ADC-D456-4058-8064-4791865F796B}.Release|x64.ActiveCfg = Release|x64
+		{05080ADC-D456-4058-8064-4791865F796B}.Release|x64.Build.0 = Release|x64
+		{2725E8EC-0892-499B-ACD5-0EA18157682A}.Debug|x64.ActiveCfg = Debug|x64
+		{2725E8EC-0892-499B-ACD5-0EA18157682A}.Debug|x64.Build.0 = Debug|x64
+		{2725E8EC-0892-499B-ACD5-0EA18157682A}.Release|x64.ActiveCfg = Release|x64
+		{2725E8EC-0892-499B-ACD5-0EA18157682A}.Release|x64.Build.0 = Release|x64
+		{7DB43F09-7BD6-4E69-8987-9A919A142852}.Debug|x64.ActiveCfg = Debug|x64
+		{7DB43F09-7BD6-4E69-8987-9A919A142852}.Debug|x64.Build.0 = Debug|x64
+		{7DB43F09-7BD6-4E69-8987-9A919A142852}.Release|x64.ActiveCfg = Release|x64
+		{7DB43F09-7BD6-4E69-8987-9A919A142852}.Release|x64.Build.0 = Release|x64
+		{B9680899-F009-406B-BEEE-D0214C1E7592}.Debug|x64.ActiveCfg = Debug|x64
+		{B9680899-F009-406B-BEEE-D0214C1E7592}.Debug|x64.Build.0 = Debug|x64
+		{B9680899-F009-406B-BEEE-D0214C1E7592}.Release|x64.ActiveCfg = Release|x64
+		{B9680899-F009-406B-BEEE-D0214C1E7592}.Release|x64.Build.0 = Release|x64
+		{69B1A348-DF87-4335-BC68-FE8C060C7A60}.Debug|x64.ActiveCfg = Debug|x64
+		{69B1A348-DF87-4335-BC68-FE8C060C7A60}.Debug|x64.Build.0 = Debug|x64
+		{69B1A348-DF87-4335-BC68-FE8C060C7A60}.Release|x64.ActiveCfg = Release|x64
+		{69B1A348-DF87-4335-BC68-FE8C060C7A60}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTightAlignment/D3D12HelloTightAlignment.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTightAlignment/D3D12HelloTightAlignment.cpp
@@ -1,0 +1,241 @@
+// D3D12HelloTightAlignment.cpp : This file contains the 'main' function. Program execution begins and ends there.
+//
+
+#include <windows.h>
+#include <iostream>
+#include <atlbase.h>
+#include <vector>
+#include <initguid.h>
+#include "dxcapi.h"
+#include "d3d12.h"
+#include "d3dx12.h"
+#include <dxgi1_6.h>
+
+extern "C" { __declspec(dllexport) extern const UINT D3D12SDKVersion = 716; }
+extern "C" { __declspec(dllexport) extern const char* D3D12SDKPath = u8".\\D3D12\\"; }
+extern "C" { __declspec(dllexport) extern const char* WarpPath = u8".\\WARP\\"; }
+
+// use a warp device instead of a hardware device
+bool g_useWarpDevice = false;
+
+#pragma region helper_and_setup
+//=================================================================================================================================
+// Helper / setup code, not specific to work graphs
+// Look for "Start of interesting code" further below or just collapse this region.
+//=================================================================================================================================
+#define PRINT(text) std::cout << (char*)text << "\n" << std::flush; 
+#define VERIFY_SUCCEEDED(hr) {HRESULT hrLocal = hr; if(FAILED(hrLocal)) {PRINT("Error at: " << __FILE__ << ", line: " << __LINE__ << ", HRESULT: 0x" << std::hex << hrLocal); throw E_FAIL;} }
+
+struct D3DContext
+{
+    CComPtr<ID3D12Device14> spDevice;
+    CComPtr<IDXGIAdapter3> spAdapter;
+    bool bIsHeapTier1;
+};
+
+//=================================================================================================================================
+void InitDeviceAndContext(D3DContext& D3D, bool useWarp)
+{
+    D3D.spDevice.Release();
+    D3D.spAdapter.Release();
+
+    CComPtr<ID3D12Debug1> pDebug;
+    VERIFY_SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&pDebug)));
+    pDebug->EnableDebugLayer();
+
+    D3D_FEATURE_LEVEL FL = D3D_FEATURE_LEVEL_11_0;
+    CComPtr<ID3D12Device> spDevice;
+    CComPtr<IDXGIFactory4> factory;
+    VERIFY_SUCCEEDED(CreateDXGIFactory2(0, IID_PPV_ARGS(&factory)));
+
+    if (useWarp)
+    {
+        VERIFY_SUCCEEDED(factory->EnumWarpAdapter(IID_PPV_ARGS(&D3D.spAdapter)));
+        VERIFY_SUCCEEDED(D3D12CreateDevice(D3D.spAdapter, FL, IID_PPV_ARGS(&spDevice)));
+    }
+    else
+    {
+        VERIFY_SUCCEEDED(D3D12CreateDevice(NULL, FL, IID_PPV_ARGS(&spDevice)));
+        LUID luid = spDevice->GetAdapterLuid();
+        factory->EnumAdapterByLuid(luid, IID_PPV_ARGS(&D3D.spAdapter));
+    }
+    D3D.spDevice = spDevice;
+    D3D.bIsHeapTier1 = false;
+}
+
+template <UINT _Size>
+LPSTR FormatMemoryUsage(UINT64 usage, CHAR(&result)[_Size])
+{
+    const UINT64 mb = 1 << 20;
+    const UINT64 kb = 1 << 10;
+    if (usage > mb)
+    {
+        sprintf_s(result, "%.2f MB", static_cast<float>(usage) / mb);
+    }
+    else if (usage > kb)
+    {
+        sprintf_s(result, "%.2f KB", static_cast<float>(usage) / kb);
+    }
+    else
+    {
+        sprintf_s(result, "%I64d B", usage);
+    }
+    return result;
+}
+
+void PrintGPUMemoryUsage(D3DContext& D3D, UINT64 baselineUsage = 0)
+{
+    DXGI_QUERY_VIDEO_MEMORY_INFO memoryInfo;
+    D3D.spAdapter->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &memoryInfo);
+
+    char text[100];
+    char usageString[20];
+    UINT64 usage = memoryInfo.CurrentUsage - baselineUsage;
+    if (baselineUsage > memoryInfo.CurrentUsage)
+    {
+        PRINT(" ## Error - baseline usage was greater than current usage");
+        return;
+    }
+    sprintf_s(text, "  Memory Used: %s", FormatMemoryUsage(usage, usageString));
+    PRINT(text);
+}
+
+#pragma endregion
+
+template<UINT32 numBuffers>
+void CreateManyPlacedBuffers(D3DContext& D3D, const CD3DX12_RESOURCE_DESC1& rDesc)
+{
+    DXGI_QUERY_VIDEO_MEMORY_INFO baslineMemoryInfo;
+    D3D.spAdapter->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &baslineMemoryInfo);
+
+    D3D12_RESOURCE_ALLOCATION_INFO1 infos[numBuffers];
+    D3D12_RESOURCE_DESC1 pResourceDescs[numBuffers];
+    std::fill_n(pResourceDescs, numBuffers, rDesc);
+    D3D12_RESOURCE_ALLOCATION_INFO aggregateInfo = D3D.spDevice->GetResourceAllocationInfo2(0, numBuffers, pResourceDescs, infos);
+
+    CComPtr<ID3D12Heap> pHeap;
+    CComPtr<ID3D12Resource> buffers[numBuffers];
+    CD3DX12_HEAP_DESC heapDesc = CD3DX12_HEAP_DESC(aggregateInfo.SizeInBytes, D3D12_HEAP_TYPE_DEFAULT);
+    heapDesc.Flags = D3D.bIsHeapTier1 ? D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS : D3D12_HEAP_FLAG_NONE;
+    VERIFY_SUCCEEDED(D3D.spDevice->CreateHeap(&heapDesc, IID_PPV_ARGS(&pHeap)));
+    for (UINT32 i = 0; i < numBuffers; i++)
+    {
+        VERIFY_SUCCEEDED(D3D.spDevice->CreatePlacedResource1(pHeap, infos[i].Offset, &rDesc, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&buffers[i])));
+    }
+    PrintGPUMemoryUsage(D3D, baslineMemoryInfo.CurrentUsage);
+}
+
+template<UINT32 numBuffers>
+void ComparePlacedBufferMemoryFootprint(D3DContext& D3D)
+{
+    PRINT("Comparing memory footprint for " << numBuffers << " placed buffers...\n");
+    CD3DX12_RESOURCE_DESC1 bufferDesc;
+    //Beyond the obvious benefits for small resources, you can also see savings for large buffers that go beyond the 64KiB mark
+    UINT bufferSizes[] = { 1, 16, 256, 4096, 32000, 65540, 80000 };
+    for (UINT bufferSize : bufferSizes)
+    {
+        PRINT("Size: " << bufferSize << " B");
+        PRINT("  Classic buffer alignment:");
+        bufferDesc = CD3DX12_RESOURCE_DESC1::Buffer(bufferSize);
+        CreateManyPlacedBuffers<numBuffers>(D3D, bufferDesc);
+
+        PRINT("  Tight buffer alignment:");
+        bufferDesc = CD3DX12_RESOURCE_DESC1::Buffer(bufferSize, D3D12_RESOURCE_FLAG_USE_TIGHT_ALIGNMENT);
+        CreateManyPlacedBuffers<numBuffers>(D3D, bufferDesc);
+
+        PRINT("----------");
+    }
+    PRINT("====================");
+}
+
+template<UINT32 numBuffers>
+void CreateManyCommittedBuffers(D3DContext& D3D, const CD3DX12_RESOURCE_DESC1& rDesc)
+{
+    DXGI_QUERY_VIDEO_MEMORY_INFO baslineMemoryInfo;
+    D3D.spAdapter->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &baslineMemoryInfo);
+
+    CD3DX12_HEAP_PROPERTIES heapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+    CComPtr<ID3D12Resource> buffers[numBuffers];
+    for (UINT32 i = 0; i < numBuffers; i++)
+    {
+        VERIFY_SUCCEEDED(D3D.spDevice->CreateCommittedResource2(&heapProperties, D3D12_HEAP_FLAG_NONE, &rDesc, D3D12_RESOURCE_STATE_COMMON, nullptr, nullptr, IID_PPV_ARGS(&buffers[i])));
+    }
+
+    PrintGPUMemoryUsage(D3D, baslineMemoryInfo.CurrentUsage);
+}
+
+template<UINT32 numBuffers>
+void CompareCommittedBufferMemoryFootprint(D3DContext& D3D)
+{
+    PRINT("Comparing memory footprint for " << numBuffers << " committed buffers...\n");
+    CD3DX12_RESOURCE_DESC1 bufferDesc;
+    
+    UINT bufferSizes[] = { 1, 16, 256, 4096, 65536, 65540, 80000 };
+    for (UINT bufferSize : bufferSizes)
+    {
+        PRINT("Size: " << bufferSize << " B");
+        PRINT("  Classic buffer alignment:");
+        bufferDesc = CD3DX12_RESOURCE_DESC1::Buffer(bufferSize);
+        CreateManyCommittedBuffers<numBuffers>(D3D, bufferDesc);
+
+        PRINT("  Tight buffer alignment:");
+        bufferDesc = CD3DX12_RESOURCE_DESC1::Buffer(bufferSize, D3D12_RESOURCE_FLAG_USE_TIGHT_ALIGNMENT);
+        CreateManyCommittedBuffers<numBuffers>(D3D, bufferDesc);
+
+        PRINT("----------");
+    }
+    PRINT("====================");
+}
+
+int main()
+{
+    try
+    {
+        PRINT("\n" <<
+            "==================================================================================\n" <<
+            " Hello Tight Alignment\n" <<
+            "==================================================================================");
+        D3DContext D3D;
+        InitDeviceAndContext(D3D, g_useWarpDevice);
+        bool warpFallback = false;
+
+        CD3DX12FeatureSupport featureSupport;
+        featureSupport.Init(D3D.spDevice);
+        if (featureSupport.TightAlignmentSupportTier() == D3D12_TIGHT_ALIGNMENT_TIER_NOT_SUPPORTED && !g_useWarpDevice)
+        {
+            PRINT("Tight alignment is not supported on this driver. Retrying with Warp...");
+            InitDeviceAndContext(D3D, true);
+            featureSupport.Init(D3D.spDevice);
+            warpFallback = true;
+        }
+        if (featureSupport.TightAlignmentSupportTier() == D3D12_TIGHT_ALIGNMENT_TIER_NOT_SUPPORTED)
+        {
+            PRINT("Tight alignment is not supported on this driver or the currently installed version of Warp. Aborting.");
+            return 0;
+        }
+        DXGI_ADAPTER_DESC desc;
+        VERIFY_SUCCEEDED(D3D.spAdapter->GetDesc(&desc));
+        std::wcout << L"Running sample on " << desc.Description << L"\n\n" << std::flush;
+
+        D3D12_FEATURE_DATA_D3D12_OPTIONS options{};
+        VERIFY_SUCCEEDED(D3D.spDevice->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options)));
+        D3D.bIsHeapTier1 = options.ResourceHeapTier == D3D12_RESOURCE_HEAP_TIER_1;
+
+        ComparePlacedBufferMemoryFootprint<1>(D3D);     // No benefit due to the heap allocations being made in 64KiB chuncks
+        ComparePlacedBufferMemoryFootprint<8>(D3D);     // Can already see some benefit being realized
+        ComparePlacedBufferMemoryFootprint<4096>(D3D);  // drastic savings in most cases
+
+        PRINT("\n========================================\n========================================\n");
+
+        CompareCommittedBufferMemoryFootprint<1>(D3D);
+        CompareCommittedBufferMemoryFootprint<8>(D3D);
+        CompareCommittedBufferMemoryFootprint<4096>(D3D);
+    }
+    catch (HRESULT)
+    {
+        PRINT("Aborting.");
+        return -1;
+    }
+    return 0;
+    
+}

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTightAlignment/D3D12HelloTightAlignment.vcxproj
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTightAlignment/D3D12HelloTightAlignment.vcxproj
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Direct3D.D3D12.1.716.0-preview\build\native\Microsoft.Direct3D.D3D12.props" Condition="Exists('..\packages\Microsoft.Direct3D.D3D12.1.716.0-preview\build\native\Microsoft.Direct3D.D3D12.props')" />
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{69b1a348-df87-4335-bc68-fe8c060c7a60}</ProjectGuid>
+    <RootNamespace>D3D12HelloTightAlignment</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+    <Import Project="..\packages\Microsoft.Direct3D.WARP.1.0.14-preview\build\native\Microsoft.Direct3D.WARP.targets" Condition="Exists('..\packages\Microsoft.Direct3D.WARP.1.0.14-preview\build\native\Microsoft.Direct3D.WARP.targets')" />
+    <Import Project="..\packages\Microsoft.Direct3D.D3D12.1.716.0-preview\build\native\Microsoft.Direct3D.D3D12.targets" Condition="Exists('..\packages\Microsoft.Direct3D.D3D12.1.716.0-preview\build\native\Microsoft.Direct3D.D3D12.targets')" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>d3d12.lib;dxgi.lib;d3dcompiler.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>d3d12.lib;dxgi.lib;d3dcompiler.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="D3D12HelloTightAlignment.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Direct3D.WARP.1.0.14-preview\build\native\Microsoft.Direct3D.WARP.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Direct3D.WARP.1.0.14-preview\build\native\Microsoft.Direct3D.WARP.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Direct3D.D3D12.1.716.0-preview\build\native\Microsoft.Direct3D.D3D12.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Direct3D.D3D12.1.716.0-preview\build\native\Microsoft.Direct3D.D3D12.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Direct3D.D3D12.1.716.0-preview\build\native\Microsoft.Direct3D.D3D12.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Direct3D.D3D12.1.716.0-preview\build\native\Microsoft.Direct3D.D3D12.targets'))" />
+  </Target>
+</Project>

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTightAlignment/D3D12HelloTightAlignment.vcxproj.filters
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTightAlignment/D3D12HelloTightAlignment.vcxproj.filters
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="D3D12HelloTightAlignment.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+</Project>

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTightAlignment/packages.config
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTightAlignment/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Direct3D.D3D12" version="1.716.0-preview" targetFramework="native" />
+  <package id="Microsoft.Direct3D.WARP" version="1.0.14-preview" targetFramework="native" />
+</packages>


### PR DESCRIPTION
Demonstrates the VRAM savings that the Tight Alignment feature provides compared to naive approaches to management of buffer resources. It is possible to achieve similar footprints via packing buffers together, but this feature enables you to do that without spending the effort. You also get better tooling support due to accurate resource bounds.

Find out more about the Tight Alignment feature here: https://devblogs.microsoft.com/directx/agility-sdk-1-716-0-preview-tight-alignment/