### PR TITLE
Replace hardcoded Agility SDK exports with D3D12_SDK_VERSION in DXR samples

### DIFF
--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingHelloWorld/D3D12RaytracingHelloWorld.cpp
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingHelloWorld/D3D12RaytracingHelloWorld.cpp
@@ -17,7 +17,7 @@
 using namespace std;
 using namespace DX;
 
-extern "C" { __declspec(dllexport) extern const UINT D3D12SDKVersion = 618; }
+extern "C" { __declspec(dllexport) extern const UINT D3D12SDKVersion = D3D12_SDK_VERSION; }
 extern "C" { __declspec(dllexport) extern const char* D3D12SDKPath = u8".\\D3D12\\"; }
 
 const wchar_t* D3D12RaytracingHelloWorld::c_hitGroupName = L"MyHitGroup";

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingLibrarySubobjects/D3D12RaytracingLibrarySubobjects.cpp
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingLibrarySubobjects/D3D12RaytracingLibrarySubobjects.cpp
@@ -17,7 +17,7 @@
 using namespace std;
 using namespace DX;
 
-extern "C" { __declspec(dllexport) extern const UINT D3D12SDKVersion = 618; }
+extern "C" { __declspec(dllexport) extern const UINT D3D12SDKVersion = D3D12_SDK_VERSION; }
 extern "C" { __declspec(dllexport) extern const char* D3D12SDKPath = u8".\\D3D12\\"; }
 
 const wchar_t* D3D12RaytracingLibrarySubobjects::c_hitGroupName = L"MyHitGroup";

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingProceduralGeometry/D3D12RaytracingProceduralGeometry.cpp
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingProceduralGeometry/D3D12RaytracingProceduralGeometry.cpp
@@ -16,7 +16,7 @@
 using namespace std;
 using namespace DX;
 
-extern "C" { __declspec(dllexport) extern const UINT D3D12SDKVersion = 618; }
+extern "C" { __declspec(dllexport) extern const UINT D3D12SDKVersion = D3D12_SDK_VERSION; }
 extern "C" { __declspec(dllexport) extern const char* D3D12SDKPath = u8".\\D3D12\\"; }
 
 // Shader entry points.

--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/D3D12RaytracingSimpleLighting.cpp
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSimpleLighting/D3D12RaytracingSimpleLighting.cpp
@@ -17,7 +17,7 @@
 using namespace std;
 using namespace DX;
 
-extern "C" { __declspec(dllexport) extern const UINT D3D12SDKVersion = 618; }
+extern "C" { __declspec(dllexport) extern const UINT D3D12SDKVersion = D3D12_SDK_VERSION; }
 extern "C" { __declspec(dllexport) extern const char* D3D12SDKPath = u8".\\D3D12\\"; }
 
 const wchar_t* D3D12RaytracingSimpleLighting::c_hitGroupName = L"MyHitGroup";


### PR DESCRIPTION
This PR replaces hardcoded Agility SDK version exports with `D3D12_SDK_VERSION` in several DXR samples.

While testing the raytracing samples, I found that `D3D12RaytracingHelloWorld` failed to launch due to an Agility SDK version mismatch. The bundled Agility SDK had already been updated to 619, but D3D12RaytracingHelloWorld.cpp was still exporting a hardcoded SDK version value of 618:

```
extern const UINT D3D12SDKVersion = 618;
```

This appears to have been unintentionally left behind during the Agility SDK 619 update in `7890a7e`, where some samples were already updated to use the `D3D12_SDK_VERSION` macro, including:

- D3D12RaytracingHelloShaderExecutionReordering
- D3D12RaytracingOpacityMicromaps
- D3D12RaytracingSakuraForestSER

However, several other DXR samples still use hardcoded SDK version exports:

- D3D12RaytracingProceduralGeometry
- D3D12RaytracingLibrarySubobjects
- D3D12RaytracingSimpleLighting
- D3D12RaytracingHelloWorld

This change updates the remaining samples to use `D3D12_SDK_VERSION` for consistency and to help prevent future SDK version mismatch issues when updating the Agility SDK.