### PR TITLE
Change ComparisonFunc to D3D12_COMPARISON_FUNC_ALWAYS

### DIFF
--- a/MiniEngine/Core/SamplerManager.h
+++ b/MiniEngine/Core/SamplerManager.h
@@ -30,7 +30,7 @@ public:
         AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
         MipLODBias = 0.0f;
         MaxAnisotropy = 16;
-        ComparisonFunc = D3D12_COMPARISON_FUNC_LESS_EQUAL;
+        ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
         BorderColor[0] = 1.0f;
         BorderColor[1] = 1.0f;
         BorderColor[2] = 1.0f;


### PR DESCRIPTION
 Remove warning during runtime when using the sampler when the filter is not a comparison filter, and therefore the comparison function is ignored. ComparisonFunc by default should be: D3D12_COMPARISON_FUNC_ALWAYS