### PR TITLE
D3dx12residency fixes for errors with debug layer enabled.

### DIFF
--- a/Libraries/D3DX12Residency/d3dx12Residency.h
+++ b/Libraries/D3DX12Residency/d3dx12Residency.h
@@ -406,9 +406,16 @@ namespace D3DX12Residency
 
             HRESULT GPUWait(ID3D12CommandQueue* pQueue)
             {
-                HRESULT hr = pQueue->Wait(pFence, FenceValue);
-                RESIDENCY_CHECK_RESULT(hr);
-                return hr;
+                if (FenceValue > 0)
+                {
+                    HRESULT hr = pQueue->Wait(pFence, FenceValue);
+                    RESIDENCY_CHECK_RESULT(hr);
+                    return hr;
+                }
+                else
+                {
+                    return S_OK;
+                }
             }
 
             HRESULT GPUSignal(ID3D12CommandQueue* pQueue)
@@ -1332,6 +1339,7 @@ namespace D3DX12Residency
                                 LRU.TrimToSyncPointInclusive(TotalUsage + INT64(SizeToMakeResident), TotalBudget, pEvictionList, NumObjectsToEvict, GenerationToWaitFor);
 
                                 RESIDENCY_CHECK_RESULT(Device->Evict(NumObjectsToEvict, pEvictionList));
+                                NumObjectsToEvict = 0;
                             }
                             else
                             {

--- a/Samples/Desktop/D3D12Residency/src/d3dx12Residency.h
+++ b/Samples/Desktop/D3D12Residency/src/d3dx12Residency.h
@@ -406,9 +406,16 @@ namespace D3DX12Residency
 
             HRESULT GPUWait(ID3D12CommandQueue* pQueue)
             {
-                HRESULT hr = pQueue->Wait(pFence, FenceValue);
-                RESIDENCY_CHECK_RESULT(hr);
-                return hr;
+                if (FenceValue > 0)
+                {
+                    HRESULT hr = pQueue->Wait(pFence, FenceValue);
+                    RESIDENCY_CHECK_RESULT(hr);
+                    return hr;
+                }
+                else
+                {
+                    return S_OK;
+                }
             }
 
             HRESULT GPUSignal(ID3D12CommandQueue* pQueue)
@@ -1296,8 +1303,8 @@ namespace D3DX12Residency
                                     if (Device3)
                                     {
                                         hr = Device3->EnqueueMakeResident(D3D12_RESIDENCY_FLAG_NONE,
-                                                                          NumObjectsInBatch,
-                                                                          &pMakeResidentList[BatchStart].pUnderlying,
+                                                                          NumObjects,
+                                                                          &pMakeResidentList[MakeResidentIndex].pUnderlying,
                                                                           AsyncThreadFence.pFence,
                                                                           AsyncThreadFence.FenceValue + 1);
                                         if (SUCCEEDED(hr))
@@ -1332,6 +1339,7 @@ namespace D3DX12Residency
                                 LRU.TrimToSyncPointInclusive(TotalUsage + INT64(SizeToMakeResident), TotalBudget, pEvictionList, NumObjectsToEvict, GenerationToWaitFor);
 
                                 RESIDENCY_CHECK_RESULT(Device->Evict(NumObjectsToEvict, pEvictionList));
+                                NumObjectsToEvict = 0;
                             }
                             else
                             {

--- a/Samples/UWP/D3D12Residency/src/d3dx12Residency.h
+++ b/Samples/UWP/D3D12Residency/src/d3dx12Residency.h
@@ -406,9 +406,16 @@ namespace D3DX12Residency
 
             HRESULT GPUWait(ID3D12CommandQueue* pQueue)
             {
-                HRESULT hr = pQueue->Wait(pFence, FenceValue);
-                RESIDENCY_CHECK_RESULT(hr);
-                return hr;
+                if (FenceValue > 0)
+                {
+                    HRESULT hr = pQueue->Wait(pFence, FenceValue);
+                    RESIDENCY_CHECK_RESULT(hr);
+                    return hr;
+                }
+                else
+                {
+                    return S_OK;
+                }
             }
 
             HRESULT GPUSignal(ID3D12CommandQueue* pQueue)
@@ -1296,8 +1303,8 @@ namespace D3DX12Residency
                                     if (Device3)
                                     {
                                         hr = Device3->EnqueueMakeResident(D3D12_RESIDENCY_FLAG_NONE,
-                                                                          NumObjectsInBatch,
-                                                                          &pMakeResidentList[BatchStart].pUnderlying,
+                                                                          NumObjects,
+                                                                          &pMakeResidentList[MakeResidentIndex].pUnderlying,
                                                                           AsyncThreadFence.pFence,
                                                                           AsyncThreadFence.FenceValue + 1);
                                         if (SUCCEEDED(hr))
@@ -1332,6 +1339,7 @@ namespace D3DX12Residency
                                 LRU.TrimToSyncPointInclusive(TotalUsage + INT64(SizeToMakeResident), TotalBudget, pEvictionList, NumObjectsToEvict, GenerationToWaitFor);
 
                                 RESIDENCY_CHECK_RESULT(Device->Evict(NumObjectsToEvict, pEvictionList));
+                                NumObjectsToEvict = 0;
                             }
                             else
                             {


### PR DESCRIPTION
3 fixes here:
There's multiple copies of d3dx12residency.h, one of which contains fixes that are missing from the others. This change makes all the files the same.
If the debug layer is enabled then it would report an error until the first resource is evicted because it tries to wait on fence value 0. If there's nothing to wait for it now returns immediately.
In extremely rare situations it's possible for the same resource to be evicted multiple times, giving it a negative residency count. This can only happen if not enough resources can be evicted for the current sync point while there are multiple syncs queued, causing it to try again. This change should make it only evict each resource once.