### PR TITLE
MiniEngine: Fix inconsistent call

### DIFF
--- a/MiniEngine/Model/Model.cpp
+++ b/MiniEngine/Model/Model.cpp
@@ -241,8 +241,7 @@ void ModelInstance::Update(GraphicsContext& gfxContext, float deltaTime)
 
     m_MeshConstantsCPU.Unmap();
 
-    gfxContext.TransitionResource(m_MeshConstantsGPU, D3D12_RESOURCE_STATE_COPY_DEST, true);
-    gfxContext.GetCommandList()->CopyBufferRegion(m_MeshConstantsGPU.GetResource(), 0, m_MeshConstantsCPU.GetResource(), 0, m_MeshConstantsCPU.GetBufferSize());
+    gfxContext.CopyBufferRegion(m_MeshConstantsGPU, 0, m_MeshConstantsCPU, 0, m_MeshConstantsCPU.GetBufferSize());
     gfxContext.TransitionResource(m_MeshConstantsGPU, D3D12_RESOURCE_STATE_GENERIC_READ);
 }
 


### PR DESCRIPTION
Removed an unecessary `CommandContext::GetCommandList` for a `CopyBufferRegion` call that could be replaced by the wrapped version available in `CommandContext`.

`CommandContext::GetCommandList` is not used anymore, but I prefer not to remove it since it could still be used by users.