### PR TITLE
Update Tight Alignment sample to use AgilitySDK 1.618.1

### DIFF
--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTightAlignment/D3D12HelloTightAlignment.cpp
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTightAlignment/D3D12HelloTightAlignment.cpp
@@ -11,7 +11,7 @@
 #include "d3dx12.h"
 #include <dxgi1_6.h>
 
-extern "C" { __declspec(dllexport) extern const UINT D3D12SDKVersion = 716; }
+extern "C" { __declspec(dllexport) extern const UINT D3D12SDKVersion = 618; }
 extern "C" { __declspec(dllexport) extern const char* D3D12SDKPath = u8".\\D3D12\\"; }
 extern "C" { __declspec(dllexport) extern const char* WarpPath = u8".\\WARP\\"; }
 
@@ -221,12 +221,14 @@ int main()
         VERIFY_SUCCEEDED(D3D.spDevice->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options)));
         D3D.bIsHeapTier1 = options.ResourceHeapTier == D3D12_RESOURCE_HEAP_TIER_1;
 
+        // Depending on the vendor, you may actually see benefits for placed resources even with only 1 resource in the heap (smaller heap allocation).
         ComparePlacedBufferMemoryFootprint<1>(D3D);     // No benefit due to the heap allocations being made in 64KiB chuncks
         ComparePlacedBufferMemoryFootprint<8>(D3D);     // Can already see some benefit being realized
         ComparePlacedBufferMemoryFootprint<4096>(D3D);  // drastic savings in most cases
 
         PRINT("\n========================================\n========================================\n");
 
+        // Depending on the vendor, there may be no difference here since they now receive a hint that the heap is being implicitly created for a single resource.
         CompareCommittedBufferMemoryFootprint<1>(D3D);
         CompareCommittedBufferMemoryFootprint<8>(D3D);
         CompareCommittedBufferMemoryFootprint<4096>(D3D);

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTightAlignment/D3D12HelloTightAlignment.vcxproj
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTightAlignment/D3D12HelloTightAlignment.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.Direct3D.D3D12.1.716.0-preview\build\native\Microsoft.Direct3D.D3D12.props" Condition="Exists('..\packages\Microsoft.Direct3D.D3D12.1.716.0-preview\build\native\Microsoft.Direct3D.D3D12.props')" />
+  <Import Project="..\packages\Microsoft.Direct3D.D3D12.1.618.1\build\native\Microsoft.Direct3D.D3D12.props" Condition="Exists('..\packages\Microsoft.Direct3D.D3D12.1.618.1\build\native\Microsoft.Direct3D.D3D12.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -58,7 +58,7 @@
   </ImportGroup>
   <ImportGroup Label="Shared">
     <Import Project="..\packages\Microsoft.Direct3D.WARP.1.0.14-preview\build\native\Microsoft.Direct3D.WARP.targets" Condition="Exists('..\packages\Microsoft.Direct3D.WARP.1.0.14-preview\build\native\Microsoft.Direct3D.WARP.targets')" />
-    <Import Project="..\packages\Microsoft.Direct3D.D3D12.1.716.0-preview\build\native\Microsoft.Direct3D.D3D12.targets" Condition="Exists('..\packages\Microsoft.Direct3D.D3D12.1.716.0-preview\build\native\Microsoft.Direct3D.D3D12.targets')" />
+    <Import Project="..\packages\Microsoft.Direct3D.D3D12.1.618.1\build\native\Microsoft.Direct3D.D3D12.targets" Condition="Exists('..\packages\Microsoft.Direct3D.D3D12.1.618.1\build\native\Microsoft.Direct3D.D3D12.targets')" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -143,7 +143,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Direct3D.WARP.1.0.14-preview\build\native\Microsoft.Direct3D.WARP.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Direct3D.WARP.1.0.14-preview\build\native\Microsoft.Direct3D.WARP.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Direct3D.D3D12.1.716.0-preview\build\native\Microsoft.Direct3D.D3D12.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Direct3D.D3D12.1.716.0-preview\build\native\Microsoft.Direct3D.D3D12.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Direct3D.D3D12.1.716.0-preview\build\native\Microsoft.Direct3D.D3D12.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Direct3D.D3D12.1.716.0-preview\build\native\Microsoft.Direct3D.D3D12.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Direct3D.D3D12.1.618.1\build\native\Microsoft.Direct3D.D3D12.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Direct3D.D3D12.1.618.1\build\native\Microsoft.Direct3D.D3D12.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Direct3D.D3D12.1.618.1\build\native\Microsoft.Direct3D.D3D12.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Direct3D.D3D12.1.618.1\build\native\Microsoft.Direct3D.D3D12.targets'))" />
   </Target>
 </Project>

--- a/Samples/Desktop/D3D12HelloWorld/src/HelloTightAlignment/packages.config
+++ b/Samples/Desktop/D3D12HelloWorld/src/HelloTightAlignment/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Direct3D.D3D12" version="1.716.0-preview" targetFramework="native" />
+  <package id="Microsoft.Direct3D.D3D12" version="1.618.1" targetFramework="native" />
   <package id="Microsoft.Direct3D.WARP" version="1.0.14-preview" targetFramework="native" />
 </packages>


### PR DESCRIPTION
Tight Alignment is out of preview now, so update to use the retail version of the AgilitySDK