### PR TITLE
Remove references to using SetHDRMetaData as that API is discouraged …

### DIFF
--- a/Samples/Desktop/D3D12HDR/src/D3D12HDR.cpp
+++ b/Samples/Desktop/D3D12HDR/src/D3D12HDR.cpp
@@ -23,15 +23,6 @@
 #include "presentPS.hlsl.h"
 
 const float D3D12HDR::ClearColor[4] = { 0.0f, 0.0f, 0.0f, 1.0f };
-const float D3D12HDR::HDRMetaDataPool[4][4] =
-{
-    // MaxOutputNits, MinOutputNits, MaxCLL, MaxFALL
-    // These values are made up for testing. You need to figure out those numbers for your app.
-    { 1000.0f, 0.001f, 2000.0f, 500.0f },
-    { 500.0f, 0.001f, 2000.0f, 500.0f },
-    { 500.0f, 0.100f, 500.0f, 100.0f },
-    { 2000.0f, 1.000f, 2000.0f, 1000.0f }
-};
 
 D3D12HDR::D3D12HDR(UINT width, UINT height, std::wstring name) :
     DXSample(width, height, name),
@@ -149,7 +140,6 @@ void D3D12HDR::LoadPipeline()
     CheckDisplayHDRSupport();
     m_enableST2084 = m_hdrSupport;
     EnsureSwapChainColorSpace(m_currentSwapChainBitDepth, m_enableST2084);
-    SetHDRMetaData(HDRMetaDataPool[m_hdrMetaDataPoolIdx][0], HDRMetaDataPool[m_hdrMetaDataPoolIdx][1], HDRMetaDataPool[m_hdrMetaDataPoolIdx][2], HDRMetaDataPool[m_hdrMetaDataPoolIdx][3]);
 
     m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 
@@ -817,7 +807,6 @@ void D3D12HDR::OnKeyDown(UINT8 key)
             m_currentSwapChainBitDepth = static_cast<SwapChainBitDepth>((m_currentSwapChainBitDepth - 1 + SwapChainBitDepthCount) % SwapChainBitDepthCount);
             DXGI_FORMAT newFormat = m_swapChainFormats[m_currentSwapChainBitDepth];
             UpdateSwapChainBuffer(m_width, m_height, newFormat);
-            SetHDRMetaData(HDRMetaDataPool[m_hdrMetaDataPoolIdx][0], HDRMetaDataPool[m_hdrMetaDataPoolIdx][1], HDRMetaDataPool[m_hdrMetaDataPoolIdx][2], HDRMetaDataPool[m_hdrMetaDataPoolIdx][3]);
             break;
         }
 
@@ -826,7 +815,6 @@ void D3D12HDR::OnKeyDown(UINT8 key)
             m_currentSwapChainBitDepth = static_cast<SwapChainBitDepth>((m_currentSwapChainBitDepth + 1) % SwapChainBitDepthCount);
             DXGI_FORMAT newFormat = m_swapChainFormats[m_currentSwapChainBitDepth];
             UpdateSwapChainBuffer(m_width, m_height, newFormat);
-            SetHDRMetaData(HDRMetaDataPool[m_hdrMetaDataPoolIdx][0], HDRMetaDataPool[m_hdrMetaDataPoolIdx][1], HDRMetaDataPool[m_hdrMetaDataPoolIdx][2], HDRMetaDataPool[m_hdrMetaDataPoolIdx][3]);
             break;
         }
 
@@ -836,7 +824,6 @@ void D3D12HDR::OnKeyDown(UINT8 key)
             if (m_currentSwapChainBitDepth == _10)
             {
                 EnsureSwapChainColorSpace(m_currentSwapChainBitDepth, m_enableST2084);
-                SetHDRMetaData(HDRMetaDataPool[m_hdrMetaDataPoolIdx][0], HDRMetaDataPool[m_hdrMetaDataPoolIdx][1], HDRMetaDataPool[m_hdrMetaDataPoolIdx][2], HDRMetaDataPool[m_hdrMetaDataPoolIdx][3]);
             }
 
             break;
@@ -854,14 +841,6 @@ void D3D12HDR::OnKeyDown(UINT8 key)
                 m_uiLayer.reset();
             }
 
-            break;
-        }
-
-        case 'M':
-        {
-            // Switch meta data value for testing. TV should adjust the content based on the metadata we sent.
-            m_hdrMetaDataPoolIdx = (m_hdrMetaDataPoolIdx + 1) % 4;
-            SetHDRMetaData(HDRMetaDataPool[m_hdrMetaDataPoolIdx][0], HDRMetaDataPool[m_hdrMetaDataPoolIdx][1], HDRMetaDataPool[m_hdrMetaDataPoolIdx][2], HDRMetaDataPool[m_hdrMetaDataPoolIdx][3]);
             break;
         }
     }
@@ -938,66 +917,6 @@ void D3D12HDR::EnsureSwapChainColorSpace(SwapChainBitDepth swapChainBitDepth, bo
         }
     }
 }
-
-// Set HDR meta data for output display to master the content and the luminance values of the content.
-// An app should estimate and set appropriate metadata based on its contents.
-// For demo purpose, we simply made up a few set of metadata for you to experience the effect of appling meta data.
-// Please see details in https://msdn.microsoft.com/en-us/library/windows/desktop/mt732700(v=vs.85).aspx.
-void D3D12HDR::SetHDRMetaData(float MaxOutputNits /*=1000.0f*/, float MinOutputNits /*=0.001f*/, float MaxCLL /*=2000.0f*/, float MaxFALL /*=500.0f*/)
-{
-    if (!m_swapChain)
-    {
-        return;
-    }
-
-    // Clean the hdr metadata if the display doesn't support HDR
-    if (!m_hdrSupport)
-    {
-        ThrowIfFailed(m_swapChain->SetHDRMetaData(DXGI_HDR_METADATA_TYPE_NONE, 0, nullptr));
-        return;
-    }
-
-    static const DisplayChromaticities DisplayChromaticityList[] =
-    {
-        { 0.64000f, 0.33000f, 0.30000f, 0.60000f, 0.15000f, 0.06000f, 0.31270f, 0.32900f }, // Display Gamut Rec709 
-        { 0.70800f, 0.29200f, 0.17000f, 0.79700f, 0.13100f, 0.04600f, 0.31270f, 0.32900f }, // Display Gamut Rec2020
-    };
-
-    // Select the chromaticity based on HDR format of the DWM.
-    int selectedChroma = 0;
-    if (m_currentSwapChainBitDepth == _16 && m_currentSwapChainColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709)
-    {
-        selectedChroma = 0;
-    }
-    else if (m_currentSwapChainBitDepth == _10 && m_currentSwapChainColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020)
-    {
-        selectedChroma = 1;
-    }
-    else
-    {
-        // Reset the metadata since this is not a supported HDR format.
-        ThrowIfFailed(m_swapChain->SetHDRMetaData(DXGI_HDR_METADATA_TYPE_NONE, 0, nullptr));
-        return;
-    }
-
-    // Set HDR meta data
-    const DisplayChromaticities& Chroma = DisplayChromaticityList[selectedChroma];
-    DXGI_HDR_METADATA_HDR10 HDR10MetaData = {};
-    HDR10MetaData.RedPrimary[0] = static_cast<UINT16>(Chroma.RedX * 50000.0f);
-    HDR10MetaData.RedPrimary[1] = static_cast<UINT16>(Chroma.RedY * 50000.0f);
-    HDR10MetaData.GreenPrimary[0] = static_cast<UINT16>(Chroma.GreenX * 50000.0f);
-    HDR10MetaData.GreenPrimary[1] = static_cast<UINT16>(Chroma.GreenY * 50000.0f);
-    HDR10MetaData.BluePrimary[0] = static_cast<UINT16>(Chroma.BlueX * 50000.0f);
-    HDR10MetaData.BluePrimary[1] = static_cast<UINT16>(Chroma.BlueY * 50000.0f);
-    HDR10MetaData.WhitePoint[0] = static_cast<UINT16>(Chroma.WhiteX * 50000.0f);
-    HDR10MetaData.WhitePoint[1] = static_cast<UINT16>(Chroma.WhiteY * 50000.0f);
-    HDR10MetaData.MaxMasteringLuminance = static_cast<UINT>(MaxOutputNits * 10000.0f);
-    HDR10MetaData.MinMasteringLuminance = static_cast<UINT>(MinOutputNits * 10000.0f);
-    HDR10MetaData.MaxContentLightLevel = static_cast<UINT16>(MaxCLL);
-    HDR10MetaData.MaxFrameAverageLightLevel = static_cast<UINT16>(MaxFALL);
-    ThrowIfFailed(m_swapChain->SetHDRMetaData(DXGI_HDR_METADATA_TYPE_HDR10, sizeof(DXGI_HDR_METADATA_HDR10), &HDR10MetaData));
-}
-
 
 void D3D12HDR::UpdateSwapChainBuffer(UINT width, UINT height, DXGI_FORMAT format)
 {

--- a/Samples/Desktop/D3D12HDR/src/D3D12HDR.h
+++ b/Samples/Desktop/D3D12HDR/src/D3D12HDR.h
@@ -40,9 +40,7 @@ public:
     }
     inline bool GetHDRSupport() { return m_hdrSupport; }
     inline float GetReferenceWhiteNits() { return m_referenceWhiteNits; }
-    inline UINT GetHDRMetaDataPoolIndex() { return m_hdrMetaDataPoolIdx; }
 
-    static const float HDRMetaDataPool[4][4];
     static const UINT FrameCount = 2;
 
 protected:
@@ -160,7 +158,6 @@ private:
     bool m_updateVertexBuffer;
     std::shared_ptr<UILayer> m_uiLayer;
     bool m_enableUI = true;
-    UINT m_hdrMetaDataPoolIdx = 0;
 
     // Color.
     bool m_hdrSupport = false;
@@ -188,6 +185,5 @@ private:
     void MoveToNextFrame();
     void EnsureSwapChainColorSpace(SwapChainBitDepth d, bool enableST2084);
     void CheckDisplayHDRSupport();
-    void SetHDRMetaData(float MaxOutputNits = 1000.0f, float MinOutputNits = 0.001f, float MaxCLL = 2000.0f, float MaxFALL = 500.0f);
     void UpdateSwapChainBuffer(UINT width, UINT height, DXGI_FORMAT format);
 };

--- a/Samples/Desktop/D3D12HDR/src/UILayer.cpp
+++ b/Samples/Desktop/D3D12HDR/src/UILayer.cpp
@@ -28,7 +28,6 @@ UILayer::UILayer(D3D12HDR* pSample) :
     m_labels[ChangeFormat] = L"PgUp/PgDn\tChange back buffer format";
     m_labels[ChangeCurve] = L"H\tToggle between sRGB and ST.2084 (10-bit swap chain only)";
     m_labels[HideUI] = L"U\tToggle UI Visibility";
-    m_labels[MetaData] = L"M\tToggle HDR Meta Data";
 
     Initialize();
 }
@@ -142,16 +141,6 @@ void UILayer::UpdateLabels()
     m_ui[Format].text = m_labels[Format];
     m_ui[Signal].text = m_labels[Signal];
     m_ui[HDRSupport].text = m_labels[HDRSupport];
-
-    float MaxOutputNits = D3D12HDR::HDRMetaDataPool[m_pSample->GetHDRMetaDataPoolIndex()][0];
-    float MinOutputNits = D3D12HDR::HDRMetaDataPool[m_pSample->GetHDRMetaDataPoolIndex()][1];
-    float MaxCLL = D3D12HDR::HDRMetaDataPool[m_pSample->GetHDRMetaDataPoolIndex()][2];
-    float MaxFALL = D3D12HDR::HDRMetaDataPool[m_pSample->GetHDRMetaDataPoolIndex()][3];
-
-    wchar_t buffer[256];
-    swprintf_s(buffer, 256, L"M\tToggle HDR Meta Data\t MaxOutputNits:%3.3f\t MinOutputNits:%3.3f\t MaxCLL:%3.3f\t MaxFALL:%3.3f", MaxOutputNits, MinOutputNits, MaxCLL, MaxFALL);
-
-    m_ui[MetaData].text = buffer;
 }
 
 // Render the UI.
@@ -263,5 +252,4 @@ void UILayer::Resize()
     m_ui[ChangeFormat] = { m_labels[ChangeFormat], D2D1::RectF(smallFontSize, height - fontSize * 5.0f, width, height), m_smallTextFormat.Get() };
     m_ui[ChangeCurve] = { m_labels[ChangeCurve], D2D1::RectF(smallFontSize, height - fontSize * 3.0f, width, height), m_smallTextFormat.Get() };
     m_ui[HideUI] = { m_labels[HideUI], D2D1::RectF(smallFontSize, height - fontSize * 2.0f, width, height), m_smallTextFormat.Get() };
-    m_ui[MetaData] = { m_labels[MetaData], D2D1::RectF(smallFontSize, height - fontSize * 1.0f, width, height), m_smallTextFormat.Get() };
 }

--- a/Samples/Desktop/D3D12HDR/src/UILayer.h
+++ b/Samples/Desktop/D3D12HDR/src/UILayer.h
@@ -43,7 +43,6 @@ private:
         ChangeFormat,
         ChangeCurve,
         HideUI,
-        MetaData,
         StringsCount
     };
 

--- a/Samples/UWP/D3D12HDR/src/D3D12HDR.h
+++ b/Samples/UWP/D3D12HDR/src/D3D12HDR.h
@@ -40,9 +40,7 @@ public:
     }
     inline bool GetHDRSupport() { return m_hdrSupport; }
     inline float GetReferenceWhiteNits() { return m_referenceWhiteNits; }
-    inline UINT GetHDRMetaDataPoolIndex() { return m_hdrMetaDataPoolIdx; }
 
-    static const float HDRMetaDataPool[4][4];
     static const UINT FrameCount = 2;
 
 protected:
@@ -160,7 +158,6 @@ private:
     bool m_updateVertexBuffer;
     std::shared_ptr<UILayer> m_uiLayer;
     bool m_enableUI = true;
-    UINT m_hdrMetaDataPoolIdx = 0;
 
     // Color.
     bool m_hdrSupport = false;
@@ -188,6 +185,5 @@ private:
     void MoveToNextFrame();
     void EnsureSwapChainColorSpace(SwapChainBitDepth d, bool enableST2084);
     void CheckDisplayHDRSupport();
-    void SetHDRMetaData(float MaxOutputNits = 1000.0f, float MinOutputNits = 0.001f, float MaxCLL = 2000.0f, float MaxFALL = 500.0f);
     void UpdateSwapChainBuffer(UINT width, UINT height, DXGI_FORMAT format);
 };

--- a/Samples/UWP/D3D12HDR/src/UILayer.cpp
+++ b/Samples/UWP/D3D12HDR/src/UILayer.cpp
@@ -28,7 +28,6 @@ UILayer::UILayer(D3D12HDR* pSample) :
     m_labels[ChangeFormat] = L"PgUp/PgDn\tChange back buffer format";
     m_labels[ChangeCurve] = L"H\tToggle between sRGB and ST.2084 (10-bit swap chain only)";
     m_labels[HideUI] = L"U\tToggle UI Visibility";
-    m_labels[MetaData] = L"M\tToggle HDR Meta Data";
 
     Initialize();
 }
@@ -142,16 +141,6 @@ void UILayer::UpdateLabels()
     m_ui[Format].text = m_labels[Format];
     m_ui[Signal].text = m_labels[Signal];
     m_ui[HDRSupport].text = m_labels[HDRSupport];
-
-    float MaxOutputNits = D3D12HDR::HDRMetaDataPool[m_pSample->GetHDRMetaDataPoolIndex()][0];
-    float MinOutputNits = D3D12HDR::HDRMetaDataPool[m_pSample->GetHDRMetaDataPoolIndex()][1];
-    float MaxCLL = D3D12HDR::HDRMetaDataPool[m_pSample->GetHDRMetaDataPoolIndex()][2];
-    float MaxFALL = D3D12HDR::HDRMetaDataPool[m_pSample->GetHDRMetaDataPoolIndex()][3];
-
-    wchar_t buffer[256];
-    swprintf_s(buffer, 256, L"M\tToggle HDR Meta Data\t MaxOutputNits:%3.3f\t MinOutputNits:%3.3f\t MaxCLL:%3.3f\t MaxFALL:%3.3f", MaxOutputNits, MinOutputNits, MaxCLL, MaxFALL);
-
-    m_ui[MetaData].text = buffer;
 }
 
 // Render the UI.
@@ -263,5 +252,4 @@ void UILayer::Resize()
     m_ui[ChangeFormat] = { m_labels[ChangeFormat], D2D1::RectF(smallFontSize, height - fontSize * 5.0f, width, height), m_smallTextFormat.Get() };
     m_ui[ChangeCurve] = { m_labels[ChangeCurve], D2D1::RectF(smallFontSize, height - fontSize * 3.0f, width, height), m_smallTextFormat.Get() };
     m_ui[HideUI] = { m_labels[HideUI], D2D1::RectF(smallFontSize, height - fontSize * 2.0f, width, height), m_smallTextFormat.Get() };
-    m_ui[MetaData] = { m_labels[MetaData], D2D1::RectF(smallFontSize, height - fontSize * 1.0f, width, height), m_smallTextFormat.Get() };
 }

--- a/Samples/UWP/D3D12HDR/src/UILayer.h
+++ b/Samples/UWP/D3D12HDR/src/UILayer.h
@@ -43,7 +43,6 @@ private:
         ChangeFormat,
         ChangeCurve,
         HideUI,
-        MetaData,
         StringsCount
     };
 


### PR DESCRIPTION
Remove references to using SetHDRMetaData as that API is discouraged … (It also wasn't being effectively used in this sample)

See [this](https://learn.microsoft.com/en-us/windows/win32/api/dxgi1_5/nf-dxgi1_5-idxgiswapchain4-sethdrmetadata) and [this](https://learn.microsoft.com/en-us/windows/win32/direct3darticles/high-dynamic-range) for further guidance.

Validated samples building locally and with an HDR display to ensure function.