### PR TITLE
Update Multithreading project to include Application Identity

### DIFF
--- a/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.cpp
+++ b/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.cpp
@@ -16,7 +16,7 @@
 D3D12Multithreading* D3D12Multithreading::s_app = nullptr;
 bool D3D12Multithreading::s_bIsEnhancedBarriersEnabled = false;
 
-extern "C" { __declspec(dllexport) extern const UINT D3D12SDKVersion = 618; }
+extern "C" { __declspec(dllexport) extern const UINT D3D12SDKVersion = 619; }
 extern "C" { __declspec(dllexport) extern const char* D3D12SDKPath = u8".\\D3D12\\"; }
 
 D3D12Multithreading::D3D12Multithreading(UINT width, UINT height, std::wstring name) :
@@ -37,11 +37,39 @@ D3D12Multithreading::D3D12Multithreading(UINT width, UINT height, std::wstring n
     m_keyboardInput.animate = true;
 
     ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
+
+    SetApplicationIdentity();
 }
 
 D3D12Multithreading::~D3D12Multithreading()
 {
     s_app = nullptr;
+}
+
+void D3D12Multithreading::SetApplicationIdentity()
+{
+    ComPtr<ID3D12ApplicationIdentity> pApplicationIdentity;
+    HRESULT hr = D3D12GetInterface(CLSID_D3D12ApplicationIdentity, IID_PPV_ARGS(&pApplicationIdentity));
+    if (E_NOINTERFACE == hr)
+    {
+        return;
+    }
+
+    D3D12_APPLICATION_DESC appDesc;
+    appDesc.pExeFilename = L"D3D12Multithreading.exe";
+    appDesc.pName = L"D3D12 Multithreading";
+    appDesc.Version.Version = 0x0001000000000000;
+    appDesc.pEngineName = nullptr;
+    appDesc.EngineVersion.Version = 0x0000000000000000;
+
+    GUID D3D12MultithreadingAppID = { /* 8367fc8a-d739-485a-a473-12dfaa190567 */
+        0x8367fc8a,
+        0xd739,
+        0x485a,
+        { 0xa4, 0x73, 0x12, 0xdf, 0xaa, 0x19, 0x05, 0x67 }
+    };
+
+    pApplicationIdentity->SetApplicationIdentity(&appDesc, D3D12MultithreadingAppID);
 }
 
 void D3D12Multithreading::OnInit()
@@ -1282,3 +1310,4 @@ void D3D12Multithreading::SetCommonPipelineState(ID3D12GraphicsCommandList* pCom
     // SRVs are set elsewhere because they change based on the object 
     // being drawn.
 }
+

--- a/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.cpp
+++ b/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.cpp
@@ -37,39 +37,11 @@ D3D12Multithreading::D3D12Multithreading(UINT width, UINT height, std::wstring n
     m_keyboardInput.animate = true;
 
     ThrowIfFailed(DXGIDeclareAdapterRemovalSupport());
-
-    SetApplicationIdentity();
 }
 
 D3D12Multithreading::~D3D12Multithreading()
 {
     s_app = nullptr;
-}
-
-void D3D12Multithreading::SetApplicationIdentity()
-{
-    ComPtr<ID3D12ApplicationIdentity> pApplicationIdentity;
-    HRESULT hr = D3D12GetInterface(CLSID_D3D12ApplicationIdentity, IID_PPV_ARGS(&pApplicationIdentity));
-    if (E_NOINTERFACE == hr)
-    {
-        return;
-    }
-
-    D3D12_APPLICATION_DESC appDesc;
-    appDesc.pExeFilename = L"D3D12Multithreading.exe";
-    appDesc.pName = L"D3D12 Multithreading";
-    appDesc.Version.Version = 0x0001000000000000;
-    appDesc.pEngineName = nullptr;
-    appDesc.EngineVersion.Version = 0x0000000000000000;
-
-    GUID D3D12MultithreadingAppID = { /* 8367fc8a-d739-485a-a473-12dfaa190567 */
-        0x8367fc8a,
-        0xd739,
-        0x485a,
-        { 0xa4, 0x73, 0x12, 0xdf, 0xaa, 0x19, 0x05, 0x67 }
-    };
-
-    pApplicationIdentity->SetApplicationIdentity(&appDesc, D3D12MultithreadingAppID);
 }
 
 void D3D12Multithreading::OnInit()

--- a/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.h
+++ b/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.h
@@ -151,5 +151,4 @@ private:
     void MidFrame();
     void EndFrame();
 
-    void SetApplicationIdentity();
 };

--- a/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.h
+++ b/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.h
@@ -150,4 +150,6 @@ private:
     void BeginFrame();
     void MidFrame();
     void EndFrame();
+
+    void SetApplicationIdentity();
 };

--- a/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.vcxproj
+++ b/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.vcxproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\Microsoft.Direct3D.D3D12.1.619.1\build\native\Microsoft.Direct3D.D3D12.props" Condition="Exists('packages\Microsoft.Direct3D.D3D12.1.619.1\build\native\Microsoft.Direct3D.D3D12.props')" />
   <Import Project="packages\Microsoft.Direct3D.DXC.1.8.2505.32\build\native\Microsoft.Direct3D.DXC.props" Condition="Exists('packages\Microsoft.Direct3D.DXC.1.8.2505.32\build\native\Microsoft.Direct3D.DXC.props')" />
-  <Import Project="packages\Microsoft.Direct3D.D3D12.1.618.3\build\native\Microsoft.Direct3D.D3D12.props" Condition="Exists('packages\Microsoft.Direct3D.D3D12.1.618.3\build\native\Microsoft.Direct3D.D3D12.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -157,18 +157,18 @@ dxc.exe -nologo -Tps_6_0 -E"PSMain" -Zi -Qembed_debug -Fo"$(OutDir)%(Filename)_P
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="packages\Microsoft.Direct3D.D3D12.1.618.3\build\native\Microsoft.Direct3D.D3D12.targets" Condition="Exists('packages\Microsoft.Direct3D.D3D12.1.618.3\build\native\Microsoft.Direct3D.D3D12.targets')" />
     <Import Project="packages\WinPixEventRuntime.1.0.240308001\build\WinPixEventRuntime.targets" Condition="Exists('packages\WinPixEventRuntime.1.0.240308001\build\WinPixEventRuntime.targets')" />
     <Import Project="packages\Microsoft.Direct3D.DXC.1.8.2505.32\build\native\Microsoft.Direct3D.DXC.targets" Condition="Exists('packages\Microsoft.Direct3D.DXC.1.8.2505.32\build\native\Microsoft.Direct3D.DXC.targets')" />
+    <Import Project="packages\Microsoft.Direct3D.D3D12.1.619.1\build\native\Microsoft.Direct3D.D3D12.targets" Condition="Exists('packages\Microsoft.Direct3D.D3D12.1.619.1\build\native\Microsoft.Direct3D.D3D12.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\Microsoft.Direct3D.D3D12.1.618.3\build\native\Microsoft.Direct3D.D3D12.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Direct3D.D3D12.1.618.3\build\native\Microsoft.Direct3D.D3D12.props'))" />
-    <Error Condition="!Exists('packages\Microsoft.Direct3D.D3D12.1.618.3\build\native\Microsoft.Direct3D.D3D12.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Direct3D.D3D12.1.618.3\build\native\Microsoft.Direct3D.D3D12.targets'))" />
     <Error Condition="!Exists('packages\WinPixEventRuntime.1.0.240308001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\WinPixEventRuntime.1.0.240308001\build\WinPixEventRuntime.targets'))" />
     <Error Condition="!Exists('packages\Microsoft.Direct3D.DXC.1.8.2505.32\build\native\Microsoft.Direct3D.DXC.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Direct3D.DXC.1.8.2505.32\build\native\Microsoft.Direct3D.DXC.props'))" />
     <Error Condition="!Exists('packages\Microsoft.Direct3D.DXC.1.8.2505.32\build\native\Microsoft.Direct3D.DXC.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Direct3D.DXC.1.8.2505.32\build\native\Microsoft.Direct3D.DXC.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.Direct3D.D3D12.1.619.1\build\native\Microsoft.Direct3D.D3D12.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Direct3D.D3D12.1.619.1\build\native\Microsoft.Direct3D.D3D12.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.Direct3D.D3D12.1.619.1\build\native\Microsoft.Direct3D.D3D12.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Direct3D.D3D12.1.619.1\build\native\Microsoft.Direct3D.D3D12.targets'))" />
   </Target>
 </Project>

--- a/Samples/Desktop/D3D12Multithreading/src/DXSample.cpp
+++ b/Samples/Desktop/D3D12Multithreading/src/DXSample.cpp
@@ -25,10 +25,45 @@ DXSample::DXSample(UINT width, UINT height, std::wstring name) :
     m_assetsPath = assetsPath;
 
     m_aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+
+    SetApplicationIdentity(name);
 }
 
 DXSample::~DXSample()
 {
+}
+
+// The Application Identity API allows drivers to recognize specific applications
+// and apply targeted optimizations, replacing fragile exe-name-based detection
+// with a reliable, application-controlled identification mechanism.
+// See: https://microsoft.github.io/DirectX-Specs/d3d/D3D12ApplicationIdentity.html
+void DXSample::SetApplicationIdentity(std::wstring& name)
+{
+    ComPtr<ID3D12ApplicationIdentity> pApplicationIdentity;
+    HRESULT hr = D3D12GetInterface(CLSID_D3D12ApplicationIdentity, IID_PPV_ARGS(&pApplicationIdentity));
+    if (E_NOINTERFACE == hr)
+    {
+        return;
+    }
+
+    D3D12_APPLICATION_DESC appDesc;
+    appDesc.pExeFilename = nullptr; // If unspecified, exe filename is filled by GetModuleFileName with a NULL handle.
+    appDesc.pName = name.c_str();
+    appDesc.Version.Version = 0x0001000000000000; // 1.0.0.0
+
+    // If EngineName is NULL, then engine version must be 0
+    appDesc.pEngineName = nullptr;
+    appDesc.EngineVersion.Version = 0x0000000000000000; // 0.0.0.0
+
+    // Create GUID from VS: Tools -> Create GUID -> Select the format
+    GUID DXSampleID = { /* 8367fc8a-d739-485a-a473-12dfaa190567 */
+        0x8367fc8a,
+        0xd739,
+        0x485a,
+        { 0xa4, 0x73, 0x12, 0xdf, 0xaa, 0x19, 0x05, 0x67 }
+    };
+
+    hr = pApplicationIdentity->SetApplicationIdentity(&appDesc, DXSampleID);
 }
 
 // Helper function for resolving the full path of assets.

--- a/Samples/Desktop/D3D12Multithreading/src/DXSample.h
+++ b/Samples/Desktop/D3D12Multithreading/src/DXSample.h
@@ -55,6 +55,8 @@ protected:
     bool m_useWarpDevice;
 
 private:
+    void SetApplicationIdentity(std::wstring& name);
+
     // Root assets path.
     std::wstring m_assetsPath;
 

--- a/Samples/Desktop/D3D12Multithreading/src/packages.config
+++ b/Samples/Desktop/D3D12Multithreading/src/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Direct3D.D3D12" version="1.618.3" targetFramework="native" />
+  <package id="Microsoft.Direct3D.D3D12" version="1.619.1" targetFramework="native" />
   <package id="Microsoft.Direct3D.DXC" version="1.8.2505.32" targetFramework="native" />
   <package id="WinPixEventRuntime" version="1.0.240308001" targetFramework="native" />
 </packages>

--- a/Samples/Desktop/D3D12Multithreading/src/stdafx.h
+++ b/Samples/Desktop/D3D12Multithreading/src/stdafx.h
@@ -19,6 +19,7 @@
 #define WIN32_LEAN_AND_MEAN            // Exclude rarely-used stuff from Windows headers.
 #endif
 
+#define INITGUID
 #include <windows.h>
 
 #include <d3d12.h>


### PR DESCRIPTION
Updated D3D12Multithreading sample to use Application Identity from AgilitySDK 1.619.