### PR TITLE
Check for minimized size on WM_SIZE message

### DIFF
--- a/MiniEngine/Core/GameCore.cpp
+++ b/MiniEngine/Core/GameCore.cpp
@@ -164,7 +164,8 @@ namespace GameCore
         switch( message )
         {
         case WM_SIZE:
-            Display::Resize((UINT)(UINT64)lParam & 0xFFFF, (UINT)(UINT64)lParam >> 16);
+			if( wParam != SIZE_MINIMIZED )
+                Display::Resize((UINT)(UINT64)lParam & 0xFFFF, (UINT)(UINT64)lParam >> 16);
             break;
 
         case WM_DESTROY:


### PR DESCRIPTION
Without this, the engine will crash when Display::Resize is called ...