### PR TITLE
remove "CommandListManager* m_OwningManager;" in CommandContext.h .cpp

### DIFF
--- a/MiniEngine/Core/CommandContext.cpp
+++ b/MiniEngine/Core/CommandContext.cpp
@@ -166,7 +166,6 @@ CommandContext::CommandContext(D3D12_COMMAND_LIST_TYPE Type) :
     m_CpuLinearAllocator(kCpuWritable), 
     m_GpuLinearAllocator(kGpuExclusive)
 {
-    m_OwningManager = nullptr;
     m_CommandList = nullptr;
     m_CurrentAllocator = nullptr;
     ZeroMemory(m_CurrentDescriptorHeaps, sizeof(m_CurrentDescriptorHeaps));

--- a/MiniEngine/Core/CommandContext.h
+++ b/MiniEngine/Core/CommandContext.h
@@ -166,7 +166,6 @@ protected:
 
     void BindDescriptorHeaps( void );
 
-    CommandListManager* m_OwningManager;
     ID3D12GraphicsCommandList* m_CommandList;
     ID3D12CommandAllocator* m_CurrentAllocator;
 


### PR DESCRIPTION
i delete the "CommandListManager* m_OwningManager;" in CommandContext.h and CommandContext.cpp because this don't used