### PR TITLE
D3D12RaytracingSakuraForestSER: Build fails due to shader model mismatch (6.3 vs 6.9)

### DIFF
--- a/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSakuraForestSER/D3D12RaytracingSakuraForestSER.vcxproj
+++ b/Samples/Desktop/D3D12Raytracing/src/D3D12RaytracingSakuraForestSER/D3D12RaytracingSakuraForestSER.vcxproj
@@ -194,11 +194,11 @@
       <EnableDebuggingInformation Condition="'$(Configuration)'=='Debug'">true</EnableDebuggingInformation>
       <AdditionalOptions Condition="'$(Configuration)'=='Debug'">-Qembed_debug %(AdditionalOptions)</AdditionalOptions>
       <ShaderType>Library</ShaderType>
-      <ShaderModel>6.3</ShaderModel>
+      <ShaderModel>6.9</ShaderModel>
       <VariableName>g_p%(Filename)</VariableName>
       <HeaderFileOutput>$(IntDir)CompiledShaders\%(Filename).hlsl.h</HeaderFileOutput>
       <AdditionalOptions>/Zpr %(AdditionalOptions)</AdditionalOptions>
-      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">6.7</ShaderModel>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">6.9</ShaderModel>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
     </FxCompile>
   </ItemGroup>


### PR DESCRIPTION
## Description

Building `D3D12RaytracingSakuraForestSER` fails with errors in `Raytracing.hlsl` because the project compiles the shader with `lib_6_3`, but the shader uses intrinsics introduced in Shader Model 6.9.

## Errors

- `G7FE0FD` potential misuse of built-in type 'dx::HitObject' in shader model lib_6_3; introduced in shader model 6.9 [-WhIsl-availability]
- `G69FD26` intrinsic dx::HitObject::TraceRay potentially used by "MyRaygenShader" requires shader model 6.9 or greater
- `G8CC35B` intrinsic dx::HitObject::Invoke potentially used by "MyRaygenShader" requires shader model 6.9 or greater
- `GFA16C7` intrinsic dx::MaybeReorderThread potentially used by "MyRaygenShader" requires shader model 6.9 or greater

## Root Cause

Commit `7890a7e` ("SM 6.9 updates") updated the shader code and NuGet packages to SM 6.9 but did not update the `<ShaderModel>` property in the `.vcxproj`. Both the default and the Debug|x64-specific override are still set to `6.3`.

## Fix

In `D3D12RaytracingSakuraForestSER.vcxproj`, change:
```
<ShaderModel>6.3</ShaderModel>
<ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">6.7</ShaderModel>
```

to:

```
<ShaderModel>6.9</ShaderModel>
<ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">6.9</ShaderModel>
```