### PR TITLE
Remove very outdated comments about PIX not supporting D3D11On12

### DIFF
--- a/Samples/Desktop/D3D12Fullscreen/src/DXSample.h
+++ b/Samples/Desktop/D3D12Fullscreen/src/DXSample.h
@@ -71,7 +71,7 @@ protected:
     // Adapter info.
     bool m_useWarpDevice;
 
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage
     bool m_enableUI;
 
 private:

--- a/Samples/Desktop/D3D12HDR/src/DXSample.h
+++ b/Samples/Desktop/D3D12HDR/src/DXSample.h
@@ -71,7 +71,7 @@ protected:
     // Adapter info.
     bool m_useWarpDevice;
 
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage
     bool m_enableUI;
 
 private:

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/DXSample.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpus/DXSample.h
@@ -71,7 +71,7 @@ protected:
     // Adapter info.
     bool m_useWarpDevice;
 
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage. 
     bool m_enableUI;
 
 private:

--- a/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.h
@@ -71,7 +71,7 @@ protected:
     // Adapter info.
     bool m_useWarpDevice;
 
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage. 
     bool m_enableUI;
 
 private:

--- a/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/DXSample.h
+++ b/Samples/Desktop/D3D12LinkedGpus/src/SingleGpu/DXSample.h
@@ -71,7 +71,7 @@ protected:
     // Adapter info.
     bool m_useWarpDevice;
 
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage. 
     bool m_enableUI;
 
 private:

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingHelloShaderExecutionReordering/DXSample.h
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingHelloShaderExecutionReordering/DXSample.h
@@ -62,7 +62,7 @@ protected:
     // Window bounds
     RECT m_windowBounds;
     
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage. 
     bool m_enableUI;
 
     // D3D device resources

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingHelloWorld/DXSample.h
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingHelloWorld/DXSample.h
@@ -62,7 +62,7 @@ protected:
     // Window bounds
     RECT m_windowBounds;
     
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage. 
     bool m_enableUI;
 
     // D3D device resources

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingLibrarySubobjects/DXSample.h
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingLibrarySubobjects/DXSample.h
@@ -62,7 +62,7 @@ protected:
     // Window bounds
     RECT m_windowBounds;
     
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage. 
     bool m_enableUI;
 
     // D3D device resources

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingOpacityMicromaps/DXSample.h
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingOpacityMicromaps/DXSample.h
@@ -62,7 +62,7 @@ protected:
     // Window bounds
     RECT m_windowBounds;
     
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage. 
     bool m_enableUI;
 
     // D3D device resources

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingProceduralGeometry/util/DXSample.h
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingProceduralGeometry/util/DXSample.h
@@ -62,7 +62,7 @@ protected:
     // Window bounds
     RECT m_windowBounds;
     
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage. 
     bool m_enableUI;
 
     // D3D device resources

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingRealTimeDenoisedAmbientOcclusion/SampleCore/util/DXSample.h
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingRealTimeDenoisedAmbientOcclusion/SampleCore/util/DXSample.h
@@ -71,7 +71,7 @@ protected:
     // Window bounds
     RECT m_windowBounds;
     
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage. 
     bool m_enableUI;
 
     // D3D device resources

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/DXSample.h
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/DXSample.h
@@ -62,7 +62,7 @@ protected:
     // Window bounds
     RECT m_windowBounds;
     
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage. 
     bool m_enableUI;
 
     // D3D device resources

--- a/Samples/Desktop/D3D12SM6WaveIntrinsics/src/DXSample.h
+++ b/Samples/Desktop/D3D12SM6WaveIntrinsics/src/DXSample.h
@@ -71,7 +71,7 @@ protected:
     // Adapter info.
     bool m_useWarpDevice;
 
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage. 
     bool m_enableUI;
 
 private:

--- a/Samples/Desktop/D3D12xGPU/src/DXSample.h
+++ b/Samples/Desktop/D3D12xGPU/src/DXSample.h
@@ -71,7 +71,7 @@ protected:
     // Adapter info.
     bool m_useWarpDevice;
 
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage. 
     bool m_enableUI;
 
 private:

--- a/Samples/UWP/D3D12Fullscreen/src/DXSample.h
+++ b/Samples/UWP/D3D12Fullscreen/src/DXSample.h
@@ -70,7 +70,7 @@ protected:
     // Adapter info.
     bool m_useWarpDevice;
 
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage. 
     bool m_enableUI;
 
 private:

--- a/Samples/UWP/D3D12HDR/src/DXSample.h
+++ b/Samples/UWP/D3D12HDR/src/DXSample.h
@@ -70,7 +70,7 @@ protected:
     // Adapter info.
     bool m_useWarpDevice;
 
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage. 
     bool m_enableUI;
 
 private:

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/DXSample.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpus/DXSample.h
@@ -70,7 +70,7 @@ protected:
     // Adapter info.
     bool m_useWarpDevice;
 
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage. 
     bool m_enableUI;
 
 private:

--- a/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/LinkedGpusAffinity/DXSample.h
@@ -70,7 +70,7 @@ protected:
     // Adapter info.
     bool m_useWarpDevice;
 
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage. 
     bool m_enableUI;
 
 private:

--- a/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/DXSample.h
+++ b/Samples/UWP/D3D12LinkedGpus/src/SingleGpu/DXSample.h
@@ -70,7 +70,7 @@ protected:
     // Adapter info.
     bool m_useWarpDevice;
 
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage. 
     bool m_enableUI;
 
 private:

--- a/Samples/UWP/D3D12SM6WaveIntrinsics/src/DXSample.h
+++ b/Samples/UWP/D3D12SM6WaveIntrinsics/src/DXSample.h
@@ -70,7 +70,7 @@ protected:
     // Adapter info.
     bool m_useWarpDevice;
 
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage. 
     bool m_enableUI;
 
 private:

--- a/Samples/UWP/D3D12VariableRateShading/src/DXSample.h
+++ b/Samples/UWP/D3D12VariableRateShading/src/DXSample.h
@@ -70,7 +70,7 @@ protected:
     // Adapter info.
     bool m_useWarpDevice;
 
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage. 
     bool m_enableUI;
 
 private:

--- a/Samples/UWP/D3D12xGPU/src/DXSample.h
+++ b/Samples/UWP/D3D12xGPU/src/DXSample.h
@@ -70,7 +70,7 @@ protected:
     // Adapter info.
     bool m_useWarpDevice;
 
-    // Override to be able to start without Dx11on12 UI for PIX. PIX doesn't support 11 on 12. 
+    // Override to be able to start without UI, to avoid 11On12 usage. 
     bool m_enableUI;
 
 private:


### PR DESCRIPTION
PIX has supported D3D11On12 for many years. This PR updates stale comments in samples, to avoid spreading misinformation.